### PR TITLE
fix: keep interrupted first session and add existing-workspace picker

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -340,6 +340,74 @@ export function appendAssistantNotification(text: string): void {
 }
 
 /**
+ * Persist an interrupted first turn so it isn't lost from the sidebar.
+ *
+ * The PI SDK persists lazily: `SessionManager` writes NOTHING to disk (not even
+ * the session header + user message) until an assistant message exists in the
+ * entries. So if the user sends the very first prompt in a brand-new session
+ * and then aborts before any assistant content is committed, the file stays
+ * header-only / 0-byte and the conversation effectively vanishes (no preview,
+ * no recoverable history — and on a fresh workspace it can't be reopened).
+ *
+ * To make an interrupted first turn recoverable, append a minimal placeholder
+ * assistant message when the latest in-memory entry is an unanswered user turn.
+ * That forces the SDK to flush the header + user message + this placeholder to
+ * disk, so the session shows up in the sidebar with its real first prompt as
+ * the preview and can be reopened.
+ *
+ * Guarded by `expectedSessionId` so a late abort can't write into a session the
+ * runtime has since switched away from. Best-effort and never throws.
+ */
+export function persistPendingUserTurn(expectedSessionId?: string): boolean {
+	if (!_runtime) return false;
+	try {
+		const session = getSession();
+		const sessionFile = session.sessionFile;
+		const currentId = sessionFile ? basename(sessionFile) : "";
+		if (!currentId) return false;
+		if (expectedSessionId && expectedSessionId !== currentId) return false;
+
+		const manager = session.sessionManager;
+		const entries = manager.getEntries();
+		// Only act when the turn was never answered: the last message entry is a
+		// user message. If an assistant message already exists the SDK has (or
+		// will) flush normally, so there is nothing to rescue.
+		let lastMessageRole: string | undefined;
+		let hasAssistant = false;
+		for (const entry of entries) {
+			if (entry.type !== "message") continue;
+			const role = (entry as { message?: { role?: string } }).message?.role;
+			if (role === "assistant") hasAssistant = true;
+			lastMessageRole = role;
+		}
+		if (hasAssistant || lastMessageRole !== "user") return false;
+
+		const placeholder: AssistantMessage = {
+			role: "assistant",
+			content: [{ type: "text", text: "[已中断,未完成回复]" }],
+			api: "inno-background",
+			provider: "inno",
+			model: "interrupted",
+			usage: {
+				input: 0,
+				output: 0,
+				cacheRead: 0,
+				cacheWrite: 0,
+				totalTokens: 0,
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+			},
+			stopReason: "aborted",
+			timestamp: Date.now(),
+		};
+		manager.appendMessage(placeholder);
+		return true;
+	} catch {
+		// best-effort — never let a persistence hiccup break the abort path
+		return false;
+	}
+}
+
+/**
  * Reload skills/extensions/resources for the active server session.
  */
 export async function reloadResources(): Promise<void> {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -21,7 +21,7 @@ import {
 	applyWorkspaceCwd,
 	setWorkspaceCwdResolver,
 } from "./agent/pi-runner.js";
-import { completePromptOnce, runPromptSerialized, runPromptStreaming, runPromptStreamingInSession, runPromptInSession, abortCurrentPrompt } from "./agent/pi-runner.js";
+import { completePromptOnce, runPromptSerialized, runPromptStreaming, runPromptStreamingInSession, runPromptInSession, abortCurrentPrompt, persistPendingUserTurn } from "./agent/pi-runner.js";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { ChannelRegistry } from "./channels/channel.js";
 import { FeishuChannel } from "./channels/feishu/feishu-channel.js";
@@ -3123,13 +3123,25 @@ const server = createServer(async (req, res) => {
 				const fullText = targetSessionPath
 					? await runPromptStreamingInSession(targetSessionPath, prompt, onEvent, imageArgs)
 					: await runPromptStreaming(prompt, onEvent, imageArgs);
-				recordCurrentSessionChannel("web", capturedSessionId, { setOriginIfEmpty: true });
 				if (!aborted) sseWrite({ type: "done", fullText });
 				maybeAutoGenerateTopic(capturedSessionId);
 			} catch (err) {
 				if (!aborted) {
 					sseWrite({ type: "error", message: err instanceof Error ? err.message : "Unknown error" });
 				}
+			} finally {
+				// Always attribute this turn to the web channel — even on abort or
+				// error — so an interrupted first prompt keeps origin "web" instead
+				// of being mislabeled "cli" (which happens when no channels.json
+				// entry exists) and grouped/lost incorrectly in the sidebar.
+				recordCurrentSessionChannel("web", capturedSessionId, { setOriginIfEmpty: true });
+				// If the turn was interrupted before any assistant content was
+				// committed, the PI SDK never flushes the session to disk (it stays
+				// header-only / 0-byte), so the conversation disappears once the user
+				// switches away. Force a flush of the header + user message so the
+				// session stays in the sidebar and can be reopened. No-op when an
+				// assistant message already exists (normal/errored turns).
+				persistPendingUserTurn(capturedSessionId);
 			}
 			if (!aborted) {
 				res.write("data: [DONE]\n\n");

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -205,6 +205,15 @@ export function ChatCenter() {
 		[sessions.preselectedWorkspaceId, workspaces.list],
 	);
 
+	// User project workspaces the user can pick for a new chat — excludes the
+	// shared temp workspace and the channel-native workspaces (feishu/wechat/cli),
+	// matching the sidebar's grouping. Lets the bottom "新建对话" button reach an
+	// existing workspace instead of being forced into temp/new.
+	const selectableWorkspaces = useMemo(
+		() => workspaces.list.filter((w) => !w.isTemp && !w.id.startsWith("channel-")),
+		[workspaces.list],
+	);
+
 	// Welcome state: brand-new chat without an active session yet.
 	const isWelcome =
 		sessions.pendingNewSession ||
@@ -523,6 +532,9 @@ export function ChatCenter() {
 								<span className="text-xs text-slate-400">工作区</span>
 								<ModeChip selected={wsMode === "temp"} onClick={() => setWsMode("temp")}>临时·用完即弃</ModeChip>
 								<ModeChip selected={wsMode === "new"} onClick={() => setWsMode("new")}>新建工作区</ModeChip>
+								{selectableWorkspaces.length > 0 ? (
+									<ModeChip selected={wsMode === "existing"} onClick={() => setWsMode("existing")}>已有工作区</ModeChip>
+								) : null}
 								{wsMode === "new" ? (
 									<>
 										<input
@@ -543,6 +555,18 @@ export function ChatCenter() {
 											<Check size={11} /> 创建并绑定
 										</button>
 									</>
+								) : null}
+								{wsMode === "existing" ? (
+									<select
+										value={wsExistingId}
+										onChange={(e) => setWsExistingId(e.target.value)}
+										className="ml-1 max-w-[220px] rounded-full border border-slate-200 bg-white px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
+									>
+										<option value="">选择一个工作区…</option>
+										{selectableWorkspaces.map((w) => (
+											<option key={w.id} value={w.id}>{w.name}</option>
+										))}
+									</select>
 								) : null}
 							</div>
 						)}


### PR DESCRIPTION
## Summary

Fixes two related issues around new-workspace conversations:

- **Interrupted first conversation was lost from the sidebar.** The PI SDK persists lazily — `SessionManager._persist` writes nothing to disk (not even the session header + user message) until an assistant message exists. `createNewSession` only touches a 0-byte file. So aborting the first prompt in a brand-new workspace left a 0-byte/header-only `.jsonl` that showed as an empty 0-message ghost or got lost entirely once you switched away. Compounding it, `recordCurrentSessionChannel("web", …)` sat after the streaming await, so abort skipped it → no `channels.json` entry → the session was mislabeled origin `cli` and grouped under the wrong workspace.
- **Bottom "新建对话" button had no existing-workspace option.** It routes through `beginNewSession()` (nulls `preselectedWorkspaceId`), and the welcome chooser only rendered temp/new chips — even though the `"existing"` `WsMode` and `buildSessionInput` already supported it. There was simply no UI affordance, forcing users into temp or new.

## Changes

- `pi-runner.ts`: new `persistPendingUserTurn(expectedSessionId?)` — when the session's last message is an unanswered user turn (no assistant yet), append a minimal placeholder assistant message (`stopReason:"aborted"`) to force the SDK to flush header + user message to disk. Guarded by session-id so a late abort can't write into a switched-away session. Best-effort, never throws.
- `server.ts`: restructured the `/api/chat/stream` handler into `try/catch/finally`, moving both `recordCurrentSessionChannel("web", …)` and `persistPendingUserTurn(…)` into `finally` so they always run — even on abort/error.
- `ChatCenter.tsx`: added a `selectableWorkspaces` memo (user project workspaces, excluding temp and `channel-*`), an "已有工作区" chip, and a `<select>` dropdown so the bottom button can bind a new chat to an existing workspace.

## Notes

- The interrupted-turn fix writes a visible `[已中断,未完成回复]` assistant bubble. That's the cleanest way to make the SDK persist; showing only the user message with no placeholder would require a more invasive change against the SDK's lazy-flush.

## Test plan

- [ ] `npm run build` passes (tsc + vite) — verified locally
- [ ] Create a new workspace, send first prompt, interrupt before completion → session stays in sidebar under the correct workspace and can be reopened
- [ ] Click the bottom "新建对话" button → "已有工作区" option appears and lets you pick an existing project workspace
- [ ] Normal (non-interrupted) turns are unaffected — no extra placeholder bubble