### PR TITLE
feat: skill library browser with one-click import

### DIFF
--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -68,6 +68,10 @@ export interface InnoConfig {
 	bridge?: {
 		token: string;
 	};
+	github?: {
+		/** Personal access token to raise GitHub API rate limits for the skill library. */
+		token: string;
+	};
 	subagents?: InnoSubagentsConfig;
 	memory?: InnoMemoryConfig;
 }
@@ -150,6 +154,7 @@ export function normalizeConfig(config: LegacyInnoConfig): InnoConfig {
 		feishu: config.feishu,
 		channels: config.channels,
 		bridge: config.bridge,
+		github: config.github,
 		subagents: config.subagents,
 		memory: normalizeMemoryConfig(config.memory),
 	} as InnoConfig;

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -225,6 +225,9 @@ function buildSafeSettings() {
 		bridge: config.bridge
 			? { token: maskSecret(config.bridge.token) }
 			: undefined,
+		github: config.github
+			? { token: maskSecret(config.github.token) }
+			: undefined,
 	};
 }
 
@@ -619,20 +622,29 @@ function installSkillZip(fileName: string, data: Buffer, targetRoot: string = sk
 			}
 		}
 
-		const skillFile = findSkillFile(extractDir);
-		if (!skillFile) {
-			throw new Error("Zip package must contain a SKILL.md file");
-		}
-		const skillRoot = dirname(skillFile);
-		const skill = ensureSkillDocument(readText(skillFile), fallbackName);
-		const targetDir = join(targetRoot, skill.name);
-		rmSync(targetDir, { recursive: true, force: true });
-		copyDirectoryContents(skillRoot, targetDir);
-		writeText(join(targetDir, "SKILL.md"), skill.content);
-		return { name: skill.name, filePath: join(targetDir, "SKILL.md") };
+		return installSkillFromExtractedDir(extractDir, fallbackName, targetRoot);
 	} finally {
 		rmSync(tempRoot, { recursive: true, force: true });
 	}
