### PR TITLE
fix: make terminate reliably abort the backend stream

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -354,6 +354,10 @@ export async function reloadResources(): Promise<void> {
  */
 export async function switchSessionFile(sessionPath: string): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
+	// Defensively abort any in-flight prompt FIRST (outside the queue, like
+	// switchModel does) so this switch can't get stuck behind a still-streaming
+	// turn holding the shared queue.
+	await abortCurrentPrompt();
 	await enqueue(async () => {
 		await switchToSession(sessionPath);
 	});
@@ -377,6 +381,10 @@ export async function applyWorkspaceCwd(sessionPath: string): Promise<void> {
  */
 export async function createNewSession(): Promise<string> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
+	// Defensively abort any in-flight prompt FIRST (outside the queue) so opening
+	// a new conversation can't get stuck behind a still-streaming turn holding the
+	// shared queue.
+	await abortCurrentPrompt();
 	return enqueue(async () => {
 		await _runtime!.newSession();
 		const sessionId = getCurrentSessionId();

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -3012,6 +3012,18 @@ const server = createServer(async (req, res) => {
 			return;
 		}
 
+		// --- Chat Abort (explicit stop from UI) ---
+		// The SSE req.on("close") handler also aborts, but connection-close is
+		// unreliable through dev proxies and during rapid terminate→switch flows.
+		// This gives the client a deterministic way to stop the backend stream so
+		// the shared prompt queue is released immediately (otherwise new-session /
+		// switch-session block behind a still-running turn).
+		if (method === "POST" && url === "/api/chat/abort") {
+			await abortCurrentPrompt();
+			json(res, 200, { aborted: true });
+			return;
+		}
+
 		// --- Chat Streaming (SSE) ---
 		if (method === "POST" && url === "/api/chat/stream") {
 			const body = (await readBody(req)) as Record<string, unknown>;

--- a/apps/inno-agent/web/src/api/chat.ts
+++ b/apps/inno-agent/web/src/api/chat.ts
@@ -17,3 +17,16 @@ export async function postChat(prompt: string, sessionId?: string | null, images
 export function streamChat(prompt: string, sessionId?: string | null, signal?: AbortSignal, images?: InlineImage[]): AsyncGenerator<ChatStreamEvent> {
 	return streamSSE<ChatStreamEvent>("/api/chat/stream", { prompt, sessionId: sessionId ?? undefined, images: images?.length ? images : undefined }, signal);
 }
+
+/**
+ * Explicitly tell the backend to abort the currently running prompt. Best-effort:
+ * connection-close from aborting the SSE fetch is unreliable through dev proxies,
+ * so the UI calls this to deterministically release the server's prompt queue.
+ */
+export async function abortChat(): Promise<void> {
+	try {
+		await fetch("/api/chat/abort", { method: "POST" });
+	} catch {
+		// best-effort — the SSE close handler is a fallback
+	}
+}

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "./event-emitter.js";
-import { streamChat } from "../api/chat.js";
+import { streamChat, abortChat } from "../api/chat.js";
 import type { InlineImage } from "../api/chat.js";
 import type { ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult } from "../types/chat.js";
 import { notebookStore } from "./notebook-store.js";
@@ -112,7 +112,13 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 
 	/** Abort the in-flight stream. */
 	cancel(): void {
+		const wasSending = this.isSending;
 		this.abortController?.abort();
+		// Aborting the local fetch may not promptly close the upstream connection
+		// (dev proxy buffering), so explicitly tell the backend to stop the run.
+		// This releases the server's shared prompt queue immediately, preventing
+		// new-session / switch-session from blocking behind a still-running turn.
+		if (wasSending) void abortChat();
 	}
 
 	/** Re-send the last user prompt. No-op while a send is in flight. */


### PR DESCRIPTION
## Summary
Follow-up to #15. That fix only aborted the backend prompt via the SSE `req.on("close")` handler, but connection-close is unreliable through dev proxies and during a rapid **terminate → switch-model → new-conversation** sequence. So `session.abort()` often never ran: the model kept streaming (visible as "still outputting after terminate") and held the shared prompt queue until it finished naturally (~10-20s), blocking new-session / switch-session the whole time.

Confirmed in PI SDK: `newSession`/`switchSession` → `teardownCurrent` → `session.dispose()` only disconnects listeners; it does **not** abort the in-flight model request.

## Changes
- **server**: add explicit `POST /api/chat/abort` → `abortCurrentPrompt()`, a deterministic stop entry that doesn't depend on connection close.
- **web**: add `abortChat()` and call it from `chatStore.cancel()` (best-effort, alongside the local `AbortController`) so terminate actively tells the backend to stop.
- **pi-runner**: defensively `await abortCurrentPrompt()` at the start of `createNewSession()` and `switchSessionFile()` (outside the queue, like `switchModel`) so opening/switching a session can't get stuck behind a still-streaming turn.

## Test plan
- [ ] Start a turn that produces long output, click terminate → confirm backend output actually stops (not just the UI)
- [ ] Terminate a long turn, switch model, open a new conversation → confirm no ~20s block; sidebar + input respond immediately
- [ ] Switch to an existing session mid-stream → confirm it activates promptly
- [x] `npm run build` passes