### PR TITLE
fix: prevent slow model API from blocking the session queue

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -455,16 +455,26 @@ export function runPromptInSession(
 /**
  * Complete a small prompt through the current model without appending anything
  * to the active chat session. Useful for UI metadata such as session titles.
+ *
+ * IMPORTANT: this is a stateless side-channel completion and must NOT go through
+ * the shared prompt/session `enqueue` queue. It makes its own network call that
+ * `abortCurrentPrompt()` cannot cancel, so queueing it would let a slow/dead API
+ * hold the queue and block `createNewSession` / `switchSessionFile` / chat — the
+ * exact "new conversation hangs, sidebar won't load" lockup. We also hard-cap it
+ * with an abortable timeout so it can never wait on the provider's long default.
  */
-export function completePromptOnce(prompt: string, maxTokens = 64): Promise<string> {
-	return enqueue(async () => {
-		const session = getSession();
-		const model = session.model;
-		if (!model) return "";
+export async function completePromptOnce(prompt: string, maxTokens = 64, timeoutMs = 20_000): Promise<string> {
+	if (!_runtime) return "";
+	const session = _runtime.session;
+	const model = session.model;
+	if (!model) return "";
 
-		const auth = await session.modelRegistry.getApiKeyAndHeaders(model);
-		if (!auth.ok || !auth.apiKey) return "";
+	const auth = await session.modelRegistry.getApiKeyAndHeaders(model);
+	if (!auth.ok || !auth.apiKey) return "";
 
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), timeoutMs);
+	try {
 		const response = await complete(
 			model,
 			{
@@ -480,6 +490,8 @@ export function completePromptOnce(prompt: string, maxTokens = 64): Promise<stri
 				apiKey: auth.apiKey,
 				headers: auth.headers,
 				maxTokens,
+				signal: controller.signal,
+				timeoutMs,
 			},
 		);
 
@@ -489,7 +501,12 @@ export function completePromptOnce(prompt: string, maxTokens = 64): Promise<stri
 			.map((item) => item.text)
 			.join("\n")
 			.trim();
-	});
+	} catch {
+		// best-effort metadata generation — timeout/abort/network errors are non-fatal
+		return "";
+	} finally {
+		clearTimeout(timer);
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary
- `completePromptOnce` (auto session-title generation) ran through the shared `enqueue` queue and called `complete()` with no abort signal or timeout. On a slow/dead API it could hold the queue for the SDK's ~10 min default, which `abortCurrentPrompt()` / `session.abort()` cannot cancel (it's a side-channel call outside the agent run lifecycle).
- After terminating a slow turn, the SSE handler still fires `maybeAutoGenerateTopic` → `completePromptOnce` against the same slow API, welding the queue shut and blocking `createNewSession` / `switchSessionFile` — i.e. new conversation hangs and the sidebar won't load.
- Fix: take `completePromptOnce` off the shared queue, add an abortable hard timeout (default 20s) with `signal` + `timeoutMs`, and swallow timeout/abort/network errors as best-effort metadata.

## Context
The earlier fix (`9266137`) that aborts the main streaming prompt on SSE close is still intact — this PR closes a second path that bypassed it.

## Test plan
- [ ] Point config at a deliberately slow/dead endpoint, start a turn, click terminate
- [x] Confirm a new conversation can be started immediately afterwards
- [ ] Confirm the session sidebar still loads
- [ ] Confirm session-title auto-generation still works against a healthy API
- [x] `npm run build` passes