### PR TITLE
fix(terminal): fix 'posix_spawnp failed' so the terminal can connect

### DIFF
--- a/apps/inno-agent/src/terminal/local-pty-backend.ts
+++ b/apps/inno-agent/src/terminal/local-pty-backend.ts
@@ -1,4 +1,40 @@
+import { chmodSync, existsSync, statSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
 import { spawn, type IPty } from "node-pty";
+
+/**
+ * node-pty ships its macOS/Linux `spawn-helper` binary without the executable
+ * bit in some published artifacts (and electron-builder's asar unpack can drop
+ * it too). When the bit is missing, node-pty's `posix_spawn` of the helper
+ * fails with the opaque error "posix_spawnp failed." and the terminal never
+ * connects. Restore the bit before the first spawn so this self-heals in both
+ * the dev tree and the packaged app.
+ */
+let _helperChecked = false;
+function ensureSpawnHelperExecutable(): void {
+	if (_helperChecked || process.platform === "win32") return;
+	_helperChecked = true;
+	try {
+		const require = createRequire(import.meta.url);
+		const root = dirname(require.resolve("node-pty/package.json"));
+		const candidates = [
+			join(root, "build", "Release", "spawn-helper"),
+			join(root, "build", "Debug", "spawn-helper"),
+			join(root, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
+		];
+		for (const helper of candidates) {
+			if (!existsSync(helper)) continue;
+			const mode = statSync(helper).mode;
+			if ((mode & 0o111) === 0) {
+				chmodSync(helper, mode | 0o755);
+			}
+		}
+	} catch {
+		// Best-effort: if resolution or chmod fails (e.g. read-only install),
+		// fall through and let spawn surface its own error.
+	}
+}
 
 export interface PtySpawnOptions {
 	cwd: string;
@@ -52,13 +88,17 @@ let _seq = 0;
 
 export class LocalPtyBackend {
 	create(opts: PtySpawnOptions): PtySession {
+		ensureSpawnHelperExecutable();
 		const shell = opts.shell || defaultShell();
 		const env = sanitizeEnv(opts.env ?? process.env);
+		// A non-existent cwd makes node-pty fail with the same opaque
+		// "posix_spawnp failed." error, so fall back to the user's home dir.
+		const cwd = existsSync(opts.cwd) ? opts.cwd : (process.env.HOME || process.cwd());
 		const pty = spawn(shell, [], {
 			name: "xterm-256color",
 			cols: opts.cols,
 			rows: opts.rows,
-			cwd: opts.cwd,
+			cwd,
 			env: env as { [key: string]: string },
 		});
 		const id = `pty_${Date.now().toString(36)}_${(_seq++).toString(36)}`;


### PR DESCRIPTION
## Summary
- Fix the terminal failing to connect with `posix_spawnp failed.` on macOS.
- Root cause: node-pty ships its macOS `spawn-helper` binary without the executable bit (mode 644). On macOS, node-pty `posix_spawn`s this helper, so a non-executable helper makes the syscall fail with the opaque `posix_spawnp failed.` and the terminal never connects.
- Add a one-time self-healing guard that restores the `+x` bit on `spawn-helper` before the first spawn. Covers both the dev tree (`node_modules`) and the packaged app (`asar.unpacked`); best-effort so it won't throw on read-only installs.
- Also fall back to `$HOME` when the requested `cwd` does not exist, since a missing cwd triggers the same error.

## Notes
- Linux is unaffected by the original bug: node-pty uses `forkpty()` there and does not use `spawn-helper`. The guard simply no-ops when no Linux `spawn-helper` prebuild is present, so it is safe cross-platform.

## Test plan
- [x] Reproduced `posix_spawnp failed.` with `spawn-helper` at mode 644.
- [x] Confirmed `chmod +x` makes node-pty spawn succeed.
- [x] Reset to 644, ran the compiled backend, verified the guard self-heals it to 755 and spawns.
- [x] Verified bad-cwd falls back to `$HOME` instead of failing.
- [x] `npm run build` passes.