### PR TITLE
fix: stop caret jumping to end in skills markdown editor

### DIFF
--- a/apps/inno-agent/web/src/stores/skills-store.ts
+++ b/apps/inno-agent/web/src/stores/skills-store.ts
@@ -183,6 +183,7 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 
 	updateEditBuffer(value: string) {
 		this.editBuffer = value;
+		this.emit("change", undefined);
 	}
 
 	cancelEditing() {


### PR DESCRIPTION
## Summary
- Skills store's `updateEditBuffer` was missing `emit("change")`, unlike the workspace and notebook stores.
- MDEditor is a controlled component: without the emit, its `value` never round-tripped through state on keystroke, so typing space/enter re-seeded the textarea from a stale value and sent the caret to the end. Same file edited fine in the preview/wiki panels (those stores emit).
- Added the emit to keep the snapshot in sync.

## Test plan
- [ ] Edit a SKILL.md in the skills panel, place caret mid-line, type space/enter — caret stays put.
- [ ] Confirm preview and wiki editors still behave normally.