+}
+
+/**
+ * Install a skill from an already-extracted directory: locate the SKILL.md,
+ * normalize its frontmatter, and copy the package into the skills directory.
+ * Shared by zip upload and skill-library import.
+ */
+function installSkillFromExtractedDir(extractDir: string, fallbackName: string, targetRoot: string = skillsDir): { name: string; filePath: string } {
+	const skillFile = findSkillFile(extractDir);
+	if (!skillFile) {
+		throw new Error("Skill package must contain a SKILL.md file");
+	}
+	const skillRoot = dirname(skillFile);
+	const skill = ensureSkillDocument(readText(skillFile), fallbackName);
+	const targetDir = join(targetRoot, skill.name);
+	rmSync(targetDir, { recursive: true, force: true });
+	copyDirectoryContents(skillRoot, targetDir);
+	writeText(join(targetDir, "SKILL.md"), skill.content);
+	return { name: skill.name, filePath: join(targetDir, "SKILL.md") };
 }
 
 function installSkillMarkdown(fileName: string, data: Buffer, targetRoot: string = skillsDir): { name: string; filePath: string } {
@@ -642,6 +654,216 @@ function installSkillMarkdown(fileName: string, data: Buffer, targetRoot: string
 	ensureDir(skillDir);
 	writeText(join(skillDir, "SKILL.md"), skill.content);
 	return { name: skill.name, filePath: join(skillDir, "SKILL.md") };
+}
+
+// ---------------------------------------------------------------------------
+// Remote skill library (GitHub: Chloris-Blaxk/inno-agent-hub/skill-library)
+// ---------------------------------------------------------------------------
+
+const SKILL_LIBRARY_OWNER = "Chloris-Blaxk";
+const SKILL_LIBRARY_REPO = "inno-agent-hub";
+const SKILL_LIBRARY_PATH = "skill-library";
+const SKILL_LIBRARY_REF = "main";
+/** Directories under skill-library/ that are not installable skills. */
+const SKILL_LIBRARY_IGNORE_DIRS = new Set(["assets", "__MACOSX"]);
+
+interface SkillLibraryItem {
+	/** Directory name under skill-library/ (used as the skill name). */
+	name: string;
+	/** description from SKILL.md frontmatter (may be empty). */
+	description: string;
+	/** Whether a skill with this slug already exists locally. */
+	installed: boolean;
+}
+
+interface GitTreeEntry {
+	path: string;
+	type: "blob" | "tree";
+	url: string;
+}
+
+interface GitTreeResponse {
+	tree: GitTreeEntry[];
+	truncated: boolean;
+}
+
+function githubHeaders(): Record<string, string> {
+	const headers: Record<string, string> = {
+		Accept: "application/vnd.github+json",
+		"User-Agent": "inno-agent",
+	};
+	const token = config.github?.token?.trim() || process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+	if (token) headers.Authorization = `Bearer ${token}`;
+	return headers;
+}
+
+async function githubGetJson<T>(url: string): Promise<T> {
+	const res = await fetch(url, { headers: githubHeaders() });
+	if (!res.ok) {
+		// Surface rate-limit exhaustion with a clearer hint than a raw 403.
+		if (res.status === 403 && res.headers.get("x-ratelimit-remaining") === "0") {
+			const reset = Number(res.headers.get("x-ratelimit-reset"));
+			const when = Number.isFinite(reset) ? new Date(reset * 1000).toLocaleTimeString() : "later";
+			throw new Error(
+				`GitHub API rate limit reached (unauthenticated is 60/hour). Try again after ${when}, ` +
+				`or set a GITHUB_TOKEN env var to raise the limit.`,
+			);
+		}
+		throw new Error(`GitHub request failed (${res.status} ${res.statusText}) for ${url}`);
+	}
+	return (await res.json()) as T;
+}
+
+function rawUrlFor(repoPath: string): string {
+	const encoded = repoPath.split("/").map(encodeURIComponent).join("/");
+	return `https://raw.githubusercontent.com/${SKILL_LIBRARY_OWNER}/${SKILL_LIBRARY_REPO}/${SKILL_LIBRARY_REF}/${encoded}`;
+}
+
+/**
+ * Extract the `description` field from a SKILL.md frontmatter block. Supports
+ * both single-line and YAML folded/literal block scalars (`>-`, `|`).
+ */
+function extractFrontmatterDescription(content: string): string {
+	const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	const fmMatch = normalized.match(/^---\n([\s\S]*?)\n---/);
+	if (!fmMatch) return "";
+	const lines = fmMatch[1].split("\n");
+	for (let i = 0; i < lines.length; i++) {
+		const m = lines[i].match(/^description:\s*(.*)$/);
+		if (!m) continue;
+		const inline = m[1].trim();
+		// Block scalar (>- , |, > , |- ...) → gather indented continuation lines.
+		if (/^[>|][+-]?\s*$/.test(inline)) {
+			const block: string[] = [];
+			for (let j = i + 1; j < lines.length; j++) {
+				if (/^\s+\S/.test(lines[j]) || lines[j].trim() === "") {
+					block.push(lines[j].trim());
+				} else {
+					break;
+				}
+			}
+			return block.join(" ").replace(/\s+/g, " ").trim();
+		}
+		return inline.replace(/^["']|["']$/g, "").trim();
+	}
+	return "";
+}
+
+/**
+ * Fetch the full repo file tree in a single Git Trees API call (`recursive=1`).
+ *
+ * This costs exactly one rate-limited request regardless of how many skills or
+ * nested files exist — the previous per-directory `contents` walk burned a
+ * call per folder and quickly exhausted the unauthenticated 60/hour budget.
+ */
+async function fetchSkillLibraryTree(): Promise<GitTreeEntry[]> {
+	const url =
+		`https://api.github.com/repos/${SKILL_LIBRARY_OWNER}/${SKILL_LIBRARY_REPO}` +
+		`/git/trees/${SKILL_LIBRARY_REF}?recursive=1`;
+	const data = await githubGetJson<GitTreeResponse>(url);
+	const prefix = `${SKILL_LIBRARY_PATH}/`;
+	return data.tree.filter((e) => e.path.startsWith(prefix));
+}
+
+/** Short-lived cache so repeated panel opens don't each spend an API call. */
+let skillLibraryTreeCache: { entries: GitTreeEntry[]; fetchedAt: number } | null = null;
+const SKILL_LIBRARY_CACHE_TTL_MS = 5 * 60 * 1000;
+
+async function getSkillLibraryTree(forceRefresh = false): Promise<GitTreeEntry[]> {
+	const now = Date.now();
+	if (!forceRefresh && skillLibraryTreeCache && now - skillLibraryTreeCache.fetchedAt < SKILL_LIBRARY_CACHE_TTL_MS) {
+		return skillLibraryTreeCache.entries;
+	}
+	const entries = await fetchSkillLibraryTree();
+	skillLibraryTreeCache = { entries, fetchedAt: now };
+	return entries;
+}
+
+/**
+ * List installable skills from the remote skill-library.
+ *
+ * Costs one Git Trees API call (cached) plus, for each skill, a raw.githubusercontent.com
+ * fetch of SKILL.md to surface the description. Raw fetches are served from a CDN and do
+ * NOT count against the GitHub API rate limit.
+ */
+async function listSkillLibrary(forceRefresh = false): Promise<SkillLibraryItem[]> {
+	const tree = await getSkillLibraryTree(forceRefresh);
+	const prefix = `${SKILL_LIBRARY_PATH}/`;
+	// A directory is an installable skill if it directly contains SKILL.md.
+	const skillNames = new Set<string>();
+	for (const entry of tree) {
+		if (entry.type !== "blob") continue;
+		const rel = entry.path.slice(prefix.length); // e.g. "edu-solid-geometry/SKILL.md"
+		const parts = rel.split("/");
+		if (parts.length === 2 && parts[1] === "SKILL.md" && !SKILL_LIBRARY_IGNORE_DIRS.has(parts[0])) {
+			skillNames.add(parts[0]);
+		}
+	}
+
+	const localNames = new Set(
+		existsSync(skillsDir)
+			? readdirSync(skillsDir, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name)
+			: [],
+	);
+
+	const items = await Promise.all(
+		Array.from(skillNames).map(async (name): Promise<SkillLibraryItem> => {
+			let description = "";
+			try {
+				const res = await fetch(rawUrlFor(`${SKILL_LIBRARY_PATH}/${name}/SKILL.md`), {
+					headers: { "User-Agent": "inno-agent" },
+				});
+				if (res.ok) description = extractFrontmatterDescription(await res.text());
+			} catch {
+				// Description is best-effort; skip on failure.
+			}
+			return {
+				name,
+				description,
+				installed: localNames.has(slugifySkillName(name)),
+			};
+		}),
+	);
+	return items.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/**
+ * Import a skill from the remote library into the global skills directory.
+ *
+ * Uses the cached repo tree to enumerate the skill's files, then downloads each
+ * blob from raw.githubusercontent.com (CDN, not rate limited). Installs through
+ * the same path as a zip upload (validates SKILL.md, normalizes frontmatter).
+ */
+async function importSkillFromLibrary(skillName: string): Promise<{ name: string; filePath: string }> {
+	// Guard against path traversal: only a single directory segment is allowed.
+	if (!skillName || skillName.includes("/") || skillName.includes("\\") || skillName.includes("..")) {
+		throw new Error("Invalid skill name");
+	}
+	const tree = await getSkillLibraryTree();
+	const dirPrefix = `${SKILL_LIBRARY_PATH}/${skillName}/`;
+	const blobs = tree.filter((e) => e.type === "blob" && e.path.startsWith(dirPrefix));
+	if (blobs.length === 0) {
+		throw new Error(`Skill "${skillName}" not found in the library`);
+	}
+
+	const tempRoot = join(tmpdir(), `inno-libskill-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const extractDir = join(tempRoot, "extract");
+	ensureDir(extractDir);
+	try {
+		for (const blob of blobs) {
+			const rel = blob.path.slice(dirPrefix.length);
+			if (!rel || rel.includes("..")) continue;
+			const localPath = join(extractDir, rel);
+			const res = await fetch(rawUrlFor(blob.path), { headers: { "User-Agent": "inno-agent" } });
+			if (!res.ok) throw new Error(`Failed to download ${blob.path} (${res.status})`);
+			const buf = Buffer.from(await res.arrayBuffer());
+			ensureDir(dirname(localPath));
+			writeFileSync(localPath, buf);
+		}
+		return installSkillFromExtractedDir(extractDir, slugifySkillName(skillName), skillsDir);
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
 }
 
 function migrateLegacyPiSkills(): void {
@@ -729,12 +951,11 @@ function listProjectSkills(): unknown[] {
 			const name = entry.name;
 			const filePath = join(skillsDir, name, "SKILL.md");
 			const content = existsSync(filePath) ? readText(filePath) : "";
-			const frontmatter = parseSkillFrontmatter(content);
 			const stat = existsSync(filePath) ? statSync(filePath) : statSync(join(skillsDir, name));
 			const loadedSkill = loadedByPath.get(resolve(filePath));
 			return {
 				name,
-				description: typeof frontmatter.description === "string" ? frontmatter.description : "",
+				description: extractFrontmatterDescription(content),
 				enabled: !disabled.has(name),
 				loaded: Boolean(loadedSkill),
 				filePath: relative(paths.workspaceDir, filePath),
@@ -1611,6 +1832,36 @@ const server = createServer(async (req, res) => {
 		if (method === "POST" && url === "/api/skills/reload") {
 			scheduleSkillsReload();
 			json(res, 200, { reloaded: true, skills: listProjectSkills() });
+			return;
+		}
+
+		// --- Remote skill library (GitHub) ---
+		if (method === "GET" && url.split("?")[0] === "/api/skill-library") {
+			const forceRefresh = new URL(url, "http://localhost").searchParams.get("refresh") === "1";
+			try {
+				json(res, 200, await listSkillLibrary(forceRefresh));
+			} catch (err) {
+				json(res, 502, { error: err instanceof Error ? err.message : "Failed to load skill library" });
+			}
+			return;
+		}
+
+		if (method === "POST" && url === "/api/skill-library/import") {
+			const body = (await readBody(req)) as Record<string, unknown>;
+			const skillName = typeof body.name === "string" ? body.name.trim() : "";
+			if (!skillName) {
+				json(res, 400, { error: "Missing skill name" });
+				return;
+			}
+			try {
+				const installed = await importSkillFromLibrary(skillName);
+				setSkillEnabled(installed.name, true);
+				const entry = listProjectSkills().find((s) => (s as { name: string }).name === installed.name);
+				json(res, 201, entry ?? { name: installed.name });
+				scheduleSkillsReload();
+			} catch (err) {
+				json(res, 502, { error: err instanceof Error ? err.message : "Failed to import skill" });
+			}
 			return;
 		}
 
@@ -2976,6 +3227,25 @@ const server = createServer(async (req, res) => {
 			config.memory = { l3Enabled: body.l3Enabled };
 			config = saveConfig(paths.configPath, config);
 			syncConfig(config);
+			json(res, 200, buildSafeSettings());
+			return;
+		}
+
+		// --- GitHub settings (token to raise skill-library API rate limit) ---
+		if (method === "PUT" && url === "/api/settings/github") {
+			const body = (await readBody(req)) as Record<string, unknown>;
+			if (typeof body.token !== "string") {
+				json(res, 400, { error: "Missing token (string)" });
+				return;
+			}
+			const incoming = body.token.trim();
+			// A masked value (e.g. "****abcd") means "keep the existing token".
+			const token = incoming.startsWith("****") ? (config.github?.token ?? "") : incoming;
+			config.github = token ? { token } : undefined;
+			config = saveConfig(paths.configPath, config);
+			syncConfig(config);
+			// Reset the cached tree so the new auth (and higher limit) takes effect.
+			skillLibraryTreeCache = null;
 			json(res, 200, buildSafeSettings());
 			return;
 		}

--- a/apps/inno-agent/web/src/api/settings.ts
+++ b/apps/inno-agent/web/src/api/settings.ts
@@ -39,6 +39,13 @@ export async function saveMemorySettings(l3Enabled: boolean): Promise<InnoSettin
 	});
 }
 
+export async function saveGithubSettings(token: string): Promise<InnoSettings> {
+	return apiFetch<InnoSettings>("/api/settings/github", {
+		method: "PUT",
+		body: JSON.stringify({ token }),
+	});
+}
+
 export async function wechatQrLogin(): Promise<{ qrId: string; qrUrl: string }> {
 	return apiFetch<{ qrId: string; qrUrl: string }>("/api/channels/wechat/qr-login", {
 		method: "POST",

--- a/apps/inno-agent/web/src/api/skills.ts
+++ b/apps/inno-agent/web/src/api/skills.ts
@@ -1,9 +1,20 @@
 import { apiFetch } from "./client.js";
-import type { SkillInfo } from "../types/skills.js";
+import type { SkillInfo, SkillLibraryItem } from "../types/skills.js";
 import type { WorkspaceTreeNode, WorkspaceFileDetail } from "../types/workspace.js";
 
 export async function listSkills(): Promise<SkillInfo[]> {
 	return apiFetch<SkillInfo[]>("/api/skills");
+}
+
+export async function listSkillLibrary(forceRefresh = false): Promise<SkillLibraryItem[]> {
+	return apiFetch<SkillLibraryItem[]>(`/api/skill-library${forceRefresh ? "?refresh=1" : ""}`);
+}
+
+export async function importSkillFromLibrary(name: string): Promise<SkillInfo> {
+	return apiFetch<SkillInfo>("/api/skill-library/import", {
+		method: "POST",
+		body: JSON.stringify({ name }),
+	});
 }
 
 export async function uploadSkill(file: File): Promise<SkillInfo> {

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -305,7 +305,15 @@
     "emptyDesc": "Upload <skill-name>.zip. It will be unpacked and loaded.",
     "noDescription": "No description",
     "loaded": "loaded",
-    "notLoaded": "not loaded"
+    "notLoaded": "not loaded",
+    "library": "Skills Library",
+    "libraryTitle": "Skills Library",
+    "librarySubtitle": "Browse and import skills from the inno-agent-hub library",
+    "libraryEmpty": "No skills available in the library",
+    "import": "Import",
+    "importing": "Importing…",
+    "installed": "Installed",
+    "libraryError": "Failed to load skills library"
   },
   "settings": {
     "title": "Settings",
@@ -328,6 +336,13 @@
       "title": "Cross-conversation memory (L3)",
       "onDesc": "On: searches past conversations via SQLite and auto-recalls relevant context.",
       "offDesc": "Off: replies use only the current workspace contents and the current conversation context."
+    },
+    "github": {
+      "title": "GitHub token",
+      "desc": "Optional. Used to fetch the skill library from GitHub. Without a token the unauthenticated API is limited to 60 requests/hour per IP; a token raises it to 5000/hour. A token with no scopes is enough for public repos.",
+      "placeholder": "ghp_… or github_pat_…",
+      "saved": "Saved",
+      "clear": "Clear"
     },
     "form": {
       "providerId": "Provider id",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -305,7 +305,15 @@
     "emptyDesc": "上传 <skill-name>.zip，Inno Agent 会自动解压并加载。",
     "noDescription": "暂无描述",
     "loaded": "已加载",
-    "notLoaded": "未加载"
+    "notLoaded": "未加载",
+    "library": "技能库",
+    "libraryTitle": "技能库",
+    "librarySubtitle": "浏览并导入 inno-agent-hub 技能库中的技能",
+    "libraryEmpty": "技能库中暂无可用技能",
+    "import": "导入",
+    "importing": "导入中…",
+    "installed": "已安装",
+    "libraryError": "加载技能库失败"
   },
   "settings": {
     "title": "设置",
@@ -328,6 +336,13 @@
       "title": "跨对话记忆 (L3)",
       "onDesc": "已开启：可通过 SQLite 检索历史对话内容，自动召回相关上下文。",
       "offDesc": "已关闭：仅基于当前工作区内容与当前对话上下文进行回复。"
+    },
+    "github": {
+      "title": "GitHub 令牌",
+      "desc": "可选。用于从 GitHub 拉取技能库。未配置令牌时，未认证 API 每 IP 每小时仅 60 次；配置后可提升至每小时 5000 次。公开仓库用无任何权限的令牌即可。",
+      "placeholder": "ghp_… 或 github_pat_…",
+      "saved": "已保存",
+      "clear": "清除"
     },
     "form": {
       "providerId": "提供方 ID",

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Trash2, Pencil, X, ChevronDown, ChevronRight, Plus, QrCode as QrCodeIcon, CheckCircle, Wifi, WifiOff } from "lucide-react";
+import { Trash2, Pencil, X, ChevronDown, ChevronRight, Plus, QrCode as QrCodeIcon, CheckCircle, Wifi, WifiOff, KeyRound } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { getWikiStats } from "../api/wiki.js";
 import { settingsStore } from "../stores/settings-store.js";
@@ -632,6 +632,87 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 	);
 }
 
+/* ---------- GitHub Settings (token to raise skill-library API rate limit) ---------- */
+
+function GithubSettings({ settings }: { settings: InnoSettings }) {
+	const { t } = useTranslation();
+	const hasToken = Boolean(settings.github?.token);
+	const [token, setToken] = useState(settings.github?.token ?? "");
+	const [saving, setSaving] = useState(false);
+	const [saved, setSaved] = useState(false);
+
+	useEffect(() => {
+		setToken(settings.github?.token ?? "");
+		setSaved(false);
+	}, [settings.github?.token]);
+
+	const dirty = token !== (settings.github?.token ?? "");
+
+	async function handleSave() {
+		setSaving(true);
+		setSaved(false);
+		try {
+			await settingsStore.saveGithub(token.trim());
+			setSaved(true);
+		} catch {
+			// error surfaced via store
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function handleClear() {
+		setSaving(true);
+		setSaved(false);
+		try {
+			await settingsStore.saveGithub("");
+			setToken("");
+		} catch {
+			// error surfaced via store
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div className="rounded-lg border border-slate-200 bg-white p-4">
+			<div className="flex items-start gap-2">
+				<KeyRound size={16} className="mt-0.5 shrink-0 text-slate-700" />
+				<div className="min-w-0 flex-1">
+					<h4 className="text-sm font-medium text-slate-950">{t("settings.github.title")}</h4>
+					<p className="mt-1 text-xs leading-relaxed text-slate-500">{t("settings.github.desc")}</p>
+					<div className="mt-3 flex items-center gap-2">
+						<input
+							type="password"
+							value={token}
+							onChange={(e) => { setToken(e.target.value); setSaved(false); }}
+							placeholder={t("settings.github.placeholder")}
+							autoComplete="off"
+							className="h-8 min-w-0 flex-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none"
+						/>
+						<button
+							disabled={saving || !dirty || !token.trim()}
+							onClick={() => void handleSave()}
+							className="flex h-8 shrink-0 items-center rounded-md bg-slate-900 px-3 text-xs text-white hover:bg-slate-800 disabled:opacity-50"
+						>
+							{saving ? t("common.loading") : saved ? t("settings.github.saved") : t("common.save")}
+						</button>
+						{hasToken && (
+							<button
+								disabled={saving}
+								onClick={() => void handleClear()}
+								className="flex h-8 shrink-0 items-center rounded-md border border-slate-200 px-3 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50"
+							>
+								{t("settings.github.clear")}
+							</button>
+						)}
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}
+
 /* ---------- Memory Settings (L3 cross-conversation recall toggle) ---------- */
 
 function MemorySettings({ settings }: { settings: InnoSettings }) {
@@ -814,6 +895,9 @@ export function SettingsPanel() {
 
 				{/* Memory Settings (L3 cross-conversation recall) */}
 				{state.settings && <MemorySettings settings={state.settings} />}
+
+				{/* GitHub token (raises skill-library API rate limit) */}
+				{state.settings && <GithubSettings settings={state.settings} />}
 
 				{/* Channels Settings */}
 				{state.settings && <ChannelsSettings settings={state.settings} />}

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -17,7 +17,7 @@ import { cpp } from "@codemirror/lang-cpp";
 import { rust } from "@codemirror/lang-rust";
 import { go } from "@codemirror/lang-go";
 import type { Extension } from "@codemirror/state";
-import { RefreshCw, Upload, Trash2, ChevronLeft, File, FileText, FileType, Folder, FolderOpen, Globe, Pencil, Save, X, PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { RefreshCw, Upload, Trash2, ChevronLeft, File, FileText, FileType, Folder, FolderOpen, Globe, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Library, Download, Check } from "lucide-react";
 import { skillsStore } from "../stores/skills-store.js";
 import { skillRawUrl } from "../api/skills.js";
 import type { SkillInfo } from "../types/skills.js";
@@ -357,6 +357,95 @@ function SkillRow({ skill, onClick }: { skill: SkillInfo; onClick: () => void })
 	);
 }
 
+/* ---------- Skill Library Modal ---------- */
+
+function SkillLibraryModal({ onClose }: { onClose: () => void }) {
+	const { t } = useTranslation();
+	const state = useStoreSnapshot(skillsStore, () => ({
+		library: skillsStore.library,
+		isLoading: skillsStore.isLoadingLibrary,
+		error: skillsStore.libraryError,
+		importing: skillsStore.importing,
+	}));
+
+	return (
+		<div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-900/40 p-4" onClick={onClose}>
+			<div
+				className="flex max-h-full w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-xl"
+				onClick={(e) => e.stopPropagation()}
+			>
+				{/* Header */}
+				<div className="flex items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+					<div className="flex min-w-0 items-center gap-2">
+						<Library size={16} className="shrink-0 text-blue-600" />
+						<div className="min-w-0">
+							<div className="truncate text-sm font-medium text-slate-950">{t("skills.libraryTitle")}</div>
+							<div className="truncate text-[11px] text-slate-500">{t("skills.librarySubtitle")}</div>
+						</div>
+					</div>
+					<div className="flex shrink-0 items-center gap-1">
+						<button
+							className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+							title={t("skills.reload")}
+							onClick={() => void skillsStore.loadLibrary(true)}
+						>
+							<RefreshCw size={14} />
+						</button>
+						<button
+							className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+							onClick={onClose}
+						>
+							<X size={16} />
+						</button>
+					</div>
+				</div>
+
+				{state.error ? <div className="border-b border-slate-200 bg-red-50 px-4 py-2 text-xs text-red-700">{state.error}</div> : null}
+
+				{/* Body */}
+				<div className="min-h-0 flex-1 overflow-y-auto">
+					{state.isLoading ? (
+						<div className="flex items-center justify-center py-12 text-slate-500">
+							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+							{t("common.loading")}
+						</div>
+					) : state.library.length === 0 ? (
+						<div className="flex h-full flex-col items-center justify-center py-12 text-center text-sm text-slate-500">
+							{t("skills.libraryEmpty")}
+						</div>
+					) : (
+						state.library.map((item) => {
+							const isImporting = state.importing.has(item.name);
+							return (
+								<div key={item.name} className="flex items-start gap-3 border-b border-slate-100 px-4 py-3">
+									<div className="min-w-0 flex-1">
+										<div className="truncate text-sm font-medium text-slate-950">{item.name}</div>
+										{item.description && <div className="mt-0.5 line-clamp-3 text-xs leading-relaxed text-slate-500">{item.description}</div>}
+									</div>
+									{item.installed ? (
+										<span className="flex shrink-0 items-center gap-1 rounded-md bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 ring-1 ring-green-100">
+											<Check size={12} /> {t("skills.installed")}
+										</span>
+									) : (
+										<button
+											disabled={isImporting}
+											className="flex h-7 shrink-0 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50"
+											onClick={() => void skillsStore.importFromLibrary(item.name)}
+										>
+											<Download size={12} />
+											{isImporting ? t("skills.importing") : t("skills.import")}
+										</button>
+									)}
+								</div>
+							);
+						})
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}
+
 /* ---------- Main SkillsPanel ---------- */
 
 export function SkillsPanel() {
@@ -368,6 +457,7 @@ export function SkillsPanel() {
 		isLoading: skillsStore.isLoading,
 		isUploading: skillsStore.isUploading,
 		error: skillsStore.error,
+		libraryOpen: skillsStore.libraryOpen,
 	}));
 
 	useEffect(() => {
@@ -396,13 +486,17 @@ export function SkillsPanel() {
 
 	// List view — one skill per row
 	return (
-		<div className="flex h-full flex-col p-3">
+		<div className="relative flex h-full flex-col p-3">
 			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white">
 				{/* Toolbar */}
 				<div className="flex items-center justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
 					<h3 className="text-sm font-medium text-slate-950">{t("skills.title")}</h3>
 					<div className="flex shrink-0 items-center gap-2">
 						<input ref={uploadRef} type="file" className="hidden" accept=".zip,application/zip,.md,text/markdown,text/plain" onChange={handleUpload} />
+						<button className="flex h-7 items-center gap-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-600 hover:bg-slate-100 hover:text-slate-950" onClick={() => skillsStore.openLibrary()}>
+							<Library size={13} />
+							{t("skills.library")}
+						</button>
 						<button className="flex h-7 items-center gap-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-500 hover:bg-slate-100 hover:text-slate-950" onClick={() => void skillsStore.reload()}>
 							<RefreshCw size={13} />
 						</button>
@@ -433,6 +527,7 @@ export function SkillsPanel() {
 					)}
 				</div>
 			</div>
+			{state.libraryOpen ? <SkillLibraryModal onClose={() => skillsStore.closeLibrary()} /> : null}
 		</div>
 	);
 }

--- a/apps/inno-agent/web/src/stores/settings-store.ts
+++ b/apps/inno-agent/web/src/stores/settings-store.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "./event-emitter.js";
-import { getSettings, switchBackendModel, upsertProvider, deleteProviderApi, saveChannelsSettings, saveMemorySettings } from "../api/settings.js";
+import { getSettings, switchBackendModel, upsertProvider, deleteProviderApi, saveChannelsSettings, saveMemorySettings, saveGithubSettings } from "../api/settings.js";
 import type { InnoSettings, UpsertProviderRequest, ChannelsSettingsPayload } from "../types/settings.js";
 
 interface SettingsStoreEvents {
@@ -13,6 +13,7 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 	isSavingProvider = false;
 	isSavingChannels = false;
 	isSavingMemory = false;
+	isSavingGithub = false;
 	error: string | null = null;
 
 	async load(): Promise<void> {
@@ -114,6 +115,22 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 			this.emit("change", undefined);
 		} finally {
 			this.isSavingMemory = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async saveGithub(token: string): Promise<void> {
+		this.isSavingGithub = true;
+		this.error = null;
+		this.emit("change", undefined);
+		try {
+			this.settings = await saveGithubSettings(token);
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : "Failed to save GitHub settings";
+			this.emit("change", undefined);
+			throw err;
+		} finally {
+			this.isSavingGithub = false;
 			this.emit("change", undefined);
 		}
 	}

--- a/apps/inno-agent/web/src/stores/skills-store.ts
+++ b/apps/inno-agent/web/src/stores/skills-store.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "./event-emitter.js";
-import { deleteSkill, listSkills, reloadSkills, updateSkill, uploadSkill, getSkillTree, getSkillFile, saveSkillFile } from "../api/skills.js";
-import type { SkillInfo } from "../types/skills.js";
+import { deleteSkill, listSkills, reloadSkills, updateSkill, uploadSkill, getSkillTree, getSkillFile, saveSkillFile, listSkillLibrary, importSkillFromLibrary } from "../api/skills.js";
+import type { SkillInfo, SkillLibraryItem } from "../types/skills.js";
 import type { WorkspaceTreeNode, WorkspaceFileDetail } from "../types/workspace.js";
 
 interface SkillsStoreEvents {
@@ -22,6 +22,14 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 	isEditing = false;
 	editBuffer = "";
 	isSaving = false;
+
+	// Remote skill library state
+	libraryOpen = false;
+	library: SkillLibraryItem[] = [];
+	isLoadingLibrary = false;
+	libraryError: string | null = null;
+	/** Names currently being imported (for per-row spinners). */
+	importing = new Set<string>();
 
 	async load() {
 		this.isLoading = true;
@@ -75,6 +83,51 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 		const result = await reloadSkills();
 		this.skills = result.skills;
 		this.emit("change", undefined);
+	}
+
+	/* --- Remote skill library --- */
+
+	openLibrary() {
+		this.libraryOpen = true;
+		this.emit("change", undefined);
+		void this.loadLibrary();
+	}
+
+	closeLibrary() {
+		this.libraryOpen = false;
+		this.emit("change", undefined);
+	}
+
+	async loadLibrary(forceRefresh = false) {
+		this.isLoadingLibrary = true;
+		this.libraryError = null;
+		this.emit("change", undefined);
+		try {
+			this.library = await listSkillLibrary(forceRefresh);
+		} catch (err) {
+			this.libraryError = err instanceof Error ? err.message : "Failed to load skill library";
+			this.library = [];
+		} finally {
+			this.isLoadingLibrary = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async importFromLibrary(name: string) {
+		if (this.importing.has(name)) return;
+		this.importing.add(name);
+		this.libraryError = null;
+		this.emit("change", undefined);
+		try {
+			const skill = await importSkillFromLibrary(name);
+			this.skills = [skill, ...this.skills.filter((item) => item.name !== skill.name)].sort((a, b) => a.name.localeCompare(b.name));
+			this.library = this.library.map((item) => (item.name === name ? { ...item, installed: true } : item));
+		} catch (err) {
+			this.libraryError = err instanceof Error ? err.message : "Failed to import skill";
+		} finally {
+			this.importing.delete(name);
+			this.emit("change", undefined);
+		}
 	}
 
 	/* --- File browsing --- */

--- a/apps/inno-agent/web/src/types/settings.ts
+++ b/apps/inno-agent/web/src/types/settings.ts
@@ -78,5 +78,6 @@ export interface InnoSettings {
 		wecom?: { enabled: boolean };
 	};
 	bridge?: { token: string }; // masked
+	github?: { token: string }; // masked
 	memory?: { l3Enabled: boolean };
 }

--- a/apps/inno-agent/web/src/types/skills.ts
+++ b/apps/inno-agent/web/src/types/skills.ts
@@ -8,3 +8,9 @@ export interface SkillInfo {
 	updatedAt: string;
 	diagnostics: string[];
 }
+
+export interface SkillLibraryItem {
+	name: string;
+	description: string;
+	installed: boolean;
+}


### PR DESCRIPTION
## Summary
- Adds a **Skills Library** button to the skills panel that opens an embedded modal listing skills from `Chloris-Blaxk/inno-agent-hub/skill-library/`, with one-click import into the global skills directory.
- Uses the GitHub **Git Trees API** (recursive, 5-min cached) + `raw.githubusercontent.com` so listing costs one rate-limited call and import costs none — avoids the unauthenticated 60/hour limit that previously caused `fetch failed`.
- Frontmatter description parsing now handles YAML block scalars (`>-`, `|`) so imported skills show proper descriptions.
- Adds an optional **GitHub token** setting (stored in `config.json`, editable in the Settings panel) to raise the API rate limit to 5000/hour.

## Test plan
- [x] `npm run build` (backend tsc + web vite) clean
- [x] `GET /api/skill-library` lists skills with descriptions; repeated calls hit the 5-min cache (only 1 core API call)
- [x] `POST /api/skill-library/import` installs a multi-folder skill with 0 core API calls; description intact; `installed` flips true
- [x] `PUT /api/settings/github` saves token (masked in response), masked value preserves existing token, empty string clears it