### PR TITLE
fix: avoid blocking save and chat when reloading skills

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1916,7 +1916,7 @@ const server = createServer(async (req, res) => {
 			const body = (await readBody(req)) as Record<string, unknown>;
 			const content = typeof body.content === "string" ? body.content : "";
 			writeFileSync(filePath, content, "utf-8");
-			await reloadResources();
+			scheduleSkillsReload();
 			json(res, 200, { name, saved: true });
 			return;
 		}
@@ -2018,7 +2018,7 @@ const server = createServer(async (req, res) => {
 				return;
 			}
 			writeFileSync(fullPath, content, "utf-8");
-			if (basename(fullPath) === "SKILL.md") await reloadResources();
+			if (basename(fullPath) === "SKILL.md") scheduleSkillsReload();
 			const st = statSync(fullPath);
 			json(res, 200, { path: relPath, saved: true, size: st.size, updatedAt: st.mtime.toISOString() });
 			return;


### PR DESCRIPTION
## Summary
- Saving a SKILL.md from the skills panel awaited `reloadResources()`, which runs through the shared serial prompt queue (`enqueue()` in `pi-runner.ts`). This stalled the save HTTP response behind the queue and occupied a queue slot, blocking chat too.
- Switched both skill-file save handlers (`PUT /api/skills/:name/content` and `PUT /api/skills/:name/file`) to fire-and-forget `scheduleSkillsReload()`, matching every other call site.

## Test plan
- [x] `npm --workspace inno-agent run build` passes
- [ ] In the web UI, edit a SKILL.md in the skills panel and save — save returns immediately
- [ ] Confirm chat is not blocked during/after the save