### PR TITLE
fix: provider switch not persisting to new sessions

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -135,8 +135,22 @@ export async function initSession(
 				noThemes: true,
 			},
 		});
+		// Register Inno's configured providers into the fresh services registry so
+		// that find() below can locate the current default model — even if it was
+		// switched *after* initSession was called (the closure-captured `config`
+		// reference goes stale once server.ts reassigns its own `config` variable
+		// via saveConfig, which returns a new normalised object).
+		const currentConfig = configHolder.current;
+		for (const [providerId, providerConfig] of Object.entries(currentConfig.providers)) {
+			services.modelRegistry.registerProvider(providerId, {
+				baseUrl: providerConfig.baseUrl,
+				apiKey: providerConfig.apiKey || "local",
+				api: providerConfig.api ?? "openai-completions",
+				models: providerConfig.models.map(modelConfigToProviderModel),
+			});
+		}
 		services.modelRegistry.refresh();
-		const defaultModel = services.modelRegistry.find(config.defaultProvider, config.defaultModel);
+		const defaultModel = services.modelRegistry.find(currentConfig.defaultProvider, currentConfig.defaultModel);
 		const created = await createAgentSessionFromServices({
 			services,
 			sessionManager,


### PR DESCRIPTION
## Summary

- **Root cause**: `createRuntime` in `pi-runner.ts` captured the original `config` reference from `initSession`. `saveConfig` returns a new normalised object, so after a provider switch the closure's `config` went stale — new sessions were created using the old `defaultProvider/defaultModel`.
- **Two-part fix**: (1) Read `configHolder.current` (always synced by `syncConfig`/`refreshConfiguredProviders`) instead of the stale closure variable. (2) Pre-register Inno's providers into the freshly created `services.modelRegistry` before calling `find()`, because extensions haven't run yet at `createRuntime` time.

## Test plan

- [ ] Switch to a different LLM provider via Settings → click "Use"
- [ ] Open a new chat and send a message — confirm the new provider is used
- [ ] Refresh the page — confirm the Settings panel shows the new provider as current
- [ ] Switch back to the original provider and repeat