### PR TITLE
Workspace rework: per-session binding, agent.md + private skills, sidebar grouping

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -1,4 +1,11 @@
-import type { ExtensionAPI, ExtensionFactory } from "@earendil-works/pi-coding-agent";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import {
+	formatSkillsForPrompt,
+	loadSkillsFromDir,
+	type ExtensionAPI,
+	type ExtensionFactory,
+} from "@earendil-works/pi-coding-agent";
 import { saveConfig, setDefaultModel, type InnoConfig } from "../config.js";
 import { createLearnerTools } from "../memory/learner/learner-tools.js";
 import { loadEvents, loadProfile } from "../memory/learner/profile-store.js";
@@ -37,6 +44,70 @@ export interface InnoExtensionDeps {
 	workspaceRegistry?: WorkspaceRegistry;
 	runRecordStore?: RunRecordStore;
 	getCurrentSessionId?: () => string;
+}
+
+/** File name for per-workspace agent context, loaded into the prompt each turn. */
+const WORKSPACE_AGENT_FILE = "agent.md";
+/** Directory holding per-workspace private skills (merged with global skills). */
+const WORKSPACE_SKILLS_DIR = ".skills";
+
+/**
+ * Resolve the directory of the workspace bound to the active session.
+ * Server: maps the current session id → workspace via the registry.
+ * CLI / no registry: falls back to the runtime workspace root.
+ */
+function resolveActiveWorkspaceDir(paths: RuntimePaths, deps?: InnoExtensionDeps): string {
+	if (deps?.workspaceRegistry && deps.getCurrentSessionId) {
+		try {
+			const sessionId = deps.getCurrentSessionId();
+			if (sessionId) {
+				const workspaceId = deps.workspaceRegistry.getSessionWorkspaceId(sessionId);
+				const dir = deps.workspaceRegistry.resolveWorkspaceDir(workspaceId);
+				if (dir) return dir;
+			}
+		} catch {
+			// Fall through to the workspace root.
+		}
+	}
+	return paths.workspaceDir;
+}
+
+/**
+ * Build extra system-prompt sections for the active workspace:
+ * - the workspace's `agent.md` content (if present)
+ * - a private-skills block discovered under `<workspace>/.skills`
+ */
+function buildWorkspaceContextSections(workspaceDir: string): string[] {
+	const sections: string[] = [];
+
+	const agentFile = join(workspaceDir, WORKSPACE_AGENT_FILE);
+	if (existsSync(agentFile)) {
+		try {
+			const content = readFileSync(agentFile, "utf-8").trim();
+			if (content) {
+				sections.push(`# 工作区上下文 (${WORKSPACE_AGENT_FILE})\n\n${content}`);
+			}
+		} catch {
+			// Ignore unreadable agent.md
+		}
+	}
+
+	const skillsDir = join(workspaceDir, WORKSPACE_SKILLS_DIR);
+	if (existsSync(skillsDir)) {
+		try {
+			const { skills } = loadSkillsFromDir({ dir: skillsDir, source: "path" });
+			if (skills.length > 0) {
+				const block = formatSkillsForPrompt(skills);
+				if (block.trim()) {
+					sections.push(`# 本工作区私有技能${block}`);
+				}
+			}
+		} catch {
+			// Ignore skill discovery failures
+		}
+	}
+
+	return sections;
 }
 
 export function createInnoExtension(
@@ -122,6 +193,10 @@ export function createInnoExtension(
 				const contextSection = formatContextPackForPrompt(contextPack);
 
 				const sections: string[] = [INNO_SYSTEM_PROMPT, contextSection];
+
+				// Inject per-workspace context: agent.md + private skills.
+				const workspaceDir = resolveActiveWorkspaceDir(paths, deps);
+				sections.push(...buildWorkspaceContextSections(workspaceDir));
 
 				// Inject the latest run record for this session, so the agent can
 				// answer "explain the last run" without separate tool calls.

--- a/apps/inno-agent/src/channels/personal-dispatcher.ts
+++ b/apps/inno-agent/src/channels/personal-dispatcher.ts
@@ -22,7 +22,7 @@ export interface PersonalChannelDispatcherOptions {
 	/** Fire-and-forget: auto-generate a topic for a session if it lacks one. */
 	maybeAutoGenerateTopic?: (sessionId: string) => void;
 	/** Called after a new session is created for a channel chat. */
-	onSessionCreated?: (sessionId: string) => void;
+	onSessionCreated?: (sessionId: string, channel: string) => void;
 	channelsDataDir: string;
 	sessionDir: string;
 }
@@ -67,7 +67,7 @@ export class PersonalChannelDispatcher {
 		if (NEW_SESSION_COMMANDS.has(rawText)) {
 			try {
 				const newSessionId = await this.opts.createNewSession();
-				this.opts.onSessionCreated?.(newSessionId);
+				this.opts.onSessionCreated?.(newSessionId, msg.channel);
 				this.opts.recordSessionChannel(msg.channel, newSessionId);
 				// Bind this chatId to the new session
 				if (chatKey) {
@@ -118,7 +118,7 @@ export class PersonalChannelDispatcher {
 		if (!targetSessionPath && chatKey) {
 			try {
 				const newSessionId = await this.opts.createNewSession();
-				this.opts.onSessionCreated?.(newSessionId);
+				this.opts.onSessionCreated?.(newSessionId, msg.channel);
 				this.chatSessionMap[chatKey] = newSessionId;
 				this.saveChatSessionMap();
 				this.opts.recordSessionChannel(msg.channel, newSessionId);

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -75,6 +75,16 @@ const skillsDir = paths.skillsDir;
 const channelRegistry = new ChannelRegistry(join(dataDir, "channels", "default-targets.json"));
 const workspaceRegistry = new WorkspaceRegistry(paths.workspaceDir, dataDir);
 workspaceRegistry.ensureBootstrapped();
+// One-time: bind legacy unbound sessions (which used to fall back to the public
+// workspace) to the now-ordinary default workspace so their files stay reachable.
+try {
+	const sessionFiles = existsSync(paths.sessionDir)
+		? readdirSync(paths.sessionDir).filter((f) => f.endsWith(".jsonl"))
+		: [];
+	workspaceRegistry.migrateUnboundSessions(sessionFiles, DEFAULT_WORKSPACE_ID);
+} catch (err) {
+	console.warn("[sessions] unbound-session migration failed:", err instanceof Error ? err.message : err);
+}
 const runRecordStore = new RunRecordStore(join(dataDir, "runs"));
 const terminalManager = new TerminalSessionManager(workspaceRegistry, runRecordStore);
 
@@ -333,7 +343,7 @@ function safeJoin(baseDir: string, userPath: string): string | null {
 }
 
 function safeWorkspacePath(workspaceId: string | null | undefined, userPath: string): string | null {
-	const root = workspaceRegistry.resolveWorkspaceDir(workspaceId ?? DEFAULT_WORKSPACE_ID);
+	const root = workspaceRegistry.resolveWorkspaceDir(workspaceId ?? TEMP_WORKSPACE_ID);
 	if (!root) return null;
 	return safeJoin(root, userPath.replace(/^\/+/, ""));
 }
@@ -342,15 +352,15 @@ function workspaceIdFromQuery(url: string): string {
 	try {
 		const params = new URL(url, "http://localhost").searchParams;
 		const id = params.get("workspaceId");
-		return id && id.trim() ? id.trim() : DEFAULT_WORKSPACE_ID;
+		return id && id.trim() ? id.trim() : TEMP_WORKSPACE_ID;
 	} catch {
-		return DEFAULT_WORKSPACE_ID;
+		return TEMP_WORKSPACE_ID;
 	}
 }
 
 function workspaceIdFromBody(body: Record<string, unknown>): string {
 	const id = typeof body.workspaceId === "string" ? body.workspaceId.trim() : "";
-	return id || DEFAULT_WORKSPACE_ID;
+	return id || TEMP_WORKSPACE_ID;
 }
 
 function clamp01(n: number): number {
@@ -500,7 +510,7 @@ function validateZipEntries(zipPath: string): void {
 	}
 }
 
-function installSkillZip(fileName: string, data: Buffer): { name: string; filePath: string } {
+function installSkillZip(fileName: string, data: Buffer, targetRoot: string = skillsDir): { name: string; filePath: string } {
 	const fallbackName = slugifySkillName(basename(fileName, extname(fileName)));
 	const tempRoot = join(tmpdir(), `inno-skill-${Date.now()}-${Math.random().toString(36).slice(2)}`);
 	const zipPath = join(tempRoot, `${fallbackName}.zip`);
@@ -521,7 +531,7 @@ function installSkillZip(fileName: string, data: Buffer): { name: string; filePa
 		}
 		const skillRoot = dirname(skillFile);
 		const skill = ensureSkillDocument(readText(skillFile), fallbackName);
-		const targetDir = join(skillsDir, skill.name);
+		const targetDir = join(targetRoot, skill.name);
 		rmSync(targetDir, { recursive: true, force: true });
 		copyDirectoryContents(skillRoot, targetDir);
 		writeText(join(targetDir, "SKILL.md"), skill.content);
@@ -531,9 +541,9 @@ function installSkillZip(fileName: string, data: Buffer): { name: string; filePa
 	}
 }
 
-function installSkillMarkdown(fileName: string, data: Buffer): { name: string; filePath: string } {
+function installSkillMarkdown(fileName: string, data: Buffer, targetRoot: string = skillsDir): { name: string; filePath: string } {
 	const skill = ensureSkillDocument(data.toString("utf-8"), basename(fileName, extname(fileName)));
-	const skillDir = join(skillsDir, skill.name);
+	const skillDir = join(targetRoot, skill.name);
 	rmSync(skillDir, { recursive: true, force: true });
 	ensureDir(skillDir);
 	writeText(join(skillDir, "SKILL.md"), skill.content);
@@ -642,8 +652,26 @@ function listProjectSkills(): unknown[] {
 		.sort((a, b) => a.name.localeCompare(b.name));
 }
 
+/**
+ * Refresh the agent's in-memory skills in the background.
+ *
+ * Skill listings (`listProjectSkills`) read from disk, so callers can respond
+ * immediately without waiting for the agent runtime to reload. Awaiting the
+ * reload inside a request handler could block the HTTP response indefinitely
+ * (the reload is serialized behind the agent prompt queue), which left the
+ * upload UI stuck on "uploading". Fire-and-forget keeps the request snappy.
+ */
+function scheduleSkillsReload(): void {
+	void reloadResources().catch((err) => {
+		console.warn(`[inno-server] skills reload failed: ${err instanceof Error ? err.message : String(err)}`);
+	});
+}
+
+
 const WIKI_PAGE_DIRS = ["sources", "entities", "concepts", "analysis"] as const;
 const WORKSPACE_IGNORES = new Set([".git", "node_modules", "dist", ".DS_Store"]);
+/** Per-workspace private skills directory (matches inno-extension WORKSPACE_SKILLS_DIR). */
+const WORKSPACE_PRIVATE_SKILLS_DIR = ".skills";
 const TEXT_PREVIEW_EXTENSIONS = new Set([
 	".txt",
 	".md",
@@ -731,10 +759,23 @@ function workspaceRelativePath(rootDir: string, filePath: string): string {
 	return relative(rootDir, filePath) || "";
 }
 
+/** Build a tree node for an installed private skill directory under `<root>/.skills`. */
+function workspaceSkillNode(root: string, skillName: string): { name: string; path: string; type: string; size: number; updatedAt: string } {
+	const dir = join(root, WORKSPACE_PRIVATE_SKILLS_DIR, skillName);
+	const stat = statSync(dir);
+	return {
+		name: skillName,
+		path: workspaceRelativePath(root, dir),
+		type: "directory",
+		size: stat.size,
+		updatedAt: stat.mtime.toISOString(),
+	};
+}
+
 function readWorkspaceTree(rootDir: string, dir: string, depth = 0): WorkspaceTreeNode[] {
 	if (depth > 4) return [];
 	return readdirSync(dir, { withFileTypes: true })
-		.filter((entry) => !WORKSPACE_IGNORES.has(entry.name) && !entry.name.startsWith("."))
+		.filter((entry) => !WORKSPACE_IGNORES.has(entry.name))
 		.sort((a, b) => Number(b.isDirectory()) - Number(a.isDirectory()) || a.name.localeCompare(b.name, "zh-CN"))
 		.slice(0, 200)
 		.map((entry) => {
@@ -1415,13 +1456,14 @@ const server = createServer(async (req, res) => {
 				? installSkillZip(fileName, data)
 				: installSkillMarkdown(fileName, data);
 			setSkillEnabled(skill.name, true);
-			await reloadResources();
-			json(res, 201, listProjectSkills().find((entry) => (entry as { name: string }).name === skill.name));
+			const installed = listProjectSkills().find((entry) => (entry as { name: string }).name === skill.name);
+			json(res, 201, installed ?? { name: skill.name });
+			scheduleSkillsReload();
 			return;
 		}
 
 		if (method === "POST" && url === "/api/skills/reload") {
-			await reloadResources();
+			scheduleSkillsReload();
 			json(res, 200, { reloaded: true, skills: listProjectSkills() });
 			return;
 		}
@@ -1438,7 +1480,7 @@ const server = createServer(async (req, res) => {
 			if (typeof body.enabled === "boolean") {
 				setSkillEnabled(name, body.enabled);
 			}
-			await reloadResources();
+			scheduleSkillsReload();
 			json(res, 200, listProjectSkills().find((entry) => (entry as { name: string }).name === name));
 			return;
 		}
@@ -1453,7 +1495,7 @@ const server = createServer(async (req, res) => {
 			}
 			rmSync(skillDir, { recursive: true, force: true });
 			setSkillEnabled(name, true);
-			await reloadResources();
+			scheduleSkillsReload();
 			json(res, 204, null);
 			return;
 		}
@@ -1713,8 +1755,9 @@ const server = createServer(async (req, res) => {
 			const body = await readBody(req).catch(() => ({})) as Record<string, unknown>;
 			const id = await createNewSession();
 
-			// Determine target workspace.
-			let workspaceId: string = DEFAULT_WORKSPACE_ID;
+			// Determine target workspace. The UI chooser always sends an explicit
+			// choice (new/existing); temp is only a safety fallback.
+			let workspaceId: string = TEMP_WORKSPACE_ID;
 			const explicitWorkspaceId = typeof body.workspaceId === "string" ? body.workspaceId.trim() : "";
 			const newWorkspaceSpec = body.newWorkspace && typeof body.newWorkspace === "object"
 				? body.newWorkspace as { name?: unknown; isTemp?: unknown }
@@ -2292,14 +2335,33 @@ const server = createServer(async (req, res) => {
 			const files = Array.isArray(body.files) ? body.files : [];
 			if (!files.length) { json(res, 400, { error: "No files provided" }); return; }
 			const uploaded: Array<{ name: string; path: string; type: string; size: number; updatedAt: string }> = [];
+			let installedSkill = false;
 			for (const entry of files) {
 				const filePath = typeof entry.path === "string" ? entry.path.trim() : "";
 				const dataBase64 = typeof entry.dataBase64 === "string" ? entry.dataBase64 : "";
 				if (!filePath || !dataBase64) continue;
 				const fullPath = safeWorkspacePath(wsId, filePath);
 				if (!fullPath) continue;
-				ensureDir(dirname(fullPath));
 				const data = Buffer.from(dataBase64, "base64");
+				const ext = extname(filePath).toLowerCase();
+
+				// A .zip or .md dropped into the workspace's private skills dir is
+				// installed as a skill (zip is extracted) rather than written raw.
+				if (filePath.split("/").includes(WORKSPACE_PRIVATE_SKILLS_DIR) && (ext === ".zip" || ext === ".md")) {
+					try {
+						const skill = ext === ".zip"
+							? installSkillZip(basename(filePath), data, join(root, WORKSPACE_PRIVATE_SKILLS_DIR))
+							: installSkillMarkdown(basename(filePath), data, join(root, WORKSPACE_PRIVATE_SKILLS_DIR));
+						uploaded.push(workspaceSkillNode(root, skill.name));
+						installedSkill = true;
+						continue;
+					} catch (err) {
+						json(res, 400, { error: err instanceof Error ? err.message : "Failed to install skill package" });
+						return;
+					}
+				}
+
+				ensureDir(dirname(fullPath));
 				writeFileSync(fullPath, data);
 				const stat = statSync(fullPath);
 				uploaded.push({
@@ -2310,7 +2372,32 @@ const server = createServer(async (req, res) => {
 					updatedAt: stat.mtime.toISOString(),
 				});
 			}
+			if (installedSkill) scheduleSkillsReload();
 			json(res, 201, { uploaded });
+			return;
+		}
+
+		// Install a skill package (.zip / .md) into the workspace's private .skills dir.
+		if (method === "POST" && url === "/api/workspace/skills/upload") {
+			const body = (await readBody(req)) as Record<string, unknown>;
+			const wsId = workspaceIdFromBody(body);
+			const root = workspaceRegistry.resolveWorkspaceDir(wsId);
+			if (!root) { json(res, 404, { error: "Workspace not found" }); return; }
+			const fileName = typeof body.fileName === "string" ? body.fileName : "";
+			const dataBase64 = typeof body.dataBase64 === "string" ? body.dataBase64 : "";
+			if (!fileName || !dataBase64) { json(res, 400, { error: "Missing fileName or dataBase64" }); return; }
+			const ext = extname(fileName).toLowerCase();
+			if (ext !== ".zip" && ext !== ".md") { json(res, 400, { error: "Only .zip or .md skill packages are supported" }); return; }
+			const data = Buffer.from(dataBase64, "base64");
+			try {
+				const skill = ext === ".zip"
+					? installSkillZip(fileName, data, join(root, WORKSPACE_PRIVATE_SKILLS_DIR))
+					: installSkillMarkdown(fileName, data, join(root, WORKSPACE_PRIVATE_SKILLS_DIR));
+				scheduleSkillsReload();
+				json(res, 201, workspaceSkillNode(root, skill.name));
+			} catch (err) {
+				json(res, 400, { error: err instanceof Error ? err.message : "Failed to install skill package" });
+			}
 			return;
 		}
 
@@ -2351,8 +2438,8 @@ const server = createServer(async (req, res) => {
 		const workspaceDeleteMatch = matchRoute("DELETE", method, url.split("?")[0], "/api/workspaces/:id");
 		if (workspaceDeleteMatch) {
 			const id = decodeURIComponent(workspaceDeleteMatch.id);
-			if (id === DEFAULT_WORKSPACE_ID || id === TEMP_WORKSPACE_ID) {
-				json(res, 400, { error: "Cannot delete default or shared tmp workspace" });
+			if (id === TEMP_WORKSPACE_ID) {
+				json(res, 400, { error: "Cannot delete the shared tmp workspace" });
 				return;
 			}
 			const params = new URL(url, "http://localhost").searchParams;
@@ -2838,10 +2925,12 @@ initSession(config, paths, channelRegistry, {
 			getCurrentSessionId,
 			recordSessionChannel: (ch, sid?) => recordCurrentSessionChannel(ch as SessionChannel, sid),
 			maybeAutoGenerateTopic,
-			onSessionCreated: (sessionId) => {
-				// Channel-originated sessions land in the public workspace by default.
+			onSessionCreated: (sessionId, channel) => {
+				// Channel-originated sessions bind to a fixed per-channel workspace
+				// (they cannot prompt the user to choose one).
 				try {
-					workspaceRegistry.bindSession(sessionId, DEFAULT_WORKSPACE_ID);
+					const ws = workspaceRegistry.ensureChannelWorkspace(channel);
+					workspaceRegistry.bindSession(sessionId, ws.id);
 				} catch (err) {
 					console.warn(`[sessions] failed to bind channel session ${sessionId}:`, err instanceof Error ? err.message : err);
 				}

--- a/apps/inno-agent/src/workspace/workspace-registry.ts
+++ b/apps/inno-agent/src/workspace/workspace-registry.ts
@@ -18,6 +18,8 @@ export interface WorkspaceMeta {
 
 interface RegistryFile {
 	workspaces: WorkspaceMeta[];
+	/** One-time flag: legacy unbound sessions have been bound to the default workspace. */
+	migratedUnboundToDefault?: boolean;
 }
 
 type SessionWorkspaceMap = Record<string, string>;
@@ -30,6 +32,13 @@ export const DEFAULT_WORKSPACE_ID = "default";
 export const TEMP_WORKSPACE_ID = "tmp";
 const DEFAULT_WORKSPACE_REL_PATH = ".pub";
 const TEMP_WORKSPACE_REL_PATH = ".tmp";
+
+/** Human-readable names for channel-backed workspaces. */
+const CHANNEL_WORKSPACE_NAMES: Record<string, string> = {
+	feishu: "飞书",
+	wechat: "微信",
+	qq: "QQ",
+};
 
 // ---------------------------------------------------------------------------
 // Slug helpers
@@ -98,7 +107,7 @@ export class WorkspaceRegistry {
 		if (defaultIdx < 0) {
 			reg.workspaces.unshift({
 				id: DEFAULT_WORKSPACE_ID,
-				name: "公共空间",
+				name: "默认工作区",
 				relPath: DEFAULT_WORKSPACE_REL_PATH,
 				createdAt: now,
 				updatedAt: now,
@@ -107,7 +116,9 @@ export class WorkspaceRegistry {
 			changed = true;
 		} else {
 			const def = reg.workspaces[defaultIdx];
-			if (def.name === "默认工作区") { def.name = "公共空间"; changed = true; }
+			// Legacy installs labelled this the shared "公共空间"; it is now an
+			// ordinary, deletable workspace with no special fallback role.
+			if (def.name === "公共空间") { def.name = "默认工作区"; changed = true; }
 			if (def.relPath !== DEFAULT_WORKSPACE_REL_PATH) {
 				def.relPath = DEFAULT_WORKSPACE_REL_PATH;
 				changed = true;
@@ -130,10 +141,9 @@ export class WorkspaceRegistry {
 	}
 
 	/**
-	 * List workspaces with their bound session ids (default first, then by lastUsedAt desc).
-	 * If `allSessionIds` is provided, any session id NOT in the registry's session map
-	 * is treated as bound to the default workspace (so CLI / channel sessions that
-	 * lack explicit bindings still appear under "公共空间").
+	 * List workspaces with their bound session ids (most recently updated first).
+	 * If `allSessionIds` is provided, any session id NOT in the registry's session
+	 * map is treated as bound to the shared temp workspace (the unbound fallback).
 	 */
 	listWorkspaces(allSessionIds?: string[]): WorkspaceWithSessions[] {
 		const reg = this.loadRegistry();
@@ -151,19 +161,15 @@ export class WorkspaceRegistry {
 				if (!mapped.has(sid)) orphans.push(sid);
 			}
 			if (orphans.length > 0) {
-				const existing = sessionsByWs.get(DEFAULT_WORKSPACE_ID) ?? [];
-				sessionsByWs.set(DEFAULT_WORKSPACE_ID, [...existing, ...orphans]);
+				const existing = sessionsByWs.get(TEMP_WORKSPACE_ID) ?? [];
+				sessionsByWs.set(TEMP_WORKSPACE_ID, [...existing, ...orphans]);
 			}
 		}
 		const enriched = reg.workspaces.map((w) => ({
 			...w,
 			sessionIds: sessionsByWs.get(w.id) ?? [],
 		}));
-		enriched.sort((a, b) => {
-			if (a.id === DEFAULT_WORKSPACE_ID) return -1;
-			if (b.id === DEFAULT_WORKSPACE_ID) return 1;
-			return Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
-		});
+		enriched.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
 		return enriched;
 	}
 
@@ -174,7 +180,7 @@ export class WorkspaceRegistry {
 
 	/** Resolve a workspace id to its absolute directory. Returns null if invalid or escapes workspaceDir. */
 	resolveWorkspaceDir(id: string | null | undefined): string | null {
-		const wsId = id || DEFAULT_WORKSPACE_ID;
+		const wsId = id || TEMP_WORKSPACE_ID;
 		const ws = this.getWorkspace(wsId);
 		if (!ws) return null;
 		const resolved = resolve(this.workspaceDir, ws.relPath);
@@ -240,6 +246,58 @@ export class WorkspaceRegistry {
 		return ws;
 	}
 
+	/**
+	 * Return (creating if needed) a stable workspace dedicated to a chat channel
+	 * (e.g. feishu/wechat/qq). Channel-originated sessions bind here because they
+	 * cannot prompt the user for a workspace choice.
+	 */
+	ensureChannelWorkspace(channel: string): WorkspaceMeta {
+		const id = `channel-${channel}`;
+		const reg = this.loadRegistry();
+		const now = new Date().toISOString();
+		let ws = reg.workspaces.find((w) => w.id === id);
+		if (!ws) {
+			ws = {
+				id,
+				name: CHANNEL_WORKSPACE_NAMES[channel] ?? channel,
+				relPath: join(".channels", channel),
+				createdAt: now,
+				updatedAt: now,
+				isTemp: false,
+			};
+			reg.workspaces.push(ws);
+			this.saveRegistry(reg);
+		}
+		ensureDir(join(this.workspaceDir, ws.relPath));
+		return ws;
+	}
+
+	/**
+	 * One-time migration: bind any session not present in the session→workspace
+	 * map to `targetWorkspaceId`. This preserves the working directory of legacy
+	 * sessions that used to fall back to the shared public workspace.
+	 */
+	migrateUnboundSessions(sessionIds: string[], targetWorkspaceId: string): void {
+		const reg = this.loadRegistry();
+		if (reg.migratedUnboundToDefault) return;
+		if (!reg.workspaces.some((w) => w.id === targetWorkspaceId)) {
+			reg.migratedUnboundToDefault = true;
+			this.saveRegistry(reg);
+			return;
+		}
+		const map = this.loadSessionMap();
+		let changed = false;
+		for (const sid of sessionIds) {
+			if (!(sid in map)) {
+				map[sid] = targetWorkspaceId;
+				changed = true;
+			}
+		}
+		if (changed) this.saveSessionMap(map);
+		reg.migratedUnboundToDefault = true;
+		this.saveRegistry(reg);
+	}
+
 	renameWorkspace(id: string, name: string): WorkspaceMeta | null {
 		const reg = this.loadRegistry();
 		const ws = reg.workspaces.find((w) => w.id === id);
@@ -250,9 +308,9 @@ export class WorkspaceRegistry {
 		return ws;
 	}
 
-	/** Delete a workspace. Refuses default and the shared tmp. */
+	/** Delete a workspace. Refuses only the shared tmp (the unbound fallback). */
 	deleteWorkspace(id: string, options: { removeFiles?: boolean } = {}): boolean {
-		if (id === DEFAULT_WORKSPACE_ID || id === TEMP_WORKSPACE_ID) return false;
+		if (id === TEMP_WORKSPACE_ID) return false;
 		const reg = this.loadRegistry();
 		const index = reg.workspaces.findIndex((w) => w.id === id);
 		if (index < 0) return false;
@@ -293,7 +351,7 @@ export class WorkspaceRegistry {
 
 	getSessionWorkspaceId(sessionId: string): string {
 		const map = this.loadSessionMap();
-		return map[sessionId] ?? DEFAULT_WORKSPACE_ID;
+		return map[sessionId] ?? TEMP_WORKSPACE_ID;
 	}
 
 	bindSession(sessionId: string, workspaceId: string): boolean {

--- a/apps/inno-agent/web/src/api/workspace.ts
+++ b/apps/inno-agent/web/src/api/workspace.ts
@@ -60,3 +60,11 @@ export async function uploadWorkspaceFiles(files: Array<{ path: string; dataBase
 		body: JSON.stringify(withWorkspace({ files }, workspaceId)),
 	});
 }
+
+/** Install a skill package (.zip / .md) into the workspace's private `.skills` dir. */
+export async function uploadWorkspaceSkill(fileName: string, dataBase64: string, workspaceId?: string): Promise<WorkspaceTreeNode> {
+	return apiFetch<WorkspaceTreeNode>("/api/workspace/skills/upload", {
+		method: "POST",
+		body: JSON.stringify(withWorkspace({ fileName, dataBase64 }, workspaceId)),
+	});
+}

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -154,6 +154,10 @@ inno-app-shell {
 	--workspace-w: 0px;
 }
 
+.app-layout--workspace-quarter {
+	--workspace-w: clamp(240px, var(--inno-workspace-width), 920px);
+}
+
 .app-layout--workspace-half {
 	--workspace-w: clamp(320px, var(--inno-workspace-width), 920px);
 }

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -5,6 +5,8 @@ import type { ChatMessage } from "../types/chat.js";
 import { chatStore } from "../stores/chat-store.js";
 import { sessionsStore } from "../stores/sessions-store.js";
 import { workspacesStore } from "../stores/workspaces-store.js";
+import { workspaceStore } from "../stores/workspace-store.js";
+import { appStore } from "../stores/app-store.js";
 import type { CreateSessionInput } from "../api/sessions.js";
 import { uploadRawFile, type RawUploadResult } from "../api/uploads.js";
 import { useStoreSnapshot } from "./hooks.js";
@@ -140,13 +142,17 @@ export function ChatCenter() {
 	const sessions = useStoreSnapshot(sessionsStore, () => ({
 		pendingNewSession: sessionsStore.pendingNewSession,
 		currentSessionId: sessionsStore.currentSessionId,
+		preselectedWorkspaceId: sessionsStore.preselectedWorkspaceId,
 	}));
 	const workspaces = useStoreSnapshot(workspacesStore, () => ({
 		list: workspacesStore.workspaces,
 	}));
 
 	const reusableWorkspaces = useMemo(
-		() => workspaces.list.filter((w) => !w.isTemp).slice().sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)),
+		() => workspaces.list
+			.filter((w) => !w.isTemp && !w.id.startsWith("channel-"))
+			.slice()
+			.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)),
 		[workspaces.list],
 	);
 
@@ -166,6 +172,25 @@ export function ChatCenter() {
 			setWsExistingId(reusableWorkspaces[0].id);
 		}
 	}, [wsMode, reusableWorkspaces, wsExistingId]);
+
+	// A workspace preselected from the sidebar ("+ 新建对话" on a group) drives the
+	// chooser to "existing" mode bound to that workspace.
+	useEffect(() => {
+		if (sessions.preselectedWorkspaceId) {
+			setWsMode("existing");
+			setWsExistingId(sessions.preselectedWorkspaceId);
+		}
+	}, [sessions.preselectedWorkspaceId]);
+
+	// When picking an existing workspace for a new chat, preview it immediately
+	// (before the first message) so the user sees its files in the right panel.
+	useEffect(() => {
+		if (isWelcome && wsMode === "existing" && wsExistingId) {
+			void workspaceStore.setActiveWorkspace(wsExistingId);
+			appStore.setRightPanelTab("preview");
+			if (appStore.workspaceMode === "collapsed") appStore.setWorkspaceMode("half");
+		}
+	}, [isWelcome, wsMode, wsExistingId]);
 
 	useEffect(() => {
 		requestAnimationFrame(() => {
@@ -386,7 +411,7 @@ export function ChatCenter() {
 										<option value="">尚无可复用工作区</option>
 									) : reusableWorkspaces.map((w) => (
 										<option key={w.id} value={w.id}>
-											{w.name}{w.id === "default" ? " (默认)" : ""}
+											{w.name}
 										</option>
 									))}
 								</select>

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion } from "motion/react";
-import { Paperclip, X, SendHorizonal, Square, RotateCcw } from "lucide-react";
+import { Paperclip, X, SendHorizonal, Square, RotateCcw, Check } from "lucide-react";
 import type { ChatMessage } from "../types/chat.js";
 import { chatStore } from "../stores/chat-store.js";
 import { sessionsStore } from "../stores/sessions-store.js";
@@ -148,12 +148,12 @@ export function ChatCenter() {
 		list: workspacesStore.workspaces,
 	}));
 
-	const reusableWorkspaces = useMemo(
-		() => workspaces.list
-			.filter((w) => !w.isTemp && !w.id.startsWith("channel-"))
-			.slice()
-			.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt)),
-		[workspaces.list],
+	// Workspace preselected from the sidebar ("+ 新建对话" on a group), if any.
+	const preselectedWs = useMemo(
+		() => sessions.preselectedWorkspaceId
+			? workspaces.list.find((w) => w.id === sessions.preselectedWorkspaceId) ?? null
+			: null,
+		[sessions.preselectedWorkspaceId, workspaces.list],
 	);
 
 	// Welcome state: brand-new chat without an active session yet.
@@ -167,14 +167,8 @@ export function ChatCenter() {
 		}
 	}, [isWelcome, workspaces.list.length]);
 
-	useEffect(() => {
-		if (wsMode === "existing" && !wsExistingId && reusableWorkspaces.length > 0) {
-			setWsExistingId(reusableWorkspaces[0].id);
-		}
-	}, [wsMode, reusableWorkspaces, wsExistingId]);
-
-	// A workspace preselected from the sidebar ("+ 新建对话" on a group) drives the
-	// chooser to "existing" mode bound to that workspace.
+	// A workspace preselected from the sidebar drives the chooser to "existing"
+	// mode bound to that workspace (and previews it in quarter mode).
 	useEffect(() => {
 		if (sessions.preselectedWorkspaceId) {
 			setWsMode("existing");
@@ -182,13 +176,16 @@ export function ChatCenter() {
 		}
 	}, [sessions.preselectedWorkspaceId]);
 
-	// When picking an existing workspace for a new chat, preview it immediately
-	// (before the first message) so the user sees its files in the right panel.
+	// When a workspace is preselected for a new chat, preview it immediately
+	// (before the first message) in quarter mode so the file tree shows.
 	useEffect(() => {
 		if (isWelcome && wsMode === "existing" && wsExistingId) {
 			void workspaceStore.setActiveWorkspace(wsExistingId);
 			appStore.setRightPanelTab("preview");
-			if (appStore.workspaceMode === "collapsed") appStore.setWorkspaceMode("half");
+			if (appStore.workspaceMode === "collapsed") {
+				appStore.setWorkspaceWidth(300);
+				appStore.setWorkspaceMode("quarter");
+			}
 		}
 	}, [isWelcome, wsMode, wsExistingId]);
 
@@ -216,6 +213,25 @@ export function ChatCenter() {
 		if (!wsExistingId) return { __error: "请选择一个工作区" };
 		return { workspaceId: wsExistingId };
 	}, [wsMode, wsName, wsExistingId]);
+
+	// Create the new workspace + session up-front (before any message) and reveal
+	// it in the right panel so the user can upload files / skills first.
+	const confirmNewWorkspace = useCallback(() => {
+		const trimmed = wsName.trim();
+		if (!trimmed) { setWsError("请填写工作区名称"); return; }
+		setWsError("");
+		void (async () => {
+			try {
+				await sessionsStore.createSessionWith({ newWorkspace: { name: trimmed, isTemp: false } });
+				appStore.setRightPanelTab("preview");
+				appStore.setWorkspaceWidth(560);
+				appStore.setWorkspaceMode("half");
+				setWsName("");
+			} catch (err) {
+				setWsError(err instanceof Error ? err.message : "创建工作区失败");
+			}
+		})();
+	}, [wsName]);
 
 	const handleSend = useCallback(() => {
 		const input = inputRef.current?.value.trim() ?? "";
@@ -381,42 +397,42 @@ export function ChatCenter() {
 						{renderUploadChips()}
 						{renderComposer("有什么想学习或实践的?发送消息开始…")}
 
-						<div className="mt-3 flex flex-wrap items-center gap-2">
-							<span className="text-xs text-slate-400">工作区</span>
-							<ModeChip selected={wsMode === "temp"} onClick={() => setWsMode("temp")}>临时·用完即弃</ModeChip>
-							<ModeChip selected={wsMode === "new"} onClick={() => setWsMode("new")}>新建工作区</ModeChip>
-							<ModeChip
-								selected={wsMode === "existing"}
-								onClick={() => setWsMode("existing")}
-								disabled={reusableWorkspaces.length === 0}
-							>
-								使用已有 ({reusableWorkspaces.length})
-							</ModeChip>
-							{wsMode === "new" ? (
-								<input
-									type="text"
-									placeholder="工作区名称,例如:pandas demo"
-									value={wsName}
-									onChange={(e) => setWsName(e.target.value)}
-									className="ml-1 w-[200px] rounded-full border border-slate-200 bg-white px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
-								/>
-							) : null}
-							{wsMode === "existing" ? (
-								<select
-									value={wsExistingId}
-									onChange={(e) => setWsExistingId(e.target.value)}
-									className="ml-1 w-[200px] rounded-full border border-slate-200 bg-white px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
-								>
-									{reusableWorkspaces.length === 0 ? (
-										<option value="">尚无可复用工作区</option>
-									) : reusableWorkspaces.map((w) => (
-										<option key={w.id} value={w.id}>
-											{w.name}
-										</option>
-									))}
-								</select>
-							) : null}
-						</div>
+						{preselectedWs ? (
+							<div className="mt-3 flex flex-wrap items-center gap-2">
+								<span className="text-xs text-slate-400">工作区</span>
+								<span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-[11px] font-medium text-blue-700 ring-1 ring-blue-100">
+									{preselectedWs.name}
+								</span>
+								<span className="text-[10px] text-slate-400">新对话将创建于此工作区</span>
+							</div>
+						) : (
+							<div className="mt-3 flex flex-wrap items-center gap-2">
+								<span className="text-xs text-slate-400">工作区</span>
+								<ModeChip selected={wsMode === "temp"} onClick={() => setWsMode("temp")}>临时·用完即弃</ModeChip>
+								<ModeChip selected={wsMode === "new"} onClick={() => setWsMode("new")}>新建工作区</ModeChip>
+								{wsMode === "new" ? (
+									<>
+										<input
+											type="text"
+											placeholder="工作区名称,例如:pandas demo"
+											value={wsName}
+											onChange={(e) => setWsName(e.target.value)}
+											onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); confirmNewWorkspace(); } }}
+											className="ml-1 w-[200px] rounded-full border border-slate-200 bg-white px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
+										/>
+										<button
+											type="button"
+											onClick={confirmNewWorkspace}
+											disabled={!wsName.trim()}
+											title="创建并绑定工作区(可先上传文件/技能,再开始对话)"
+											className="flex items-center gap-1 rounded-full bg-blue-600 px-2 py-0.5 text-[10px] font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-40"
+										>
+											<Check size={11} /> 创建并绑定
+										</button>
+									</>
+								) : null}
+							</div>
+						)}
 
 						{wsError ? <p className="mt-2 text-xs text-red-600">{wsError}</p> : null}
 					</div>

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import {
 	PanelLeftOpen,
@@ -13,10 +13,14 @@ import {
 	ChevronRight,
 	Search,
 	X,
+	FolderKanban,
 } from "lucide-react";
 import { appStore } from "../stores/app-store.js";
 import { chatStore } from "../stores/chat-store.js";
-import { sessionsStore, type DateGroup, type SessionGroup } from "../stores/sessions-store.js";
+import { sessionsStore } from "../stores/sessions-store.js";
+import { workspacesStore } from "../stores/workspaces-store.js";
+import { workspaceStore } from "../stores/workspace-store.js";
+import type { WorkspaceMeta } from "../api/workspaces.js";
 import type { SessionChannel, SessionMeta } from "../api/sessions.js";
 import { useStoreSnapshot } from "./hooks.js";
 
@@ -82,23 +86,120 @@ function channelFilterClass(channel: SessionChannel | null, active: boolean): st
 	return map[channel] ?? "bg-slate-700 text-white ring-1 ring-slate-700";
 }
 
+/* ── Workspace group definition ── */
+
+interface WsGroup {
+	id: string;
+	name: string;
+	/** Whether rename/delete actions are offered (false for temp + archived bucket). */
+	manageable: boolean;
+	/** Whether a new chat can be started directly in this workspace (false for synthetic groups). */
+	canCreate: boolean;
+	sessions: SessionMeta[];
+}
+
 /* ── Group header component ── */
 
-function GroupHeader({ group, collapsed, onToggle }: { group: SessionGroup; collapsed: boolean; onToggle: () => void }) {
+function GroupHeader({
+	group,
+	collapsed,
+	active,
+	onToggle,
+	onSelect,
+	onNewChat,
+	editing,
+	editingName,
+	onStartEdit,
+	onEditChange,
+	onEditSave,
+	onEditCancel,
+	onDelete,
+}: {
+	group: WsGroup;
+	collapsed: boolean;
+	active: boolean;
+	onToggle: () => void;
+	onSelect: () => void;
+	onNewChat: () => void;
+	editing: boolean;
+	editingName: string;
+	onStartEdit: () => void;
+	onEditChange: (v: string) => void;
+	onEditSave: () => void;
+	onEditCancel: () => void;
+	onDelete: () => void;
+}) {
 	return (
-		<button
-			className="inno-sidebar-meta sticky top-0 z-10 flex w-full items-center gap-1.5 bg-[var(--inno-sidebar-bg)] px-2 py-1.5 font-semibold uppercase text-slate-400 transition-colors hover:text-slate-600"
-			onClick={onToggle}
-		>
-			<ChevronRight
-				size={12}
-				className={`shrink-0 transition-transform duration-150 ${collapsed ? "" : "rotate-90"}`}
-			/>
-			<span>{group.label}</span>
-			<span className="inno-sidebar-meta ml-auto rounded-full bg-slate-200 px-1.5 py-0 font-medium text-slate-500 tabular-nums">
+		<div className={`group/wsh sticky top-0 z-10 flex w-full items-center gap-1.5 px-2 py-1.5 ${active ? "bg-slate-100" : "bg-[var(--inno-sidebar-bg)]"}`}>
+			<button
+				className="shrink-0 text-slate-400 transition-colors hover:text-slate-600"
+				title={collapsed ? "展开" : "折叠"}
+				onClick={onToggle}
+			>
+				<ChevronRight
+					size={12}
+					className={`transition-transform duration-150 ${collapsed ? "" : "rotate-90"}`}
+				/>
+			</button>
+			<button
+				className="inno-sidebar-meta flex min-w-0 flex-1 items-center gap-1.5 font-semibold uppercase text-slate-400 transition-colors hover:text-slate-600"
+				title={group.canCreate ? "加载此工作区到预览面板" : undefined}
+				onClick={onSelect}
+			>
+				<FolderKanban size={12} className="shrink-0 text-slate-400" />
+				{editing ? (
+					<input
+						className="min-w-0 flex-1 rounded border border-blue-300 bg-white px-1 py-0.5 text-[11px] normal-case text-slate-800 outline-none focus:ring-1 focus:ring-blue-200"
+						value={editingName}
+						autoFocus
+						onClick={(e) => { e.stopPropagation(); }}
+						onChange={(e) => onEditChange(e.target.value)}
+						onBlur={onEditSave}
+						onKeyDown={(e) => {
+							e.stopPropagation();
+							if (e.key === "Enter") onEditSave();
+							if (e.key === "Escape") onEditCancel();
+						}}
+					/>
+				) : (
+					<span className="min-w-0 truncate normal-case text-slate-500">{group.name}</span>
+				)}
+			</button>
+			{!editing ? (
+				<div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/wsh:opacity-100">
+					{group.canCreate ? (
+						<button
+							className="rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+							title="在此工作区新建对话"
+							onClick={(e) => { e.stopPropagation(); onNewChat(); }}
+						>
+							<Plus size={12} />
+						</button>
+					) : null}
+					{group.manageable ? (
+						<>
+							<button
+								className="rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+								title="重命名工作区"
+								onClick={(e) => { e.stopPropagation(); onStartEdit(); }}
+							>
+								<Pencil size={11} />
+							</button>
+							<button
+								className="rounded p-0.5 text-slate-400 hover:bg-red-50 hover:text-red-600"
+								title="删除工作区"
+								onClick={(e) => { e.stopPropagation(); onDelete(); }}
+							>
+								<Trash2 size={11} />
+							</button>
+						</>
+					) : null}
+				</div>
+			) : null}
+			<span className="inno-sidebar-meta rounded-full bg-slate-200 px-1.5 py-0 font-medium text-slate-500 tabular-nums">
 				{group.sessions.length}
 			</span>
-		</button>
+		</div>
 	);
 }
 
@@ -240,12 +341,13 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editingName, setEditingName] = useState("");
 	const [generatingId, setGeneratingId] = useState<string | null>(null);
-	const [collapsedGroups, setCollapsedGroups] = useState<Set<DateGroup>>(() => new Set(["archived"]));
+	const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set(["archived"]));
 	const [showSearch, setShowSearch] = useState(false);
+	const [editingWsId, setEditingWsId] = useState<string | null>(null);
+	const [editingWsName, setEditingWsName] = useState("");
 
 	const state = useStoreSnapshot(sessionsStore, () => ({
 		sessions: sessionsStore.sessions,
-		groups: sessionsStore.groupedSessions,
 		currentSessionId: sessionsStore.currentSessionId,
 		isLoading: sessionsStore.isLoading,
 		openingSessionId: sessionsStore.openingSessionId,
@@ -254,11 +356,51 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 		availableChannels: sessionsStore.availableChannels,
 		filteredSessions: sessionsStore.filteredSessions,
 	}));
+	const wsState = useStoreSnapshot(workspacesStore, () => ({
+		list: workspacesStore.workspaces,
+	}));
+	const wsActive = useStoreSnapshot(workspaceStore, () => ({
+		activeWorkspaceId: workspaceStore.activeWorkspaceId,
+	}));
 	const orderedChannels = CHANNEL_FILTER_ORDER.filter((ch) => state.availableChannels.includes(ch as SessionChannel));
 
 	useEffect(() => {
 		void sessionsStore.load();
+		void workspacesStore.load();
 	}, []);
+
+	// Build workspace-grouped session list. Non-archived sessions are grouped by
+	// their bound workspace (in workspace recency order); archived sessions go to
+	// a single trailing group.
+	const groups = useMemo<WsGroup[]>(() => {
+		const sessionToWs = new Map<string, WorkspaceMeta>();
+		for (const w of wsState.list) {
+			for (const sid of w.sessionIds ?? []) sessionToWs.set(sid, w);
+		}
+		const archived: SessionMeta[] = [];
+		const byWs = new Map<string, SessionMeta[]>();
+		const unknown: SessionMeta[] = [];
+		for (const s of state.filteredSessions) {
+			if (s.archived) { archived.push(s); continue; }
+			const w = sessionToWs.get(s.id);
+			if (!w) { unknown.push(s); continue; }
+			if (!byWs.has(w.id)) byWs.set(w.id, []);
+			byWs.get(w.id)!.push(s);
+		}
+		const result: WsGroup[] = [];
+		for (const w of wsState.list) {
+			const sessions = byWs.get(w.id);
+			if (!sessions || sessions.length === 0) continue;
+			result.push({ id: w.id, name: w.name, manageable: !w.isTemp, canCreate: true, sessions });
+		}
+		if (unknown.length > 0) {
+			result.push({ id: "__unknown__", name: "未分组", manageable: false, canCreate: false, sessions: unknown });
+		}
+		if (archived.length > 0) {
+			result.push({ id: "archived", name: "已归档", manageable: false, canCreate: false, sessions: archived });
+		}
+		return result;
+	}, [wsState.list, state.filteredSessions]);
 
 	const newChat = useCallback(() => {
 		void (async () => {
@@ -266,6 +408,22 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 			chatStore.clear();
 			appStore.setRightPanelTab("preview");
 		})();
+	}, []);
+
+	// Click a workspace group header → load that workspace into the right panel.
+	const selectWorkspace = useCallback((group: WsGroup) => {
+		if (!group.canCreate) return; // synthetic groups (未分组 / 已归档)
+		void workspaceStore.setActiveWorkspace(group.id);
+		appStore.setRightPanelTab("preview");
+		if (appStore.workspaceMode === "collapsed") appStore.setWorkspaceMode("half");
+	}, []);
+
+	// Start a new chat pre-bound to this workspace.
+	const newChatIn = useCallback((group: WsGroup) => {
+		sessionsStore.beginNewSessionIn(group.id);
+		void workspaceStore.setActiveWorkspace(group.id);
+		appStore.setRightPanelTab("preview");
+		if (appStore.workspaceMode === "collapsed") appStore.setWorkspaceMode("half");
 	}, []);
 
 	const openSession = useCallback((session: SessionMeta) => {
@@ -305,13 +463,31 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 		void sessionsStore.deleteSession(session.id);
 	}, []);
 
-	const toggleGroup = useCallback((key: DateGroup) => {
+	const toggleGroup = useCallback((key: string) => {
 		setCollapsedGroups((prev) => {
 			const next = new Set(prev);
 			if (next.has(key)) next.delete(key);
 			else next.add(key);
 			return next;
 		});
+	}, []);
+
+	const saveWsName = useCallback((id: string) => {
+		const name = editingWsName.trim();
+		setEditingWsId(null);
+		if (!name) return;
+		void workspacesStore.rename(id, name);
+	}, [editingWsName]);
+
+	const handleDeleteWorkspace = useCallback((group: WsGroup) => {
+		const confirmed = typeof window === "undefined" ? true : window.confirm(
+			`删除工作区「${group.name}」？\n其中的 ${group.sessions.length} 个会话将解绑(归入临时工作区),会话记录与文件不会被删除。`,
+		);
+		if (!confirmed) return;
+		void (async () => {
+			await workspacesStore.remove(group.id);
+			await Promise.all([workspacesStore.load(), sessionsStore.refresh()]);
+		})();
 	}, []);
 
 	/* ── Collapsed sidebar ── */
@@ -434,16 +610,30 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 					<div className="flex items-center justify-center py-8">
 						<span className="h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-transparent" />
 					</div>
-				) : state.groups.length === 0 ? (
+				) : groups.length === 0 ? (
 					<div className="inno-sidebar-text px-2 py-8 text-center text-slate-400">
 						{state.searchQuery || state.channelFilter ? "无匹配结果" : "暂无对话记录"}
 					</div>
 				) : (
-					state.groups.map((group) => {
-						const isGroupCollapsed = collapsedGroups.has(group.key);
+					groups.map((group) => {
+						const isGroupCollapsed = collapsedGroups.has(group.id);
 						return (
-							<div key={group.key} className="mt-0.5">
-								<GroupHeader group={group} collapsed={isGroupCollapsed} onToggle={() => toggleGroup(group.key)} />
+							<div key={group.id} className="mt-0.5">
+								<GroupHeader
+									group={group}
+									collapsed={isGroupCollapsed}
+									active={group.canCreate && wsActive.activeWorkspaceId === group.id}
+									onToggle={() => toggleGroup(group.id)}
+									onSelect={() => selectWorkspace(group)}
+									onNewChat={() => newChatIn(group)}
+									editing={editingWsId === group.id}
+									editingName={editingWsName}
+									onStartEdit={() => { setEditingWsId(group.id); setEditingWsName(group.name); }}
+									onEditChange={setEditingWsName}
+									onEditSave={() => saveWsName(group.id)}
+									onEditCancel={() => setEditingWsId(null)}
+									onDelete={() => handleDeleteWorkspace(group)}
+								/>
 								<AnimatePresence initial={false}>
 									{!isGroupCollapsed && (
 										<motion.div

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -388,11 +388,16 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 			byWs.get(w.id)!.push(s);
 		}
 		const result: WsGroup[] = [];
+		// Non-temp workspaces first (by recency), then the temp workspace last.
+		const tempGroups: WsGroup[] = [];
 		for (const w of wsState.list) {
 			const sessions = byWs.get(w.id);
 			if (!sessions || sessions.length === 0) continue;
-			result.push({ id: w.id, name: w.name, manageable: !w.isTemp, canCreate: true, sessions });
+			const g: WsGroup = { id: w.id, name: w.name, manageable: !w.isTemp, canCreate: true, sessions };
+			if (w.isTemp) tempGroups.push(g);
+			else result.push(g);
 		}
+		result.push(...tempGroups);
 		if (unknown.length > 0) {
 			result.push({ id: "__unknown__", name: "未分组", manageable: false, canCreate: false, sessions: unknown });
 		}
@@ -410,24 +415,29 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 		})();
 	}, []);
 
-	// Click a workspace group header → load that workspace into the right panel.
+	// Click a workspace group header → load that workspace into the right panel (half screen).
 	const selectWorkspace = useCallback((group: WsGroup) => {
 		if (!group.canCreate) return; // synthetic groups (未分组 / 已归档)
 		void workspaceStore.setActiveWorkspace(group.id);
 		appStore.setRightPanelTab("preview");
-		if (appStore.workspaceMode === "collapsed") appStore.setWorkspaceMode("half");
+		appStore.setWorkspaceWidth(560);
+		appStore.setWorkspaceMode("half");
 	}, []);
 
-	// Start a new chat pre-bound to this workspace.
+	// Start a new chat pre-bound to this workspace → preview its files (quarter, tree only).
 	const newChatIn = useCallback((group: WsGroup) => {
 		sessionsStore.beginNewSessionIn(group.id);
 		void workspaceStore.setActiveWorkspace(group.id);
 		appStore.setRightPanelTab("preview");
-		if (appStore.workspaceMode === "collapsed") appStore.setWorkspaceMode("half");
+		appStore.setWorkspaceWidth(300);
+		appStore.setWorkspaceMode("quarter");
 	}, []);
 
+	// Open a session → preview its workspace files (quarter, tree only).
 	const openSession = useCallback((session: SessionMeta) => {
 		appStore.setRightPanelTab("preview");
+		appStore.setWorkspaceWidth(300);
+		appStore.setWorkspaceMode("quarter");
 		void sessionsStore.openSession(session.id);
 	}, []);
 

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -17,7 +17,7 @@ import { cpp } from "@codemirror/lang-cpp";
 import { rust } from "@codemirror/lang-rust";
 import { go } from "@codemirror/lang-go";
 import type { Extension } from "@codemirror/state";
-import { RefreshCw, FilePlus, FolderPlus, Upload, Trash2, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { RefreshCw, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Sparkles } from "lucide-react";
 import { workspaceStore } from "../stores/workspace-store.js";
 import { workspacesStore } from "../stores/workspaces-store.js";
 import { sessionsStore } from "../stores/sessions-store.js";
@@ -354,6 +354,7 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 			}}
 			onContextMenu={(e) => {
 				e.preventDefault();
+				e.stopPropagation();
 				node.select();
 				const ev = new CustomEvent("workspace-ctx", { detail: { x: e.clientX, y: e.clientY, node: node.data }, bubbles: true });
 				e.currentTarget.dispatchEvent(ev);
@@ -396,18 +397,25 @@ interface CtxMenuState {
 	nodePath: string;
 	nodeName: string;
 	isDir: boolean;
+	/** True when the menu was opened on empty tree space (create at root). */
+	isRoot?: boolean;
 }
 
 function ContextMenu({ state, onClose, treeRef }: { state: CtxMenuState; onClose: () => void; treeRef: React.RefObject<TreeApi<ArboristNode> | null> }) {
 	const { t } = useTranslation();
-	const items = [
-		{ label: t("files.rename", "Rename"), action: () => { const n = treeRef.current?.get(state.nodePath); n?.edit(); } },
-		{ label: t("files.delete", "Delete"), action: () => { const n = treeRef.current?.get(state.nodePath); if (n) treeRef.current?.delete(n.id); } },
-		...(state.isDir ? [
-			{ label: t("files.newFileHere", "New File Here"), action: () => { const n = treeRef.current?.get(state.nodePath); n?.open(); treeRef.current?.create({ parentId: state.nodePath, type: "leaf" }); } },
-			{ label: t("files.newFolderHere", "New Folder Here"), action: () => { const n = treeRef.current?.get(state.nodePath); n?.open(); treeRef.current?.create({ parentId: state.nodePath, type: "internal" }); } },
-		] : []),
-	];
+	const items = state.isRoot
+		? [
+			{ label: t("files.newFile", "New File"), action: () => { treeRef.current?.create({ parentId: null, type: "leaf" }); } },
+			{ label: t("files.newFolder", "New Folder"), action: () => { treeRef.current?.create({ parentId: null, type: "internal" }); } },
+		]
+		: [
+			{ label: t("files.rename", "Rename"), action: () => { const n = treeRef.current?.get(state.nodePath); n?.edit(); } },
+			{ label: t("files.delete", "Delete"), action: () => { const n = treeRef.current?.get(state.nodePath); if (n) treeRef.current?.delete(n.id); } },
+			...(state.isDir ? [
+				{ label: t("files.newFileHere", "New File Here"), action: () => { const n = treeRef.current?.get(state.nodePath); n?.open(); treeRef.current?.create({ parentId: state.nodePath, type: "leaf" }); } },
+				{ label: t("files.newFolderHere", "New Folder Here"), action: () => { const n = treeRef.current?.get(state.nodePath); n?.open(); treeRef.current?.create({ parentId: state.nodePath, type: "internal" }); } },
+			] : []),
+		];
 
 	return (
 		<>
@@ -458,7 +466,7 @@ function DeleteConfirm({ paths, onConfirm, onCancel }: { paths: string[]; onConf
 export function WorkspaceBrowser() {
 	const { t } = useTranslation();
 	const treeRef = useRef<TreeApi<ArboristNode>>(null);
-	const uploadRef = useRef<HTMLInputElement>(null);
+	const skillUploadRef = useRef<HTMLInputElement>(null);
 	const treeContainerRef = useRef<HTMLDivElement>(null);
 	const [treeHeight, setTreeHeight] = useState(400);
 	const [sidebarOpen, setSidebarOpen] = useState(true);
@@ -511,23 +519,20 @@ export function WorkspaceBrowser() {
 		return () => { cancelled = true; };
 	}, [sessState.currentSessionId]);
 
-	// Dropdown visible options: the session's bound workspace + the public ("default") workspace.
-	const visibleWorkspaces = useMemo(() => {
-		const list = wsState.list;
-		const pub = list.find((w) => w.id === "default")
-			?? { id: "default", name: "公共空间", relPath: "", createdAt: "", updatedAt: "", isTemp: false };
-		const bound = boundWorkspaceId ? list.find((w) => w.id === boundWorkspaceId) : null;
-		const items = [pub];
-		if (bound && bound.id !== "default") items.unshift(bound);
-		return items;
-	}, [wsState.list, boundWorkspaceId]);
+	// Default the panel view to the session's bound workspace once known.
+	useEffect(() => {
+		if (boundWorkspaceId && state.activeWorkspaceId == null) {
+			void workspaceStore.setActiveWorkspace(boundWorkspaceId);
+		}
+	}, [boundWorkspaceId, state.activeWorkspaceId]);
 
-	const handleWorkspaceSelect = useCallback(async (workspaceId: string) => {
-		if (workspaceId === (state.activeWorkspaceId ?? "default")) return;
-		// View-only switch — no rebind. The session's bound workspace (and the
-		// agent's cwd) stays fixed for the lifetime of the conversation.
-		await workspaceStore.setActiveWorkspace(workspaceId);
-	}, [state.activeWorkspaceId]);
+	// The session is fixed to one workspace; show its name (no switcher).
+	const activeWorkspaceName = useMemo(() => {
+		const id = state.activeWorkspaceId ?? boundWorkspaceId;
+		if (!id) return "";
+		const ws = wsState.list.find((w) => w.id === id);
+		return ws ? `${ws.isTemp ? "🗒 " : ""}${ws.name}` : id;
+	}, [state.activeWorkspaceId, boundWorkspaceId, wsState.list]);
 
 	// Listen for custom context-menu events from node renderer
 	useEffect(() => {
@@ -590,12 +595,15 @@ export function WorkspaceBrowser() {
 		return sel.isLeaf ? (sel.parent?.id ?? "") : sel.id;
 	}, []);
 
-	const handleUploadChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-		if (e.target.files?.length) {
-			void workspaceStore.uploadFiles(selectedParentPath(), e.target.files);
+	const handleSkillUploadChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+		const files = e.target.files;
+		if (files?.length) {
+			for (const file of Array.from(files)) {
+				void workspaceStore.uploadSkillPackage(file);
+			}
 			e.target.value = "";
 		}
-	}, [selectedParentPath]);
+	}, []);
 
 	/** Only true when dragging files from OS (not internal react-dnd tree drags) */
 	const isExternalFileDrag = useCallback((e: DragEvent) => {
@@ -638,40 +646,29 @@ export function WorkspaceBrowser() {
 				{/* Toolbar */}
 				<div className="flex h-10 items-center gap-1 border-b border-slate-200 bg-slate-50 px-2">
 					<div className="min-w-0 flex-1">
-						<select
-							className="w-full max-w-[200px] truncate rounded bg-transparent px-1 py-0.5 text-xs font-medium text-slate-700 outline-none hover:bg-slate-100 focus:bg-white"
-							value={state.activeWorkspaceId ?? "default"}
-							onChange={(e) => void handleWorkspaceSelect(e.target.value)}
-							title="查看工作区"
-							disabled={visibleWorkspaces.length <= 1}
-						>
-							{visibleWorkspaces.map((w) => (
-								<option key={w.id} value={w.id}>
-									{w.isTemp ? "🗒 " : ""}{w.name}{w.id === boundWorkspaceId && visibleWorkspaces.length > 1 ? " · 当前" : ""}
-								</option>
-							))}
-						</select>
+						<span className="block max-w-[220px] truncate px-1 text-xs font-medium text-slate-700" title={activeWorkspaceName}>
+							{activeWorkspaceName || "工作区"}
+						</span>
 					</div>
-					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700 disabled:opacity-40" title={t("files.newFile", "New File")} onClick={() => treeRef.current?.createLeaf()}>
-						<FilePlus size={13} />
-					</button>
-					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700 disabled:opacity-40" title={t("files.newFolder", "New Folder")} onClick={() => treeRef.current?.createInternal()}>
-						<FolderPlus size={13} />
-					</button>
-					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700 disabled:opacity-40" title={t("files.upload", "Upload")} onClick={() => uploadRef.current?.click()}>
-						<Upload size={13} />
-					</button>
-					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-slate-400 transition-colors hover:bg-red-50 hover:text-red-600 disabled:opacity-40" title={t("files.deleteSelected", "Delete")} onClick={() => { const ids = treeRef.current?.selectedIds; if (ids?.size) setDeleteConfirm({ ids: [...ids] }); }}>
-						<Trash2 size={13} />
+					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-slate-400 transition-colors hover:bg-violet-100 hover:text-violet-600 disabled:opacity-40" title={t("files.uploadSkill", "上传技能包 (.zip/.md) 到 .skills")} onClick={() => skillUploadRef.current?.click()}>
+						<Sparkles size={13} />
 					</button>
 					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700 disabled:opacity-40" title={t("preview.refresh", "Refresh")} onClick={() => void workspaceStore.loadTree()}>
 						<RefreshCw size={13} />
 					</button>
-					<input ref={uploadRef} type="file" multiple className="hidden" onChange={handleUploadChange} />
+					<input ref={skillUploadRef} type="file" multiple accept=".zip,application/zip,.md,text/markdown" className="hidden" onChange={handleSkillUploadChange} />
 				</div>
 
 				{/* Tree */}
-				<div ref={treeContainerRef} className="workspace-scroll min-h-0 flex-1 overflow-hidden">
+				<div
+					ref={treeContainerRef}
+					className="workspace-scroll min-h-0 flex-1 overflow-hidden"
+					onContextMenu={(e) => {
+						// Right-click on empty space → create at workspace root.
+						e.preventDefault();
+						setCtxMenu({ x: e.clientX, y: e.clientY, nodePath: "", nodeName: "", isDir: true, isRoot: true });
+					}}
+				>
 					{state.isLoadingTree && !arboristData.length ? (
 						<div className="p-3 text-xs text-slate-500">{t("preview.loading", "Loading...")}</div>
 					) : !arboristData.length ? (

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -467,8 +467,11 @@ export function WorkspaceBrowser() {
 	const { t } = useTranslation();
 	const treeRef = useRef<TreeApi<ArboristNode>>(null);
 	const skillUploadRef = useRef<HTMLInputElement>(null);
+	const rootRef = useRef<HTMLDivElement>(null);
 	const treeContainerRef = useRef<HTMLDivElement>(null);
 	const [treeHeight, setTreeHeight] = useState(400);
+	const [treeWidth, setTreeWidth] = useState(260);
+	const [panelWidth, setPanelWidth] = useState(600);
 	const [sidebarOpen, setSidebarOpen] = useState(true);
 	const [ctxMenu, setCtxMenu] = useState<CtxMenuState | null>(null);
 	const [deleteConfirm, setDeleteConfirm] = useState<{ ids: string[] } | null>(null);
@@ -486,13 +489,32 @@ export function WorkspaceBrowser() {
 	const sessState = useStoreSnapshot(sessionsStore, () => ({
 		currentSessionId: sessionsStore.currentSessionId,
 	}));
+	// The file tree pane keeps a fixed width; the content preview pane appears
+	// only once the panel is dragged wide enough to fit it beside the tree.
+	const TREE_PANE_WIDTH = 260;
+	const CONTENT_REVEAL_WIDTH = TREE_PANE_WIDTH + 150;
+	const showContent = sidebarOpen ? panelWidth >= CONTENT_REVEAL_WIDTH : true;
 
-	// Measure tree container height for react-window (required by react-arborist)
+	// Measure the panel width to decide whether the content pane fits.
+	useLayoutEffect(() => {
+		const el = rootRef.current;
+		if (!el) return;
+		const ro = new ResizeObserver(([entry]) => {
+			if (entry) setPanelWidth(Math.floor(entry.contentRect.width));
+		});
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, []);
+
+	// Measure tree container size for react-window (required by react-arborist)
 	useLayoutEffect(() => {
 		const el = treeContainerRef.current;
 		if (!el) return;
 		const ro = new ResizeObserver(([entry]) => {
-			if (entry) setTreeHeight(Math.floor(entry.contentRect.height));
+			if (entry) {
+				setTreeHeight(Math.floor(entry.contentRect.height));
+				setTreeWidth(Math.max(180, Math.floor(entry.contentRect.width)));
+			}
 		});
 		ro.observe(el);
 		return () => ro.disconnect();
@@ -635,7 +657,7 @@ export function WorkspaceBrowser() {
 	const busy = state.isMutating || state.isLoadingTree;
 
 	return (
-		<div className={`grid h-full min-h-0 gap-3 bg-transparent p-3 transition-[grid-template-columns] duration-200 ${sidebarOpen ? "grid-cols-[260px_minmax(0,1fr)]" : "grid-cols-[0px_minmax(0,1fr)]"}`}>
+		<div ref={rootRef} className={`grid h-full min-h-0 gap-3 bg-transparent p-3 transition-[grid-template-columns] duration-200 ${showContent ? (sidebarOpen ? "grid-cols-[260px_minmax(0,1fr)]" : "grid-cols-[0px_minmax(0,1fr)]") : "grid-cols-[minmax(0,1fr)]"}`}>
 			{/* --- Tree pane --- */}
 			<aside
 				className={`inno-workspace-card relative flex min-h-0 flex-col overflow-hidden rounded-lg transition-opacity duration-200 ${isDragOver ? "border-blue-400 bg-blue-50" : ""} ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
@@ -677,7 +699,7 @@ export function WorkspaceBrowser() {
 						<Tree<ArboristNode>
 							ref={treeRef}
 							data={arboristData}
-							width={260}
+							width={treeWidth}
 							height={treeHeight}
 							indent={16}
 							rowHeight={28}
@@ -703,12 +725,14 @@ export function WorkspaceBrowser() {
 			</aside>
 
 			{/* --- Preview / Edit pane --- */}
-			<section className="inno-workspace-card flex min-w-0 min-h-0 flex-col overflow-hidden rounded-lg">
-				<div className="flex min-h-0 flex-1 flex-col">
-					<FileContentPane onToggleSidebar={() => setSidebarOpen((v) => !v)} sidebarOpen={sidebarOpen} />
-				</div>
-				<TerminalDrawer />
-			</section>
+			{showContent ? (
+				<section className="inno-workspace-card flex min-w-0 min-h-0 flex-col overflow-hidden rounded-lg">
+					<div className="flex min-h-0 flex-1 flex-col">
+						<FileContentPane onToggleSidebar={() => setSidebarOpen((v) => !v)} sidebarOpen={sidebarOpen} />
+					</div>
+					<TerminalDrawer />
+				</section>
+			) : null}
 
 			{/* Context Menu */}
 			{ctxMenu && <ContextMenu state={ctxMenu} onClose={() => setCtxMenu(null)} treeRef={treeRef} />}

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -92,7 +92,7 @@ export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChan
 
 	return (
 		<aside className="workspace-panel inno-workspace-scope relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden border-l border-[var(--inno-border)] bg-[var(--inno-workspace-bg)]">
-			{mode !== "full" ? (
+			{mode === "half" || mode === "quarter" ? (
 				<button
 					className="workspace-resize-handle"
 					aria-label={t("workspace.resize") ?? ""}

--- a/apps/inno-agent/web/src/react/workspaces/NewSessionWorkspaceChooser.tsx
+++ b/apps/inno-agent/web/src/react/workspaces/NewSessionWorkspaceChooser.tsx
@@ -29,7 +29,7 @@ export function NewSessionWorkspaceChooser() {
 
 	const reusable = useMemo<WorkspaceMeta[]>(() => {
 		return workspaces.list
-			.filter((w) => !w.isTemp)
+			.filter((w) => !w.isTemp && !w.id.startsWith("channel-"))
 			.slice()
 			.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
 	}, [workspaces.list]);
@@ -108,7 +108,7 @@ export function NewSessionWorkspaceChooser() {
 						) : (
 							reusable.map((w) => (
 								<option key={w.id} value={w.id}>
-									{w.name}{w.id === "default" ? " (默认)" : ""}
+									{w.name}
 								</option>
 							))
 						)}

--- a/apps/inno-agent/web/src/stores/app-store.ts
+++ b/apps/inno-agent/web/src/stores/app-store.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "./event-emitter.js";
 
 export type RightPanelTab = "notebook" | "preview" | "profile" | "skills" | "jobs" | "settings";
 export type SidebarSection = "chat" | "wiki" | "jobs" | "settings";
-export type WorkspaceMode = "collapsed" | "half" | "full";
+export type WorkspaceMode = "collapsed" | "quarter" | "half" | "full";
 
 interface AppStoreEvents {
 	change: void;
@@ -48,7 +48,7 @@ class AppStoreImpl extends EventEmitter<AppStoreEvents> {
 	}
 
 	setWorkspaceWidth(width: number) {
-		this.workspaceWidth = Math.max(320, Math.min(920, Math.round(width)));
+		this.workspaceWidth = Math.max(240, Math.min(920, Math.round(width)));
 		if (typeof window !== "undefined") {
 			window.localStorage.setItem("inno.workspaceWidth", String(this.workspaceWidth));
 		}

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -64,6 +64,8 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	searchQuery = "";
 	/** When true, ChatCenter shows the workspace chooser instead of opening a session. */
 	pendingNewSession = false;
+	/** When set, a new session should be pre-bound to this workspace (set from the sidebar). */
+	preselectedWorkspaceId: string | null = null;
 	private _openRequestId = 0;
 	private _messageCache = new Map<string, Awaited<ReturnType<typeof getSession>>["messages"]>();
 
@@ -203,14 +205,27 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	beginNewSession(): void {
 		this.currentSessionId = null;
 		this.pendingNewSession = true;
+		this.preselectedWorkspaceId = null;
 		chatStore.cancel();
 		chatStore.clear();
 		void terminalStore.disconnect();
 		this.emit("change", undefined);
 	}
 
+	/**
+	 * Enter "new session" mode pre-bound to a specific workspace (from the
+	 * sidebar). ChatCenter's chooser reads `preselectedWorkspaceId` to default to
+	 * that workspace and previews it immediately.
+	 */
+	beginNewSessionIn(workspaceId: string): void {
+		this.beginNewSession();
+		this.preselectedWorkspaceId = workspaceId;
+		this.emit("change", undefined);
+	}
+
 	cancelPendingNewSession(): void {
 		this.pendingNewSession = false;
+		this.preselectedWorkspaceId = null;
 		this.emit("change", undefined);
 	}
 
@@ -220,6 +235,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	async createSessionWith(input: CreateSessionInput = {}): Promise<void> {
 		this.isLoading = true;
 		this.pendingNewSession = false;
+		this.preselectedWorkspaceId = null;
 		// Make sure no previous stream / terminal lingers.
 		chatStore.cancel();
 		void terminalStore.disconnect();

--- a/apps/inno-agent/web/src/stores/workspace-store.ts
+++ b/apps/inno-agent/web/src/stores/workspace-store.ts
@@ -8,6 +8,7 @@ import {
 	moveWorkspaceItem,
 	uploadWorkspaceFiles,
 	saveWorkspaceFile,
+	uploadWorkspaceSkill,
 } from "../api/workspace.js";
 import type { WorkspaceFileDetail, WorkspaceTree } from "../types/workspace.js";
 
@@ -212,6 +213,31 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 			await this.loadTree();
 		} catch (err) {
 			this.error = err instanceof Error ? err.message : "Failed to upload";
+		} finally {
+			this.isMutating = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	/** Install a skill package (.zip / .md) into the workspace's private `.skills` dir. */
+	async uploadSkillPackage(file: File): Promise<void> {
+		this.isMutating = true;
+		this.error = "";
+		this.emit("change", undefined);
+		try {
+			const dataBase64 = await new Promise<string>((resolve, reject) => {
+				const reader = new FileReader();
+				reader.onload = () => {
+					const result = String(reader.result ?? "");
+					resolve(result.includes(",") ? result.split(",")[1] : result);
+				};
+				reader.onerror = () => reject(reader.error ?? new Error("Failed to read file"));
+				reader.readAsDataURL(file);
+			});
+			await uploadWorkspaceSkill(file.name, dataBase64, this.wsId);
+			await this.loadTree();
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : "Failed to install skill";
 		} finally {
 			this.isMutating = false;
 			this.emit("change", undefined);


### PR DESCRIPTION
## Summary
Reworks the workspace model so each session is bound to a (new or existing) workspace, with per-workspace context/skills and a redesigned, workspace-centric UI.

### Backend
- Inject the active workspace's `agent.md` and private `.skills/` into each turn's system prompt; global skills still load from the skills panel library.
- Workspace skill-package upload (zip auto-extract) + show hidden files in the preview tree.
- Drop the "public space" concept: sessions bind to a new/existing workspace; temp workspace is the fallback. Legacy unbound sessions migrate to the (now ordinary) default workspace.
- Each chat channel (feishu/wechat/qq) binds to its own fixed workspace.
- Fix skills upload getting stuck "uploading" (reload runs in background, non-blocking).

### Web UI
- Left sidebar groups sessions by workspace, with rename/delete and per-workspace new-chat; temp workspace pinned to the bottom.
- Click a workspace → preview it (half); click a session / new chat → preview in quarter mode (file tree only).
- Quarter mode opens just wide enough for the fixed-width file tree; dragging wider reveals the content preview pane. Width is draggable in quarter and half modes.
- New-session chooser: removed "use existing" (handled from the sidebar); added a confirm button to create + bind a new workspace before chatting so users can upload files/skills first.

## Test plan
- [x] `npm run build` succeeds (app + web)
- [ ] Create session in new / existing / temp workspace; verify binding + preview
- [ ] Upload a skill zip into a workspace `.skills/` and confirm it extracts
- [ ] Channel (feishu) message lands in its dedicated workspace
- [ ] Drag the right panel width in quarter/half modes; content pane reveals when widened
- [ ] Rename / delete a workspace from the sidebar