### PR TITLE
fix(ci): fix empty version in release title/artifact name

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -72,7 +72,9 @@ jobs:
       # ── 8. 读取实际版本号 ────────────────────────────────────────────────────
       - name: Read version
         id: pkg
-        run: echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       # ── 9. 上传产物（可在 Actions 页面直接下载，不走 Release） ───────────────
       - name: Upload DMG artifact


### PR DESCRIPTION
## Summary
- The release was published as **"Inno Agent v"** with no version number.
- Root cause: the `Read version` step used a single-line inline command where the inner quotes around `require('./package.json').version` were escaped (`\"`). After YAML + bash processing the quotes were stripped, `node -p` lost its argument, and the step wrote an empty `version` output.
- Switch to a block scalar (`run: |`) so the quotes pass through to bash intact. The version now populates the Release name (`Inno Agent v<version>`) and the artifact name.

## Test plan
- [x] `yaml.safe_load` parses the workflow.
- [ ] Next tag push produces a release titled `Inno Agent v<version>` (verify on next release).