### PR TITLE
fix: surface backend LLM errors in the chat UI

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -3085,6 +3085,13 @@ const server = createServer(async (req, res) => {
 
 			questionBridge.setEmitter(sseWrite);
 
+			// Track whether the model API surfaced an error this turn. The PI SDK
+			// does NOT throw on model API errors (e.g. HTTP 413 from an over-long
+			// context) — it converts them into a terminal assistant message with
+			// stopReason "error" + errorMessage, delivered via message_end. If we
+			// don't forward that, runPromptStreaming resolves with empty text and
+			// the UI shows nothing. So we detect it here and emit an error event.
+			let emittedError = false;
 			const onEvent = (event: import("@earendil-works/pi-coding-agent").AgentSessionEvent) => {
 				if (aborted) return;
 				switch (event.type) {
@@ -3094,6 +3101,18 @@ const server = createServer(async (req, res) => {
 							sseWrite({ type: "text_delta", delta: ev.delta });
 						} else if (ev.type === "thinking_delta") {
 							sseWrite({ type: "thinking_delta", delta: ev.delta });
+						}
+						break;
+					}
+					case "message_end": {
+						const msg = event.message;
+						if (
+							msg && typeof msg === "object" && "stopReason" in msg &&
+							(msg as { stopReason?: string }).stopReason === "error"
+						) {
+							emittedError = true;
+							const detail = (msg as { errorMessage?: string }).errorMessage;
+							sseWrite({ type: "error", message: detail || "The model request failed." });
 						}
 						break;
 					}
@@ -3124,9 +3143,12 @@ const server = createServer(async (req, res) => {
 					? await runPromptStreamingInSession(targetSessionPath, prompt, onEvent, imageArgs)
 					: await runPromptStreaming(prompt, onEvent, imageArgs);
 				if (!aborted) sseWrite({ type: "done", fullText });
-				maybeAutoGenerateTopic(capturedSessionId);
+				// Skip topic auto-generation when the turn errored — there is no
+				// meaningful assistant reply to summarize and the model API is
+				// likely still failing (which would just block again).
+				if (!emittedError) maybeAutoGenerateTopic(capturedSessionId);
 			} catch (err) {
-				if (!aborted) {
+				if (!aborted && !emittedError) {
 					sseWrite({ type: "error", message: err instanceof Error ? err.message : "Unknown error" });
 				}
 			} finally {

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "motion/react";
-import { Paperclip, X, SendHorizonal, Square, RotateCcw, Check, Image } from "lucide-react";
+import { Paperclip, X, SendHorizonal, Square, RotateCcw, Check, Image, AlertTriangle } from "lucide-react";
 import type { ChatMessage } from "../types/chat.js";
 import type { InlineImage } from "../api/chat.js";
 import { chatStore } from "../stores/chat-store.js";
@@ -67,6 +67,26 @@ function ImageLightbox({ src, onClose }: { src: string; onClose: () => void }) {
 			</button>
 		</div>,
 		document.body,
+	);
+}
+
+/**
+ * Collapsible red-tinted block for surfacing backend / model API errors
+ * (e.g. HTTP 413 when the context is too long). Shows a short headline by
+ * default and reveals the full backend message when expanded, so users know
+ * something failed instead of seeing a silent dead end.
+ */
+function ErrorBlock({ error }: { error: string }) {
+	const isLong = error.length > 80 || error.includes("\n");
+	return (
+		<details className="rounded-md border border-red-200 bg-red-50 px-2.5 py-1.5 text-xs text-red-700" open={!isLong}>
+			<summary className="flex cursor-pointer select-none items-center gap-1.5 font-medium">
+				<AlertTriangle size={13} className="shrink-0" />
+				Request failed
+				{isLong ? <span className="text-red-400">· click to expand</span> : null}
+			</summary>
+			<pre className="mt-1.5 max-h-48 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-red-600">{error}</pre>
+		</details>
 	);
 }
 
@@ -138,6 +158,11 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 					</details>
 				) : null}
 				<markdown-artifact content={message.content} />
+				{message.error ? (
+					<div className={message.content.trim() ? "mt-2" : ""}>
+						<ErrorBlock error={message.error} />
+					</div>
+				) : null}
 			</div>
 		</motion.div>
 	);
@@ -183,6 +208,7 @@ export function ChatCenter() {
 		isLoadingHistory: chatStore.isLoadingHistory,
 		streamingText: chatStore.streamingText,
 		streamingThinking: chatStore.streamingThinking,
+		streamingError: chatStore.streamingError,
 		activeTools: chatStore.activeTools,
 		completedTools: chatStore.completedTools,
 		lastUserPrompt: chatStore.lastUserPrompt,
@@ -671,7 +697,20 @@ export function ChatCenter() {
 						</motion.div>
 					) : null}
 
-					{chat.isSending && !chat.streamingText && chat.activeTools.length === 0 ? (
+					{chat.streamingError ? (
+						<motion.div
+							className="flex justify-start"
+							initial={{ opacity: 0, y: 8 }}
+							animate={{ opacity: 1, y: 0 }}
+							transition={{ duration: 0.2, ease: "easeOut" }}
+						>
+							<div className="inno-message max-w-[78%]">
+								<ErrorBlock error={chat.streamingError} />
+							</div>
+						</motion.div>
+					) : null}
+
+					{chat.isSending && !chat.streamingText && !chat.streamingError && chat.activeTools.length === 0 ? (
 						<motion.div
 							className="flex justify-start"
 							initial={{ opacity: 0 }}

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -15,6 +15,8 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	isLoadingHistory = false;
 	streamingText = "";
 	streamingThinking = "";
+	/** Backend/model error for the in-flight turn, surfaced in the UI (collapsible). */
+	streamingError = "";
 	/** Active tool calls in progress */
 	activeTools: ChatToolRecord[] = [];
 	completedTools: ChatToolRecord[] = [];
@@ -49,6 +51,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.isSending = true;
 		this.streamingText = "";
 		this.streamingThinking = "";
+		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
 		this.wikiInvalidated = false;
@@ -61,8 +64,10 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				this._handleStreamEvent(event);
 			}
 			const aborted = controller.signal.aborted;
-			// Finalize: add accumulated text as assistant message
-			if (this.streamingText || aborted) {
+			// Finalize: add accumulated text as assistant message. Also finalize
+			// when the turn produced only an error (no text), so the error is
+			// preserved in history instead of vanishing when streaming state resets.
+			if (this.streamingText || this.streamingError || aborted) {
 				this.messages = [
 					...this.messages,
 					{
@@ -73,6 +78,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 						timestamp: Date.now(),
 						thinking: this.streamingThinking || undefined,
 						tools: this.completedTools.length > 0 ? this.completedTools : undefined,
+						error: this.streamingError || undefined,
 					},
 				];
 			}
@@ -81,13 +87,14 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				const message = err instanceof Error ? err.message : "Unknown error";
 				this.messages = [
 					...this.messages,
-					{ role: "assistant", content: `Error: ${message}`, timestamp: Date.now() },
+					{ role: "assistant", content: "", timestamp: Date.now(), error: message },
 				];
 			}
 		} finally {
 			this.isSending = false;
 			this.streamingText = "";
 			this.streamingThinking = "";
+			this.streamingError = "";
 			this.activeTools = [];
 			this.completedTools = [];
 			this.abortController = null;
@@ -170,7 +177,11 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				this.emit("change", undefined);
 				break;
 			case "error":
-				this.streamingText += `\n\nError: ${event.message}`;
+				// Keep the error separate from the reply text so the UI can render
+				// it as a distinct, collapsible block rather than inline markdown.
+				this.streamingError = this.streamingError
+					? `${this.streamingError}\n${event.message}`
+					: event.message;
 				this.emit("change", undefined);
 				break;
 			case "question":
@@ -218,6 +229,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.isSending = false;
 		this.streamingText = "";
 		this.streamingThinking = "";
+		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
 		this.pendingQuestion = null;
@@ -229,6 +241,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.isSending = false;
 		this.streamingText = "";
 		this.streamingThinking = "";
+		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
 		this.emit("change", undefined);

--- a/apps/inno-agent/web/src/types/chat.ts
+++ b/apps/inno-agent/web/src/types/chat.ts
@@ -6,6 +6,8 @@ export interface ChatMessage {
 	tools?: ChatToolRecord[];
 	channel?: string;
 	images?: Array<{ previewUrl: string; mimeType: string }>;
+	/** Backend/model error surfaced for this turn (e.g. HTTP 413 over-long context). */
+	error?: string;
 }
 
 export interface ChatToolRecord {


### PR DESCRIPTION
## Summary

When the model API returns a runtime error (e.g. HTTP 413 from an over-long context), the chat UI showed nothing — the loading dots just vanished and the user had no idea anything failed.

**Root cause:** The PI SDK does not throw on model API errors. The agent loop converts them into a terminal assistant message with `stopReason:"error"` + `errorMessage`, delivered only via `message_end`/`turn_end`/`agent_end`. The server's `onEvent` only handled `message_update` + tool events, so the error was silently dropped — `runPromptStreaming` resolved with empty text and the UI added no message.

## Changes

- `server.ts`: `/api/chat/stream` `onEvent` now handles `message_end` — when `stopReason === "error"`, emits `{type:"error", message: errorMessage}` so the error reaches the client. Skips topic auto-generation on error and guards the catch to avoid duplicate error events.
- `chat-store.ts` + `types/chat.ts`: new `streamingError` state and `error?:string` on `ChatMessage`. The `error` SSE event is kept separate from reply text (instead of appending into the markdown body) and preserved into the finalized assistant message.
- `ChatCenter.tsx`: new `ErrorBlock` component — a red-tinted collapsible `<details>` with an alert icon. Short errors expand by default; long/multiline ones collapse to a "Request failed" headline with the full backend message in a scrollable block. Rendered in finalized bubbles and the live streaming area.

## Test plan

- [ ] `npm run build` passes (tsc + vite) — verified locally
- [ ] Trigger a 413 (over-long context) → a red collapsible error block appears instead of silence
- [ ] Long errors collapse; short errors expand inline
- [ ] Normal turns unaffected