### PR TITLE
fix(build): fix 'posix_spawnp failed' in packaged DMG release

### DIFF
--- a/apps/inno-agent/src/terminal/local-pty-backend.ts
+++ b/apps/inno-agent/src/terminal/local-pty-backend.ts
@@ -5,11 +5,14 @@ import { spawn, type IPty } from "node-pty";
 
 /**
  * node-pty ships its macOS/Linux `spawn-helper` binary without the executable
- * bit in some published artifacts (and electron-builder's asar unpack can drop
- * it too). When the bit is missing, node-pty's `posix_spawn` of the helper
- * fails with the opaque error "posix_spawnp failed." and the terminal never
- * connects. Restore the bit before the first spawn so this self-heals in both
- * the dev tree and the packaged app.
+ * bit. node-pty `posix_spawn`s this helper, so a missing bit fails with the
+ * opaque error "posix_spawnp failed." and the terminal never connects.
+ *
+ * The primary fix lives in the electron-builder `afterPack` hook (the installed
+ * app bundle is read-only, so the bit must be set at pack time). This runtime
+ * guard is a best-effort fallback for dev runs and any writable install. It
+ * mirrors node-pty's own asar→asar.unpacked path translation so it targets the
+ * file that is actually executed, not the virtual copy inside app.asar.
  */
 let _helperChecked = false;
 function ensureSpawnHelperExecutable(): void {
@@ -23,7 +26,11 @@ function ensureSpawnHelperExecutable(): void {
 			join(root, "build", "Debug", "spawn-helper"),
 			join(root, "prebuilds", `${process.platform}-${process.arch}`, "spawn-helper"),
 		];
-		for (const helper of candidates) {
+		for (const candidate of candidates) {
+			// node-pty execs the asar.unpacked copy, never the one inside app.asar.
+			const helper = candidate
+				.replace("app.asar", "app.asar.unpacked")
+				.replace("node_modules.asar", "node_modules.asar.unpacked");
 			if (!existsSync(helper)) continue;
 			const mode = statSync(helper).mode;
 			if ((mode & 0o111) === 0) {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	"build": {
 		"appId": "com.inno.agent",
 		"productName": "Inno Agent",
+		"afterPack": "scripts/after-pack.cjs",
 		"directories": {
 			"output": "dist-electron"
 		},

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -1,0 +1,41 @@
+// electron-builder afterPack hook.
+//
+// node-pty ships its macOS/Linux `spawn-helper` binary without the executable
+// bit. node-pty execs the *asar.unpacked* copy via posix_spawn, so when the bit
+// is missing the terminal fails with "posix_spawnp failed.". The app bundle is
+// read-only once installed, so this must be fixed at pack time, not runtime.
+const { existsSync, chmodSync, statSync } = require("node:fs");
+const { join } = require("node:path");
+
+exports.default = async function afterPack(context) {
+	if (context.electronPlatformName === "win32") return;
+
+	const resourcesDir =
+		context.electronPlatformName === "darwin"
+			? join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`, "Contents", "Resources")
+			: join(context.appOutDir, "resources");
+
+	const unpacked = join(resourcesDir, "app.asar.unpacked", "node_modules", "node-pty");
+	const candidates = [
+		join(unpacked, "build", "Release", "spawn-helper"),
+		join(unpacked, "build", "Debug", "spawn-helper"),
+		join(unpacked, "prebuilds", "darwin-arm64", "spawn-helper"),
+		join(unpacked, "prebuilds", "darwin-x64", "spawn-helper"),
+		join(unpacked, "prebuilds", "linux-x64", "spawn-helper"),
+		join(unpacked, "prebuilds", "linux-arm64", "spawn-helper"),
+	];
+
+	let fixed = 0;
+	for (const helper of candidates) {
+		if (!existsSync(helper)) continue;
+		const mode = statSync(helper).mode;
+		if ((mode & 0o111) === 0) {
+			chmodSync(helper, mode | 0o755);
+			console.log(`[afterPack] chmod +x ${helper}`);
+			fixed++;
+		}
+	}
+	if (fixed === 0) {
+		console.log("[afterPack] spawn-helper already executable (or not found)");
+	}
+};


### PR DESCRIPTION
## Summary
The earlier runtime fix worked in `npm run server` (dev) but the **downloaded DMG release still failed** with `posix_spawnp failed.` when opening the terminal.

Root cause — the runtime guard could not fix a packaged app:
1. **Wrong file**: it chmod'd the `spawn-helper` inside `app.asar`, but node-pty execs the `app.asar.unpacked` copy (node-pty applies its own `app.asar` → `app.asar.unpacked` path translation).
2. **Read-only bundle**: an installed `/Applications` app is not writable, so a runtime `chmod` fails with `EPERM`/`EROFS` anyway.

Fix:
- **`scripts/after-pack.cjs`** — new electron-builder `afterPack` hook that sets the executable bit on the unpacked `spawn-helper` inside the produced bundle (darwin + linux prebuild/build paths), wired via `build.afterPack` in `package.json`. This bakes the bit into the DMG.
- **Runtime guard** — kept as a best-effort fallback for dev/writable installs, now mirroring node-pty's `app.asar` → `app.asar.unpacked` translation so it targets the file actually executed.

## Test plan
- [x] `npm run build` (tsc) passes.
- [x] `afterPack` hook loads as valid CJS; `build.afterPack` resolves in package.json.
- [ ] Cut a release tag, download the DMG, open the terminal, confirm it connects (no `posix_spawnp failed.`). Check Actions log for `[afterPack] chmod +x ...`.