### PR TITLE
fix: 修复模型切换卡死、图片历史丢失及图片放大预览

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -206,22 +206,22 @@ function modelConfigToProviderModel(model: InnoConfig["providers"][string]["mode
 
 /**
  * Re-register configured providers for the active runtime after config changes.
+ * Bypasses the enqueue queue — this is pure in-memory registry work and must
+ * not block on a running prompt.
  */
 export async function refreshConfiguredProviders(config: InnoConfig): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
-	await enqueue(async () => {
-		_config = config;
-		if (_configHolder) _configHolder.current = config;
-		for (const [providerId, providerConfig] of Object.entries(config.providers)) {
-			_runtime!.session.modelRegistry.registerProvider(providerId, {
-				baseUrl: providerConfig.baseUrl,
-				apiKey: providerConfig.apiKey || "local",
-				api: providerConfig.api ?? "openai-completions",
-				models: providerConfig.models.map(modelConfigToProviderModel),
-			});
-		}
-		_runtime!.session.modelRegistry.refresh();
-	});
+	_config = config;
+	if (_configHolder) _configHolder.current = config;
+	for (const [providerId, providerConfig] of Object.entries(config.providers)) {
+		_runtime.session.modelRegistry.registerProvider(providerId, {
+			baseUrl: providerConfig.baseUrl,
+			apiKey: providerConfig.apiKey || "local",
+			api: providerConfig.api ?? "openai-completions",
+			models: providerConfig.models.map(modelConfigToProviderModel),
+		});
+	}
+	_runtime.session.modelRegistry.refresh();
 }
 
 export function syncConfig(config: InnoConfig): void {
@@ -256,17 +256,17 @@ export function getAvailableModels() {
 
 /**
  * Switch the active runtime model and persist it as the default PI model.
+ * Intentionally bypasses the enqueue queue so it can execute immediately
+ * even while a prompt is streaming, avoiding UI lockup.
  */
 export async function switchModel(provider: string, modelId: string): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
-	await enqueue(async () => {
-		_runtime!.session.modelRegistry.refresh();
-		const model = _runtime!.session.modelRegistry.find(provider, modelId);
-		if (!model) {
-			throw new Error(`Model ${provider}/${modelId} not found`);
-		}
-		await _runtime!.session.setModel(model);
-	});
+	_runtime.session.modelRegistry.refresh();
+	const model = _runtime.session.modelRegistry.find(provider, modelId);
+	if (!model) {
+		throw new Error(`Model ${provider}/${modelId} not found`);
+	}
+	await _runtime.session.setModel(model);
 }
 
 /**

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -403,6 +403,26 @@ function textFromContent(content: unknown): string {
 		.trim();
 }
 
+function imagesFromContent(content: unknown): Array<{ previewUrl: string; mimeType: string }> {
+	if (!Array.isArray(content)) return [];
+	const result: Array<{ previewUrl: string; mimeType: string }> = [];
+	for (const part of content) {
+		if (!part || typeof part !== "object") continue;
+		const record = part as Record<string, unknown>;
+		if (
+			record.type === "image" &&
+			typeof record.data === "string" &&
+			typeof record.mimeType === "string"
+		) {
+			result.push({
+				previewUrl: `data:${record.mimeType};base64,${record.data}`,
+				mimeType: record.mimeType,
+			});
+		}
+	}
+	return result;
+}
+
 function sanitizeUploadName(name: string): string {
 	const cleaned = name
 		.replace(/[/\\?%*:|"<>]/g, "-")
@@ -889,6 +909,7 @@ interface SessionMessageSummary {
 		isError?: boolean;
 	}>;
 	channel?: SessionChannel;
+	images?: Array<{ previewUrl: string; mimeType: string }>;
 }
 
 type SessionChannel = "cli" | "web" | "feishu" | "qq" | "wechat" | "scheduler" | "unknown";
@@ -988,7 +1009,10 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 				finalizeAssistant();
 				const content = textFromContent(message.content);
 				if (!content) continue;
-				messages.push({ role: "user", content, timestamp: ts, channel: entryChannel });
+				const images = imagesFromContent(message.content);
+				const msg: SessionMessageSummary = { role: "user", content, timestamp: ts, channel: entryChannel };
+				if (images.length > 0) msg.images = images;
+				messages.push(msg);
 				continue;
 			}
 

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { Paperclip, X, SendHorizonal, Square, RotateCcw, Check, Image } from "lucide-react";
 import type { ChatMessage } from "../types/chat.js";
@@ -40,7 +41,38 @@ function ChannelBadge({ channel }: { channel: string }) {
 	);
 }
 
+function ImageLightbox({ src, onClose }: { src: string; onClose: () => void }) {
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [onClose]);
+
+	return createPortal(
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+			onClick={onClose}
+		>
+			<img
+				src={src}
+				alt="enlarged"
+				className="max-h-[90vh] max-w-[90vw] rounded-lg object-contain shadow-2xl"
+				onClick={(e) => e.stopPropagation()}
+			/>
+			<button
+				className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full bg-white/20 text-white hover:bg-white/40"
+				onClick={onClose}
+			>
+				<X size={16} />
+			</button>
+		</div>,
+		document.body,
+	);
+}
+
 function MessageBubble({ message, showChannel }: { message: ChatMessage; showChannel?: boolean }) {
+	const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+
 	if (message.role === "user") {
 		return (
 			<motion.div
@@ -56,10 +88,17 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 					{message.images?.length ? (
 						<div className="mb-2 flex flex-wrap gap-1.5">
 							{message.images.map((img, i) => (
-								<img key={i} src={img.previewUrl} alt="attached" className="max-h-48 max-w-full rounded object-contain" />
+								<img
+									key={i}
+									src={img.previewUrl}
+									alt="attached"
+									className="max-h-48 max-w-full cursor-zoom-in rounded object-contain"
+									onClick={() => setLightboxSrc(img.previewUrl)}
+								/>
 							))}
 						</div>
 					) : null}
+					{lightboxSrc ? <ImageLightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} /> : null}
 					{message.content.trim()}
 				</div>
 			</motion.div>

--- a/apps/inno-agent/web/src/stores/settings-store.ts
+++ b/apps/inno-agent/web/src/stores/settings-store.ts
@@ -34,7 +34,10 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 		this.error = null;
 		this.emit("change", undefined);
 		try {
-			const next = await switchBackendModel(provider, model);
+			const timeout = new Promise<never>((_, reject) =>
+				setTimeout(() => reject(new Error("Switch model timed out")), 10_000),
+			);
+			const next = await Promise.race([switchBackendModel(provider, model), timeout]);
 			if (this.settings) {
 				this.settings = {
 					...this.settings,


### PR DESCRIPTION
## Summary

- **模型切换卡死**：`switchModel` 和 `refreshConfiguredProviders` 移出 `enqueue` 串行队列，流式对话进行中也能立即切换模型；前端增加 10 秒超时保护防止 UI 永久 loading
- **图片历史丢失**：`parseSessionFile` 解析用户消息时新增图片内容提取，刷新页面或切换 session 后图片不再消失
- **图片放大预览**：新增 `ImageLightbox` 组件，点击对话中的图片可全屏放大，支持点击遮罩、Esc 键、X 按钮关闭

## Test plan

- [ ] 流式对话进行中切换模型，验证可以正常切换不卡死
- [ ] 发送含图片的消息后刷新页面，验证图片仍然显示
- [ ] 发送含图片的消息后切换到其他 session 再切回来，验证图片仍然显示
- [ ] 点击对话中的图片，验证全屏放大效果正常，三种关闭方式均有效