### PR TITLE
fix: 修复终止对话后新对话卡死的消息阻塞问题

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -238,6 +238,19 @@ export function getSession(): AgentSession {
 }
 
 /**
+ * Abort the currently running agent prompt, releasing the enqueue queue.
+ * Safe to call even when no prompt is running.
+ */
+export async function abortCurrentPrompt(): Promise<void> {
+	if (!_runtime) return;
+	try {
+		await _runtime.session.abort();
+	} catch {
+		// ignore — session may already be idle
+	}
+}
+
+/**
  * Return current runtime session id.
  */
 export function getCurrentSessionId(): string {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -21,7 +21,7 @@ import {
 	applyWorkspaceCwd,
 	setWorkspaceCwdResolver,
 } from "./agent/pi-runner.js";
-import { completePromptOnce, runPromptSerialized, runPromptStreaming, runPromptStreamingInSession, runPromptInSession } from "./agent/pi-runner.js";
+import { completePromptOnce, runPromptSerialized, runPromptStreaming, runPromptStreamingInSession, runPromptInSession, abortCurrentPrompt } from "./agent/pi-runner.js";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { ChannelRegistry } from "./channels/channel.js";
 import { FeishuChannel } from "./channels/feishu/feishu-channel.js";
@@ -2887,6 +2887,7 @@ const server = createServer(async (req, res) => {
 				aborted = true;
 				questionBridge.setEmitter(null);
 				questionBridge.cancel();
+				void abortCurrentPrompt();
 			});
 
 			questionBridge.setEmitter(sseWrite);


### PR DESCRIPTION
## Summary

用户在对话进行中点击终止后，再开启新对话或切换 session 会卡死，侧边栏和对话框均无响应。

**根本原因：** 前端 abort 只断开了 SSE 连接，但后端 `enqueue` 队列里的 `session.prompt()` 仍在继续执行（PI SDK agent loop 未停止），导致后续所有需要排队的操作（`switchSessionFile`、`createNewSession` 等）永久阻塞。

**修复：**
- `pi-runner`: 新增 `abortCurrentPrompt()`，调用 PI SDK 的 `session.abort()` 立即中断当前 agent loop，释放 enqueue 队列
- `server`: SSE `req.on("close")` 时调用 `abortCurrentPrompt()`，确保客户端断开后后端立即停止

## Test plan

- [ ] 对话进行中点击终止，然后立即点击新建对话，验证可以正常开启
- [ ] 对话进行中点击终止，然后切换到其他 session，验证侧边栏不卡死
- [ ] 正常完成对话后新建/切换 session，验证正常流程不受影响