### PR TITLE
fix: enable right-click create in empty workspace

### DIFF
--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -818,7 +818,7 @@ export function WorkspaceBrowser() {
 				{/* Tree */}
 				<div
 					ref={treeContainerRef}
-					className="workspace-scroll min-h-0 flex-1 overflow-hidden"
+					className="workspace-scroll relative min-h-0 flex-1 overflow-hidden"
 					onContextMenu={(e) => {
 						// Right-click on empty space → create at workspace root.
 						e.preventDefault();
@@ -827,26 +827,33 @@ export function WorkspaceBrowser() {
 				>
 					{state.isLoadingTree && !arboristData.length ? (
 						<div className="p-3 text-xs text-slate-500">{t("preview.loading", "Loading...")}</div>
-					) : !arboristData.length ? (
-						<div className="p-3 text-xs text-slate-500">{t("preview.empty", "Empty workspace")}</div>
 					) : (
-						<Tree<ArboristNode>
-							ref={treeRef}
-							data={arboristData}
-							width={treeWidth}
-							height={treeHeight}
-							indent={16}
-							rowHeight={28}
-							openByDefault={false}
-							disableDrag={busy}
-							disableDrop={busy}
-							onCreate={onCreate}
-							onRename={onRename}
-							onDelete={onDelete}
-							onMove={onMove}
-						>
-							{Node}
-						</Tree>
+						<>
+							{/* Always mount the Tree (even when empty) so treeRef is available
+							    for root-level create actions from the context menu. */}
+							<Tree<ArboristNode>
+								ref={treeRef}
+								data={arboristData}
+								width={treeWidth}
+								height={treeHeight}
+								indent={16}
+								rowHeight={28}
+								openByDefault={false}
+								disableDrag={busy}
+								disableDrop={busy}
+								onCreate={onCreate}
+								onRename={onRename}
+								onDelete={onDelete}
+								onMove={onMove}
+							>
+								{Node}
+							</Tree>
+							{!arboristData.length && (
+								<div className="pointer-events-none absolute left-0 top-0 p-3 text-xs text-slate-500">
+									{t("preview.empty", "Empty workspace")}
+								</div>
+							)}
+						</>
 					)}
 				</div>
 


### PR DESCRIPTION
## Summary
- Fix the bug where right-click "New File"/"New Folder" did nothing in a fresh empty workspace, and only started working after a file was uploaded via drag-and-drop.

## Root cause
`WorkspaceBrowser.tsx` only mounted the `<Tree>` component when the workspace had files (`!arboristData.length` rendered a plain "Empty workspace" div instead). With no `<Tree>` mounted, `treeRef.current` was `null`, so the root context-menu actions calling `treeRef.current?.create({ parentId: null, ... })` silently no-opped. After an upload populated the tree, `<Tree>` mounted, `treeRef` became available, and create began working.

## Fix
- Always mount the `<Tree>` (even when empty) so `treeRef` is available for root-level create actions from the context menu.
- Show the empty-workspace hint as a non-blocking `pointer-events-none absolute` overlay instead of replacing the Tree.

## Test plan
- [x] `npm run build` passes (backend tsc + web vite)
- [ ] In a fresh empty workspace, right-click empty space → New File / New Folder creates items
- [ ] Empty-workspace hint still shows and does not block right-click
- [ ] Existing populated workspaces unaffected