### PR TITLE
feat: add manual toggle for L3 cross-conversation memory

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -187,9 +187,13 @@ export function createInnoExtension(
 			pi.registerTool(tool);
 		}
 
-		// 4a. Register L3 cross-conversation memory (sqlite-backed recall)
+		// 4a. Register L3 cross-conversation memory (sqlite-backed recall).
+		// Recall (auto-inject + the l3_recall tool) is gated at runtime on
+		// config.memory.l3Enabled (default on); indexing always runs so the
+		// switch can be flipped back on without a backfill gap.
 		const l3Memory = new L3Memory(paths.l3DataDir, paths.sessionDir);
-		const l3Tools = createL3Tools(l3Memory, deps?.getCurrentSessionId);
+		const isL3Enabled = () => configHolder.current.memory?.l3Enabled !== false;
+		const l3Tools = createL3Tools(l3Memory, deps?.getCurrentSessionId, isL3Enabled);
 		for (const tool of l3Tools) {
 			pi.registerTool(tool);
 		}
@@ -228,17 +232,20 @@ export function createInnoExtension(
 
 				// Inject threshold-gated cross-conversation recall (L3). Only
 				// injects when past snippets clear the relevance threshold, so
-				// unrelated turns stay clean.
-				try {
-					let currentSessionId = "";
-					const sessionFile = ctx.sessionManager.getSessionFile?.();
-					if (sessionFile) currentSessionId = sessionFile.split(/[\\/]/).pop() ?? "";
-					if (!currentSessionId && deps?.getCurrentSessionId) currentSessionId = deps.getCurrentSessionId();
-					const recalled = await l3Memory.recall(event.prompt, currentSessionId || undefined);
-					const recallSection = formatRecallForPrompt(recalled);
-					if (recallSection) sections.push(recallSection);
-				} catch {
-					// best-effort — recall failures must not block the turn
+				// unrelated turns stay clean. Skipped entirely when the user has
+				// turned L3 recall off in settings.
+				if (isL3Enabled()) {
+					try {
+						let currentSessionId = "";
+						const sessionFile = ctx.sessionManager.getSessionFile?.();
+						if (sessionFile) currentSessionId = sessionFile.split(/[\\/]/).pop() ?? "";
+						if (!currentSessionId && deps?.getCurrentSessionId) currentSessionId = deps.getCurrentSessionId();
+						const recalled = await l3Memory.recall(event.prompt, currentSessionId || undefined);
+						const recallSection = formatRecallForPrompt(recalled);
+						if (recallSection) sections.push(recallSection);
+					} catch {
+						// best-effort — recall failures must not block the turn
+					}
 				}
 
 				// Inject the latest run record for this session, so the agent can

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -23,6 +23,16 @@ export interface InnoSubagentsConfig {
 	enabled: boolean;
 }
 
+export interface InnoMemoryConfig {
+	/**
+	 * When true (default), L3 cross-conversation recall is active: past sessions
+	 * are searched via sqlite and relevant snippets are auto-injected / the
+	 * `l3_recall` tool is exposed. When false, replies use only the current
+	 * workspace contents and the current session context.
+	 */
+	l3Enabled: boolean;
+}
+
 export interface PersonalChannelConfig {
 	enabled: boolean;
 	personalOnly?: boolean;
@@ -59,6 +69,7 @@ export interface InnoConfig {
 		token: string;
 	};
 	subagents?: InnoSubagentsConfig;
+	memory?: InnoMemoryConfig;
 }
 
 interface LegacyInnoConfig extends Partial<InnoConfig> {
@@ -102,6 +113,11 @@ export function normalizeProviderConfig(provider: Partial<InnoProviderConfig>): 
 	};
 }
 
+export function normalizeMemoryConfig(memory: Partial<InnoMemoryConfig> | undefined): InnoMemoryConfig {
+	// L3 recall defaults to ON; only an explicit `false` disables it.
+	return { l3Enabled: memory?.l3Enabled !== false };
+}
+
 export function normalizeConfig(config: LegacyInnoConfig): InnoConfig {
 	const providers: Record<string, InnoProviderConfig> = {};
 	for (const [providerId, providerConfig] of Object.entries(config.providers ?? {})) {
@@ -135,6 +151,7 @@ export function normalizeConfig(config: LegacyInnoConfig): InnoConfig {
 		channels: config.channels,
 		bridge: config.bridge,
 		subagents: config.subagents,
+		memory: normalizeMemoryConfig(config.memory),
 	} as InnoConfig;
 }
 

--- a/apps/inno-agent/src/memory/l3/l3-tools.ts
+++ b/apps/inno-agent/src/memory/l3/l3-tools.ts
@@ -81,7 +81,11 @@ export class L3Memory {
  * Register the `l3_recall` tool. The agent calls this to deliberately search
  * its memory of past conversations (separate from the automatic injection).
  */
-export function createL3Tools(memory: L3Memory, getCurrentSessionId?: () => string): ToolDefinition[] {
+export function createL3Tools(
+	memory: L3Memory,
+	getCurrentSessionId?: () => string,
+	isEnabled?: () => boolean,
+): ToolDefinition[] {
 	const recallTool = defineTool({
 		name: "l3_recall",
 		label: "回忆历史对话",
@@ -98,6 +102,12 @@ export function createL3Tools(memory: L3Memory, getCurrentSessionId?: () => stri
 			),
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			if (isEnabled && !isEnabled()) {
+				return {
+					content: [{ type: "text" as const, text: "跨对话历史检索（L3）已在设置中关闭，当前仅使用本工作区与当前对话上下文。" }],
+					details: { results: 0, disabled: true },
+				};
+			}
 			const query = String((params as { query?: string }).query ?? "").trim();
 			const limit = Number((params as { limit?: number }).limit ?? 4);
 			if (!query) {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -2966,6 +2966,20 @@ const server = createServer(async (req, res) => {
 			return;
 		}
 
+		// --- Memory Settings (L3 cross-conversation recall toggle) ---
+		if (method === "PUT" && url === "/api/settings/memory") {
+			const body = (await readBody(req)) as Record<string, unknown>;
+			if (typeof body.l3Enabled !== "boolean") {
+				json(res, 400, { error: "Missing l3Enabled (boolean)" });
+				return;
+			}
+			config.memory = { l3Enabled: body.l3Enabled };
+			config = saveConfig(paths.configPath, config);
+			syncConfig(config);
+			json(res, 200, buildSafeSettings());
+			return;
+		}
+
 		// --- Chat API ---
 		if (method === "POST" && url === "/api/chat") {
 			const body = (await readBody(req)) as Record<string, unknown>;

--- a/apps/inno-agent/web/src/api/settings.ts
+++ b/apps/inno-agent/web/src/api/settings.ts
@@ -32,6 +32,13 @@ export async function saveChannelsSettings(payload: ChannelsSettingsPayload): Pr
 	});
 }
 
+export async function saveMemorySettings(l3Enabled: boolean): Promise<InnoSettings> {
+	return apiFetch<InnoSettings>("/api/settings/memory", {
+		method: "PUT",
+		body: JSON.stringify({ l3Enabled }),
+	});
+}
+
 export async function wechatQrLogin(): Promise<{ qrId: string; qrUrl: string }> {
 	return apiFetch<{ qrId: string; qrUrl: string }>("/api/channels/wechat/qr-login", {
 		method: "POST",

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -324,6 +324,11 @@
     "use": "Use",
     "providers": "Providers",
     "newProvider": "New provider",
+    "memory": {
+      "title": "Cross-conversation memory (L3)",
+      "onDesc": "On: searches past conversations via SQLite and auto-recalls relevant context.",
+      "offDesc": "Off: replies use only the current workspace contents and the current conversation context."
+    },
     "form": {
       "providerId": "Provider id",
       "baseUrl": "Base URL",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -324,6 +324,11 @@
     "use": "使用",
     "providers": "服务提供方",
     "newProvider": "新增提供方",
+    "memory": {
+      "title": "跨对话记忆 (L3)",
+      "onDesc": "已开启：可通过 SQLite 检索历史对话内容，自动召回相关上下文。",
+      "offDesc": "已关闭：仅基于当前工作区内容与当前对话上下文进行回复。"
+    },
     "form": {
       "providerId": "提供方 ID",
       "baseUrl": "Base URL",

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -632,6 +632,52 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 	);
 }
 
+/* ---------- Memory Settings (L3 cross-conversation recall toggle) ---------- */
+
+function MemorySettings({ settings }: { settings: InnoSettings }) {
+	const { t } = useTranslation();
+	const [enabled, setEnabled] = useState(settings.memory?.l3Enabled !== false);
+	const [saving, setSaving] = useState(false);
+
+	useEffect(() => {
+		setEnabled(settings.memory?.l3Enabled !== false);
+	}, [settings.memory?.l3Enabled]);
+
+	async function handleToggle(next: boolean) {
+		setEnabled(next);
+		setSaving(true);
+		try {
+			await settingsStore.saveMemory(next);
+		} catch {
+			setEnabled(!next);
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div className="rounded-lg border border-slate-200 bg-white p-4">
+			<div className="flex items-start justify-between gap-3">
+				<div className="min-w-0">
+					<h4 className="text-sm font-medium text-slate-950">{t("settings.memory.title")}</h4>
+					<p className="mt-1 text-xs text-slate-500">
+						{enabled ? t("settings.memory.onDesc") : t("settings.memory.offDesc")}
+					</p>
+				</div>
+				<button
+					role="switch"
+					aria-checked={enabled}
+					disabled={saving}
+					onClick={() => void handleToggle(!enabled)}
+					className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${enabled ? "bg-blue-600" : "bg-slate-300"}`}
+				>
+					<span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${enabled ? "translate-x-[18px]" : "translate-x-1"}`} />
+				</button>
+			</div>
+		</div>
+	);
+}
+
 /* ---------- Main SettingsPanel ---------- */
 
 export function SettingsPanel() {
@@ -765,6 +811,9 @@ export function SettingsPanel() {
 
 				{/* New Provider (collapsed by default) */}
 				<NewProviderForm />
+
+				{/* Memory Settings (L3 cross-conversation recall) */}
+				{state.settings && <MemorySettings settings={state.settings} />}
 
 				{/* Channels Settings */}
 				{state.settings && <ChannelsSettings settings={state.settings} />}

--- a/apps/inno-agent/web/src/stores/settings-store.ts
+++ b/apps/inno-agent/web/src/stores/settings-store.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "./event-emitter.js";
-import { getSettings, switchBackendModel, upsertProvider, deleteProviderApi, saveChannelsSettings } from "../api/settings.js";
+import { getSettings, switchBackendModel, upsertProvider, deleteProviderApi, saveChannelsSettings, saveMemorySettings } from "../api/settings.js";
 import type { InnoSettings, UpsertProviderRequest, ChannelsSettingsPayload } from "../types/settings.js";
 
 interface SettingsStoreEvents {
@@ -12,6 +12,7 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 	isSavingModel = false;
 	isSavingProvider = false;
 	isSavingChannels = false;
+	isSavingMemory = false;
 	error: string | null = null;
 
 	async load(): Promise<void> {
@@ -98,6 +99,21 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 			this.emit("change", undefined);
 		} finally {
 			this.isSavingChannels = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async saveMemory(l3Enabled: boolean): Promise<void> {
+		this.isSavingMemory = true;
+		this.error = null;
+		this.emit("change", undefined);
+		try {
+			this.settings = await saveMemorySettings(l3Enabled);
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : "Failed to save memory settings";
+			this.emit("change", undefined);
+		} finally {
+			this.isSavingMemory = false;
 			this.emit("change", undefined);
 		}
 	}

--- a/apps/inno-agent/web/src/types/settings.ts
+++ b/apps/inno-agent/web/src/types/settings.ts
@@ -78,4 +78,5 @@ export interface InnoSettings {
 		wecom?: { enabled: boolean };
 	};
 	bridge?: { token: string }; // masked
+	memory?: { l3Enabled: boolean };
 }

--- a/config.example.json
+++ b/config.example.json
@@ -46,5 +46,8 @@
 	},
 	"subagents": {
 		"enabled": false
+	},
+	"memory": {
+		"l3Enabled": true
 	}
 }


### PR DESCRIPTION
## Summary
- Add a settings switch (default **on**) to control L3 cross-conversation recall.
- When **off**, replies use only the current workspace contents and the current session context — cross-conversation SQLite retrieval and auto-injection are skipped.
- Indexing keeps running while disabled, so the switch can be flipped back on without a backfill gap.

## Changes
- **Backend**
  - `config.ts`: new `InnoMemoryConfig { l3Enabled }` + `config.memory?`; `normalizeMemoryConfig` defaults to `true` (only explicit `false` disables).
  - `inno-extension.ts`: `isL3Enabled()` reads the config holder at runtime so toggles take effect immediately (no restart). Gates both the `before_agent_start` auto-inject and the `l3_recall` tool; indexing (`backfill`/`turn_end`) still runs.
  - `l3-tools.ts`: `createL3Tools` takes an `isEnabled?` gate; tool returns a friendly message when off.
  - `server.ts`: new `PUT /api/settings/memory` route persisting `{ l3Enabled }` + `syncConfig`. `buildSafeSettings` exposes `memory` via its config spread.
  - `config.example.json`: documents `memory.l3Enabled: true`.
- **Frontend**
  - `types/settings.ts`, `api/settings.ts` (`saveMemorySettings`), `settings-store.ts` (`saveMemory` + `isSavingMemory`).
  - `SettingsPanel.tsx`: new `MemorySettings` toggle card with optimistic flip + rollback on error.
  - i18n labels `settings.memory.{title,onDesc,offDesc}` (zh-CN + en).

## Test plan
- [x] `npm run build` passes (backend tsc + web bundle, no errors)
- [x] `PUT /api/settings/memory` persists to `config.json` and is reflected in `GET /api/settings`
- [x] Toggle off → `l3_recall` returns disabled message; auto-inject skipped
- [x] Toggle back on → recall active again (no backfill gap)
- [ ] Manual UI smoke test of the toggle in the settings page