### PR TITLE
feat(theme): add UI theme system with light, warm, ocean, innospark presets

### DIFF
--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -147,6 +147,9 @@ export interface InnoConfig {
 	subagents?: InnoSubagentsConfig;
 	memory?: InnoMemoryConfig;
 	simpleMode?: InnoSimpleModeConfig;
+	ui?: {
+		theme: string;
+	};
 }
 
 interface LegacyInnoConfig extends Partial<InnoConfig> {
@@ -268,6 +271,7 @@ export function normalizeConfig(config: LegacyInnoConfig): InnoConfig {
 		subagents: config.subagents,
 		memory: normalizeMemoryConfig(config.memory),
 		simpleMode: normalizeSimpleModeConfig(config.simpleMode),
+		ui: config.ui,
 	} as InnoConfig;
 }
 

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -3409,6 +3409,21 @@ const server = createServer(async (req, res) => {
 			return;
 		}
 
+		// PUT /api/settings/theme — persist UI theme preference
+		if (method === "PUT" && url === "/api/settings/theme") {
+			const body = (await readBody(req)) as Record<string, unknown>;
+			const theme = typeof body.theme === "string" ? body.theme.trim() : "";
+			const ALLOWED_THEMES = ["light", "warm", "ocean"];
+			if (!ALLOWED_THEMES.includes(theme)) {
+				json(res, 400, { error: `Invalid theme. Allowed: ${ALLOWED_THEMES.join(", ")}` });
+				return;
+			}
+			config.ui = { theme };
+			config = saveConfig(paths.configPath, config);
+			json(res, 200, buildSafeSettings());
+			return;
+		}
+
 		// --- Chat API ---
 		if (method === "POST" && url === "/api/chat") {
 			const body = (await readBody(req)) as Record<string, unknown>;

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -3413,7 +3413,7 @@ const server = createServer(async (req, res) => {
 		if (method === "PUT" && url === "/api/settings/theme") {
 			const body = (await readBody(req)) as Record<string, unknown>;
 			const theme = typeof body.theme === "string" ? body.theme.trim() : "";
-			const ALLOWED_THEMES = ["light", "warm", "ocean"];
+			const ALLOWED_THEMES = ["light", "warm", "ocean", "innospark"];
 			if (!ALLOWED_THEMES.includes(theme)) {
 				json(res, 400, { error: `Invalid theme. Allowed: ${ALLOWED_THEMES.join(", ")}` });
 				return;

--- a/apps/inno-agent/web/index.html
+++ b/apps/inno-agent/web/index.html
@@ -4,6 +4,17 @@
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>Inno Agent</title>
+		<script>
+			// Apply theme before first paint to prevent flash of wrong theme (FOWT).
+			(function () {
+				try {
+					var t = localStorage.getItem("inno.theme") || "light";
+					var valid = ["light", "warm", "ocean"];
+					if (valid.indexOf(t) === -1) t = "light";
+					document.documentElement.setAttribute("data-theme", t);
+				} catch (e) {}
+			})();
+		</script>
 	</head>
 	<body class="h-full m-0 bg-background text-foreground">
 		<div id="root" class="h-full"></div>

--- a/apps/inno-agent/web/index.html
+++ b/apps/inno-agent/web/index.html
@@ -9,7 +9,7 @@
 			(function () {
 				try {
 					var t = localStorage.getItem("inno.theme") || "light";
-					var valid = ["light", "warm", "ocean"];
+					var valid = ["light", "warm", "ocean", "innospark"];
 					if (valid.indexOf(t) === -1) t = "light";
 					document.documentElement.setAttribute("data-theme", t);
 				} catch (e) {}

--- a/apps/inno-agent/web/src/api/settings.ts
+++ b/apps/inno-agent/web/src/api/settings.ts
@@ -84,6 +84,13 @@ export async function saveContentHubSettings(payload: ContentHubPayload): Promis
 	});
 }
 
+export async function saveThemeSettings(theme: string): Promise<InnoSettings> {
+	return apiFetch<InnoSettings>("/api/settings/theme", {
+		method: "PUT",
+		body: JSON.stringify({ theme }),
+	});
+}
+
 export async function wechatQrLogin(): Promise<{ qrId: string; qrUrl: string }> {
 	return apiFetch<{ qrId: string; qrUrl: string }>("/api/channels/wechat/qr-login", {
 		method: "POST",

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -3,29 +3,31 @@
 @import "./themes.css";
 
 :root {
-	--inno-background: #f7f8fa;
+	--inno-background: #f7f7f8;
 	--inno-surface: #ffffff;
-	--inno-surface-muted: #f3f4f6;
-	--inno-surface-raised: #fafafa;
-	--inno-sidebar-bg: #eceff3;
-	--inno-sidebar-active: #dde2e8;
+	--inno-surface-muted: #f1f1f2;
+	--inno-surface-raised: #fbfbfb;
+	--inno-sidebar-bg: #f3f4f4;
+	--inno-sidebar-active: #e8e8e9;
 	--inno-chat-bg: #ffffff;
-	--inno-workspace-bg: #f8fafc;
-	--inno-workspace-chrome: #f1f5f9;
-	--inno-border: #e5e7eb;
-	--inno-border-strong: #c9d0d9;
-	--inno-text: #171a1f;
-	--inno-text-muted: #667085;
-	--inno-text-subtle: #8a94a3;
-	--inno-accent: #2563eb;
-	--inno-accent-soft: #dbeafe;
-	--inno-tech: #06b6d4;
+	--inno-workspace-bg: #f8f8f8;
+	--inno-workspace-chrome: #f1f1f2;
+	--inno-border: #e3e3e4;
+	--inno-border-strong: #c8c8ca;
+	--inno-text: #202123;
+	--inno-text-muted: #6f7377;
+	--inno-text-subtle: #92969a;
+	--inno-accent: #34363a;
+	--inno-accent-soft: #ededee;
+	--inno-tech: #111827;
 	--inno-success: #16a34a;
 	--inno-warning: #d97706;
 	--inno-danger: #dc2626;
 	--inno-workspace-width: 520px;
-	--inno-shadow-soft: 0 1px 2px rgba(15, 23, 42, 0.05), 0 10px 28px rgba(15, 23, 42, 0.04);
-	--inno-ring: 0 0 0 3px rgba(37, 99, 235, 0.13);
+	--inno-shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.04), 0 10px 28px rgba(0, 0, 0, 0.035);
+	--inno-ring: 0 0 0 3px rgba(52, 54, 58, 0.14);
+	--inno-selection-bg: rgba(52, 54, 58, 0.12);
+	--inno-grid-color: rgba(32, 33, 35, 0.025);
 	color: var(--inno-text);
 	background: var(--inno-background);
 	font-synthesis-weight: none;
@@ -289,6 +291,32 @@ inno-workspace-panel textarea {
 	transform: translateY(1px);
 }
 
+.inno-primary-button,
+.inno-primary-icon-button {
+	border-color: transparent;
+	background: var(--inno-accent);
+	color: #ffffff;
+	box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
+	transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+}
+
+.inno-primary-button:hover:not(:disabled),
+.inno-primary-icon-button:hover:not(:disabled) {
+	background: var(--inno-tech);
+	color: #ffffff;
+	box-shadow: 0 2px 8px rgba(15, 23, 42, 0.12);
+}
+
+.inno-primary-button:active:not(:disabled),
+.inno-primary-icon-button:active:not(:disabled) {
+	transform: translateY(1px);
+}
+
+.inno-primary-button:disabled,
+.inno-primary-icon-button:disabled {
+	cursor: not-allowed;
+}
+
 .inno-chat-grid {
 	background:
 		linear-gradient(90deg, var(--inno-grid-color, rgba(226, 232, 240, 0.38)) 1px, transparent 1px),
@@ -411,6 +439,10 @@ inno-workspace-panel textarea {
 
 .inno-workspace-scope button {
 	white-space: nowrap;
+}
+
+.inno-workspace-scope button.inno-settings-card-toggle {
+	white-space: normal;
 }
 
 .inno-workspace-scope .inno-workspace-tab {

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -65,7 +65,7 @@ summary:focus-visible {
 }
 
 ::selection {
-	background: rgba(37, 99, 235, 0.16);
+	background: var(--inno-selection-bg, rgba(37, 99, 235, 0.16));
 }
 
 /* Three-column layout */
@@ -291,15 +291,35 @@ inno-workspace-panel textarea {
 
 .inno-chat-grid {
 	background:
-		linear-gradient(90deg, rgba(226, 232, 240, 0.38) 1px, transparent 1px),
-		linear-gradient(rgba(226, 232, 240, 0.38) 1px, transparent 1px),
-		radial-gradient(circle at 50% 0, rgba(37, 99, 235, 0.045), transparent 42%),
+		linear-gradient(90deg, var(--inno-grid-color, rgba(226, 232, 240, 0.38)) 1px, transparent 1px),
+		linear-gradient(var(--inno-grid-color, rgba(226, 232, 240, 0.38)) 1px, transparent 1px),
 		var(--inno-chat-bg);
-	background-size: 36px 36px, 36px 36px, auto, auto;
+	background-size: 36px 36px, 36px 36px, auto;
 }
 
 .inno-message {
+	min-width: 0;
+	max-width: 100%;
 	box-shadow: 0 1px 1px rgba(15, 23, 42, 0.03);
+}
+
+.inno-message details,
+.inno-message summary,
+.inno-message pre,
+.inno-message code {
+	min-width: 0;
+	max-width: 100%;
+}
+
+.inno-message pre,
+.inno-message code {
+	overflow-wrap: anywhere;
+	word-break: break-word;
+}
+
+.inno-message pre {
+	overflow-x: auto;
+	white-space: pre-wrap;
 }
 
 .inno-message markdown-artifact {
@@ -474,6 +494,164 @@ inno-workspace-panel textarea {
 .workspace-resizing {
 	cursor: col-resize;
 	user-select: none;
+}
+
+/* InnoSpark theme: inspired by agent.aiecnu.net's public chat UI. */
+:root[data-theme="innospark"] body {
+	background: var(--inno-background);
+}
+
+:root[data-theme="innospark"] .app-layout {
+	background: var(--inno-background);
+	box-shadow: inset 0 2px 0 rgba(85, 90, 255, 0.48);
+}
+
+:root[data-theme="innospark"] .app-layout::before {
+	background:
+		linear-gradient(120deg, transparent 0 30%, rgba(85, 90, 255, 0.025) 30.2% 30.8%, transparent 31% 100%),
+		linear-gradient(155deg, transparent 0 56%, rgba(85, 90, 255, 0.018) 56.2% 56.7%, transparent 57% 100%);
+	background-size: 560px 280px, 760px 360px;
+	mask-image: linear-gradient(to right, rgba(0, 0, 0, 0.38), transparent 42%, transparent 100%);
+}
+
+:root[data-theme="innospark"] inno-chat-center,
+:root[data-theme="innospark"] .inno-chat-grid {
+	background: var(--inno-chat-bg);
+}
+
+:root[data-theme="innospark"] .inno-chat-grid {
+	background-image: none;
+}
+
+:root[data-theme="innospark"] .inno-sidebar-scope,
+:root[data-theme="innospark"] inno-session-sidebar {
+	border-color: rgba(85, 90, 255, 0.08);
+	background: var(--inno-sidebar-bg);
+}
+
+:root[data-theme="innospark"] .inno-sidebar-scope header,
+:root[data-theme="innospark"] .inno-sidebar-scope [class*="border-b"] {
+	border-color: rgba(85, 90, 255, 0.1);
+}
+
+:root[data-theme="innospark"] .inno-sidebar-scope [role="button"],
+:root[data-theme="innospark"] .inno-sidebar-scope button {
+	transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+:root[data-theme="innospark"] .inno-sidebar-scope [role="button"]:hover,
+:root[data-theme="innospark"] .inno-sidebar-scope button:hover:not(:disabled):not(.inno-channel-filter-chip) {
+	background: rgba(255, 255, 255, 0.86);
+	box-shadow: 0 1px 2px rgba(85, 90, 255, 0.05);
+}
+
+:root[data-theme="innospark"] .inno-sidebar-scope [role="button"]:active,
+:root[data-theme="innospark"] .inno-sidebar-scope button:active:not(:disabled) {
+	transform: translateY(1px);
+}
+
+:root[data-theme="innospark"] .inno-panel-title,
+:root[data-theme="innospark"] .inno-sidebar-title,
+:root[data-theme="innospark"] .inno-workspace-tab,
+:root[data-theme="innospark"] h1,
+:root[data-theme="innospark"] h2 {
+	color: var(--inno-text);
+}
+
+:root[data-theme="innospark"] inno-chat-center h1,
+:root[data-theme="innospark"] inno-chat-center h2,
+:root[data-theme="innospark"] .inno-chat-grid h1,
+:root[data-theme="innospark"] .inno-chat-grid h2 {
+	color: var(--inno-accent);
+	text-shadow: 0 8px 22px rgba(85, 90, 255, 0.12);
+}
+
+:root[data-theme="innospark"] .inno-composer {
+	border: 2px solid rgba(85, 90, 255, 0.25);
+	border-radius: 22px;
+	background: #ffffff;
+	box-shadow: 0 2px 4px rgba(85, 90, 255, 0.08), 0 10px 28px rgba(85, 90, 255, 0.1);
+	transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+}
+
+:root[data-theme="innospark"] .inno-composer:focus-within {
+	border-color: rgba(85, 90, 255, 0.36);
+	box-shadow: 0 3px 8px rgba(85, 90, 255, 0.1), 0 14px 34px rgba(85, 90, 255, 0.14);
+}
+
+:root[data-theme="innospark"] .inno-composer textarea {
+	color: var(--inno-text);
+}
+
+:root[data-theme="innospark"] .inno-icon-button,
+:root[data-theme="innospark"] .inno-composer button {
+	border-radius: 999px;
+}
+
+:root[data-theme="innospark"] .inno-icon-button {
+	border-color: rgba(85, 90, 255, 0.14);
+	background: #ffffff;
+	color: var(--inno-text-muted);
+	box-shadow: 0 1px 2px rgba(85, 90, 255, 0.06);
+}
+
+:root[data-theme="innospark"] .inno-icon-button:hover:not(:disabled) {
+	border-color: rgba(85, 90, 255, 0.28);
+	color: var(--inno-text);
+	box-shadow: 0 2px 8px rgba(85, 90, 255, 0.1);
+}
+
+:root[data-theme="innospark"] .inno-composer button[title="Send"],
+:root[data-theme="innospark"] .inno-composer button[title="Stop generation"] {
+	background: var(--inno-accent);
+	color: #ffffff;
+	box-shadow: 0 6px 18px rgba(85, 90, 255, 0.22);
+}
+
+:root[data-theme="innospark"] .inno-composer button[title="Send"]:hover:not(:disabled),
+:root[data-theme="innospark"] .inno-composer button[title="Stop generation"]:hover:not(:disabled) {
+	background: #474cf2;
+}
+
+:root[data-theme="innospark"] .inno-message {
+	border-radius: 22px;
+	box-shadow: none;
+}
+
+:root[data-theme="innospark"] .justify-end > .inno-message {
+	border-color: transparent;
+	background: var(--inno-accent-soft);
+}
+
+:root[data-theme="innospark"] .justify-start > .inno-message:has(markdown-artifact) {
+	border-color: transparent;
+	background: transparent;
+	box-shadow: none;
+}
+
+:root[data-theme="innospark"] .justify-start > details.inno-message {
+	border-color: rgba(85, 90, 255, 0.16);
+	background: rgba(255, 255, 255, 0.7);
+}
+
+:root[data-theme="innospark"] .workspace-panel,
+:root[data-theme="innospark"] inno-workspace-panel {
+	border-color: rgba(85, 90, 255, 0.12);
+	background: var(--inno-workspace-bg);
+}
+
+:root[data-theme="innospark"] .inno-workspace-card,
+:root[data-theme="innospark"] .inno-workspace-scope .rounded-lg,
+:root[data-theme="innospark"] .inno-workspace-scope .rounded {
+	border-color: rgba(85, 90, 255, 0.12);
+	background-color: rgba(255, 255, 255, 0.86);
+}
+
+:root[data-theme="innospark"] .workspace-resize-handle:hover::after,
+:root[data-theme="innospark"].workspace-resizing .workspace-resize-handle::after,
+:root[data-theme="innospark"] .workspace-resizing .workspace-resize-handle::after {
+	background: rgba(85, 90, 255, 0.5);
+	box-shadow: 0 0 0 2px rgba(85, 90, 255, 0.1);
 }
 
 @media (max-width: 960px) {

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -1,5 +1,6 @@
 @import "@earendil-works/pi-web-ui/app.css";
 @import "tailwindcss";
+@import "./themes.css";
 
 :root {
 	--inno-background: #f7f8fa;

--- a/apps/inno-agent/web/src/components/chat/chat-center.ts
+++ b/apps/inno-agent/web/src/components/chat/chat-center.ts
@@ -104,7 +104,7 @@ export class ChatCenter extends LitElement {
 			return html`
 				<div class="flex justify-end">
 					<div
-						class="w-fit rounded-lg border border-slate-200 bg-slate-100/80 px-3 py-2 text-[13px] leading-normal text-slate-950 whitespace-pre-wrap break-words"
+						class="w-fit rounded-lg border border-[var(--inno-border)] bg-slate-100/80 px-3 py-2 text-[13px] leading-normal text-[var(--inno-text)] whitespace-pre-wrap break-words"
 						style="max-width: min(68%, 36rem);"
 					>${msg.content.trim()}</div>
 				</div>
@@ -112,7 +112,7 @@ export class ChatCenter extends LitElement {
 		}
 		return html`
 			<div class="flex justify-start">
-				<div class="max-w-[76%] rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-950">
+				<div class="max-w-[76%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] leading-relaxed text-[var(--inno-text)]">
 					<markdown-artifact .content=${msg.content}></markdown-artifact>
 				</div>
 			</div>
@@ -145,7 +145,7 @@ export class ChatCenter extends LitElement {
 			${this._streamingThinking
 				? html`
 						<div class="flex justify-start">
-							<details class="max-w-[76%] rounded-lg border border-slate-200 bg-white/90 px-3 py-2 text-xs text-slate-500">
+							<details class="max-w-[76%] rounded-lg border border-[var(--inno-border)] bg-white/90 px-3 py-2 text-xs text-[var(--inno-text-muted)]">
 								<summary class="cursor-pointer">Thinking...</summary>
 								<pre class="whitespace-pre-wrap mt-1 font-mono">${this._streamingThinking}</pre>
 							</details>
@@ -157,7 +157,7 @@ export class ChatCenter extends LitElement {
 			${this._streamingText
 				? html`
 						<div class="flex justify-start">
-							<div class="max-w-[76%] rounded-lg border border-slate-200 bg-white px-3 py-2 text-[13px] leading-relaxed text-slate-950">
+							<div class="max-w-[76%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] leading-relaxed text-[var(--inno-text)]">
 								<markdown-artifact .content=${this._streamingText}></markdown-artifact>
 							</div>
 						</div>
@@ -168,7 +168,7 @@ export class ChatCenter extends LitElement {
 			${!this._streamingText && this._activeTools.length === 0
 				? html`
 						<div class="flex justify-start">
-							<div class="max-w-[76%] rounded-lg bg-slate-100 px-3 py-2 text-sm text-slate-500">
+							<div class="max-w-[76%] rounded-lg bg-[var(--inno-surface-muted)] px-3 py-2 text-sm text-[var(--inno-text-muted)]">
 								<span class="inline-flex gap-1">
 									<span class="animate-bounce" style="animation-delay: 0ms">\u00B7</span>
 									<span class="animate-bounce" style="animation-delay: 150ms">\u00B7</span>
@@ -196,9 +196,9 @@ export class ChatCenter extends LitElement {
 				<div class="max-w-3xl mx-auto flex flex-col gap-2.5">
 					${this._messages.length === 0 && !this._isSending
 						? html`
-								<div class="flex flex-col items-center justify-center h-full text-slate-500 pt-20">
-									<div class="mb-4 flex h-11 w-11 items-center justify-center rounded-xl border border-slate-200 bg-white text-sm font-semibold text-blue-600 shadow-sm">IA</div>
-									<h2 class="text-lg font-medium mb-1 text-slate-950">Inno Agent</h2>
+								<div class="flex flex-col items-center justify-center h-full text-[var(--inno-text-muted)] pt-20">
+									<div class="mb-4 flex h-11 w-11 items-center justify-center rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] text-sm font-semibold text-[var(--inno-accent)] shadow-sm">IA</div>
+									<h2 class="text-lg font-medium mb-1 text-[var(--inno-text)]">Inno Agent</h2>
 									<p class="text-sm">Ask me anything to get started</p>
 								</div>
 							`
@@ -209,13 +209,13 @@ export class ChatCenter extends LitElement {
 			</div>
 
 			<!-- Input -->
-			<div class="shrink-0 border-t border-slate-200 bg-white/95 p-3">
+			<div class="shrink-0 border-t border-[var(--inno-border)] bg-white/95 p-3">
 				<div class="max-w-3xl mx-auto">
 					${this._uploads.length > 0
 						? html`
 								<div class="mb-2 flex flex-wrap gap-1.5">
 									${this._uploads.map((file, index) => html`
-										<span class="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs">
+										<span class="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1 text-xs">
 											<span class="max-w-[220px] truncate">${file.fileName}</span>
 											<span class="text-muted-foreground">${file.rawPath}</span>
 											<button
@@ -239,7 +239,7 @@ export class ChatCenter extends LitElement {
 						@change=${this._handleFiles}
 					/>
 					<button
-						class="h-10 w-10 shrink-0 rounded-lg border border-slate-200 bg-white text-sm text-slate-500 hover:bg-slate-100 hover:text-slate-950 disabled:opacity-50"
+						class="h-10 w-10 shrink-0 rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-50"
 						title="Upload files to L2 raw"
 						?disabled=${this._isSending || this._isUploading}
 						@click=${() => this._fileInputEl?.click()}
@@ -248,7 +248,7 @@ export class ChatCenter extends LitElement {
 					</button>
 					<textarea
 						id="chat-input"
-						class="flex-1 resize-none rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-sm shadow-sm
+						class="flex-1 resize-none rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2.5 text-sm shadow-sm
 							focus:outline-none focus:ring-2 focus:ring-blue-100 focus:border-blue-300 min-h-[40px] max-h-[140px]"
 						placeholder="Type a message..."
 						rows="1"
@@ -259,7 +259,7 @@ export class ChatCenter extends LitElement {
 					<button
 						class="h-10 rounded-lg px-3 text-sm font-medium transition-colors
 							${this._isSending || this._isUploading
-								? "bg-slate-100 text-slate-500 cursor-not-allowed"
+								? "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] cursor-not-allowed"
 								: "bg-primary text-primary-foreground hover:bg-primary/90"}"
 						?disabled=${this._isSending || this._isUploading}
 						@click=${this._handleSend}

--- a/apps/inno-agent/web/src/components/sidebar/session-sidebar.ts
+++ b/apps/inno-agent/web/src/components/sidebar/session-sidebar.ts
@@ -143,7 +143,7 @@ export class SessionSidebar extends LitElement {
 			return html`
 				<div class="flex h-full flex-col items-center border-r border-black/10 bg-[var(--inno-sidebar-bg)] py-2">
 					<button
-						class="mb-2 flex h-9 w-9 items-center justify-center rounded-md bg-slate-900 text-white text-lg hover:bg-slate-800"
+						class="mb-2 flex h-9 w-9 items-center justify-center rounded-md inno-primary-button text-white text-lg"
 						title="New chat"
 						@click=${() => this._newChat()}
 					>
@@ -192,7 +192,7 @@ export class SessionSidebar extends LitElement {
 					<h2 class="text-xs font-medium uppercase tracking-wide text-[var(--inno-text-muted)]">Chat Sessions</h2>
 					<div class="flex items-center gap-2">
 						<button
-							class="rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white hover:bg-slate-800"
+							class="rounded-md inno-primary-button px-2 py-1 text-xs font-medium text-white"
 							title="New chat"
 							@click=${() => this._newChat()}
 						>
@@ -220,7 +220,7 @@ export class SessionSidebar extends LitElement {
 			<div class="p-2 border-t border-black/10">
 				<button
 					class="flex items-center justify-center gap-2 px-3 py-2 rounded-md text-sm w-full
-						bg-slate-900 text-white hover:bg-slate-800 transition-colors"
+						inno-primary-button text-white transition-colors"
 					@click=${() => this._newChat()}
 				>
 					+ New Chat

--- a/apps/inno-agent/web/src/components/sidebar/session-sidebar.ts
+++ b/apps/inno-agent/web/src/components/sidebar/session-sidebar.ts
@@ -74,13 +74,13 @@ export class SessionSidebar extends LitElement {
 
 	private _channelClass(channel: SessionChannel): string {
 		const classes: Record<SessionChannel, string> = {
-			cli: "bg-blue-50 text-blue-700 ring-1 ring-blue-100",
-			web: "bg-white/70 text-slate-700 ring-1 ring-slate-200",
+			cli: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100",
+			web: "bg-white/70 text-[var(--inno-text)] ring-1 ring-slate-200",
 			feishu: "bg-green-50 text-green-700 ring-1 ring-green-100",
 			qq: "bg-cyan-50 text-cyan-700 ring-1 ring-cyan-100",
 			wechat: "bg-lime-50 text-lime-700 ring-1 ring-lime-100",
 			scheduler: "bg-amber-50 text-amber-700 ring-1 ring-amber-100",
-			unknown: "bg-white/60 text-slate-500 ring-1 ring-slate-200",
+			unknown: "bg-white/60 text-[var(--inno-text-muted)] ring-1 ring-slate-200",
 		};
 		return classes[channel] ?? classes.unknown;
 	}
@@ -91,8 +91,8 @@ export class SessionSidebar extends LitElement {
 			<button
 				class="w-full text-left rounded-md px-2.5 py-2.5 mb-1.5 transition-colors border
 					${active
-						? "bg-[var(--inno-sidebar-active)] text-slate-950 border-black/5"
-						: "border-transparent text-slate-700 hover:bg-black/[0.055] hover:text-slate-950"}"
+						? "bg-[var(--inno-sidebar-active)] text-[var(--inno-text)] border-black/5"
+						: "border-transparent text-[var(--inno-text)] hover:bg-black/[0.055] hover:text-[var(--inno-text)]"}"
 				@click=${() => {
 					appStore.setRightPanelTab("preview");
 					sessionsStore.openSession(session.id);
@@ -100,10 +100,10 @@ export class SessionSidebar extends LitElement {
 			>
 				<div class="flex items-start justify-between gap-2">
 					<div class="text-sm font-medium leading-snug line-clamp-2">${session.name}</div>
-					<div class="text-[10px] text-slate-500 shrink-0">${this._formatTime(session.updatedAt)}</div>
+					<div class="text-[10px] text-[var(--inno-text-muted)] shrink-0">${this._formatTime(session.updatedAt)}</div>
 				</div>
 				${session.preview && session.preview !== session.name
-					? html`<div class="mt-1 text-xs text-slate-500 line-clamp-2">${session.preview}</div>`
+					? html`<div class="mt-1 text-xs text-[var(--inno-text-muted)] line-clamp-2">${session.preview}</div>`
 					: ""}
 				<div class="flex items-center justify-between gap-2 mt-2">
 					<div class="flex items-center gap-1 flex-wrap">
@@ -113,7 +113,7 @@ export class SessionSidebar extends LitElement {
 							</span>
 						`)}
 					</div>
-					<span class="text-[11px] text-slate-500">${session.messageCount}</span>
+					<span class="text-[11px] text-[var(--inno-text-muted)]">${session.messageCount}</span>
 				</div>
 			</button>
 		`;
@@ -125,7 +125,7 @@ export class SessionSidebar extends LitElement {
 		return html`
 			<button
 				class="relative mx-auto mb-2 flex h-9 w-9 items-center justify-center rounded-md border text-[11px] font-medium transition-colors
-					${active ? "border-black/5 bg-[var(--inno-sidebar-active)] text-slate-950" : "border-black/10 bg-white/70 text-slate-600 hover:bg-black/[0.055] hover:text-slate-950"}"
+					${active ? "border-black/5 bg-[var(--inno-sidebar-active)] text-[var(--inno-text)]" : "border-black/10 bg-white/70 text-[var(--inno-text-muted)] hover:bg-black/[0.055] hover:text-[var(--inno-text)]"}"
 				title="${session.name} · ${this._channelLabel(channel)}"
 				@click=${() => {
 					appStore.setRightPanelTab("preview");
@@ -150,7 +150,7 @@ export class SessionSidebar extends LitElement {
 						+
 					</button>
 					<button
-						class="mb-2 flex h-9 w-9 items-center justify-center rounded-md border border-black/10 bg-white/70 text-sm text-slate-600 hover:bg-black/[0.055] hover:text-slate-950"
+						class="mb-2 flex h-9 w-9 items-center justify-center rounded-md border border-black/10 bg-white/70 text-sm text-[var(--inno-text-muted)] hover:bg-black/[0.055] hover:text-[var(--inno-text)]"
 						title="Expand sessions"
 						@click=${() => appStore.setSidebarCollapsed(false)}
 					>
@@ -173,11 +173,11 @@ export class SessionSidebar extends LitElement {
 							<span class="h-3 w-3 rounded-full bg-[#febc2e] ring-1 ring-black/10"></span>
 							<span class="h-3 w-3 rounded-full bg-[#28c840] ring-1 ring-black/10"></span>
 						</div>
-						<h1 class="text-base font-semibold tracking-tight text-slate-950">Inno Agent</h1>
-						<p class="text-xs text-slate-500 mt-0.5">Personal Learning Workstation</p>
+						<h1 class="text-base font-semibold tracking-tight text-[var(--inno-text)]">Inno Agent</h1>
+						<p class="text-xs text-[var(--inno-text-muted)] mt-0.5">Personal Learning Workstation</p>
 					</div>
 					<button
-						class="h-8 w-8 shrink-0 rounded-md border border-black/10 bg-white/70 text-sm text-slate-500 hover:bg-black/[0.055] hover:text-slate-950"
+						class="h-8 w-8 shrink-0 rounded-md border border-black/10 bg-white/70 text-sm text-[var(--inno-text-muted)] hover:bg-black/[0.055] hover:text-[var(--inno-text)]"
 						title="Collapse sessions"
 						@click=${() => appStore.setSidebarCollapsed(true)}
 					>
@@ -189,7 +189,7 @@ export class SessionSidebar extends LitElement {
 			<!-- Sessions -->
 			<div class="flex-1 min-h-0">
 				<div class="flex items-center justify-between px-3 py-2">
-					<h2 class="text-xs font-medium uppercase tracking-wide text-slate-500">Chat Sessions</h2>
+					<h2 class="text-xs font-medium uppercase tracking-wide text-[var(--inno-text-muted)]">Chat Sessions</h2>
 					<div class="flex items-center gap-2">
 						<button
 							class="rounded-md bg-slate-900 px-2 py-1 text-xs font-medium text-white hover:bg-slate-800"
@@ -199,7 +199,7 @@ export class SessionSidebar extends LitElement {
 							New
 						</button>
 						<button
-							class="text-xs text-slate-500 hover:text-slate-950"
+							class="text-xs text-[var(--inno-text-muted)] hover:text-[var(--inno-text)]"
 							title="Refresh sessions"
 							@click=${() => sessionsStore.load()}
 						>
@@ -209,9 +209,9 @@ export class SessionSidebar extends LitElement {
 				</div>
 				<div class="overflow-y-auto px-2 pb-2 h-[calc(100%-34px)]">
 					${this._isLoadingSessions
-						? html`<div class="px-2 py-3 text-xs text-slate-500">Loading...</div>`
+						? html`<div class="px-2 py-3 text-xs text-[var(--inno-text-muted)]">Loading...</div>`
 						: this._sessions.length === 0
-							? html`<div class="px-2 py-3 text-xs text-slate-500">No saved sessions</div>`
+							? html`<div class="px-2 py-3 text-xs text-[var(--inno-text-muted)]">No saved sessions</div>`
 							: this._sessions.map((session) => this._renderSession(session))}
 				</div>
 			</div>

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -394,7 +394,8 @@
 		"themeOptions": {
 			"light": "Light",
 			"warm": "Warm",
-			"ocean": "Ocean"
+			"ocean": "Ocean",
+			"innospark": "InnoSpark"
 		},
 		"channels": {
 			"title": "Channels",

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -213,7 +213,7 @@
 	"jobs": {
 		"title": "Scheduled Jobs",
 		"subtitle": "Recurring automations and reminders",
-		"newJob": "+ New",
+		"newJob": "New",
 		"empty": "No scheduled jobs.",
 		"lastRun": "Last run: {{time}}",
 		"nextRun": "Next: {{time}}",

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -390,6 +390,12 @@
 			"zh-CN": "中文",
 			"en": "English"
 		},
+		"theme": "Theme",
+		"themeOptions": {
+			"light": "Light",
+			"warm": "Warm",
+			"ocean": "Ocean"
+		},
 		"channels": {
 			"title": "Channels",
 			"feishu": {

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -394,7 +394,8 @@
 		"themeOptions": {
 			"light": "浅色",
 			"warm": "暖色",
-			"ocean": "海洋"
+			"ocean": "海洋",
+			"innospark": "启创"
 		},
 		"channels": {
 			"title": "消息渠道",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -390,6 +390,12 @@
 			"zh-CN": "中文",
 			"en": "English"
 		},
+		"theme": "主题",
+		"themeOptions": {
+			"light": "浅色",
+			"warm": "暖色",
+			"ocean": "海洋"
+		},
 		"channels": {
 			"title": "消息渠道",
 			"feishu": {

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -213,7 +213,7 @@
 	"jobs": {
 		"title": "定时任务",
 		"subtitle": "自动复习、推送提醒等周期任务",
-		"newJob": "+ 新建",
+		"newJob": "新建",
 		"empty": "还没有定时任务。",
 		"lastRun": "上次运行：{{time}}",
 		"nextRun": "下次运行：{{time}}",

--- a/apps/inno-agent/web/src/main.tsx
+++ b/apps/inno-agent/web/src/main.tsx
@@ -1,5 +1,6 @@
 import "./app.css";
 import "./i18n/index.js";
+import "./stores/theme-store.js";
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";

--- a/apps/inno-agent/web/src/react/App.tsx
+++ b/apps/inno-agent/web/src/react/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef } from "react";
 import { appStore, type RightPanelTab, type WorkspaceMode } from "../stores/app-store.js";
 import { settingsStore } from "../stores/settings-store.js";
+import { themeStore, type ThemeId } from "../stores/theme-store.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { ChatCenter } from "./ChatCenter.js";
 import { SessionSidebar } from "./SessionSidebar.js";
@@ -22,6 +23,16 @@ export function App() {
 	// available app-wide before the user ever opens the Settings panel.
 	useEffect(() => {
 		void settingsStore.load();
+		// After settings load, sync theme from backend if it differs from local.
+		// localStorage is the instant source (FOWT prevention); backend keeps
+		// theme consistent across devices.
+		const unsubscribe = settingsStore.on("change", () => {
+			const remote = settingsStore.settings?.ui?.theme as ThemeId | undefined;
+			if (remote && remote !== themeStore.current) {
+				themeStore.apply(remote);
+			}
+		});
+		return unsubscribe;
 	}, []);
 
 	// Track whether user manually toggled the sidebar so we don't fight them

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -135,25 +135,25 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.25, ease: "easeOut" }}
 		>
-			<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
+			<div className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
 				{showChannel && message.channel ? (
 					<div className="mb-1"><ChannelBadge channel={message.channel} /></div>
 				) : null}
 				{message.thinking || message.tools?.length ? (
-					<details className="mb-2 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1.5 text-xs text-[var(--inno-text-muted)]">
-						<summary className="cursor-pointer select-none font-medium text-[var(--inno-text-muted)]">
+					<details className="mb-2 min-w-0 max-w-full overflow-hidden rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1.5 text-xs text-[var(--inno-text-muted)]">
+						<summary className="cursor-pointer select-none break-words font-medium text-[var(--inno-text-muted)] [overflow-wrap:anywhere]">
 							Thinking & tool calls
 							{message.tools?.length ? ` · ${message.tools.length}` : ""}
 						</summary>
-						{message.thinking ? <pre className="mt-2 max-h-44 overflow-auto whitespace-pre-wrap font-mono">{message.thinking}</pre> : null}
+						{message.thinking ? <pre className="mt-2 max-h-44 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono [overflow-wrap:anywhere]">{message.thinking}</pre> : null}
 						{message.tools?.length ? (
-							<div className="mt-2 grid gap-1.5">
+							<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
 								{message.tools.map((tool) => (
-									<details key={tool.toolCallId} className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1">
-										<summary className={tool.isError ? "cursor-pointer text-red-600" : "cursor-pointer text-[var(--inno-text-muted)]"}>
+									<details key={tool.toolCallId} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1">
+										<summary className={tool.isError ? "cursor-pointer break-words text-red-600 [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>
 											{tool.toolName}
 										</summary>
-										<pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap font-mono text-[11px]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
+										<pre className="mt-1 max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] [overflow-wrap:anywhere]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
 									</details>
 								))}
 							</div>
@@ -745,7 +745,7 @@ export function ChatCenter() {
 				ref={scrollRef}
 				className="chat-scroll inno-chat-grid flex-1 min-h-0 overflow-y-auto px-4 py-4"
 			>
-				<div className="mx-auto flex max-w-3xl flex-col gap-3">
+				<div className="mx-auto flex min-w-0 max-w-3xl flex-col gap-3">
 					{chat.isLoadingHistory && chat.messages.length === 0 ? (
 						<div className="flex h-full flex-col items-center justify-center pt-20 text-[var(--inno-text-muted)]">
 							<span className="mb-3 inline-block h-5 w-5 animate-spin rounded-full border-2 border-slate-400 border-t-transparent" />
@@ -768,11 +768,11 @@ export function ChatCenter() {
 							animate={{ opacity: 1, y: 0 }}
 							transition={{ duration: 0.2, ease: "easeOut" }}
 						>
-							<div className="inno-message max-w-[78%] rounded-lg border border-blue-100 bg-[var(--inno-accent-soft)] px-3 py-2 text-[13px]">
+							<div className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-blue-100 bg-[var(--inno-accent-soft)] px-3 py-2 text-[13px]">
 								{chat.activeTools.map((tool) => (
-									<div key={tool.toolCallId} className="flex items-center gap-2 text-[var(--inno-text-muted)]">
-										<span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-										<span className="font-mono text-xs">{tool.toolName}</span>
+									<div key={tool.toolCallId} className="flex min-w-0 items-center gap-2 text-[var(--inno-text-muted)]">
+										<span className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
+										<span className="min-w-0 break-words font-mono text-xs [overflow-wrap:anywhere]">{tool.toolName}</span>
 									</div>
 								))}
 							</div>
@@ -786,9 +786,9 @@ export function ChatCenter() {
 							animate={{ opacity: 1, y: 0 }}
 							transition={{ duration: 0.2, ease: "easeOut" }}
 						>
-							<details className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
-								<summary className="cursor-pointer">Thinking...</summary>
-								<pre className="mt-1 whitespace-pre-wrap font-mono">{chat.streamingThinking}</pre>
+							<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
+								<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Thinking...</summary>
+								<pre className="mt-1 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono [overflow-wrap:anywhere]">{chat.streamingThinking}</pre>
 							</details>
 						</motion.div>
 					) : null}
@@ -800,13 +800,13 @@ export function ChatCenter() {
 							animate={{ opacity: 1 }}
 							transition={{ duration: 0.2 }}
 						>
-							<details className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
-								<summary className="cursor-pointer">Completed tool calls · {chat.completedTools.length}</summary>
-								<div className="mt-2 grid gap-1.5">
+							<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
+								<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Completed tool calls · {chat.completedTools.length}</summary>
+								<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
 									{chat.completedTools.map((tool) => (
-										<details key={tool.toolCallId} className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1">
-											<summary className={tool.isError ? "cursor-pointer text-red-600" : "cursor-pointer text-[var(--inno-text-muted)]"}>{tool.toolName}</summary>
-											<pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap font-mono text-[11px]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
+										<details key={tool.toolCallId} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1">
+											<summary className={tool.isError ? "cursor-pointer break-words text-red-600 [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>{tool.toolName}</summary>
+											<pre className="mt-1 max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] [overflow-wrap:anywhere]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
 										</details>
 									))}
 								</div>

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -19,8 +19,8 @@ import { QuestionDialog } from "./QuestionDialog.js";
 import "@earendil-works/pi-web-ui";
 
 const CHANNEL_BADGE_CLASS: Record<string, string> = {
-	cli: "bg-slate-100 text-slate-500",
-	web: "bg-blue-50 text-blue-500",
+	cli: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]",
+	web: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]",
 	feishu: "bg-emerald-50 text-emerald-500",
 	scheduler: "bg-amber-50 text-amber-500",
 	qq: "bg-cyan-50 text-cyan-500",
@@ -38,7 +38,7 @@ const CHANNEL_LABEL: Record<string, string> = {
 
 function ChannelBadge({ channel }: { channel: string }) {
 	return (
-		<span className={`inline-block rounded px-1.5 py-px text-[9px] font-medium leading-tight ring-1 ring-black/5 ${CHANNEL_BADGE_CLASS[channel] ?? "bg-slate-50 text-slate-400"}`}>
+		<span className={`inline-block rounded px-1.5 py-px text-[9px] font-medium leading-tight ring-1 ring-black/5 ${CHANNEL_BADGE_CLASS[channel] ?? "bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]"}`}>
 			{CHANNEL_LABEL[channel] ?? channel}
 		</span>
 	);
@@ -104,7 +104,7 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 				animate={{ opacity: 1, y: 0 }}
 				transition={{ duration: 0.25, ease: "easeOut" }}
 			>
-				<div className="inno-message w-fit whitespace-pre-wrap break-words rounded-lg border border-slate-200 bg-slate-100 px-3.5 py-2.5 text-[13px] leading-relaxed text-slate-950" style={{ maxWidth: "min(70%, 38rem)" }}>
+				<div className="inno-message w-fit whitespace-pre-wrap break-words rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]" style={{ maxWidth: "min(70%, 38rem)" }}>
 					{showChannel && message.channel ? (
 						<div className="mb-1 flex justify-end"><ChannelBadge channel={message.channel} /></div>
 					) : null}
@@ -135,13 +135,13 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.25, ease: "easeOut" }}
 		>
-			<div className="inno-message max-w-[78%] rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-[13px] leading-relaxed text-slate-950">
+			<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
 				{showChannel && message.channel ? (
 					<div className="mb-1"><ChannelBadge channel={message.channel} /></div>
 				) : null}
 				{message.thinking || message.tools?.length ? (
-					<details className="mb-2 rounded-md border border-slate-200 bg-slate-50 px-2 py-1.5 text-xs text-slate-500">
-						<summary className="cursor-pointer select-none font-medium text-slate-600">
+					<details className="mb-2 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1.5 text-xs text-[var(--inno-text-muted)]">
+						<summary className="cursor-pointer select-none font-medium text-[var(--inno-text-muted)]">
 							Thinking & tool calls
 							{message.tools?.length ? ` · ${message.tools.length}` : ""}
 						</summary>
@@ -149,8 +149,8 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 						{message.tools?.length ? (
 							<div className="mt-2 grid gap-1.5">
 								{message.tools.map((tool) => (
-									<details key={tool.toolCallId} className="rounded border border-slate-200 bg-white px-2 py-1">
-										<summary className={tool.isError ? "cursor-pointer text-red-600" : "cursor-pointer text-slate-600"}>
+									<details key={tool.toolCallId} className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1">
+										<summary className={tool.isError ? "cursor-pointer text-red-600" : "cursor-pointer text-[var(--inno-text-muted)]"}>
 											{tool.toolName}
 										</summary>
 										<pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap font-mono text-[11px]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
@@ -207,8 +207,8 @@ function ModeChip({ selected, onClick, disabled, children }: { selected: boolean
 			disabled={disabled}
 			className={`rounded-full border px-1.5 py-px text-[10px] leading-tight transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
 				selected
-					? "border-blue-300 bg-blue-50 text-blue-700"
-					: "border-slate-200 bg-white text-slate-600 hover:bg-slate-50"
+					? "border-blue-300 bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
+					: "border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
 			}`}
 		>
 			{children}
@@ -519,10 +519,10 @@ export function ChatCenter() {
 		uploads.length > 0 ? (
 			<div className="mb-2 flex flex-wrap gap-1.5">
 				{uploads.map((file: RawUploadResult, index: number) => (
-					<span key={`${file.rawPath}-${index}`} className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-slate-50 px-2 py-1 text-xs shadow-sm">
+					<span key={`${file.rawPath}-${index}`} className="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1 text-xs shadow-sm">
 						<span className="max-w-[220px] truncate">{file.fileName}</span>
-						<span className="text-slate-500">{file.rawPath}</span>
-						<button className="text-slate-500 hover:text-slate-950" title="Remove upload" onClick={() => removeUpload(index)}>
+						<span className="text-[var(--inno-text-muted)]">{file.rawPath}</span>
+						<button className="text-[var(--inno-text-muted)] hover:text-[var(--inno-text)]" title="Remove upload" onClick={() => removeUpload(index)}>
 							<X size={14} />
 						</button>
 					</span>
@@ -535,7 +535,7 @@ export function ChatCenter() {
 		inlineImages.length > 0 ? (
 			<div className="mb-2 flex flex-wrap gap-1.5">
 				{inlineImages.map((img, index) => (
-					<span key={`${img.name}-${index}`} className="relative inline-flex items-center gap-1 rounded-md border border-slate-200 bg-slate-50 p-1 shadow-sm">
+					<span key={`${img.name}-${index}`} className="relative inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-1 shadow-sm">
 						<img src={img.previewUrl} alt={img.name} className="h-12 w-12 rounded object-cover" />
 						<button
 							className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-slate-600 text-white hover:bg-slate-800"
@@ -563,7 +563,7 @@ export function ChatCenter() {
 			<textarea
 				ref={inputRef}
 				id="chat-input"
-				className="min-h-[36px] max-h-[140px] flex-1 resize-none overflow-hidden rounded-md border-0 bg-transparent px-2 py-2 text-sm leading-5 text-slate-950 outline-none placeholder:text-slate-400 disabled:opacity-60"
+				className="min-h-[36px] max-h-[140px] flex-1 resize-none overflow-hidden rounded-md border-0 bg-transparent px-2 py-2 text-sm leading-5 text-[var(--inno-text)] outline-none placeholder:text-[var(--inno-text-subtle)] disabled:opacity-60"
 				placeholder={placeholder}
 				rows={1}
 				onKeyDown={handleKeyDown}
@@ -592,7 +592,7 @@ export function ChatCenter() {
 						</button>
 					) : null}
 					<button
-						className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-md transition-colors ${isUploading ? "cursor-not-allowed bg-slate-100 text-slate-500" : "bg-slate-900 text-white hover:bg-slate-800"}`}
+						className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-md transition-colors ${isUploading ? "cursor-not-allowed bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]" : "bg-slate-900 text-white hover:bg-slate-800"}`}
 						title="Send"
 						disabled={isUploading}
 						onClick={handleSend}
@@ -628,21 +628,21 @@ export function ChatCenter() {
 								>
 									{/* Front — Normal mode */}
 									<span
-										className="absolute inset-0 flex items-center justify-center rounded-xl border border-slate-200 bg-white text-base font-semibold text-blue-600 shadow-sm transition-colors hover:border-blue-300"
+										className="absolute inset-0 flex items-center justify-center rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] text-base font-semibold text-[var(--inno-accent)] shadow-sm transition-colors hover:border-blue-300"
 										style={{ backfaceVisibility: "hidden" }}
 									>
 										IA
 									</span>
 									{/* Back — Simple mode */}
 									<span
-										className="absolute inset-0 flex items-center justify-center rounded-xl border border-blue-400 bg-blue-600 text-base font-semibold text-white shadow-sm"
+										className="absolute inset-0 flex items-center justify-center rounded-xl border border-blue-400 bg-[var(--inno-accent)] text-base font-semibold text-white shadow-sm"
 										style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
 									>
 										IA
 									</span>
 								</motion.div>
 							</button>
-							<h2 className="text-lg font-medium text-slate-950">Inno Agent</h2>
+							<h2 className="text-lg font-medium text-[var(--inno-text)]">Inno Agent</h2>
 							{/* Explicit, labeled mode switch (P4): the flip logo above is a nice
 							    secondary affordance, but a worded pill makes the toggle
 							    discoverable instead of hidden behind an icon click. */}
@@ -650,7 +650,7 @@ export function ChatCenter() {
 								type="button"
 								onClick={toggleMode}
 								disabled={togglingMode}
-								className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-slate-200 bg-white px-2.5 py-1 text-[11px] text-slate-500 transition-colors hover:border-blue-300 hover:text-blue-700 disabled:cursor-wait disabled:opacity-60"
+								className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1 text-[11px] text-[var(--inno-text-muted)] transition-colors hover:border-blue-300 hover:text-[var(--inno-accent)] disabled:cursor-wait disabled:opacity-60"
 							>
 								<span className={`h-1.5 w-1.5 rounded-full ${simpleMode ? "bg-blue-500" : "bg-slate-300"}`} />
 								{simpleMode ? "简单模式 · 切换到普通模式" : "普通模式 · 切换到简单模式"}
@@ -663,7 +663,7 @@ export function ChatCenter() {
 
 						{simpleMode && presets.length > 0 ? (
 							<div className="mt-5">
-								<div className="mb-2 text-xs font-medium text-slate-500">开箱即用 · 选一个开始</div>
+								<div className="mb-2 text-xs font-medium text-[var(--inno-text-muted)]">开箱即用 · 选一个开始</div>
 								<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
 									{presets.map((preset) => (
 										<button
@@ -672,18 +672,18 @@ export function ChatCenter() {
 											disabled={openingPresetId !== null}
 											onClick={() => openPreset(preset.id)}
 											title={preset.description}
-											className="group flex flex-col items-start rounded-lg border border-slate-200 bg-white px-3 py-2.5 text-left transition-colors hover:border-blue-300 hover:bg-blue-50/40 disabled:opacity-50"
+											className="group flex flex-col items-start rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2.5 text-left transition-colors hover:border-blue-300 hover:bg-blue-50/40 disabled:opacity-50"
 										>
-											<span className="text-sm font-medium text-slate-900 group-hover:text-blue-700">
+											<span className="text-sm font-medium text-[var(--inno-text)] group-hover:text-[var(--inno-accent)]">
 												{preset.name}
 											</span>
 											{preset.description ? (
-												<span className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-slate-500">
+												<span className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-[var(--inno-text-muted)]">
 													{preset.description}
 												</span>
 											) : null}
 											{openingPresetId === preset.id ? (
-												<span className="mt-1 text-[10px] text-blue-600">正在打开…</span>
+												<span className="mt-1 text-[10px] text-[var(--inno-accent)]">正在打开…</span>
 											) : null}
 										</button>
 									))}
@@ -693,15 +693,15 @@ export function ChatCenter() {
 
 						{simpleMode ? null : preselectedWs ? (
 							<div className="mt-3 flex flex-wrap items-center gap-2">
-								<span className="text-xs text-slate-400">工作区</span>
-								<span className="rounded-full bg-blue-50 px-2.5 py-0.5 text-[11px] font-medium text-blue-700 ring-1 ring-blue-100">
+								<span className="text-xs text-[var(--inno-text-subtle)]">工作区</span>
+								<span className="rounded-full bg-[var(--inno-accent-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--inno-accent)] ring-1 ring-blue-100">
 									{preselectedWs.name}
 								</span>
-								<span className="text-[10px] text-slate-400">新对话将创建于此工作区</span>
+								<span className="text-[10px] text-[var(--inno-text-subtle)]">新对话将创建于此工作区</span>
 							</div>
 						) : (
 							<div className="mt-3 flex flex-wrap items-center gap-2">
-								<span className="text-xs text-slate-400">工作区</span>
+								<span className="text-xs text-[var(--inno-text-subtle)]">工作区</span>
 								<ModeChip selected={wsMode === "temp"} onClick={() => setWsMode("temp")}>临时·用完即弃</ModeChip>
 								<ModeChip selected={wsMode === "new"} onClick={() => setWsMode("new")}>新建工作区</ModeChip>
 								{selectableWorkspaces.length > 0 ? (
@@ -713,14 +713,14 @@ export function ChatCenter() {
 										placeholder="工作区名称,例如:pandas demo"
 										value={wsName}
 										onChange={(e) => setWsName(e.target.value)}
-										className="ml-1 w-[200px] rounded-full border border-slate-200 bg-white px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
+										className="ml-1 w-[200px] rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
 									/>
 								) : null}
 								{wsMode === "existing" ? (
 									<select
 										value={wsExistingId}
 										onChange={(e) => setWsExistingId(e.target.value)}
-										className="ml-1 max-w-[220px] rounded-full border border-slate-200 bg-white px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
+										className="ml-1 max-w-[220px] rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
 									>
 										<option value="">选择一个工作区…</option>
 										{selectableWorkspaces.map((w) => (
@@ -747,7 +747,7 @@ export function ChatCenter() {
 			>
 				<div className="mx-auto flex max-w-3xl flex-col gap-3">
 					{chat.isLoadingHistory && chat.messages.length === 0 ? (
-						<div className="flex h-full flex-col items-center justify-center pt-20 text-slate-500">
+						<div className="flex h-full flex-col items-center justify-center pt-20 text-[var(--inno-text-muted)]">
 							<span className="mb-3 inline-block h-5 w-5 animate-spin rounded-full border-2 border-slate-400 border-t-transparent" />
 							<p className="text-sm">Loading session…</p>
 						</div>
@@ -768,9 +768,9 @@ export function ChatCenter() {
 							animate={{ opacity: 1, y: 0 }}
 							transition={{ duration: 0.2, ease: "easeOut" }}
 						>
-							<div className="inno-message max-w-[78%] rounded-lg border border-blue-100 bg-blue-50 px-3 py-2 text-[13px]">
+							<div className="inno-message max-w-[78%] rounded-lg border border-blue-100 bg-[var(--inno-accent-soft)] px-3 py-2 text-[13px]">
 								{chat.activeTools.map((tool) => (
-									<div key={tool.toolCallId} className="flex items-center gap-2 text-slate-500">
+									<div key={tool.toolCallId} className="flex items-center gap-2 text-[var(--inno-text-muted)]">
 										<span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
 										<span className="font-mono text-xs">{tool.toolName}</span>
 									</div>
@@ -786,7 +786,7 @@ export function ChatCenter() {
 							animate={{ opacity: 1, y: 0 }}
 							transition={{ duration: 0.2, ease: "easeOut" }}
 						>
-							<details className="inno-message max-w-[78%] rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-500">
+							<details className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
 								<summary className="cursor-pointer">Thinking...</summary>
 								<pre className="mt-1 whitespace-pre-wrap font-mono">{chat.streamingThinking}</pre>
 							</details>
@@ -800,12 +800,12 @@ export function ChatCenter() {
 							animate={{ opacity: 1 }}
 							transition={{ duration: 0.2 }}
 						>
-							<details className="inno-message max-w-[78%] rounded-lg border border-slate-200 bg-white px-3 py-2 text-xs text-slate-500">
+							<details className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
 								<summary className="cursor-pointer">Completed tool calls · {chat.completedTools.length}</summary>
 								<div className="mt-2 grid gap-1.5">
 									{chat.completedTools.map((tool) => (
-										<details key={tool.toolCallId} className="rounded border border-slate-200 bg-slate-50 px-2 py-1">
-											<summary className={tool.isError ? "cursor-pointer text-red-600" : "cursor-pointer text-slate-600"}>{tool.toolName}</summary>
+										<details key={tool.toolCallId} className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1">
+											<summary className={tool.isError ? "cursor-pointer text-red-600" : "cursor-pointer text-[var(--inno-text-muted)]"}>{tool.toolName}</summary>
 											<pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap font-mono text-[11px]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
 										</details>
 									))}
@@ -825,7 +825,7 @@ export function ChatCenter() {
 							animate={{ opacity: 1, y: 0 }}
 							transition={{ duration: 0.2, ease: "easeOut" }}
 						>
-							<div className="inno-message max-w-[78%] rounded-lg border border-slate-200 bg-white px-3.5 py-2.5 text-[13px] leading-relaxed text-slate-950">
+							<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
 								<markdown-artifact content={chat.streamingText} />
 							</div>
 						</motion.div>
@@ -851,7 +851,7 @@ export function ChatCenter() {
 							animate={{ opacity: 1 }}
 							transition={{ duration: 0.15 }}
 						>
-							<div className="inno-message max-w-[78%] rounded-lg border border-slate-200 bg-slate-100 px-3 py-2 text-sm text-slate-500">
+							<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3 py-2 text-sm text-[var(--inno-text-muted)]">
 								<span className="inline-flex gap-1">
 									<span className="animate-bounce">·</span>
 									<span className="animate-bounce" style={{ animationDelay: "150ms" }}>·</span>
@@ -863,7 +863,7 @@ export function ChatCenter() {
 				</div>
 			</div>
 
-			<div className="shrink-0 border-t border-slate-200 bg-white p-3">
+			<div className="shrink-0 border-t border-[var(--inno-border)] bg-[var(--inno-surface)] p-3">
 				<div className="mx-auto max-w-3xl">
 					{renderUploadChips()}
 					{renderInlineImagePreviews()}

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -538,7 +538,7 @@ export function ChatCenter() {
 					<span key={`${img.name}-${index}`} className="relative inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-1 shadow-sm">
 						<img src={img.previewUrl} alt={img.name} className="h-12 w-12 rounded object-cover" />
 						<button
-							className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full bg-slate-600 text-white hover:bg-slate-800"
+							className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text-muted)] shadow-sm hover:bg-[var(--inno-accent-soft)] hover:text-[var(--inno-accent)]"
 							title="Remove image"
 							onClick={() => removeInlineImage(index)}
 						>
@@ -592,7 +592,7 @@ export function ChatCenter() {
 						</button>
 					) : null}
 					<button
-						className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-md transition-colors ${isUploading ? "cursor-not-allowed bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]" : "bg-slate-900 text-white hover:bg-slate-800"}`}
+						className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-md transition-colors ${isUploading ? "cursor-not-allowed bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]" : "inno-primary-button"}`}
 						title="Send"
 						disabled={isUploading}
 						onClick={handleSend}

--- a/apps/inno-agent/web/src/react/JobsPanel.tsx
+++ b/apps/inno-agent/web/src/react/JobsPanel.tsx
@@ -165,11 +165,11 @@ export function JobsPanel() {
 
 	return (
 		<div className="flex h-full flex-col p-3">
-			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white">
-				<div className="flex items-center justify-between border-b border-slate-200 px-3 py-3">
+			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
+				<div className="flex items-center justify-between border-b border-[var(--inno-border)] px-3 py-3">
 					<div>
-						<h3 className="text-sm font-medium text-slate-950">{t("jobs.title")}</h3>
-						<p className="text-xs text-slate-500">{t("jobs.subtitle")}</p>
+						<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("jobs.title")}</h3>
+						<p className="text-xs text-[var(--inno-text-muted)]">{t("jobs.subtitle")}</p>
 					</div>
 					<button className="flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800" onClick={openNewForm}>
 						<Plus size={14} />
@@ -179,33 +179,33 @@ export function JobsPanel() {
 
 				<div className="min-h-0 flex-1 overflow-y-auto p-3">
 					{state.isLoading ? (
-						<div className="flex items-center justify-center py-8 text-slate-500">
+						<div className="flex items-center justify-center py-8 text-[var(--inno-text-muted)]">
 							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
 							{t("common.loading")}
 						</div>
 					) : null}
 					{!state.isLoading && state.jobs.length === 0 ? (
-						<p className="py-8 text-center text-sm text-slate-500">{t("jobs.empty")}</p>
+						<p className="py-8 text-center text-sm text-[var(--inno-text-muted)]">{t("jobs.empty")}</p>
 					) : null}
 					<div className="flex flex-col gap-2">
 						{state.jobs.map((job) => {
 							const isRunning = state.runningJobId === job.id;
 							const human = humanizeCron(job.cron, humanI18n);
 							return (
-								<div key={job.id} className={`rounded-lg border border-slate-200 bg-white p-3 ${job.enabled ? "" : "opacity-60"}`}>
+								<div key={job.id} className={`rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-3 ${job.enabled ? "" : "opacity-60"}`}>
 									<div className="flex items-start justify-between gap-2">
 										<div className="min-w-0 flex-1">
-											<div className="truncate text-sm font-medium text-slate-950">{job.name}</div>
-											<div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
-												<span className="rounded bg-slate-100 px-1.5 py-0.5 text-slate-700">{human}</span>
-												<span className="rounded bg-slate-100 px-1.5 py-0.5 text-slate-600">
+											<div className="truncate text-sm font-medium text-[var(--inno-text)]">{job.name}</div>
+											<div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[var(--inno-text-muted)]">
+												<span className="rounded bg-[var(--inno-surface-muted)] px-1.5 py-0.5 text-[var(--inno-text)]">{human}</span>
+												<span className="rounded bg-[var(--inno-surface-muted)] px-1.5 py-0.5 text-[var(--inno-text-muted)]">
 													{t(`jobs.taskTypes.${job.taskType}`)}
 												</span>
 												<span className={job.enabled ? "text-green-600" : "text-red-500"}>
 													{job.enabled ? t("common.enabled") : t("common.disabled")}
 												</span>
 											</div>
-											<div className="mt-1 text-xs text-slate-500">
+											<div className="mt-1 text-xs text-[var(--inno-text-muted)]">
 												{t("jobs.lastRun", { time: job.lastRunAt ? formatDate(job.lastRunAt) : t("jobs.never") })}
 												{job.nextRunAt ? ` · ${t("jobs.nextRun", { time: formatDate(job.nextRunAt) })}` : ""}
 											</div>
@@ -223,7 +223,7 @@ export function JobsPanel() {
 											{isRunning ? t("jobs.actions.running") : t("jobs.actions.run")}
 										</button>
 										<button
-											className="flex items-center gap-1 rounded bg-slate-100 px-2 py-1 text-xs text-slate-500 hover:bg-slate-200 hover:text-slate-950"
+											className="flex items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]"
 											title={t("jobs.actions.edit")}
 											onClick={() => openEditForm(job)}
 										>
@@ -231,7 +231,7 @@ export function JobsPanel() {
 											{t("jobs.actions.edit")}
 										</button>
 										<button
-											className="flex items-center gap-1 rounded bg-slate-100 px-2 py-1 text-xs text-slate-500 hover:bg-slate-200 hover:text-slate-950"
+											className="flex items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]"
 											title={job.enabled ? t("jobs.actions.disable") : t("jobs.actions.enable")}
 											onClick={() => void jobsStore.update(job.id, { enabled: !job.enabled })}
 										>
@@ -254,9 +254,9 @@ export function JobsPanel() {
 				</div>
 
 				{state.lastRunResult ? (
-					<div className="border-t border-slate-200 p-3">
-						<div className="mb-1 text-xs font-medium text-slate-950">{t("jobs.lastResult")}</div>
-						<pre className="max-h-32 overflow-y-auto whitespace-pre-wrap rounded bg-slate-50 p-2 text-xs text-slate-700">{state.lastRunResult}</pre>
+					<div className="border-t border-[var(--inno-border)] p-3">
+						<div className="mb-1 text-xs font-medium text-[var(--inno-text)]">{t("jobs.lastResult")}</div>
+						<pre className="max-h-32 overflow-y-auto whitespace-pre-wrap rounded bg-[var(--inno-surface-muted)] p-2 text-xs text-[var(--inno-text)]">{state.lastRunResult}</pre>
 					</div>
 				) : null}
 			</div>
@@ -270,20 +270,20 @@ export function JobsPanel() {
 					onClick={() => setShowForm(false)}
 				>
 					<motion.div
-						className="max-h-[85vh] w-[460px] overflow-y-auto rounded-xl bg-white p-5 shadow-xl"
+						className="max-h-[85vh] w-[460px] overflow-y-auto rounded-xl bg-[var(--inno-surface)] p-5 shadow-xl"
 						initial={{ opacity: 0, scale: 0.95 }}
 						animate={{ opacity: 1, scale: 1 }}
 						transition={{ duration: 0.2, ease: "easeOut" }}
 						onClick={(event) => event.stopPropagation()}
 					>
-						<h3 className="mb-4 text-base font-medium text-slate-950">
+						<h3 className="mb-4 text-base font-medium text-[var(--inno-text)]">
 							{editingJob ? t("jobs.form.editTitle") : t("jobs.form.newTitle")}
 						</h3>
 						<div className="flex flex-col gap-3">
 							<label className="block text-sm">
-								<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.name")}</span>
+								<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.name")}</span>
 								<input
-									className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+									className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 									placeholder={t("jobs.form.namePlaceholder") ?? ""}
 									value={form.name}
 									onChange={(event) => setForm({ ...form, name: event.target.value })}
@@ -291,21 +291,21 @@ export function JobsPanel() {
 							</label>
 
 							<div className="block text-sm">
-								<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.schedule")}</span>
+								<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.schedule")}</span>
 								<ScheduleEditor
 									value={form.schedule}
 									onChange={(schedule) => setForm({ ...form, schedule })}
 								/>
-								<div className="mt-1 text-xs text-slate-500">
+								<div className="mt-1 text-xs text-[var(--inno-text-muted)]">
 									<span className="font-mono">{previewCron || "-"}</span>
 									{previewLabel ? <span className="ml-2">· {previewLabel}</span> : null}
 								</div>
 							</div>
 
 							<label className="block text-sm">
-								<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.taskType")}</span>
+								<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.taskType")}</span>
 								<select
-									className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+									className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 									value={form.taskType}
 									onChange={(event) => setForm({ ...form, taskType: event.target.value as TaskType })}
 								>
@@ -318,16 +318,16 @@ export function JobsPanel() {
 							</label>
 
 							<label className="block text-sm">
-								<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.prompt")}</span>
+								<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.prompt")}</span>
 								<textarea
-									className="h-24 w-full resize-none rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+									className="h-24 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 									placeholder={t("jobs.form.promptPlaceholder") ?? ""}
 									value={form.prompt}
 									onChange={(event) => setForm({ ...form, prompt: event.target.value })}
 								/>
 							</label>
 
-							<label className="flex items-center gap-2 text-sm text-slate-700">
+							<label className="flex items-center gap-2 text-sm text-[var(--inno-text)]">
 								<input
 									type="checkbox"
 									checked={form.enabled}
@@ -339,7 +339,7 @@ export function JobsPanel() {
 						<div className="mt-4 flex justify-end gap-2">
 							{formError ? <div className="mr-auto text-xs text-red-600">{formError}</div> : null}
 							<button
-								className="rounded-md bg-slate-100 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-200 hover:text-slate-950 disabled:opacity-50"
+								className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)] disabled:opacity-50"
 								disabled={isSaving}
 								onClick={() => setShowForm(false)}
 							>

--- a/apps/inno-agent/web/src/react/JobsPanel.tsx
+++ b/apps/inno-agent/web/src/react/JobsPanel.tsx
@@ -171,7 +171,7 @@ export function JobsPanel() {
 						<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("jobs.title")}</h3>
 						<p className="text-xs text-[var(--inno-text-muted)]">{t("jobs.subtitle")}</p>
 					</div>
-					<button className="flex items-center gap-1 rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800" onClick={openNewForm}>
+					<button className="flex items-center gap-1 rounded-md inno-primary-button px-3 py-1.5 text-sm text-white" onClick={openNewForm}>
 						<Plus size={14} />
 						{t("jobs.newJob")}
 					</button>
@@ -214,7 +214,7 @@ export function JobsPanel() {
 
 									<div className="mt-2 flex flex-wrap gap-1.5">
 										<button
-											className={`flex items-center gap-1 rounded bg-slate-900 px-2 py-1 text-xs text-white hover:bg-slate-800 ${isRunning ? "cursor-wait opacity-50" : ""}`}
+											className={`flex items-center gap-1 rounded inno-primary-button px-2 py-1 text-xs text-white ${isRunning ? "cursor-wait opacity-50" : ""}`}
 											disabled={isRunning}
 											title={t("jobs.actions.run")}
 											onClick={() => void jobsStore.run(job.id)}
@@ -346,7 +346,7 @@ export function JobsPanel() {
 								{t("common.cancel")}
 							</button>
 							<button
-								className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50"
+								className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white disabled:opacity-50"
 								disabled={isSaving}
 								onClick={() => void saveForm()}
 							>

--- a/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
+++ b/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
@@ -45,7 +45,7 @@ function Section({
 }) {
 	const [collapsed, setCollapsed] = useState(defaultCollapsed);
 	return (
-		<section className="rounded-lg border border-slate-200 bg-white">
+		<section className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
 			<div className="flex items-center justify-between gap-3 px-4 py-3.5">
 				<button
 					className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
@@ -53,16 +53,16 @@ function Section({
 					aria-expanded={!collapsed}
 				>
 					<svg
-						className={`h-4 w-4 shrink-0 text-slate-400 transition-transform duration-150 ${collapsed ? "" : "rotate-90"}`}
+						className={`h-4 w-4 shrink-0 text-[var(--inno-text-subtle)] transition-transform duration-150 ${collapsed ? "" : "rotate-90"}`}
 						viewBox="0 0 16 16"
 						fill="none"
 						aria-hidden
 					>
 						<path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
 					</svg>
-					<h4 className="truncate text-base font-semibold text-slate-950">{title}</h4>
+					<h4 className="truncate text-base font-semibold text-[var(--inno-text)]">{title}</h4>
 					{typeof count === "number" ? (
-						<span className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-500">{count}</span>
+						<span className="rounded-full bg-[var(--inno-surface-muted)] px-2 py-0.5 text-xs font-medium text-[var(--inno-text-muted)]">{count}</span>
 					) : null}
 				</button>
 				{!collapsed && action ? <div className="shrink-0">{action}</div> : null}
@@ -76,7 +76,7 @@ function Section({
 						transition={{ duration: 0.2, ease: "easeOut" }}
 						style={{ overflow: "hidden" }}
 					>
-						<div className="border-t border-slate-100 px-4 py-4">{children}</div>
+						<div className="border-t border-[var(--inno-border)] px-4 py-4">{children}</div>
 					</motion.div>
 				) : null}
 			</AnimatePresence>
@@ -112,7 +112,7 @@ function SummarySection() {
 				<Stat label={t("profile.summary.openMisconceptions")} value={openMisc} />
 			</div>
 			<textarea
-				className="h-32 w-full resize-none rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+				className="h-32 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 				placeholder={t("profile.summary.placeholder") ?? ""}
 				value={buffer}
 				onChange={(e) => {
@@ -123,7 +123,7 @@ function SummarySection() {
 			{dirty ? (
 				<div className="mt-2 flex justify-end gap-2">
 					<button
-						className="rounded-md bg-slate-100 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-200 hover:text-slate-950"
+						className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]"
 						onClick={() => {
 							setBuffer(profile?.profile_summary ?? "");
 							setDirty(false);
@@ -149,9 +149,9 @@ function SummarySection() {
 
 function Stat({ label, value }: { label: string; value: number }) {
 	return (
-		<div className="rounded border border-slate-200 bg-slate-50 p-3">
-			<div className="text-xs text-slate-500">{label}</div>
-			<div className="text-lg font-medium text-slate-950">{value}</div>
+		<div className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
+			<div className="text-xs text-[var(--inno-text-muted)]">{label}</div>
+			<div className="text-lg font-medium text-[var(--inno-text)]">{value}</div>
 		</div>
 	);
 }
@@ -216,7 +216,7 @@ function GoalsSection() {
 			>
 				{error ? <div className="mb-2 rounded bg-red-50 p-2 text-xs text-red-700">{error}</div> : null}
 				{goals.length === 0 ? (
-					<p className="text-sm text-slate-500">{t("profile.goals.empty")}</p>
+					<p className="text-sm text-[var(--inno-text-muted)]">{t("profile.goals.empty")}</p>
 				) : (
 					<div className="flex flex-col gap-3">
 						{goals.map((g) => (
@@ -262,18 +262,18 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 			onClick={onClose}
 		>
 			<motion.div
-				className="max-h-[85vh] w-[460px] overflow-y-auto rounded-xl bg-white p-5 shadow-xl"
+				className="max-h-[85vh] w-[460px] overflow-y-auto rounded-xl bg-[var(--inno-surface)] p-5 shadow-xl"
 				initial={{ opacity: 0, scale: 0.95 }}
 				animate={{ opacity: 1, scale: 1 }}
 				transition={{ duration: 0.2, ease: "easeOut" }}
 				onClick={(e) => e.stopPropagation()}
 			>
-				<h3 className="mb-4 text-base font-medium text-slate-950">{t("profile.goals.newTitle")}</h3>
+				<h3 className="mb-4 text-base font-medium text-[var(--inno-text)]">{t("profile.goals.newTitle")}</h3>
 				<div className="flex flex-col gap-3">
 					<label className="block text-sm">
-						<span className="mb-1 block font-medium text-slate-700">{t("profile.goals.title")}</span>
+						<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.goals.title")}</span>
 						<input
-							className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+							className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 							placeholder={t("profile.goals.namePlaceholder") ?? ""}
 							value={draft.title}
 							autoFocus
@@ -282,9 +282,9 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 					</label>
 					<div className="grid grid-cols-2 gap-2">
 						<label className="block text-sm">
-							<span className="mb-1 block font-medium text-slate-700">{t("profile.goals.type")}</span>
+							<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.goals.type")}</span>
 							<select
-								className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
+								className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm"
 								value={draft.type}
 								onChange={(e) => setDraft({ ...draft, type: e.target.value as GoalType })}
 							>
@@ -294,9 +294,9 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 							</select>
 						</label>
 						<label className="block text-sm">
-							<span className="mb-1 block font-medium text-slate-700">{t("profile.goals.status")}</span>
+							<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.goals.status")}</span>
 							<select
-								className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
+								className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm"
 								value={draft.status}
 								onChange={(e) => setDraft({ ...draft, status: e.target.value as GoalStatus })}
 							>
@@ -307,7 +307,7 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 						</label>
 					</div>
 					<label className="block text-sm">
-						<span className="mb-1 block font-medium text-slate-700">
+						<span className="mb-1 block font-medium text-[var(--inno-text)]">
 							{t("profile.goals.priority")}: {Math.round(draft.priority * 100)}%
 						</span>
 						<input
@@ -320,9 +320,9 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 						/>
 					</label>
 					<label className="block text-sm">
-						<span className="mb-1 block font-medium text-slate-700">{t("profile.goals.successCriteria")}</span>
+						<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.goals.successCriteria")}</span>
 						<textarea
-							className="h-20 w-full resize-none rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+							className="h-20 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 							placeholder={t("profile.goals.successCriteriaPlaceholder") ?? ""}
 							value={draft.success_criteria.join("\n")}
 							onChange={(e) =>
@@ -337,7 +337,7 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 				<div className="mt-4 flex justify-end gap-2">
 					{error ? <div className="mr-auto text-xs text-red-600">{error}</div> : null}
 					<button
-						className="rounded-md bg-slate-100 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-200 hover:text-slate-950 disabled:opacity-50"
+						className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)] disabled:opacity-50"
 						disabled={saving}
 						onClick={onClose}
 					>
@@ -397,17 +397,17 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 
 	if (!editing) {
 		return (
-			<div className="rounded-lg border border-slate-200 bg-white p-3">
+			<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-3">
 				<div className="flex items-start justify-between gap-2">
 					<div className="min-w-0">
-						<div className="text-sm font-medium text-slate-950">{goal.title}</div>
-						<div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
-							<span className="rounded bg-slate-100 px-1.5 py-0.5">{t(`profile.goals.typeOptions.${goal.type}`)}</span>
+						<div className="text-sm font-medium text-[var(--inno-text)]">{goal.title}</div>
+						<div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-[var(--inno-text-muted)]">
+							<span className="rounded bg-[var(--inno-surface-muted)] px-1.5 py-0.5">{t(`profile.goals.typeOptions.${goal.type}`)}</span>
 							<span className={`rounded px-1.5 py-0.5 ${statusToneFor(goal.status)}`}>{t(`profile.goals.statusOptions.${goal.status}`)}</span>
 							<span>· {t("profile.goals.priority")} {(goal.priority * 100).toFixed(0)}%</span>
 						</div>
 						{goal.success_criteria.length > 0 ? (
-							<ul className="mt-2 list-disc pl-5 text-xs text-slate-600">
+							<ul className="mt-2 list-disc pl-5 text-xs text-[var(--inno-text-muted)]">
 								{goal.success_criteria.map((s) => (
 									<li key={s}>{s}</li>
 								))}
@@ -415,7 +415,7 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 						) : null}
 					</div>
 					<div className="flex shrink-0 gap-1.5">
-						<button className="rounded bg-slate-100 px-2 py-1 text-xs text-slate-500 hover:bg-slate-200 hover:text-slate-950" onClick={() => setEditing(true)}>
+						<button className="rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={() => setEditing(true)}>
 							{t("common.edit")}
 						</button>
 						<button className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50" onClick={() => void doDelete()}>
@@ -428,18 +428,18 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 		);
 	}
 	return (
-		<div className="rounded-lg border border-blue-200 bg-blue-50/40 p-3">
+		<div className="rounded-lg border border-[var(--inno-accent-soft)] bg-blue-50/40 p-3">
 			<div className="grid gap-2">
 				<input
-					className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm"
+					className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm"
 					value={draft.title}
 					onChange={(e) => setDraft({ ...draft, title: e.target.value })}
 				/>
 				<div className="grid grid-cols-2 gap-2">
 					<label className="block text-xs">
-						<span className="mb-0.5 block text-slate-500">{t("profile.goals.type")}</span>
+						<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.goals.type")}</span>
 						<select
-							className="w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm"
+							className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5 text-sm"
 							value={draft.type}
 							onChange={(e) => setDraft({ ...draft, type: e.target.value as GoalType })}
 						>
@@ -451,9 +451,9 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 						</select>
 					</label>
 					<label className="block text-xs">
-						<span className="mb-0.5 block text-slate-500">{t("profile.goals.status")}</span>
+						<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.goals.status")}</span>
 						<select
-							className="w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm"
+							className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5 text-sm"
 							value={draft.status}
 							onChange={(e) => setDraft({ ...draft, status: e.target.value as GoalStatus })}
 						>
@@ -466,7 +466,7 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 					</label>
 				</div>
 				<label className="block text-xs">
-					<span className="mb-0.5 block text-slate-500">{t("profile.goals.priority")}: {(draft.priority * 100).toFixed(0)}%</span>
+					<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.goals.priority")}: {(draft.priority * 100).toFixed(0)}%</span>
 					<input
 						type="range"
 						min={0}
@@ -477,16 +477,16 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 					/>
 				</label>
 				<label className="block text-xs">
-					<span className="mb-0.5 block text-slate-500">{t("profile.goals.successCriteria")}</span>
+					<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.goals.successCriteria")}</span>
 					<textarea
-						className="h-20 w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm"
+						className="h-20 w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5 text-sm"
 						placeholder={t("profile.goals.successCriteriaPlaceholder") ?? ""}
 						value={draft.success_criteria.join("\n")}
 						onChange={(e) => setDraft({ ...draft, success_criteria: e.target.value.split("\n").map((s) => s.trim()).filter(Boolean) })}
 					/>
 				</label>
 				<div className="flex justify-end gap-2 pt-1">
-					<button className="rounded-md bg-slate-100 px-3 py-1 text-xs text-slate-500" onClick={() => setEditing(false)}>
+					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1 text-xs text-[var(--inno-text-muted)]" onClick={() => setEditing(false)}>
 						{t("common.cancel")}
 					</button>
 					<button className="rounded-md bg-slate-900 px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
@@ -506,17 +506,17 @@ function statusToneFor(status: string): string {
 		case "paused":
 			return "bg-yellow-50 text-yellow-700 ring-1 ring-yellow-100";
 		case "completed":
-			return "bg-blue-50 text-blue-700 ring-1 ring-blue-100";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100";
 		case "archived":
-			return "bg-slate-100 text-slate-500";
+			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 		case "repairing":
 			return "bg-orange-50 text-orange-700 ring-1 ring-orange-100";
 		case "resolved":
 			return "bg-green-50 text-green-700 ring-1 ring-green-100";
 		case "stale":
-			return "bg-slate-100 text-slate-500";
+			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 		default:
-			return "bg-slate-100 text-slate-600";
+			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 	}
 }
 
@@ -528,7 +528,7 @@ function KnowledgeSection() {
 	if (knowledge.length === 0) {
 		return (
 			<Section title={t("profile.sections.knowledge")} count={0}>
-				<p className="text-sm text-slate-500">{t("profile.knowledge.empty")}</p>
+				<p className="text-sm text-[var(--inno-text-muted)]">{t("profile.knowledge.empty")}</p>
 			</Section>
 		);
 	}
@@ -578,29 +578,29 @@ function KnowledgeRow({ state }: { state: KnowledgeState }) {
 	}
 
 	return (
-		<div className="rounded-lg border border-slate-200 bg-white">
+		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
 			<button
-				className="grid w-full grid-cols-[1fr_120px_100px_90px] items-center gap-3 px-3 py-2 text-left text-sm hover:bg-slate-50"
+				className="grid w-full grid-cols-[1fr_120px_100px_90px] items-center gap-3 px-3 py-2 text-left text-sm hover:bg-[var(--inno-surface-muted)]"
 				onClick={() => setExpanded(!expanded)}
 			>
 				<div className="min-w-0">
-					<div className="truncate font-medium text-slate-950">{state.concept_name}</div>
-					<div className="truncate text-xs text-slate-500">{state.concept_id}</div>
+					<div className="truncate font-medium text-[var(--inno-text)]">{state.concept_name}</div>
+					<div className="truncate text-xs text-[var(--inno-text-muted)]">{state.concept_id}</div>
 				</div>
-				<div className="truncate text-xs text-slate-500">{state.domain || "-"}</div>
+				<div className="truncate text-xs text-[var(--inno-text-muted)]">{state.domain || "-"}</div>
 				<div>
 					<div className="h-1.5 w-full rounded-full bg-slate-200">
 						<div className="h-1.5 rounded-full bg-blue-500" style={{ width: `${pct}%` }} />
 					</div>
-					<div className="mt-0.5 text-[10px] text-slate-500">{pct}%</div>
+					<div className="mt-0.5 text-[10px] text-[var(--inno-text-muted)]">{pct}%</div>
 				</div>
-				<div className="text-right text-xs text-slate-500">{state.review_due_at ? formatDate(state.review_due_at) : "-"}</div>
+				<div className="text-right text-xs text-[var(--inno-text-muted)]">{state.review_due_at ? formatDate(state.review_due_at) : "-"}</div>
 			</button>
 			{expanded ? (
-				<div className="border-t border-slate-200 p-3">
+				<div className="border-t border-[var(--inno-border)] p-3">
 					<div className="grid gap-2">
 						<label className="block text-xs">
-							<span className="mb-0.5 block text-slate-500">{t("profile.knowledge.mastery")}: {Math.round(draft.mastery * 100)}%</span>
+							<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.knowledge.mastery")}: {Math.round(draft.mastery * 100)}%</span>
 							<input
 								type="range"
 								min={0}
@@ -611,25 +611,25 @@ function KnowledgeRow({ state }: { state: KnowledgeState }) {
 							/>
 						</label>
 						<label className="block text-xs">
-							<span className="mb-0.5 block text-slate-500">{t("profile.knowledge.diagnosis")}</span>
+							<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.knowledge.diagnosis")}</span>
 							<textarea
-								className="h-20 w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm"
+								className="h-20 w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5 text-sm"
 								placeholder={t("profile.knowledge.diagnosisPlaceholder") ?? ""}
 								value={draft.diagnosis}
 								onChange={(e) => setDraft({ ...draft, diagnosis: e.target.value })}
 							/>
 						</label>
 						<label className="block text-xs">
-							<span className="mb-0.5 block text-slate-500">{t("profile.knowledge.nextActions")}</span>
+							<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.knowledge.nextActions")}</span>
 							<textarea
-								className="h-20 w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm"
+								className="h-20 w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5 text-sm"
 								placeholder={t("profile.knowledge.nextActionsPlaceholder") ?? ""}
 								value={draft.nextActions.join("\n")}
 								onChange={(e) => setDraft({ ...draft, nextActions: e.target.value.split("\n").map((s) => s.trim()).filter(Boolean) })}
 							/>
 						</label>
 						<div className="flex justify-end gap-2 pt-1">
-							<button className="rounded-md bg-slate-100 px-3 py-1 text-xs text-slate-500" onClick={() => setExpanded(false)}>
+							<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1 text-xs text-[var(--inno-text-muted)]" onClick={() => setExpanded(false)}>
 								{t("common.cancel")}
 							</button>
 							<button className="rounded-md bg-slate-900 px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
@@ -651,7 +651,7 @@ function MisconceptionsSection() {
 	if (items.length === 0) {
 		return (
 			<Section title={t("profile.sections.misconceptions")} count={0}>
-				<p className="text-sm text-slate-500">{t("profile.misconceptions.empty")}</p>
+				<p className="text-sm text-[var(--inno-text-muted)]">{t("profile.misconceptions.empty")}</p>
 			</Section>
 		);
 	}
@@ -695,14 +695,14 @@ function MisconceptionRow({ item }: { item: Misconception }) {
 	}
 
 	return (
-		<div className="rounded-lg border border-slate-200 bg-white p-3">
-			<div className="mb-2 text-sm text-slate-950">{item.description}</div>
-			<div className="mb-2 text-xs text-slate-500">{item.concept_id} · {formatDate(item.last_seen_at)}</div>
+		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-3">
+			<div className="mb-2 text-sm text-[var(--inno-text)]">{item.description}</div>
+			<div className="mb-2 text-xs text-[var(--inno-text-muted)]">{item.concept_id} · {formatDate(item.last_seen_at)}</div>
 			<div className="grid grid-cols-2 gap-2">
 				<label className="block text-xs">
-					<span className="mb-0.5 block text-slate-500">{t("profile.misconceptions.status")}</span>
+					<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.misconceptions.status")}</span>
 					<select
-						className="w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5 text-sm"
 						value={draft.status}
 						onChange={(e) => {
 							setDraft({ ...draft, status: e.target.value as MisconceptionStatus });
@@ -717,7 +717,7 @@ function MisconceptionRow({ item }: { item: Misconception }) {
 					</select>
 				</label>
 				<label className="block text-xs">
-					<span className="mb-0.5 block text-slate-500">{t("profile.misconceptions.severity")}: {Math.round(draft.severity * 100)}%</span>
+					<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.misconceptions.severity")}: {Math.round(draft.severity * 100)}%</span>
 					<input
 						type="range"
 						min={0}
@@ -732,9 +732,9 @@ function MisconceptionRow({ item }: { item: Misconception }) {
 				</label>
 			</div>
 			<label className="mt-2 block text-xs">
-				<span className="mb-0.5 block text-slate-500">{t("profile.misconceptions.repair")}</span>
+				<span className="mb-0.5 block text-[var(--inno-text-muted)]">{t("profile.misconceptions.repair")}</span>
 				<textarea
-					className="h-16 w-full rounded-md border border-slate-200 bg-white px-2 py-1.5 text-sm"
+					className="h-16 w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5 text-sm"
 					value={draft.repair}
 					onChange={(e) => {
 						setDraft({ ...draft, repair: e.target.value });
@@ -744,7 +744,7 @@ function MisconceptionRow({ item }: { item: Misconception }) {
 			</label>
 			{dirty ? (
 				<div className="mt-2 flex justify-end gap-2">
-					<button className="rounded-md bg-slate-100 px-3 py-1 text-xs text-slate-500" onClick={() => setDirty(false)}>
+					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1 text-xs text-[var(--inno-text-muted)]" onClick={() => setDirty(false)}>
 						{t("common.cancel")}
 					</button>
 					<button className="rounded-md bg-slate-900 px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
@@ -793,7 +793,7 @@ function PreferencesSection() {
 			</div>
 			{dirty ? (
 				<div className="mt-3 flex justify-end gap-2">
-					<button className="rounded-md bg-slate-100 px-3 py-1.5 text-sm text-slate-500" onClick={() => setDirty(false)}>
+					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)]" onClick={() => setDirty(false)}>
 						{t("common.cancel")}
 					</button>
 					<button className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white disabled:opacity-50" disabled={state.isSaving} onClick={() => void save()}>
@@ -818,18 +818,18 @@ function ChipInput({ label, values, onChange, placeholder }: { label: string; va
 	}
 	return (
 		<div>
-			<div className="mb-1 text-xs font-medium text-slate-700">{label}</div>
+			<div className="mb-1 text-xs font-medium text-[var(--inno-text)]">{label}</div>
 			<div className="flex flex-wrap gap-1">
 				{values.map((v) => (
-					<span key={v} className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-xs text-blue-700 ring-1 ring-blue-100">
+					<span key={v} className="inline-flex items-center gap-1 rounded-full bg-[var(--inno-accent-soft)] px-2 py-0.5 text-xs text-[var(--inno-accent)] ring-1 ring-blue-100">
 						{v}
-						<button className="text-blue-500 hover:text-blue-700" onClick={() => onChange(values.filter((x) => x !== v))}>
+						<button className="text-[var(--inno-accent)] hover:text-[var(--inno-accent)]" onClick={() => onChange(values.filter((x) => x !== v))}>
 							×
 						</button>
 					</span>
 				))}
 				<input
-					className="min-w-[120px] flex-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-xs focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+					className="min-w-[120px] flex-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 text-xs focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 					placeholder={placeholder}
 					value={input}
 					onChange={(e) => setInput(e.target.value)}
@@ -861,23 +861,23 @@ export function LearnerProfilePanel() {
 	return (
 		<div className="h-full overflow-y-auto p-3">
 			<div className="flex flex-col gap-3">
-				<div className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-4 py-3">
+				<div className="flex items-center justify-between rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-4 py-3">
 					<div>
-						<h3 className="text-sm font-medium text-slate-950">{t("profile.title")}</h3>
-						<p className="text-xs text-slate-500">{t("profile.subtitle")}</p>
+						<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("profile.title")}</h3>
+						<p className="text-xs text-[var(--inno-text-muted)]">{t("profile.subtitle")}</p>
 						{state.profile ? (
-							<p className="mt-1 text-xs text-slate-500">
+							<p className="mt-1 text-xs text-[var(--inno-text-muted)]">
 								{t("profile.version", { version: state.profile.version, updated: formatDate(state.profile.updated_at) })}
 							</p>
 						) : null}
 					</div>
-					<button className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 hover:text-slate-950" onClick={() => void learnerStore.load()}>
+					<button className="rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void learnerStore.load()}>
 						{t("profile.refresh")}
 					</button>
 				</div>
 
 				{state.isLoading ? (
-					<div className="flex items-center justify-center py-8 text-slate-500">
+					<div className="flex items-center justify-center py-8 text-[var(--inno-text-muted)]">
 						<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
 						{t("common.loading")}
 					</div>

--- a/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
+++ b/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
@@ -132,7 +132,7 @@ function SummarySection() {
 						{t("common.cancel")}
 					</button>
 					<button
-						className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50"
+						className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white disabled:opacity-50"
 						disabled={state.isSaving}
 						onClick={async () => {
 							await learnerStore.patchSummary(buffer);
@@ -207,7 +207,7 @@ function GoalsSection() {
 				count={goals.length}
 				action={
 					<button
-						className="rounded-md bg-slate-900 px-3 py-1.5 text-xs text-white hover:bg-slate-800"
+						className="rounded-md inno-primary-button px-3 py-1.5 text-xs text-white"
 						onClick={openForm}
 					>
 						{t("profile.goals.addNew")}
@@ -344,7 +344,7 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 						{t("common.cancel")}
 					</button>
 					<button
-						className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50"
+						className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white disabled:opacity-50"
 						disabled={saving}
 						onClick={() => void save()}
 					>
@@ -489,7 +489,7 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1 text-xs text-[var(--inno-text-muted)]" onClick={() => setEditing(false)}>
 						{t("common.cancel")}
 					</button>
-					<button className="rounded-md bg-slate-900 px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
+					<button className="rounded-md inno-primary-button px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
 						{saving ? t("common.saving") : t("common.save")}
 					</button>
 				</div>
@@ -632,7 +632,7 @@ function KnowledgeRow({ state }: { state: KnowledgeState }) {
 							<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1 text-xs text-[var(--inno-text-muted)]" onClick={() => setExpanded(false)}>
 								{t("common.cancel")}
 							</button>
-							<button className="rounded-md bg-slate-900 px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
+							<button className="rounded-md inno-primary-button px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
 								{saving ? t("common.saving") : t("common.save")}
 							</button>
 						</div>
@@ -747,7 +747,7 @@ function MisconceptionRow({ item }: { item: Misconception }) {
 					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1 text-xs text-[var(--inno-text-muted)]" onClick={() => setDirty(false)}>
 						{t("common.cancel")}
 					</button>
-					<button className="rounded-md bg-slate-900 px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
+					<button className="rounded-md inno-primary-button px-3 py-1 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void save()}>
 						{saving ? t("common.saving") : t("common.save")}
 					</button>
 				</div>
@@ -796,7 +796,7 @@ function PreferencesSection() {
 					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)]" onClick={() => setDirty(false)}>
 						{t("common.cancel")}
 					</button>
-					<button className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white disabled:opacity-50" disabled={state.isSaving} onClick={() => void save()}>
+					<button className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white disabled:opacity-50" disabled={state.isSaving} onClick={() => void save()}>
 						{state.isSaving ? t("common.saving") : t("common.save")}
 					</button>
 				</div>

--- a/apps/inno-agent/web/src/react/Notebook.tsx
+++ b/apps/inno-agent/web/src/react/Notebook.tsx
@@ -12,7 +12,7 @@ const FILTER_TYPES: (WikiPageType | "all")[] = ["all", "source-summary", "entity
 function typeColor(type?: WikiPageType): string {
 	switch (type) {
 		case "source-summary":
-			return "bg-blue-50 text-blue-700 ring-1 ring-blue-100";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100";
 		case "entity":
 			return "bg-green-50 text-green-700 ring-1 ring-green-100";
 		case "concept":
@@ -20,7 +20,7 @@ function typeColor(type?: WikiPageType): string {
 		case "analysis":
 			return "bg-purple-50 text-purple-700 ring-1 ring-purple-100";
 		default:
-			return "bg-slate-100 text-slate-500";
+			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 	}
 }
 
@@ -43,24 +43,24 @@ export function Notebook() {
 
 	return (
 		<div className={`grid h-full min-h-0 gap-3 p-3 transition-[grid-template-columns] duration-200 ${sidebarOpen ? "grid-cols-[260px_minmax(0,1fr)]" : "grid-cols-[0px_minmax(0,1fr)]"}`}>
-			<aside className={`flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white transition-opacity duration-200 ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}>
-				<div className="border-b border-slate-100 p-2">
+			<aside className={`flex h-full min-h-0 flex-col overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] transition-opacity duration-200 ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}>
+				<div className="border-b border-[var(--inno-border)] p-2">
 					<input
 						type="text"
-						className="w-full rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 						placeholder={t("notebook.search") ?? ""}
 						value={state.searchQuery}
 						onChange={(event) => notebookStore.setSearchQuery(event.target.value)}
 					/>
 				</div>
-				<div className="flex flex-wrap gap-1 border-b border-slate-100 px-2 py-2">
+				<div className="flex flex-wrap gap-1 border-b border-[var(--inno-border)] px-2 py-2">
 					{FILTER_TYPES.map((type) => (
 						<button
 							key={type}
 							className={`rounded-full px-2 py-0.5 text-xs transition-colors ${
 								state.filterType === type
-									? "bg-blue-50 text-blue-700 ring-1 ring-blue-100"
-									: "bg-slate-100 text-slate-500 hover:bg-slate-200 hover:text-slate-950"
+									? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100"
+									: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]"
 							}`}
 							onClick={() => notebookStore.setFilterType(type)}
 						>
@@ -70,22 +70,22 @@ export function Notebook() {
 				</div>
 				<div className="min-h-0 flex-1 overflow-y-auto">
 					{state.pages.length === 0 ? (
-						<p className="p-4 text-center text-sm text-slate-500">{t("notebook.noPages")}</p>
+						<p className="p-4 text-center text-sm text-[var(--inno-text-muted)]">{t("notebook.noPages")}</p>
 					) : null}
 					{state.pages.map((page) => {
 						const selected = state.currentPagePath === page.path || state.selectedNodeId === page.path;
 						return (
 							<button
 								key={page.path}
-								className={`w-full border-b border-slate-100 px-3 py-2 text-left text-sm transition-colors ${selected ? "bg-blue-50" : "hover:bg-slate-50"}`}
+								className={`w-full border-b border-[var(--inno-border)] px-3 py-2 text-left text-sm transition-colors ${selected ? "bg-[var(--inno-accent-soft)]" : "hover:bg-[var(--inno-surface-muted)]"}`}
 								onClick={() => void notebookStore.selectPage(page.path)}
 							>
-								<div className="truncate font-medium text-slate-950">{page.frontmatter?.title || page.path}</div>
+								<div className="truncate font-medium text-[var(--inno-text)]">{page.frontmatter?.title || page.path}</div>
 								<div className="mt-1 flex items-center gap-1.5">
 									<span className={`rounded px-1.5 text-xs ${typeColor(page.frontmatter?.type)}`}>
 										{page.frontmatter?.type ? t(`notebook.types.${page.frontmatter.type}`) : t("notebook.types.unknown")}
 									</span>
-									<span className="truncate text-xs text-slate-500">{page.frontmatter?.updated || ""}</span>
+									<span className="truncate text-xs text-[var(--inno-text-muted)]">{page.frontmatter?.updated || ""}</span>
 								</div>
 							</button>
 						);
@@ -93,19 +93,19 @@ export function Notebook() {
 				</div>
 			</aside>
 
-			<section className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white">
-				<div className="@container flex items-center justify-between border-b border-slate-100 bg-white px-3 py-2">
+			<section className="flex min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
+				<div className="@container flex items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2">
 					<div className="flex items-center gap-2">
 						<button
-							className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+							className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 							onClick={() => setSidebarOpen((v) => !v)}
 							title={sidebarOpen ? t("common.collapseSidebar", "Collapse sidebar") : t("common.expandSidebar", "Expand sidebar")}
 						>
 							{sidebarOpen ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
 						</button>
-						<div className="inline-flex rounded-md border border-slate-200 bg-slate-50 p-0.5 text-xs">
+						<div className="inline-flex rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-0.5 text-xs">
 							<button
-								className={`inline-flex items-center gap-1 rounded px-3 py-1 ${state.view === "graph" ? "bg-white shadow text-slate-950" : "text-slate-500"}`}
+								className={`inline-flex items-center gap-1 rounded px-3 py-1 ${state.view === "graph" ? "bg-[var(--inno-surface)] shadow text-[var(--inno-text)]" : "text-[var(--inno-text-muted)]"}`}
 								onClick={() => notebookStore.setView("graph")}
 								title={t("notebook.view.graph")}
 							>
@@ -113,7 +113,7 @@ export function Notebook() {
 								<span className="hidden @[680px]:inline">{t("notebook.view.graph")}</span>
 							</button>
 							<button
-								className={`inline-flex items-center gap-1 rounded px-3 py-1 ${state.view === "page" ? "bg-white shadow text-slate-950" : "text-slate-500"}`}
+								className={`inline-flex items-center gap-1 rounded px-3 py-1 ${state.view === "page" ? "bg-[var(--inno-surface)] shadow text-[var(--inno-text)]" : "text-[var(--inno-text-muted)]"}`}
 								onClick={() => notebookStore.setView("page")}
 								title={t("notebook.view.page")}
 							>
@@ -122,7 +122,7 @@ export function Notebook() {
 							</button>
 						</div>
 					</div>
-					<div className="text-xs text-slate-500">{state.currentPagePath ?? ""}</div>
+					<div className="text-xs text-[var(--inno-text-muted)]">{state.currentPagePath ?? ""}</div>
 				</div>
 				<div className="min-h-0 flex-1 overflow-auto">
 					{state.view === "graph" ? <GraphView /> : <PageView />}

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -22,20 +22,20 @@ function OptionRow({
 		<button
 			className={`flex w-full items-start gap-2.5 rounded-md border px-3 py-2 text-left text-[13px] transition-colors ${
 				selected
-					? "border-blue-400 bg-blue-50 text-slate-950"
-					: "border-slate-200 bg-white text-slate-700 hover:border-slate-300 hover:bg-slate-50"
+					? "border-blue-400 bg-[var(--inno-accent-soft)] text-[var(--inno-text)]"
+					: "border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text)] hover:border-[var(--inno-border-strong)] hover:bg-[var(--inno-surface-muted)]"
 			}`}
 			onClick={onSelect}
 			onMouseEnter={onFocus}
 		>
-			<span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-slate-300">
+			<span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-[var(--inno-border-strong)]">
 				{selected ? (
 					<span className={`block ${multi ? "h-2 w-2 rounded-sm bg-blue-500" : "h-2 w-2 rounded-full bg-blue-500"}`} />
 				) : null}
 			</span>
 			<span className="min-w-0 flex-1">
 				<span className="font-medium">{label}</span>
-				{description ? <span className="mt-0.5 block text-xs text-slate-500">{description}</span> : null}
+				{description ? <span className="mt-0.5 block text-xs text-[var(--inno-text-muted)]">{description}</span> : null}
 			</span>
 		</button>
 	);
@@ -100,7 +100,7 @@ function QuestionTab({
 
 	return (
 		<div className="space-y-3">
-			<p className="text-sm font-medium text-slate-800">{q.question}</p>
+			<p className="text-sm font-medium text-[var(--inno-text)]">{q.question}</p>
 
 			<div className={hasPreview ? "flex gap-3" : ""}>
 				<div className={`space-y-1.5 ${hasPreview ? "w-1/2" : ""}`}>
@@ -120,7 +120,7 @@ function QuestionTab({
 						<div className="flex items-center gap-1.5 pt-1">
 							<input
 								type="text"
-								className="min-w-0 flex-1 rounded-md border border-slate-200 px-2.5 py-1.5 text-[13px] focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+								className="min-w-0 flex-1 rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-[13px] focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 								placeholder="Type something..."
 								value={customText}
 								onChange={(e) => setCustomText(e.target.value)}
@@ -136,14 +136,14 @@ function QuestionTab({
 				</div>
 
 				{hasPreview && preview ? (
-					<div className="w-1/2 rounded-md border border-slate-200 bg-slate-50 p-3">
-						<pre className="whitespace-pre-wrap font-mono text-xs text-slate-700">{preview}</pre>
+					<div className="w-1/2 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
+						<pre className="whitespace-pre-wrap font-mono text-xs text-[var(--inno-text)]">{preview}</pre>
 					</div>
 				) : null}
 			</div>
 
 			<button
-				className="text-xs text-slate-400 underline hover:text-slate-600"
+				className="text-xs text-[var(--inno-text-subtle)] underline hover:text-[var(--inno-text-muted)]"
 				onClick={onDismiss}
 			>
 				Chat about this
@@ -203,7 +203,7 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.3, ease: "easeOut" }}
 		>
-			<div className="w-full max-w-[76%] rounded-lg border border-blue-200 bg-white px-4 py-3 shadow-sm">
+			<div className="w-full max-w-[76%] rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-surface)] px-4 py-3 shadow-sm">
 				{questions.length > 1 ? (
 					<div className="mb-3 flex gap-1">
 						{questions.map((q, i) => (
@@ -211,8 +211,8 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 								key={q.header}
 								className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
 									activeTab === i
-										? "bg-blue-100 text-blue-700"
-										: "bg-slate-100 text-slate-500 hover:bg-slate-200"
+										? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
+										: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] hover:bg-slate-200"
 								}${answers.has(i) ? " ring-1 ring-green-300" : ""}`}
 								onClick={() => setActiveTab(i)}
 							>
@@ -237,7 +237,7 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 						className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
 							allAnswered
 								? "bg-slate-900 text-white hover:bg-slate-800"
-								: "cursor-not-allowed bg-slate-100 text-slate-400"
+								: "cursor-not-allowed bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]"
 						}`}
 						disabled={!allAnswered}
 						onClick={handleSubmit}

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -234,11 +234,7 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 
 				<div className="mt-3 flex justify-end">
 					<button
-						className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${
-							allAnswered
-								? "bg-slate-900 text-white hover:bg-slate-800"
-								: "cursor-not-allowed bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]"
-						}`}
+						className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${ allAnswered ? "inno-primary-button" : "cursor-not-allowed bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]" }`}
 						disabled={!allAnswered}
 						onClick={handleSubmit}
 					>

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -107,16 +107,16 @@ function orderedSessionChannels(session: SessionMeta): Array<{ channel: SessionC
 
 function channelFilterClass(channel: SessionChannel | null, active: boolean): string {
 	if (!active) return "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-slate-200 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] hover:ring-slate-300";
-	if (!channel) return "bg-slate-800 text-white ring-1 ring-slate-800 hover:bg-slate-800 hover:text-white";
+	if (!channel) return "inno-primary-button ring-1 ring-[var(--inno-accent)]";
 	const map: Record<string, string> = {
 		cli: "bg-[var(--inno-accent)] text-white ring-1 ring-blue-600 hover:bg-[var(--inno-accent)] hover:text-white",
-		web: "bg-slate-900 text-white ring-1 ring-slate-900 hover:bg-slate-900 hover:text-white",
+		web: "inno-primary-button ring-1 ring-[var(--inno-accent)]",
 		feishu: "bg-emerald-600 text-white ring-1 ring-emerald-600 hover:bg-emerald-600 hover:text-white",
 		scheduler: "bg-amber-600 text-white ring-1 ring-amber-600 hover:bg-amber-600 hover:text-white",
 		qq: "bg-cyan-600 text-white ring-1 ring-cyan-600 hover:bg-cyan-600 hover:text-white",
 		wechat: "bg-lime-600 text-white ring-1 ring-lime-600 hover:bg-lime-600 hover:text-white",
 	};
-	return map[channel] ?? "bg-slate-700 text-white ring-1 ring-slate-700 hover:bg-slate-700 hover:text-white";
+	return map[channel] ?? "inno-primary-button ring-1 ring-[var(--inno-accent)]";
 }
 
 /* ── Workspace group definition ── */
@@ -731,7 +731,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 				{/* Footer: new chat (mode switch lives on the IA logo above) */}
 				<div className="border-t border-slate-200/70 p-2">
 					<button
-						className="inno-sidebar-text flex w-full items-center justify-center gap-2 rounded-lg bg-slate-800 px-3 py-1.5 font-medium text-white shadow-sm transition-colors hover:bg-slate-700"
+						className="inno-sidebar-text flex w-full items-center justify-center gap-2 rounded-lg inno-primary-button px-3 py-1.5 font-medium text-white shadow-sm transition-colors"
 						onClick={newChat}
 					>
 						<Plus size={14} /> 新建对话
@@ -939,7 +939,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 			{/* Footer */}
 			<div className="border-t border-slate-200/70 p-2">
 				<button
-					className="inno-sidebar-text flex w-full items-center justify-center gap-2 rounded-lg bg-slate-800 px-3 py-1.5 font-medium text-white shadow-sm transition-colors hover:bg-slate-700"
+					className="inno-sidebar-text flex w-full items-center justify-center gap-2 rounded-lg inno-primary-button px-3 py-1.5 font-medium text-white shadow-sm transition-colors"
 					onClick={newChat}
 				>
 					<Plus size={14} /> 新建对话

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -107,16 +107,16 @@ function orderedSessionChannels(session: SessionMeta): Array<{ channel: SessionC
 
 function channelFilterClass(channel: SessionChannel | null, active: boolean): string {
 	if (!active) return "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-slate-200 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] hover:ring-slate-300";
-	if (!channel) return "bg-slate-800 text-white ring-1 ring-slate-800";
+	if (!channel) return "bg-slate-800 text-white ring-1 ring-slate-800 hover:bg-slate-800 hover:text-white";
 	const map: Record<string, string> = {
-		cli: "bg-[var(--inno-accent)] text-white ring-1 ring-blue-600",
-		web: "bg-slate-900 text-white ring-1 ring-slate-900",
-		feishu: "bg-emerald-600 text-white ring-1 ring-emerald-600",
-		scheduler: "bg-amber-600 text-white ring-1 ring-amber-600",
-		qq: "bg-cyan-600 text-white ring-1 ring-cyan-600",
-		wechat: "bg-lime-600 text-white ring-1 ring-lime-600",
+		cli: "bg-[var(--inno-accent)] text-white ring-1 ring-blue-600 hover:bg-[var(--inno-accent)] hover:text-white",
+		web: "bg-slate-900 text-white ring-1 ring-slate-900 hover:bg-slate-900 hover:text-white",
+		feishu: "bg-emerald-600 text-white ring-1 ring-emerald-600 hover:bg-emerald-600 hover:text-white",
+		scheduler: "bg-amber-600 text-white ring-1 ring-amber-600 hover:bg-amber-600 hover:text-white",
+		qq: "bg-cyan-600 text-white ring-1 ring-cyan-600 hover:bg-cyan-600 hover:text-white",
+		wechat: "bg-lime-600 text-white ring-1 ring-lime-600 hover:bg-lime-600 hover:text-white",
 	};
-	return map[channel] ?? "bg-slate-700 text-white ring-1 ring-slate-700";
+	return map[channel] ?? "bg-slate-700 text-white ring-1 ring-slate-700 hover:bg-slate-700 hover:text-white";
 }
 
 /* ── Workspace group definition ── */
@@ -853,14 +853,14 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 						{orderedChannels.map((ch) => (
 							<button
 								key={ch}
-								className={`inno-sidebar-meta rounded-full px-1.5 py-px font-medium transition-colors ${channelFilterClass(ch, state.channelFilter === ch)}`}
+								className={`inno-channel-filter-chip inno-sidebar-meta rounded-full px-1.5 py-px font-medium transition-colors ${channelFilterClass(ch, state.channelFilter === ch)}`}
 								onClick={() => sessionsStore.setChannelFilter(state.channelFilter === ch ? null : ch)}
 							>
 								{channelLabel(ch)}
 							</button>
 						))}
 						<button
-							className={`inno-sidebar-meta rounded-full px-1.5 py-px font-medium transition-colors ${channelFilterClass(null, state.channelFilter === null)}`}
+							className={`inno-channel-filter-chip inno-sidebar-meta rounded-full px-1.5 py-px font-medium transition-colors ${channelFilterClass(null, state.channelFilter === null)}`}
 							onClick={() => sessionsStore.setChannelFilter(null)}
 						>
 							全部

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -62,13 +62,13 @@ function channelLabel(channel: SessionChannel): string {
 
 function channelClass(channel: SessionChannel): string {
 	const classes: Record<string, string> = {
-		cli: "bg-blue-50 text-blue-600 ring-1 ring-blue-200/60",
-		web: "bg-slate-100 text-slate-700 ring-1 ring-slate-200/80",
+		cli: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-200/60",
+		web: "bg-[var(--inno-surface-muted)] text-[var(--inno-text)] ring-1 ring-slate-200/80",
 		feishu: "bg-emerald-50 text-emerald-600 ring-1 ring-emerald-200/60",
 		scheduler: "bg-amber-50 text-amber-600 ring-1 ring-amber-200/60",
 		qq: "bg-cyan-50 text-cyan-600 ring-1 ring-cyan-200/60",
 		wechat: "bg-lime-50 text-lime-600 ring-1 ring-lime-200/60",
-		unknown: "bg-slate-50 text-slate-400 ring-1 ring-slate-200/60",
+		unknown: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)] ring-1 ring-slate-200/60",
 	};
 	return classes[channel] ?? classes.unknown;
 }
@@ -80,13 +80,13 @@ function channelClass(channel: SessionChannel): string {
  */
 function channelInteractionClass(channel: SessionChannel): string {
 	const classes: Record<string, string> = {
-		cli: "bg-transparent text-blue-500 ring-1 ring-blue-300/70",
-		web: "bg-transparent text-slate-500 ring-1 ring-slate-300/70",
+		cli: "bg-transparent text-[var(--inno-accent)] ring-1 ring-blue-300/70",
+		web: "bg-transparent text-[var(--inno-text-muted)] ring-1 ring-slate-300/70",
 		feishu: "bg-transparent text-emerald-500 ring-1 ring-emerald-300/70",
 		scheduler: "bg-transparent text-amber-500 ring-1 ring-amber-300/70",
 		qq: "bg-transparent text-cyan-500 ring-1 ring-cyan-300/70",
 		wechat: "bg-transparent text-lime-500 ring-1 ring-lime-300/70",
-		unknown: "bg-transparent text-slate-400 ring-1 ring-slate-200/70",
+		unknown: "bg-transparent text-[var(--inno-text-subtle)] ring-1 ring-slate-200/70",
 	};
 	return classes[channel] ?? classes.unknown;
 }
@@ -106,10 +106,10 @@ function orderedSessionChannels(session: SessionMeta): Array<{ channel: SessionC
 }
 
 function channelFilterClass(channel: SessionChannel | null, active: boolean): string {
-	if (!active) return "bg-white text-slate-500 ring-1 ring-slate-200 hover:bg-slate-50 hover:text-slate-700 hover:ring-slate-300";
+	if (!active) return "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-slate-200 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] hover:ring-slate-300";
 	if (!channel) return "bg-slate-800 text-white ring-1 ring-slate-800";
 	const map: Record<string, string> = {
-		cli: "bg-blue-600 text-white ring-1 ring-blue-600",
+		cli: "bg-[var(--inno-accent)] text-white ring-1 ring-blue-600",
 		web: "bg-slate-900 text-white ring-1 ring-slate-900",
 		feishu: "bg-emerald-600 text-white ring-1 ring-emerald-600",
 		scheduler: "bg-amber-600 text-white ring-1 ring-amber-600",
@@ -163,9 +163,9 @@ function GroupHeader({
 	onDelete: () => void;
 }) {
 	return (
-		<div className={`group/wsh sticky top-0 z-10 flex w-full items-center gap-1.5 px-2 py-1.5 ${active ? "bg-slate-100" : "bg-[var(--inno-sidebar-bg)]"}`}>
+		<div className={`group/wsh sticky top-0 z-10 flex w-full items-center gap-1.5 px-2 py-1.5 ${active ? "bg-[var(--inno-surface-muted)]" : "bg-[var(--inno-sidebar-bg)]"}`}>
 			<button
-				className="shrink-0 text-slate-400 transition-colors hover:text-slate-600"
+				className="shrink-0 text-[var(--inno-text-subtle)] transition-colors hover:text-[var(--inno-text-muted)]"
 				title={collapsed ? "展开" : "折叠"}
 				onClick={onToggle}
 			>
@@ -175,14 +175,14 @@ function GroupHeader({
 				/>
 			</button>
 			<button
-				className="inno-sidebar-meta flex min-w-0 flex-1 items-center gap-1.5 font-semibold uppercase text-slate-400 transition-colors hover:text-slate-600"
+				className="inno-sidebar-meta flex min-w-0 flex-1 items-center gap-1.5 font-semibold uppercase text-[var(--inno-text-subtle)] transition-colors hover:text-[var(--inno-text-muted)]"
 				title={group.canCreate ? "加载此工作区到预览面板" : undefined}
 				onClick={onSelect}
 			>
-				<FolderKanban size={12} className="shrink-0 text-slate-400" />
+				<FolderKanban size={12} className="shrink-0 text-[var(--inno-text-subtle)]" />
 				{editing ? (
 					<input
-						className="min-w-0 flex-1 rounded border border-blue-300 bg-white px-1 py-0.5 text-[11px] normal-case text-slate-800 outline-none focus:ring-1 focus:ring-blue-200"
+						className="min-w-0 flex-1 rounded border border-blue-300 bg-[var(--inno-surface)] px-1 py-0.5 text-[11px] normal-case text-[var(--inno-text)] outline-none focus:ring-1 focus:ring-blue-200"
 						value={editingName}
 						autoFocus
 						onClick={(e) => { e.stopPropagation(); }}
@@ -195,14 +195,14 @@ function GroupHeader({
 						}}
 					/>
 				) : (
-					<span className="min-w-0 truncate normal-case text-slate-500">{group.name}</span>
+					<span className="min-w-0 truncate normal-case text-[var(--inno-text-muted)]">{group.name}</span>
 				)}
 			</button>
 			{!editing ? (
 				<div className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/wsh:opacity-100">
 					{group.canCreate ? (
 						<button
-							className="rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+							className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 							title="在此工作区新建对话"
 							onClick={(e) => { e.stopPropagation(); onNewChat(); }}
 						>
@@ -212,14 +212,14 @@ function GroupHeader({
 					{group.manageable ? (
 						<>
 							<button
-								className="rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+								className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 								title="重命名工作区"
 								onClick={(e) => { e.stopPropagation(); onStartEdit(); }}
 							>
 								<Pencil size={11} />
 							</button>
 							<button
-								className="rounded p-0.5 text-slate-400 hover:bg-red-50 hover:text-red-600"
+								className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-red-50 hover:text-red-600"
 								title="删除工作区"
 								onClick={(e) => { e.stopPropagation(); onDelete(); }}
 							>
@@ -229,7 +229,7 @@ function GroupHeader({
 					) : null}
 				</div>
 			) : null}
-			<span className="inno-sidebar-meta rounded-full bg-slate-200 px-1.5 py-0 font-medium text-slate-500 tabular-nums">
+			<span className="inno-sidebar-meta rounded-full bg-slate-200 px-1.5 py-0 font-medium text-[var(--inno-text-muted)] tabular-nums">
 				{group.sessions.length}
 			</span>
 		</div>
@@ -273,8 +273,8 @@ function SessionCard({
 		<div
 			className={`group/card relative mb-1 w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
 				active
-					? "border-slate-200 bg-slate-100 shadow-sm"
-					: "border-transparent hover:border-slate-200 hover:bg-white"
+					? "border-[var(--inno-border)] bg-[var(--inno-surface-muted)] shadow-sm"
+					: "border-transparent hover:border-[var(--inno-border)] hover:bg-[var(--inno-surface)]"
 			}`}
 			role="button"
 			tabIndex={0}
@@ -290,7 +290,7 @@ function SessionCard({
 			<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
 				{editing ? (
 					<input
-						className="inno-sidebar-title min-w-0 flex-1 rounded border border-blue-300 bg-white px-1.5 py-0.5 outline-none focus:ring-2 focus:ring-blue-200"
+						className="inno-sidebar-title min-w-0 flex-1 rounded border border-blue-300 bg-[var(--inno-surface)] px-1.5 py-0.5 outline-none focus:ring-2 focus:ring-blue-200"
 						value={editingName}
 						autoFocus
 						onClick={(e) => e.stopPropagation()}
@@ -303,16 +303,16 @@ function SessionCard({
 						}}
 					/>
 				) : (
-					<div className="inno-sidebar-title min-w-0 truncate font-medium text-slate-800 transition-colors group-hover/card:text-slate-950">
+					<div className="inno-sidebar-title min-w-0 truncate font-medium text-[var(--inno-text)] transition-colors group-hover/card:text-[var(--inno-text)]">
 						{session.name}
 					</div>
 				)}
-				<span className="inno-sidebar-meta shrink-0 pt-0.5 tabular-nums text-slate-400">{formatTime(session.updatedAt)}</span>
+				<span className="inno-sidebar-meta shrink-0 pt-0.5 tabular-nums text-[var(--inno-text-subtle)]">{formatTime(session.updatedAt)}</span>
 			</div>
 
 			{/* Preview */}
 			{session.preview && session.preview !== session.name ? (
-				<div className="inno-sidebar-meta mt-0.5 truncate text-slate-400">{session.preview}</div>
+				<div className="inno-sidebar-meta mt-0.5 truncate text-[var(--inno-text-subtle)]">{session.preview}</div>
 			) : null}
 
 			{/* Bottom row: channels + actions */}
@@ -333,7 +333,7 @@ function SessionCard({
 						<span className="h-3 w-3 animate-spin rounded-full border-2 border-slate-400 border-t-transparent" />
 					) : null}
 					<button
-						className="rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700 disabled:opacity-40"
+						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-40"
 						title="AI generate topic"
 						disabled={generatingId === session.id}
 						onClick={(e) => { e.stopPropagation(); onGenerate(); }}
@@ -345,27 +345,27 @@ function SessionCard({
 						)}
 					</button>
 					<button
-						className="rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 						title="Rename"
 						onClick={(e) => { e.stopPropagation(); onStartEdit(); }}
 					>
 						<Pencil size={12} />
 					</button>
 					<button
-						className="rounded p-0.5 text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 						title={session.archived ? "Unarchive" : "Archive"}
 						onClick={(e) => { e.stopPropagation(); onArchive(); }}
 					>
 						{session.archived ? <ArchiveRestore size={12} /> : <Archive size={12} />}
 					</button>
 					<button
-						className="rounded p-0.5 text-slate-400 hover:bg-red-50 hover:text-red-600"
+						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-red-50 hover:text-red-600"
 						title="Delete"
 						onClick={(e) => { e.stopPropagation(); onDelete(); }}
 					>
 						<Trash2 size={12} />
 					</button>
-					<span className="inno-sidebar-meta ml-0.5 tabular-nums text-slate-400">{session.messageCount}</span>
+					<span className="inno-sidebar-meta ml-0.5 tabular-nums text-[var(--inno-text-subtle)]">{session.messageCount}</span>
 				</div>
 			</div>
 		</div>
@@ -607,7 +607,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 		return (
 			<aside className="relative h-full w-0 overflow-visible">
 				<button
-					className="absolute left-2 top-2 z-20 flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-white/90 hover:text-slate-700 hover:shadow-sm"
+					className="absolute left-2 top-2 z-20 flex h-8 w-8 items-center justify-center rounded-lg text-[var(--inno-text-subtle)] transition-colors hover:bg-white/90 hover:text-[var(--inno-text)] hover:shadow-sm"
 					title="Expand"
 					onClick={() => appStore.setSidebarCollapsed(false)}
 				>
@@ -641,25 +641,25 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 								className="h-7 w-7"
 							>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-slate-200 bg-white text-[10px] font-semibold text-slate-800 shadow-sm"
+									className="absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] text-[10px] font-semibold text-[var(--inno-text)] shadow-sm"
 									style={{ backfaceVisibility: "hidden" }}
 								>
 									IA
 								</span>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-blue-400 bg-blue-600 text-[10px] font-semibold text-white shadow-sm"
+									className="absolute inset-0 flex items-center justify-center rounded-lg border border-blue-400 bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
 									style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
 								>
 									IA
 								</span>
 							</motion.div>
 						</button>
-						<h1 className="inno-sidebar-title truncate font-semibold tracking-tight text-slate-800">
+						<h1 className="inno-sidebar-title truncate font-semibold tracking-tight text-[var(--inno-text)]">
 							Inno Agent
 						</h1>
 					</div>
 					<button
-						className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-white hover:text-slate-600"
+						className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text-muted)]"
 						title="Collapse"
 						onClick={() => appStore.setSidebarCollapsed(true)}
 					>
@@ -669,13 +669,13 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 
 				{/* Recent conversations — the way back to a generated artifact */}
 				<div className="flex-1 min-h-0 overflow-y-auto px-1.5 py-2 sidebar-scroll">
-					<div className="px-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-slate-400">最近</div>
+					<div className="px-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-[var(--inno-text-subtle)]">最近</div>
 					{state.isLoading ? (
 						<div className="flex items-center justify-center py-8">
-							<span className="h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-transparent" />
+							<span className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--inno-border-strong)] border-t-transparent" />
 						</div>
 					) : recentSessions.length === 0 ? (
-						<div className="inno-sidebar-text px-2 py-8 text-center text-slate-400">暂无对话</div>
+						<div className="inno-sidebar-text px-2 py-8 text-center text-[var(--inno-text-subtle)]">暂无对话</div>
 					) : (
 						recentSessions.map((session) => {
 							const ws = sessionToWorkspace.get(session.id);
@@ -693,14 +693,14 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 									}}
 									className={`group/srow relative mb-1 block w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
 										state.currentSessionId === session.id
-											? "border-slate-200 bg-slate-100 shadow-sm"
-											: "border-transparent hover:border-slate-200 hover:bg-white"
+											? "border-[var(--inno-border)] bg-[var(--inno-surface-muted)] shadow-sm"
+											: "border-transparent hover:border-[var(--inno-border)] hover:bg-[var(--inno-surface)]"
 									}`}
 								>
 									<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
-										<div className="inno-sidebar-title min-w-0 truncate font-medium text-slate-800">{session.name}</div>
+										<div className="inno-sidebar-title min-w-0 truncate font-medium text-[var(--inno-text)]">{session.name}</div>
 										<button
-											className="rounded p-0.5 text-slate-400 opacity-0 transition-opacity hover:bg-red-50 hover:text-red-600 group-hover/srow:opacity-100"
+											className="rounded p-0.5 text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-red-50 hover:text-red-600 group-hover/srow:opacity-100"
 											title="删除对话"
 											onClick={(e) => { e.stopPropagation(); handleDelete(session); }}
 										>
@@ -708,19 +708,19 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 										</button>
 									</div>
 									{session.preview && session.preview !== session.name ? (
-										<div className="inno-sidebar-meta mt-0.5 truncate text-slate-400">{session.preview}</div>
+										<div className="inno-sidebar-meta mt-0.5 truncate text-[var(--inno-text-subtle)]">{session.preview}</div>
 									) : null}
 									<div className="mt-1 flex items-center gap-1.5">
 										{ws ? (
 											<span
-												className="inline-flex max-w-[140px] items-center gap-1 rounded bg-slate-100 px-1.5 py-px text-[9px] font-medium leading-none text-slate-500 ring-1 ring-slate-200/70"
+												className="inline-flex max-w-[140px] items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-1.5 py-px text-[9px] font-medium leading-none text-[var(--inno-text-muted)] ring-1 ring-slate-200/70"
 												title={`工作区:${ws.name}`}
 											>
 												<FolderKanban size={9} className="shrink-0" />
 												<span className="truncate">{ws.name}</span>
 											</span>
 										) : null}
-										<span className="inno-sidebar-meta tabular-nums text-slate-400">{formatTime(session.updatedAt)}</span>
+										<span className="inno-sidebar-meta tabular-nums text-[var(--inno-text-subtle)]">{formatTime(session.updatedAt)}</span>
 									</div>
 								</div>
 							);
@@ -765,13 +765,13 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 								className="h-7 w-7"
 							>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-slate-200 bg-white text-[10px] font-semibold text-slate-800 shadow-sm"
+									className="absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] text-[10px] font-semibold text-[var(--inno-text)] shadow-sm"
 									style={{ backfaceVisibility: "hidden" }}
 								>
 									IA
 								</span>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-blue-400 bg-blue-600 text-[10px] font-semibold text-white shadow-sm"
+									className="absolute inset-0 flex items-center justify-center rounded-lg border border-blue-400 bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
 									style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
 								>
 									IA
@@ -779,21 +779,21 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 							</motion.div>
 						</button>
 						<div className="min-w-0">
-							<h1 className="inno-sidebar-title font-semibold tracking-tight text-slate-800">
-								Inno Agent{simpleMode ? <span className="font-normal text-blue-600">(简单模式)</span> : null}
+							<h1 className="inno-sidebar-title font-semibold tracking-tight text-[var(--inno-text)]">
+								Inno Agent{simpleMode ? <span className="font-normal text-[var(--inno-accent)]">(简单模式)</span> : null}
 							</h1>
 						</div>
 					</div>
 					<div className="flex items-center gap-1">
 						<button
-							className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-white hover:text-slate-600"
+							className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text-muted)]"
 							title="Refresh"
 							onClick={() => void sessionsStore.load()}
 						>
 							<RefreshCw size={13} />
 						</button>
 						<button
-							className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-white hover:text-slate-600"
+							className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text-muted)]"
 							title="Collapse"
 							onClick={() => appStore.setSidebarCollapsed(true)}
 						>
@@ -810,9 +810,9 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 					{showSearch ? (
 						<div className="flex items-center gap-1">
 							<div className="relative flex-1">
-								<Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-slate-400" />
+								<Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-[var(--inno-text-subtle)]" />
 								<input
-									className="inno-sidebar-text w-full rounded-md border border-slate-200 bg-white py-1 pl-7 pr-7 outline-none placeholder:text-slate-400 focus:border-blue-300 focus:ring-1 focus:ring-blue-200"
+									className="inno-sidebar-text w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] py-1 pl-7 pr-7 outline-none placeholder:text-[var(--inno-text-subtle)] focus:border-blue-300 focus:ring-1 focus:ring-blue-200"
 									placeholder="搜索对话..."
 									value={state.searchQuery}
 									autoFocus
@@ -820,7 +820,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 								/>
 								{state.searchQuery && (
 									<button
-										className="absolute right-1.5 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600"
+										className="absolute right-1.5 top-1/2 -translate-y-1/2 text-[var(--inno-text-subtle)] hover:text-[var(--inno-text-muted)]"
 										onClick={() => sessionsStore.setSearchQuery("")}
 									>
 										<X size={12} />
@@ -828,7 +828,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 								)}
 							</div>
 							<button
-								className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-600"
+								className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text-muted)]"
 								onClick={() => { setShowSearch(false); sessionsStore.setSearchQuery(""); }}
 							>
 								<X size={13} />
@@ -836,9 +836,9 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 						</div>
 					) : (
 						<div className="relative">
-							<Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-slate-400 pointer-events-none" />
+							<Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-[var(--inno-text-subtle)] pointer-events-none" />
 							<button
-								className="inno-sidebar-text w-full rounded-md border border-slate-200 bg-white py-1.5 pl-7 pr-3 text-left text-slate-400 transition-colors hover:border-slate-300 hover:bg-slate-50"
+								className="inno-sidebar-text w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] py-1.5 pl-7 pr-3 text-left text-[var(--inno-text-subtle)] transition-colors hover:border-[var(--inno-border-strong)] hover:bg-[var(--inno-surface-muted)]"
 								onClick={() => setShowSearch(true)}
 							>
 								搜索对话...
@@ -873,10 +873,10 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 			<div className="flex-1 min-h-0 overflow-y-auto px-1.5 pb-2 sidebar-scroll">
 				{state.isLoading ? (
 					<div className="flex items-center justify-center py-8">
-						<span className="h-4 w-4 animate-spin rounded-full border-2 border-slate-300 border-t-transparent" />
+						<span className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--inno-border-strong)] border-t-transparent" />
 					</div>
 				) : groups.length === 0 ? (
-					<div className="inno-sidebar-text px-2 py-8 text-center text-slate-400">
+					<div className="inno-sidebar-text px-2 py-8 text-center text-[var(--inno-text-subtle)]">
 						{state.searchQuery || state.channelFilter ? "无匹配结果" : "暂无对话记录"}
 					</div>
 				) : (

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -166,7 +166,7 @@ function ModelEditForm({ model, settings, onClose }: {
 			</div>
 			{formError ? <div className="mt-2 rounded bg-red-50 px-2 py-1 text-xs text-red-700">{formError}</div> : null}
 			<div className="mt-2 flex gap-2">
-				<button className="rounded-md bg-slate-900 px-3 py-1.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
+				<button className="rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
 					{saving ? t("settings.savingProvider") : t("settings.saveProvider")}
 				</button>
 				<button className="rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]" onClick={onClose}>
@@ -311,7 +311,7 @@ function NewProviderForm() {
 					</div>
 					{formError ? <div className="mt-2 rounded bg-red-50 px-2 py-1 text-xs text-red-700">{formError}</div> : null}
 					{saveMessage ? <div className="mt-2 rounded bg-green-50 px-2 py-1 text-xs text-green-700">{saveMessage}</div> : null}
-					<button className="mt-3 rounded-md bg-slate-900 px-3 py-1.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
+					<button className="mt-3 rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
 						{saving ? t("settings.savingProvider") : t("settings.saveProvider")}
 					</button>
 				</div>
@@ -607,7 +607,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 									)}
 									{(!qrStatus || qrStatus === "confirmed" || qrStatus === "expired") && (
 										<button
-											className="flex items-center gap-1.5 rounded-md bg-slate-900 px-3 py-1.5 text-xs text-white hover:bg-slate-800"
+											className="flex items-center gap-1.5 rounded-md inno-primary-button px-3 py-1.5 text-xs text-white"
 											onClick={() => void startQrLogin()}
 										>
 											<QrCodeIcon size={13} />
@@ -651,7 +651,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 					{formError && <div className="rounded bg-red-50 px-2 py-1 text-xs text-red-700">{formError}</div>}
 					{saveMsg && <div className="rounded bg-green-50 px-2 py-1 text-xs text-green-700">{saveMsg}</div>}
 					<button
-						className="rounded-md bg-slate-900 px-3 py-1.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50 justify-self-start"
+						className="rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50 justify-self-start"
 						disabled={saving}
 						onClick={() => void handleSave()}
 					>
@@ -715,21 +715,21 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 		}
 	}
 
-	const inputCls = "h-8 min-w-0 flex-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:border-blue-400 focus:outline-none";
+	const inputCls = "h-8 min-w-0 w-full rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:border-blue-400 focus:outline-none";
 	const sourceLabel = type === "github"
 		? `GitHub · ${owner || "?"}/${repo || "?"}`
 		: `${t("settings.contentHub.bundle", "自托管服务")} · ${baseUrl || "?"}`;
 
 	return (
-		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
-			<button className="flex w-full items-start gap-2 text-left" onClick={() => setOpen((v) => !v)}>
+		<div className="min-w-0 rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+			<button className="inno-settings-card-toggle flex w-full min-w-0 items-start gap-2 text-left" onClick={() => setOpen((v) => !v)}>
 				<Database size={16} className="mt-0.5 shrink-0 text-[var(--inno-text)]" />
 				<div className="min-w-0 flex-1">
-					<h4 className="text-sm font-medium text-[var(--inno-text)]">{t("settings.contentHub.title", "内容源(技能库 + 预设)")}</h4>
-					<p className="mt-1 text-xs leading-relaxed text-[var(--inno-text-muted)]">
+					<h4 className="break-words text-sm font-medium text-[var(--inno-text)]">{t("settings.contentHub.title", "内容源(技能库 + 预设)")}</h4>
+					<p className="mt-1 max-w-full break-words text-xs leading-relaxed text-[var(--inno-text-muted)]">
 						{t("settings.contentHub.desc", "技能库和预设工作区从这里拉取。默认公共仓库,可改为私有 GitHub 仓库或自托管服务。")}
 					</p>
-					{!open && <p className="mt-1 truncate text-[11px] text-[var(--inno-text-subtle)]">{sourceLabel}</p>}
+					{!open && <p className="mt-1 break-all text-[11px] leading-relaxed text-[var(--inno-text-subtle)]">{sourceLabel}</p>}
 				</div>
 				<ChevronDown size={14} className={`mt-1 shrink-0 text-[var(--inno-text-subtle)] transition-transform ${open ? "rotate-180" : ""}`} />
 			</button>
@@ -737,7 +737,7 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 			{open ? (
 				<div className="mt-3 grid gap-2.5">
 					{/* Type selector */}
-					<div className="flex items-center gap-1.5">
+					<div className="flex flex-wrap items-center gap-1.5">
 						<button
 							onClick={() => setType("github")}
 							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "github" ? "border-blue-400 bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]" : "border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"}`}
@@ -754,12 +754,12 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 
 					{type === "github" ? (
 						<>
-							<div className="flex items-center gap-2">
+							<div className="grid min-w-0 grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-2">
 								<input className={inputCls} value={owner} onChange={(e) => { setOwner(e.target.value); setSaved(false); }} placeholder="owner" autoComplete="off" />
 								<input className={inputCls} value={repo} onChange={(e) => { setRepo(e.target.value); setSaved(false); }} placeholder="repo" autoComplete="off" />
 								<input className={inputCls} value={ref} onChange={(e) => { setRef(e.target.value); setSaved(false); }} placeholder="ref (main)" autoComplete="off" />
 							</div>
-							<div className="flex items-center gap-2">
+							<div className="grid min-w-0 grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] gap-2">
 								<input className={inputCls} value={skillsPath} onChange={(e) => { setSkillsPath(e.target.value); setSaved(false); }} placeholder="skill-library" autoComplete="off" />
 								<input className={inputCls} value={presetsPath} onChange={(e) => { setPresetsPath(e.target.value); setSaved(false); }} placeholder="workspace-templates" autoComplete="off" />
 							</div>
@@ -768,9 +768,9 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 						<input className={inputCls} value={baseUrl} onChange={(e) => { setBaseUrl(e.target.value); setSaved(false); }} placeholder="https://hub.example.com" autoComplete="off" />
 					)}
 
-					<div className="flex items-center gap-2">
+					<div className="flex min-w-0 flex-wrap items-center gap-2">
 						<input
-							className={inputCls}
+							className={`${inputCls} flex-1 basis-44`}
 							type="password"
 							value={token}
 							onChange={(e) => { setToken(e.target.value); setSaved(false); }}
@@ -780,7 +780,7 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 						<button
 							disabled={saving}
 							onClick={() => void handleSave()}
-							className="flex h-8 shrink-0 items-center rounded-md bg-slate-900 px-3 text-xs text-white hover:bg-slate-800 disabled:opacity-50"
+							className="flex h-8 shrink-0 items-center rounded-md inno-primary-button px-3 text-xs text-white disabled:opacity-50"
 						>
 							{saving ? t("common.loading") : saved ? t("settings.github.saved", "已保存") : t("common.save")}
 						</button>

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -4,6 +4,7 @@ import { Trash2, Pencil, X, ChevronDown, ChevronRight, Plus, QrCode as QrCodeIco
 import { QRCodeSVG } from "qrcode.react";
 import { getWikiStats } from "../api/wiki.js";
 import { settingsStore } from "../stores/settings-store.js";
+import { themeStore, THEME_IDS, THEME_PREVIEW_COLORS, type ThemeId } from "../stores/theme-store.js";
 import { wechatQrLogin, wechatQrStatus, wechatStatus } from "../api/settings.js";
 import type { InnoModelInfo, InnoProviderModel as ProviderModel, InnoSettings, ChannelsSettingsPayload, PersonalBridgeChannelConfig } from "../types/settings.js";
 import type { WikiStats } from "../types/wiki.js";
@@ -117,48 +118,48 @@ function ModelEditForm({ model, settings, onClose }: {
 	const maskedKey = provider?.apiKey ? "••••••••" : "";
 
 	return (
-		<div className="rounded-lg border border-blue-200 bg-blue-50/50 p-3">
+		<div className="rounded-lg border border-[var(--inno-accent-soft)] bg-blue-50/50 p-3">
 			<div className="mb-2 flex items-center justify-between">
-				<span className="text-xs font-medium text-slate-700">{t("settings.editModel", "Edit Model")}</span>
-				<button className="flex h-6 w-6 items-center justify-center rounded text-slate-400 hover:bg-slate-200 hover:text-slate-700" onClick={onClose}><X size={14} /></button>
+				<span className="text-xs font-medium text-[var(--inno-text)]">{t("settings.editModel", "Edit Model")}</span>
+				<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={onClose}><X size={14} /></button>
 			</div>
 			<div className="grid grid-cols-2 gap-2">
 				<div>
-					<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.providerId")}</label>
-					<input className="w-full rounded-md border border-slate-200 bg-slate-100 px-2.5 py-1.5 text-xs text-slate-500" value={form.providerId} readOnly />
+					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.providerId")}</label>
+					<input className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2.5 py-1.5 text-xs text-[var(--inno-text-muted)]" value={form.providerId} readOnly />
 				</div>
 				<div>
-					<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.apiType", "API Type")}</label>
-					<select className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.api} onChange={(e) => setForm({ ...form, api: e.target.value })}>
+					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiType", "API Type")}</label>
+					<select className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.api} onChange={(e) => setForm({ ...form, api: e.target.value })}>
 						{apiOptions.map((api) => <option key={api} value={api}>{api}</option>)}
 					</select>
 				</div>
 				<div className="col-span-2">
-					<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.baseUrl")}</label>
-					<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.baseUrl} onChange={(e) => setForm({ ...form, baseUrl: e.target.value })} />
+					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.baseUrl")}</label>
+					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.baseUrl} onChange={(e) => setForm({ ...form, baseUrl: e.target.value })} />
 				</div>
 				<div className="col-span-2">
-					<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.apiKey")} {maskedKey && <span className="text-slate-400">({maskedKey})</span>}</label>
-					<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" type="password" placeholder={form.preserveApiKey ? t("settings.form.apiKeyPreserved", "Leave empty to keep current key") ?? "" : ""} value={form.apiKey} onChange={(e) => setForm({ ...form, apiKey: e.target.value })} />
+					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiKey")} {maskedKey && <span className="text-[var(--inno-text-subtle)]">({maskedKey})</span>}</label>
+					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" type="password" placeholder={form.preserveApiKey ? t("settings.form.apiKeyPreserved", "Leave empty to keep current key") ?? "" : ""} value={form.apiKey} onChange={(e) => setForm({ ...form, apiKey: e.target.value })} />
 				</div>
 				<div>
-					<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.modelId")}</label>
-					<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.modelId} onChange={(e) => setForm({ ...form, modelId: e.target.value })} />
+					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelId")}</label>
+					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.modelId} onChange={(e) => setForm({ ...form, modelId: e.target.value })} />
 				</div>
 				<div>
-					<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.modelName")}</label>
-					<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.modelName} onChange={(e) => setForm({ ...form, modelName: e.target.value })} />
+					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelName")}</label>
+					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.modelName} onChange={(e) => setForm({ ...form, modelName: e.target.value })} />
 				</div>
 				<div>
-					<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.contextWindow")}</label>
-					<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.contextWindow} onChange={(e) => setForm({ ...form, contextWindow: e.target.value })} />
+					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.contextWindow")}</label>
+					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.contextWindow} onChange={(e) => setForm({ ...form, contextWindow: e.target.value })} />
 				</div>
 				<div>
-					<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.maxTokens")}</label>
-					<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.maxTokens} onChange={(e) => setForm({ ...form, maxTokens: e.target.value })} />
+					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.maxTokens")}</label>
+					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.maxTokens} onChange={(e) => setForm({ ...form, maxTokens: e.target.value })} />
 				</div>
 			</div>
-			<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-slate-600">
+			<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
 				<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
 				<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
 				<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.preserveApiKey} onChange={(e) => setForm({ ...form, preserveApiKey: e.target.checked })} /> {t("settings.form.preserveApiKey")}</label>
@@ -168,7 +169,7 @@ function ModelEditForm({ model, settings, onClose }: {
 				<button className="rounded-md bg-slate-900 px-3 py-1.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
 					{saving ? t("settings.savingProvider") : t("settings.saveProvider")}
 				</button>
-				<button className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50" onClick={onClose}>
+				<button className="rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]" onClick={onClose}>
 					{t("common.cancel", "Cancel")}
 				</button>
 			</div>
@@ -177,6 +178,36 @@ function ModelEditForm({ model, settings, onClose }: {
 }
 
 /* ---------- New Provider Form (collapsible) ---------- */
+
+function ThemeSettings() {
+	const { t } = useTranslation();
+	const state = useStoreSnapshot(themeStore, () => ({ current: themeStore.current }));
+	return (
+		<div className="flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
+			<span>{t("settings.theme")}</span>
+			<div className="flex gap-1">
+				{THEME_IDS.map((id) => {
+					const active = state.current === id;
+					return (
+						<button
+							key={id}
+							type="button"
+							aria-label={t(`settings.themeOptions.${id}`)}
+							title={t(`settings.themeOptions.${id}`)}
+							onClick={() => void themeStore.save(id)}
+							className={`h-5 w-5 rounded-full border-2 transition-all ${
+								active
+									? "border-[var(--inno-accent)] ring-2 ring-[var(--inno-accent)]/30 scale-110"
+									: "border-[var(--inno-border-strong)] hover:border-slate-400"
+							}`}
+							style={{ backgroundColor: THEME_PREVIEW_COLORS[id] }}
+						/>
+					);
+				})}
+			</div>
+		</div>
+	);
+}
 
 function NewProviderForm() {
 	const { t } = useTranslation();
@@ -225,56 +256,56 @@ function NewProviderForm() {
 	}
 
 	return (
-		<div className="rounded-lg border border-slate-200 bg-white">
+		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
 			<button
 				className="flex w-full items-center justify-between px-4 py-3 text-left"
 				onClick={() => { setExpanded((v) => !v); setFormError(null); setSaveMessage(null); }}
 			>
 				<div className="flex items-center gap-2">
-					{expanded ? <ChevronDown size={14} className="text-slate-400" /> : <ChevronRight size={14} className="text-slate-400" />}
-					<span className="text-sm font-medium text-slate-950">{t("settings.newProvider")}</span>
+					{expanded ? <ChevronDown size={14} className="text-[var(--inno-text-subtle)]" /> : <ChevronRight size={14} className="text-[var(--inno-text-subtle)]" />}
+					<span className="text-sm font-medium text-[var(--inno-text)]">{t("settings.newProvider")}</span>
 				</div>
-				<Plus size={14} className="text-slate-400" />
+				<Plus size={14} className="text-[var(--inno-text-subtle)]" />
 			</button>
 			{expanded && (
-				<div className="border-t border-slate-100 px-4 pb-4 pt-3">
+				<div className="border-t border-[var(--inno-border)] px-4 pb-4 pt-3">
 					<div className="grid grid-cols-2 gap-2">
 						<div>
-							<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.providerId")}</label>
-							<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" placeholder={t("settings.form.providerId") ?? ""} value={form.providerId} onChange={(e) => setForm({ ...form, providerId: e.target.value })} />
+							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.providerId")}</label>
+							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" placeholder={t("settings.form.providerId") ?? ""} value={form.providerId} onChange={(e) => setForm({ ...form, providerId: e.target.value })} />
 						</div>
 						<div>
-							<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.apiType", "API Type")}</label>
-							<select className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.api} onChange={(e) => setForm({ ...form, api: e.target.value })}>
+							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiType", "API Type")}</label>
+							<select className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.api} onChange={(e) => setForm({ ...form, api: e.target.value })}>
 								{apiOptions.map((api) => <option key={api} value={api}>{api}</option>)}
 							</select>
 						</div>
 						<div className="col-span-2">
-							<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.baseUrl")}</label>
-							<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" placeholder={t("settings.form.baseUrl") ?? ""} value={form.baseUrl} onChange={(e) => setForm({ ...form, baseUrl: e.target.value })} />
+							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.baseUrl")}</label>
+							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" placeholder={t("settings.form.baseUrl") ?? ""} value={form.baseUrl} onChange={(e) => setForm({ ...form, baseUrl: e.target.value })} />
 						</div>
 						<div className="col-span-2">
-							<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.apiKey")}</label>
-							<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" type="password" placeholder={t("settings.form.apiKey") ?? ""} value={form.apiKey} onChange={(e) => setForm({ ...form, apiKey: e.target.value })} />
+							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiKey")}</label>
+							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" type="password" placeholder={t("settings.form.apiKey") ?? ""} value={form.apiKey} onChange={(e) => setForm({ ...form, apiKey: e.target.value })} />
 						</div>
 						<div>
-							<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.modelId")}</label>
-							<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" placeholder={t("settings.form.modelId") ?? ""} value={form.modelId} onChange={(e) => setForm({ ...form, modelId: e.target.value })} />
+							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelId")}</label>
+							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" placeholder={t("settings.form.modelId") ?? ""} value={form.modelId} onChange={(e) => setForm({ ...form, modelId: e.target.value })} />
 						</div>
 						<div>
-							<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.modelName")}</label>
-							<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" placeholder={t("settings.form.modelName") ?? ""} value={form.modelName} onChange={(e) => setForm({ ...form, modelName: e.target.value })} />
+							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelName")}</label>
+							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" placeholder={t("settings.form.modelName") ?? ""} value={form.modelName} onChange={(e) => setForm({ ...form, modelName: e.target.value })} />
 						</div>
 						<div>
-							<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.contextWindow")}</label>
-							<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.contextWindow} onChange={(e) => setForm({ ...form, contextWindow: e.target.value })} />
+							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.contextWindow")}</label>
+							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.contextWindow} onChange={(e) => setForm({ ...form, contextWindow: e.target.value })} />
 						</div>
 						<div>
-							<label className="mb-0.5 block text-[10px] text-slate-500">{t("settings.form.maxTokens")}</label>
-							<input className="w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs" value={form.maxTokens} onChange={(e) => setForm({ ...form, maxTokens: e.target.value })} />
+							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.maxTokens")}</label>
+							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.maxTokens} onChange={(e) => setForm({ ...form, maxTokens: e.target.value })} />
 						</div>
 					</div>
-					<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-slate-600">
+					<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
 						<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
 						<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
 					</div>
@@ -431,34 +462,34 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 		}
 	}
 
-	const inputCls = "w-full rounded-md border border-slate-200 px-2.5 py-1.5 text-xs";
-	const labelCls = "mb-0.5 block text-[10px] text-slate-500";
-	const checkCls = "flex items-center gap-1.5 text-xs text-slate-600";
+	const inputCls = "w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs";
+	const labelCls = "mb-0.5 block text-[10px] text-[var(--inno-text-muted)]";
+	const checkCls = "flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]";
 
 	return (
-		<div className="rounded-lg border border-slate-200 bg-white">
+		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
 			<button
 				className="flex w-full items-center justify-between px-4 py-3 text-left"
 				onClick={() => { setExpanded((v) => !v); setFormError(null); setSaveMsg(null); }}
 			>
 				<div className="flex items-center gap-2">
-					{expanded ? <ChevronDown size={14} className="text-slate-400" /> : <ChevronRight size={14} className="text-slate-400" />}
-					<span className="text-sm font-medium text-slate-950">{t("settings.channels.title")}</span>
+					{expanded ? <ChevronDown size={14} className="text-[var(--inno-text-subtle)]" /> : <ChevronRight size={14} className="text-[var(--inno-text-subtle)]" />}
+					<span className="text-sm font-medium text-[var(--inno-text)]">{t("settings.channels.title")}</span>
 				</div>
-				<div className="flex items-center gap-2 text-xs text-slate-400">
+				<div className="flex items-center gap-2 text-xs text-[var(--inno-text-subtle)]">
 					{feishuEnabled && <span className="rounded bg-green-50 px-1.5 py-0.5 text-green-700">{t("settings.channels.feishu.title")}</span>}
-					{qqEnabled && <span className="rounded bg-blue-50 px-1.5 py-0.5 text-blue-700">{t("settings.channels.qq.title")}</span>}
+					{qqEnabled && <span className="rounded bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-[var(--inno-accent)]">{t("settings.channels.qq.title")}</span>}
 					{wechatEnabled && <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-emerald-700">{t("settings.channels.wechat.title")}</span>}
 				</div>
 			</button>
 			{expanded && (
-				<div className="border-t border-slate-100 px-4 pb-4 pt-3 grid gap-4">
+				<div className="border-t border-[var(--inno-border)] px-4 pb-4 pt-3 grid gap-4">
 					{/* Feishu */}
-					<div className="rounded-lg border border-slate-100 p-3">
+					<div className="rounded-lg border border-[var(--inno-border)] p-3">
 						<div className="mb-2 flex items-center justify-between">
 							<div>
-								<div className="text-xs font-medium text-slate-950">{t("settings.channels.feishu.title")}</div>
-								<div className="text-[10px] text-slate-400">{t("settings.channels.feishu.desc")}</div>
+								<div className="text-xs font-medium text-[var(--inno-text)]">{t("settings.channels.feishu.title")}</div>
+								<div className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.channels.feishu.desc")}</div>
 							</div>
 							<label className={checkCls}>
 								<input type="checkbox" className="h-3.5 w-3.5" checked={feishuEnabled} onChange={(e) => setFeishuEnabled(e.target.checked)} />
@@ -472,7 +503,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 									<input className={inputCls} value={feishuAppId} onChange={(e) => setFeishuAppId(e.target.value)} />
 								</div>
 								<div>
-									<label className={labelCls}>{t("settings.channels.feishu.appSecret")} {settings.feishu?.appSecret && <span className="text-slate-400">(••••)</span>}</label>
+									<label className={labelCls}>{t("settings.channels.feishu.appSecret")} {settings.feishu?.appSecret && <span className="text-[var(--inno-text-subtle)]">(••••)</span>}</label>
 									<input className={inputCls} type="password" placeholder={t("settings.channels.feishu.appSecretHint") ?? ""} value={feishuAppSecret} onChange={(e) => setFeishuAppSecret(e.target.value)} />
 								</div>
 								<div className="col-span-2 flex items-center gap-3">
@@ -490,11 +521,11 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 					</div>
 
 					{/* QQ */}
-					<div className="rounded-lg border border-slate-100 p-3">
+					<div className="rounded-lg border border-[var(--inno-border)] p-3">
 						<div className="mb-2 flex items-center justify-between">
 							<div>
-								<div className="text-xs font-medium text-slate-950">{t("settings.channels.qq.title")}</div>
-								<div className="text-[10px] text-slate-400">{t("settings.channels.qq.desc")}</div>
+								<div className="text-xs font-medium text-[var(--inno-text)]">{t("settings.channels.qq.title")}</div>
+								<div className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.channels.qq.desc")}</div>
 							</div>
 							<label className={checkCls}>
 								<input type="checkbox" className="h-3.5 w-3.5" checked={qqEnabled} onChange={(e) => setQqEnabled(e.target.checked)} />
@@ -522,11 +553,11 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 					</div>
 
 					{/* WeChat (iLink native) */}
-					<div className="rounded-lg border border-slate-100 p-3">
+					<div className="rounded-lg border border-[var(--inno-border)] p-3">
 						<div className="mb-2 flex items-center justify-between">
 							<div>
-								<div className="text-xs font-medium text-slate-950">{t("settings.channels.wechat.title")}</div>
-								<div className="text-[10px] text-slate-400">{t("settings.channels.wechat.desc")}</div>
+								<div className="text-xs font-medium text-[var(--inno-text)]">{t("settings.channels.wechat.title")}</div>
+								<div className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.channels.wechat.desc")}</div>
 							</div>
 							<label className={checkCls}>
 								<input type="checkbox" className="h-3.5 w-3.5" checked={wechatEnabled} onChange={(e) => setWechatEnabled(e.target.checked)} />
@@ -536,23 +567,23 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 						{wechatEnabled && (
 							<div className="grid gap-2">
 								{/* Connection status */}
-								<div className="flex items-center gap-2 rounded border border-slate-100 bg-slate-50 px-2.5 py-2">
+								<div className="flex items-center gap-2 rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2.5 py-2">
 									{wxConnected ? (
 										<>
 											<Wifi size={14} className="text-green-600" />
 											<span className="text-xs font-medium text-green-700">{t("settings.channels.wechat.connected")}</span>
-											{wxBotId && <span className="text-[10px] text-slate-400 ml-1">{t("settings.channels.wechat.botId")}: {wxBotId}</span>}
+											{wxBotId && <span className="text-[10px] text-[var(--inno-text-subtle)] ml-1">{t("settings.channels.wechat.botId")}: {wxBotId}</span>}
 										</>
 									) : (
 										<>
-											<WifiOff size={14} className="text-slate-400" />
-											<span className="text-xs text-slate-500">{t("settings.channels.wechat.disconnected")}</span>
+											<WifiOff size={14} className="text-[var(--inno-text-subtle)]" />
+											<span className="text-xs text-[var(--inno-text-muted)]">{t("settings.channels.wechat.disconnected")}</span>
 										</>
 									)}
 								</div>
 
 								{/* QR login area */}
-								<div className="flex flex-col items-center gap-2 rounded border border-dashed border-slate-200 bg-white p-3">
+								<div className="flex flex-col items-center gap-2 rounded border border-dashed border-[var(--inno-border)] bg-[var(--inno-surface)] p-3">
 									{qrUrl && qrStatus !== "confirmed" && qrStatus !== "expired" && (
 										<QRCodeSVG value={qrUrl} size={192} level="M" />
 									)}
@@ -566,13 +597,13 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 										<div className="text-xs text-amber-600">{t("settings.channels.wechat.expired")}</div>
 									)}
 									{qrStatus === "scanning" && (
-										<div className="text-xs text-slate-400">{t("settings.channels.wechat.scanning")}</div>
+										<div className="text-xs text-[var(--inno-text-subtle)]">{t("settings.channels.wechat.scanning")}</div>
 									)}
 									{qrStatus === "waitingScan" && (
-										<div className="text-xs text-slate-500">{t("settings.channels.wechat.waitingScan")}</div>
+										<div className="text-xs text-[var(--inno-text-muted)]">{t("settings.channels.wechat.waitingScan")}</div>
 									)}
 									{qrStatus === "scanned" && (
-										<div className="text-xs text-blue-600">{t("settings.channels.wechat.scanned")}</div>
+										<div className="text-xs text-[var(--inno-accent)]">{t("settings.channels.wechat.scanned")}</div>
 									)}
 									{(!qrStatus || qrStatus === "confirmed" || qrStatus === "expired") && (
 										<button
@@ -603,9 +634,9 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 
 					{/* Bridge Token (used by QQ sidecar) */}
 					{qqEnabled && (
-						<div className="rounded-lg border border-slate-100 p-3">
-							<div className="text-xs font-medium text-slate-950 mb-1">{t("settings.channels.bridgeToken")}</div>
-							<div className="text-[10px] text-slate-400 mb-2">{t("settings.channels.bridgeTokenHint")}</div>
+						<div className="rounded-lg border border-[var(--inno-border)] p-3">
+							<div className="text-xs font-medium text-[var(--inno-text)] mb-1">{t("settings.channels.bridgeToken")}</div>
+							<div className="text-[10px] text-[var(--inno-text-subtle)] mb-2">{t("settings.channels.bridgeTokenHint")}</div>
 							<input
 								className={inputCls}
 								type="password"
@@ -613,7 +644,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								value={bridgeToken}
 								onChange={(e) => setBridgeToken(e.target.value)}
 							/>
-							{settings.bridge?.token && <div className="mt-1 text-[10px] text-slate-400">({settings.bridge.token})</div>}
+							{settings.bridge?.token && <div className="mt-1 text-[10px] text-[var(--inno-text-subtle)]">({settings.bridge.token})</div>}
 						</div>
 					)}
 
@@ -684,23 +715,23 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 		}
 	}
 
-	const inputCls = "h-8 min-w-0 flex-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-900 placeholder:text-slate-400 focus:border-blue-400 focus:outline-none";
+	const inputCls = "h-8 min-w-0 flex-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:border-blue-400 focus:outline-none";
 	const sourceLabel = type === "github"
 		? `GitHub · ${owner || "?"}/${repo || "?"}`
 		: `${t("settings.contentHub.bundle", "自托管服务")} · ${baseUrl || "?"}`;
 
 	return (
-		<div className="rounded-lg border border-slate-200 bg-white p-4">
+		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
 			<button className="flex w-full items-start gap-2 text-left" onClick={() => setOpen((v) => !v)}>
-				<Database size={16} className="mt-0.5 shrink-0 text-slate-700" />
+				<Database size={16} className="mt-0.5 shrink-0 text-[var(--inno-text)]" />
 				<div className="min-w-0 flex-1">
-					<h4 className="text-sm font-medium text-slate-950">{t("settings.contentHub.title", "内容源(技能库 + 预设)")}</h4>
-					<p className="mt-1 text-xs leading-relaxed text-slate-500">
+					<h4 className="text-sm font-medium text-[var(--inno-text)]">{t("settings.contentHub.title", "内容源(技能库 + 预设)")}</h4>
+					<p className="mt-1 text-xs leading-relaxed text-[var(--inno-text-muted)]">
 						{t("settings.contentHub.desc", "技能库和预设工作区从这里拉取。默认公共仓库,可改为私有 GitHub 仓库或自托管服务。")}
 					</p>
-					{!open && <p className="mt-1 truncate text-[11px] text-slate-400">{sourceLabel}</p>}
+					{!open && <p className="mt-1 truncate text-[11px] text-[var(--inno-text-subtle)]">{sourceLabel}</p>}
 				</div>
-				<ChevronDown size={14} className={`mt-1 shrink-0 text-slate-400 transition-transform ${open ? "rotate-180" : ""}`} />
+				<ChevronDown size={14} className={`mt-1 shrink-0 text-[var(--inno-text-subtle)] transition-transform ${open ? "rotate-180" : ""}`} />
 			</button>
 
 			{open ? (
@@ -709,13 +740,13 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 					<div className="flex items-center gap-1.5">
 						<button
 							onClick={() => setType("github")}
-							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "github" ? "border-blue-400 bg-blue-50 text-blue-700" : "border-slate-200 text-slate-600 hover:bg-slate-50"}`}
+							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "github" ? "border-blue-400 bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]" : "border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"}`}
 						>
 							GitHub
 						</button>
 						<button
 							onClick={() => setType("bundle")}
-							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "bundle" ? "border-blue-400 bg-blue-50 text-blue-700" : "border-slate-200 text-slate-600 hover:bg-slate-50"}`}
+							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "bundle" ? "border-blue-400 bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]" : "border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"}`}
 						>
 							{t("settings.contentHub.bundle", "自托管服务")}
 						</button>
@@ -784,17 +815,17 @@ function MemoryToggleRow({
 	return (
 		<div className={`flex items-start justify-between gap-3 ${locked ? "opacity-60" : ""}`}>
 			<div className="min-w-0">
-				<h4 className="text-sm font-medium text-slate-950">{title}</h4>
-				<p className="mt-1 text-xs text-slate-500">{desc}</p>
+				<h4 className="text-sm font-medium text-[var(--inno-text)]">{title}</h4>
+				<p className="mt-1 text-xs text-[var(--inno-text-muted)]">{desc}</p>
 			</div>
 			<button
 				role="switch"
 				aria-checked={shown}
 				disabled={saving || locked}
 				onClick={() => onToggle(!enabled)}
-				className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${shown ? "bg-blue-600" : "bg-slate-300"}`}
+				className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${shown ? "bg-[var(--inno-accent)]" : "bg-slate-300"}`}
 			>
-				<span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${shown ? "translate-x-[18px]" : "translate-x-1"}`} />
+				<span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-[var(--inno-surface)] transition-transform ${shown ? "translate-x-[18px]" : "translate-x-1"}`} />
 			</button>
 		</div>
 	);
@@ -838,8 +869,8 @@ function MemorySettings({ settings }: { settings: InnoSettings }) {
 	];
 
 	return (
-		<div className="rounded-lg border border-slate-200 bg-white p-4">
-			<h4 className="mb-3 text-sm font-medium text-slate-950">{t("settings.memorySection")}</h4>
+		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+			<h4 className="mb-3 text-sm font-medium text-[var(--inno-text)]">{t("settings.memorySection")}</h4>
 			{locked ? <p className="mb-3 text-xs text-amber-600">{t("settings.simpleMode.memoryLocked")}</p> : null}
 			<div className="grid gap-4">
 				{layers.map(({ key, ns }) => {
@@ -885,11 +916,11 @@ function SimpleModeSettings({ settings }: { settings: InnoSettings }) {
 	}
 
 	return (
-		<div className="rounded-lg border border-slate-200 bg-white p-4">
+		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
 			<div className="flex items-start justify-between gap-3">
 				<div className="min-w-0">
-					<h4 className="text-sm font-medium text-slate-950">{t("settings.simpleMode.title")}</h4>
-					<p className="mt-1 text-xs leading-relaxed text-slate-500">
+					<h4 className="text-sm font-medium text-[var(--inno-text)]">{t("settings.simpleMode.title")}</h4>
+					<p className="mt-1 text-xs leading-relaxed text-[var(--inno-text-muted)]">
 						{enabled ? t("settings.simpleMode.onDesc") : t("settings.simpleMode.offDesc")}
 					</p>
 				</div>
@@ -898,9 +929,9 @@ function SimpleModeSettings({ settings }: { settings: InnoSettings }) {
 					aria-checked={enabled}
 					disabled={saving}
 					onClick={() => void handleToggle(!enabled)}
-					className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${enabled ? "bg-blue-600" : "bg-slate-300"}`}
+					className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${enabled ? "bg-[var(--inno-accent)]" : "bg-slate-300"}`}
 				>
-					<span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform ${enabled ? "translate-x-[18px]" : "translate-x-1"}`} />
+					<span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-[var(--inno-surface)] transition-transform ${enabled ? "translate-x-[18px]" : "translate-x-1"}`} />
 				</button>
 			</div>
 		</div>
@@ -935,14 +966,15 @@ export function SettingsPanel() {
 		<div className="h-full overflow-y-auto p-3">
 			<div className="grid gap-3">
 				{/* Status cards */}
-				<div className="rounded-lg border border-slate-200 bg-white p-4">
+				<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
 					<div className="mb-3 flex items-center justify-between">
-						<h3 className="text-sm font-medium text-slate-950">{t("settings.title")}</h3>
+						<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("settings.title")}</h3>
 						<div className="flex items-center gap-2">
-							<label className="flex items-center gap-1.5 text-xs text-slate-500">
+							<ThemeSettings />
+							<label className="flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
 								<span>{t("settings.language")}</span>
 								<select
-									className="rounded-md border border-slate-200 bg-white px-2 py-1 text-xs"
+									className="rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 text-xs"
 									value={i18n.language}
 									onChange={(e) => setLocale(e.target.value as "zh-CN" | "en")}
 								>
@@ -950,27 +982,27 @@ export function SettingsPanel() {
 									<option value="en">{t("settings.languageOptions.en")}</option>
 								</select>
 							</label>
-							<button className="rounded-md border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-100 hover:text-slate-950" onClick={() => void settingsStore.load()}>
+							<button className="rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void settingsStore.load()}>
 								{t("settings.refresh")}
 							</button>
 						</div>
 					</div>
-					{state.isLoading ? <div className="text-sm text-slate-500">{t("settings.loading")}</div> : null}
+					{state.isLoading ? <div className="text-sm text-[var(--inno-text-muted)]">{t("settings.loading")}</div> : null}
 					{state.error ? <div className="rounded bg-red-50 p-2 text-sm text-red-700">{state.error}</div> : null}
 					<div className="grid grid-cols-3 gap-3 text-sm">
-						<div className="rounded border border-slate-200 bg-slate-50 p-3">
-							<div className="text-xs text-slate-500">{t("settings.stats.server")}</div>
+						<div className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
+							<div className="text-xs text-[var(--inno-text-muted)]">{t("settings.stats.server")}</div>
 							<div className={healthOk ? "font-medium text-green-700" : "font-medium text-red-600"}>
 								{healthOk ? t("settings.stats.healthy") : t("settings.stats.offline")}
 							</div>
 						</div>
-						<div className="rounded border border-slate-200 bg-slate-50 p-3">
-							<div className="text-xs text-slate-500">{t("settings.stats.defaultModel")}</div>
-							<div className="font-medium text-slate-950">{state.settings ? `${state.settings.defaultProvider}/${state.settings.defaultModel}` : "-"}</div>
+						<div className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
+							<div className="text-xs text-[var(--inno-text-muted)]">{t("settings.stats.defaultModel")}</div>
+							<div className="font-medium text-[var(--inno-text)]">{state.settings ? `${state.settings.defaultProvider}/${state.settings.defaultModel}` : "-"}</div>
 						</div>
-						<div className="rounded border border-slate-200 bg-slate-50 p-3">
-							<div className="text-xs text-slate-500">{t("settings.stats.wiki")}</div>
-							<div className="font-medium text-slate-950">
+						<div className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
+							<div className="text-xs text-[var(--inno-text-muted)]">{t("settings.stats.wiki")}</div>
+							<div className="font-medium text-[var(--inno-text)]">
 								{wikiStats ? t("settings.stats.wikiStat", { count: wikiStats.pageCount, size: formatBytes(wikiStats.totalSize) }) : "-"}
 							</div>
 						</div>
@@ -978,8 +1010,8 @@ export function SettingsPanel() {
 				</div>
 
 				{/* Models */}
-				<div className="rounded-lg border border-slate-200 bg-white p-4">
-					<h4 className="mb-3 text-sm font-medium text-slate-950">{t("settings.models")}</h4>
+				<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+					<h4 className="mb-3 text-sm font-medium text-[var(--inno-text)]">{t("settings.models")}</h4>
 					<div className="grid gap-2">
 						{models.map((model) => {
 							const key = modelKey(model);
@@ -998,21 +1030,21 @@ export function SettingsPanel() {
 							}
 
 							return (
-								<div key={key} className={`group flex items-center justify-between rounded border p-3 ${current ? "border-blue-200 bg-blue-50" : "border-slate-200 bg-white"}`}>
+								<div key={key} className={`group flex items-center justify-between rounded border p-3 ${current ? "border-[var(--inno-accent-soft)] bg-[var(--inno-accent-soft)]" : "border-[var(--inno-border)] bg-[var(--inno-surface)]"}`}>
 									<div className="min-w-0 flex-1">
-										<div className="text-sm font-medium text-slate-950">{model.name || model.id}</div>
-										<div className="text-xs text-slate-500">{model.provider} · {formatTokens(model.contextWindow)} context · {formatTokens(model.maxTokens)} max</div>
+										<div className="text-sm font-medium text-[var(--inno-text)]">{model.name || model.id}</div>
+										<div className="text-xs text-[var(--inno-text-muted)]">{model.provider} · {formatTokens(model.contextWindow)} context · {formatTokens(model.maxTokens)} max</div>
 									</div>
 									<div className="flex items-center gap-1.5">
 										<button
-											className="flex h-7 w-7 items-center justify-center rounded text-slate-400 opacity-0 transition-opacity hover:bg-slate-100 hover:text-slate-700 group-hover:opacity-100"
+											className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] group-hover:opacity-100"
 											title={t("common.edit", "Edit")}
 											onClick={() => setEditingModel(key)}
 										>
 											<Pencil size={13} />
 										</button>
 										<button
-											className="flex h-7 w-7 items-center justify-center rounded text-slate-400 opacity-0 transition-opacity hover:bg-red-50 hover:text-red-600 group-hover:opacity-100"
+											className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-red-50 hover:text-red-600 group-hover:opacity-100"
 											title={t("common.delete", "Delete")}
 											onClick={() => {
 												if (window.confirm(t("settings.confirmDelete", { id: `${model.provider}/${model.id}` }) ?? "")) {
@@ -1024,14 +1056,14 @@ export function SettingsPanel() {
 										</button>
 										{!current && (
 											<button
-												className="rounded-md border border-slate-200 px-2.5 py-1 text-xs text-slate-500 hover:bg-slate-100 hover:text-slate-950"
+												className="rounded-md border border-[var(--inno-border)] px-2.5 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 												disabled={state.isSavingModel}
 												onClick={() => void settingsStore.switchModel(model.provider, model.id)}
 											>
 												{t("settings.use")}
 											</button>
 										)}
-										{current && <span className="rounded-md bg-blue-100 px-2.5 py-1 text-xs font-medium text-blue-700">{t("settings.current")}</span>}
+										{current && <span className="rounded-md bg-[var(--inno-accent-soft)] px-2.5 py-1 text-xs font-medium text-[var(--inno-accent)]">{t("settings.current")}</span>}
 									</div>
 								</div>
 							);

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -89,28 +89,28 @@ function cmLangExtension(lang: string): Extension[] {
 }
 
 function SkillHtmlPreview({ file }: { file: WorkspaceFileDetail }) {
-  return <iframe className="h-full w-full border-0 bg-white" sandbox="allow-scripts allow-same-origin" srcDoc={file.content ?? ""} title={file.name} />;
+  return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" sandbox="allow-scripts allow-same-origin" srcDoc={file.content ?? ""} title={file.name} />;
 }
 
 /* ---------- File Preview ---------- */
 
 function FilePreview({ file, skillName, isLoading }: { file: WorkspaceFileDetail; skillName: string; isLoading: boolean }) {
 	const { t } = useTranslation();
-	if (isLoading) return <div className="flex h-full items-center justify-center text-sm text-slate-500">{t("preview.loadingFile", "Loading...")}</div>;
+	if (isLoading) return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.loadingFile", "Loading...")}</div>;
 	if (file.kind === "markdown") return <div className="h-full overflow-y-auto p-5"><markdown-artifact content={file.content ?? ""} /></div>;
 	if (file.kind === "html") return <SkillHtmlPreview file={file} />;
-	if (file.kind === "pdf") return <iframe className="h-full w-full border-0 bg-white" src={file.url ?? skillRawUrl(skillName, file.path)} title={file.name} />;
+	if (file.kind === "pdf") return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" src={file.url ?? skillRawUrl(skillName, file.path)} title={file.name} />;
 	if (file.kind === "image") {
 		return (
-			<div className="flex h-full items-center justify-center overflow-auto bg-slate-50 p-4">
+			<div className="flex h-full items-center justify-center overflow-auto bg-[var(--inno-surface-muted)] p-4">
 				<img className="max-h-full max-w-full object-contain" src={file.url ?? skillRawUrl(skillName, file.path)} alt={file.name} />
 			</div>
 		);
 	}
 	if (file.kind === "binary") {
 		return (
-			<div className="flex h-full flex-col items-center justify-center text-sm text-slate-500">
-				<div className="mb-2 text-lg font-medium text-slate-950">{file.name}</div>
+			<div className="flex h-full flex-col items-center justify-center text-sm text-[var(--inno-text-muted)]">
+				<div className="mb-2 text-lg font-medium text-[var(--inno-text)]">{file.name}</div>
 				<div>{t("preview.binaryFile", "Binary file")} · {formatSize(file.size)}</div>
 			</div>
 		);
@@ -141,7 +141,7 @@ function SkillFileNode({ node, style, dragHandle }: NodeRendererProps<ArboristNo
 			ref={dragHandle}
 			style={style}
 			className={`group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer select-none ${
-				selected ? "bg-blue-50 text-blue-700 ring-1 ring-blue-100" : "text-slate-600 hover:bg-slate-100 hover:text-slate-950"
+				selected ? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100" : "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 			}`}
 			onClick={(e) => {
 				e.stopPropagation();
@@ -152,7 +152,7 @@ function SkillFileNode({ node, style, dragHandle }: NodeRendererProps<ArboristNo
 				}
 			}}
 		>
-			<span className="flex h-4 w-4 shrink-0 items-center justify-center text-slate-400">
+			<span className="flex h-4 w-4 shrink-0 items-center justify-center text-[var(--inno-text-subtle)]">
 				{nodeIcon(node.data.name, isDir, node.isOpen)}
 			</span>
 			<span className="min-w-0 flex-1 truncate">{node.data.name}</span>
@@ -181,21 +181,21 @@ function SkillFilePane({ skillName, onToggleSidebar, sidebarOpen }: { skillName:
 		const extensions = cmLangExtension(lang);
 		return (
 			<div className="flex h-full flex-col">
-				<div className="flex h-10 items-center justify-between border-b border-slate-200 bg-white px-3">
+				<div className="flex h-10 items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3">
 					<div className="flex min-w-0 flex-1 items-center gap-2">
-						<button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700" onClick={onToggleSidebar}>
+						<button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={onToggleSidebar}>
 							{sidebarOpen ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
 						</button>
 						<div className="min-w-0">
 							<div className="truncate text-sm font-medium">{state.file.name}</div>
-							<div className="truncate text-[10px] text-slate-500">{t("files.editing", "Editing")} · {state.file.path}</div>
+							<div className="truncate text-[10px] text-[var(--inno-text-muted)]">{t("files.editing", "Editing")} · {state.file.path}</div>
 						</div>
 					</div>
 					<div className="flex items-center gap-1.5">
 						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50" onClick={() => void skillsStore.saveFile()}>
 							<Save size={12} /> {t("common.save", "Save")}
 						</button>
-						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50" onClick={() => skillsStore.cancelEditing()}>
+						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] disabled:opacity-50" onClick={() => skillsStore.cancelEditing()}>
 							<X size={12} /> {t("common.cancel", "Cancel")}
 						</button>
 					</div>
@@ -217,27 +217,27 @@ function SkillFilePane({ skillName, onToggleSidebar, sidebarOpen }: { skillName:
 
 	return (
 		<div className="flex h-full flex-col">
-			<div className="flex h-10 items-center justify-between border-b border-slate-200 bg-white px-3">
+			<div className="flex h-10 items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3">
 				<div className="flex min-w-0 flex-1 items-center gap-2">
-					<button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700" onClick={onToggleSidebar}>
+					<button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={onToggleSidebar}>
 						{sidebarOpen ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
 					</button>
 					<div className="min-w-0">
 						<div className="truncate text-sm font-medium">{state.file?.name ?? t("preview.noFile", "No file selected")}</div>
-						<div className="truncate text-[10px] text-slate-500">
+						<div className="truncate text-[10px] text-[var(--inno-text-muted)]">
 							{state.file ? `${state.file.path} · ${formatSize(state.file.size)}` : t("preview.selectFile", "Select a file to preview")}
 						</div>
 					</div>
 				</div>
 				{canEdit && (
-					<button className="flex h-7 items-center gap-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-600 hover:bg-slate-100 hover:text-slate-950" onClick={() => skillsStore.startEditing()}>
+					<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => skillsStore.startEditing()}>
 						<Pencil size={12} /> {t("common.edit", "Edit")}
 					</button>
 				)}
 			</div>
 			<div className="min-h-0 flex-1 overflow-auto">
 				{state.file ? <FilePreview file={state.file} skillName={skillName} isLoading={state.isLoadingFile} /> : (
-					<div className="flex h-full items-center justify-center text-sm text-slate-500">{t("preview.noPreview", "Nothing to preview")}</div>
+					<div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.noPreview", "Nothing to preview")}</div>
 				)}
 			</div>
 		</div>
@@ -279,16 +279,16 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 	return (
 		<div className={`grid h-full min-h-0 gap-3 transition-[grid-template-columns] duration-200 ${sidebarOpen ? "grid-cols-[240px_minmax(0,1fr)]" : "grid-cols-[0px_minmax(0,1fr)]"}`}>
 			{/* File tree sidebar */}
-			<aside className={`flex min-h-0 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white transition-opacity duration-200 ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}>
+			<aside className={`flex min-h-0 flex-col overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] transition-opacity duration-200 ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}>
 				{/* Skill header */}
-				<div className="flex items-center gap-2 border-b border-slate-200 px-2 py-2">
-					<button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700" onClick={onBack}>
+				<div className="flex items-center gap-2 border-b border-[var(--inno-border)] px-2 py-2">
+					<button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={onBack}>
 						<ChevronLeft size={16} />
 					</button>
 					<div className="min-w-0 flex-1">
 						<div className="flex items-center gap-2">
-							<span className="truncate text-sm font-medium text-slate-950">{skill.name}</span>
-							<span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${skill.enabled ? "bg-green-50 text-green-700 ring-1 ring-green-100" : "bg-slate-100 text-slate-500"}`}>
+							<span className="truncate text-sm font-medium text-[var(--inno-text)]">{skill.name}</span>
+							<span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${skill.enabled ? "bg-green-50 text-green-700 ring-1 ring-green-100" : "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]"}`}>
 								{skill.enabled ? t("common.enabled", "Enabled") : t("common.disabled", "Disabled")}
 							</span>
 						</div>
@@ -296,13 +296,13 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 				</div>
 
 				{/* Toolbar */}
-				<div className="flex items-center gap-1 border-b border-slate-100 px-2 py-1.5">
-					<label className="flex items-center gap-1.5 text-xs text-slate-500">
+				<div className="flex items-center gap-1 border-b border-[var(--inno-border)] px-2 py-1.5">
+					<label className="flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
 						<input type="checkbox" className="h-3.5 w-3.5" checked={skill.enabled} onChange={(e) => void skillsStore.setEnabled(skill.name, e.target.checked)} />
 						{t("common.enable", "Enable")}
 					</label>
 					<div className="flex-1" />
-					<button className="flex h-6 w-6 items-center justify-center rounded text-slate-400 hover:bg-slate-200 hover:text-slate-700" title={t("preview.refresh", "Refresh")} onClick={() => void skillsStore.refreshTree()}>
+					<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-slate-200 hover:text-[var(--inno-text)]" title={t("preview.refresh", "Refresh")} onClick={() => void skillsStore.refreshTree()}>
 						<RefreshCw size={12} />
 					</button>
 					<button className="flex h-6 w-6 items-center justify-center rounded text-red-400 hover:bg-red-50 hover:text-red-600" title={t("common.delete", "Delete")} onClick={() => { void skillsStore.remove(skill.name); onBack(); }}>
@@ -313,11 +313,11 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 				{/* File tree */}
 				<div ref={treeContainerRef} className="min-h-0 flex-1 overflow-hidden">
 					{state.isLoadingTree && !arboristData.length ? (
-						<div className="flex items-center justify-center py-8 text-slate-500">
+						<div className="flex items-center justify-center py-8 text-[var(--inno-text-muted)]">
 							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
 						</div>
 					) : !arboristData.length ? (
-						<div className="p-3 text-xs text-slate-500">{t("preview.empty", "Empty")}</div>
+						<div className="p-3 text-xs text-[var(--inno-text-muted)]">{t("preview.empty", "Empty")}</div>
 					) : (
 						<Tree<ArboristNode>
 							data={arboristData}
@@ -336,7 +336,7 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 			</aside>
 
 			{/* File content pane */}
-			<section className="flex min-w-0 min-h-0 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white">
+			<section className="flex min-w-0 min-h-0 flex-col overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
 				<SkillFilePane skillName={skill.name} onToggleSidebar={() => setSidebarOpen((v) => !v)} sidebarOpen={sidebarOpen} />
 			</section>
 		</div>
@@ -348,15 +348,15 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 function SkillRow({ skill, onClick }: { skill: SkillInfo; onClick: () => void }) {
 	return (
 		<button
-			className="flex w-full items-center gap-3 border-b border-slate-100 px-3 py-2.5 text-left transition-colors hover:bg-slate-50"
+			className="flex w-full items-center gap-3 border-b border-[var(--inno-border)] px-3 py-2.5 text-left transition-colors hover:bg-[var(--inno-surface-muted)]"
 			onClick={onClick}
 		>
 			<span className={`h-2 w-2 shrink-0 rounded-full ${skill.enabled ? "bg-green-500" : "bg-slate-300"}`} />
 			<div className="min-w-0 flex-1">
-				<div className="truncate text-sm font-medium text-slate-950">{skill.name}</div>
-				{skill.description && <div className="truncate text-xs text-slate-500">{skill.description}</div>}
+				<div className="truncate text-sm font-medium text-[var(--inno-text)]">{skill.name}</div>
+				{skill.description && <div className="truncate text-xs text-[var(--inno-text-muted)]">{skill.description}</div>}
 			</div>
-			<span className="shrink-0 text-[10px] text-slate-400">{formatSize(skill.size)}</span>
+			<span className="shrink-0 text-[10px] text-[var(--inno-text-subtle)]">{formatSize(skill.size)}</span>
 		</button>
 	);
 }
@@ -375,28 +375,28 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 	return (
 		<div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-900/40 p-4" onClick={onClose}>
 			<div
-				className="flex max-h-full w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-slate-200 bg-white shadow-xl"
+				className="flex max-h-full w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] shadow-xl"
 				onClick={(e) => e.stopPropagation()}
 			>
 				{/* Header */}
-				<div className="flex items-center justify-between gap-3 border-b border-slate-200 px-4 py-3">
+				<div className="flex items-center justify-between gap-3 border-b border-[var(--inno-border)] px-4 py-3">
 					<div className="flex min-w-0 items-center gap-2">
-						<Library size={16} className="shrink-0 text-blue-600" />
+						<Library size={16} className="shrink-0 text-[var(--inno-accent)]" />
 						<div className="min-w-0">
-							<div className="truncate text-sm font-medium text-slate-950">{t("skills.libraryTitle")}</div>
-							<div className="truncate text-[11px] text-slate-500">{t("skills.librarySubtitle")}</div>
+							<div className="truncate text-sm font-medium text-[var(--inno-text)]">{t("skills.libraryTitle")}</div>
+							<div className="truncate text-[11px] text-[var(--inno-text-muted)]">{t("skills.librarySubtitle")}</div>
 						</div>
 					</div>
 					<div className="flex shrink-0 items-center gap-1">
 						<button
-							className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+							className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 							title={t("skills.reload")}
 							onClick={() => void skillsStore.loadLibrary(true)}
 						>
 							<RefreshCw size={14} />
 						</button>
 						<button
-							className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+							className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 							onClick={onClose}
 						>
 							<X size={16} />
@@ -404,27 +404,27 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 					</div>
 				</div>
 
-				{state.error ? <div className="border-b border-slate-200 bg-red-50 px-4 py-2 text-xs text-red-700">{state.error}</div> : null}
+				{state.error ? <div className="border-b border-[var(--inno-border)] bg-red-50 px-4 py-2 text-xs text-red-700">{state.error}</div> : null}
 
 				{/* Body */}
 				<div className="min-h-0 flex-1 overflow-y-auto">
 					{state.isLoading ? (
-						<div className="flex items-center justify-center py-12 text-slate-500">
+						<div className="flex items-center justify-center py-12 text-[var(--inno-text-muted)]">
 							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
 							{t("common.loading")}
 						</div>
 					) : state.library.length === 0 ? (
-						<div className="flex h-full flex-col items-center justify-center py-12 text-center text-sm text-slate-500">
+						<div className="flex h-full flex-col items-center justify-center py-12 text-center text-sm text-[var(--inno-text-muted)]">
 							{t("skills.libraryEmpty")}
 						</div>
 					) : (
 						state.library.map((item) => {
 							const isImporting = state.importing.has(item.name);
 							return (
-								<div key={item.name} className="flex items-start gap-3 border-b border-slate-100 px-4 py-3">
+								<div key={item.name} className="flex items-start gap-3 border-b border-[var(--inno-border)] px-4 py-3">
 									<div className="min-w-0 flex-1">
-										<div className="truncate text-sm font-medium text-slate-950">{item.name}</div>
-										{item.description && <div className="mt-0.5 line-clamp-3 text-xs leading-relaxed text-slate-500">{item.description}</div>}
+										<div className="truncate text-sm font-medium text-[var(--inno-text)]">{item.name}</div>
+										{item.description && <div className="mt-0.5 line-clamp-3 text-xs leading-relaxed text-[var(--inno-text-muted)]">{item.description}</div>}
 									</div>
 									{item.installed ? (
 										<span className="flex shrink-0 items-center gap-1 rounded-md bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 ring-1 ring-green-100">
@@ -491,17 +491,17 @@ export function SkillsPanel() {
 	// List view — one skill per row
 	return (
 		<div className="relative flex h-full flex-col p-3">
-			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-slate-200 bg-white">
+			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
 				{/* Toolbar */}
-				<div className="flex items-center justify-between gap-3 border-b border-slate-200 px-3 py-2.5">
-					<h3 className="text-sm font-medium text-slate-950">{t("skills.title")}</h3>
+				<div className="flex items-center justify-between gap-3 border-b border-[var(--inno-border)] px-3 py-2.5">
+					<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("skills.title")}</h3>
 					<div className="flex shrink-0 items-center gap-2">
 						<input ref={uploadRef} type="file" className="hidden" accept=".zip,application/zip,.md,text/markdown,text/plain" onChange={handleUpload} />
-						<button className="flex h-7 items-center gap-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-600 hover:bg-slate-100 hover:text-slate-950" onClick={() => skillsStore.openLibrary()}>
+						<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => skillsStore.openLibrary()}>
 							<Library size={13} />
 							{t("skills.library")}
 						</button>
-						<button className="flex h-7 items-center gap-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-500 hover:bg-slate-100 hover:text-slate-950" onClick={() => void skillsStore.reload()}>
+						<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void skillsStore.reload()}>
 							<RefreshCw size={13} />
 						</button>
 						<button className="flex h-7 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50" disabled={state.isUploading} onClick={() => uploadRef.current?.click()}>
@@ -510,18 +510,18 @@ export function SkillsPanel() {
 						</button>
 					</div>
 				</div>
-				{state.error ? <div className="border-b border-slate-200 bg-red-50 px-3 py-2 text-xs text-red-700">{state.error}</div> : null}
+				{state.error ? <div className="border-b border-[var(--inno-border)] bg-red-50 px-3 py-2 text-xs text-red-700">{state.error}</div> : null}
 
 				{/* Skills list */}
 				<div className="min-h-0 flex-1 overflow-y-auto">
 					{state.isLoading ? (
-						<div className="flex items-center justify-center py-8 text-slate-500">
+						<div className="flex items-center justify-center py-8 text-[var(--inno-text-muted)]">
 							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
 							{t("common.loading")}
 						</div>
 					) : state.skills.length === 0 ? (
-						<div className="flex h-full flex-col items-center justify-center text-center text-sm text-slate-500">
-							<div className="text-base font-medium text-slate-950">{t("skills.empty")}</div>
+						<div className="flex h-full flex-col items-center justify-center text-center text-sm text-[var(--inno-text-muted)]">
+							<div className="text-base font-medium text-[var(--inno-text)]">{t("skills.empty")}</div>
 							<p className="mt-1 max-w-sm text-xs">{t("skills.emptyDesc")}</p>
 						</div>
 					) : (

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -141,7 +141,9 @@ function SkillFileNode({ node, style, dragHandle }: NodeRendererProps<ArboristNo
 			ref={dragHandle}
 			style={style}
 			className={`group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer select-none ${
-				selected ? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100" : "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+				selected
+					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100"
+					: "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 			}`}
 			onClick={(e) => {
 				e.stopPropagation();
@@ -192,7 +194,7 @@ function SkillFilePane({ skillName, onToggleSidebar, sidebarOpen }: { skillName:
 						</div>
 					</div>
 					<div className="flex items-center gap-1.5">
-						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50" onClick={() => void skillsStore.saveFile()}>
+						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md inno-primary-button px-2.5 text-xs text-white disabled:opacity-50" onClick={() => void skillsStore.saveFile()}>
 							<Save size={12} /> {t("common.save", "Save")}
 						</button>
 						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] disabled:opacity-50" onClick={() => skillsStore.cancelEditing()}>
@@ -433,7 +435,7 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 									) : (
 										<button
 											disabled={isImporting}
-											className="flex h-7 shrink-0 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50"
+											className="flex h-7 shrink-0 items-center gap-1 rounded-md inno-primary-button px-2.5 text-xs text-white disabled:opacity-50"
 											onClick={() => void skillsStore.importFromLibrary(item.name)}
 										>
 											<Download size={12} />
@@ -504,7 +506,7 @@ export function SkillsPanel() {
 						<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void skillsStore.reload()}>
 							<RefreshCw size={13} />
 						</button>
-						<button className="flex h-7 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50" disabled={state.isUploading} onClick={() => uploadRef.current?.click()}>
+						<button className="flex h-7 items-center gap-1 rounded-md inno-primary-button px-2.5 text-xs text-white disabled:opacity-50" disabled={state.isUploading} onClick={() => uploadRef.current?.click()}>
 							<Upload size={13} />
 							{state.isUploading ? t("skills.uploading") : t("skills.upload")}
 						</button>

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -394,7 +394,7 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 					<div className="flex items-center gap-1.5">
 						<button
 							disabled={state.isSaving}
-							className="flex h-7 items-center gap-1 rounded-md bg-slate-900 px-2.5 text-xs text-white hover:bg-slate-800 disabled:opacity-50"
+							className="flex h-7 items-center gap-1 rounded-md inno-primary-button px-2.5 text-xs text-white disabled:opacity-50"
 							onClick={() => void workspaceStore.saveFile()}
 						>
 							<Save size={12} />
@@ -474,7 +474,9 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 			ref={dragHandle}
 			style={style}
 			className={`group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer select-none ${
-				selected ? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100" : "text-[var(--inno-text-muted)] hover:bg-slate-100/85 hover:text-[var(--inno-text)]"
+				selected
+					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100"
+					: "text-[var(--inno-text-muted)] hover:bg-slate-100/85 hover:text-[var(--inno-text)]"
 			}`}
 			onClick={(e) => {
 				e.stopPropagation();

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -145,16 +145,16 @@ function CsvPreview({ name, content }: { name: string; content: string }) {
 	}, [name, content]);
 
 	if (!rows.length) {
-		return <div className="flex h-full items-center justify-center text-sm text-slate-500">{t("preview.emptyTable", "Empty table")}</div>;
+		return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.emptyTable", "Empty table")}</div>;
 	}
 	const [header, ...body] = rows;
 	return (
-		<div className="h-full overflow-auto bg-white p-3">
+		<div className="h-full overflow-auto bg-[var(--inno-surface)] p-3">
 			<table className="w-full border-collapse text-xs">
 				<thead className="sticky top-0 z-10">
 					<tr>
 						{header.map((cell, i) => (
-							<th key={i} className="border border-slate-200 bg-slate-50 px-2 py-1 text-left font-semibold text-slate-700">
+							<th key={i} className="border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1 text-left font-semibold text-[var(--inno-text)]">
 								{cell}
 							</th>
 						))}
@@ -162,9 +162,9 @@ function CsvPreview({ name, content }: { name: string; content: string }) {
 				</thead>
 				<tbody>
 					{body.map((r, ri) => (
-						<tr key={ri} className="odd:bg-white even:bg-slate-50/60">
+						<tr key={ri} className="odd:bg-[var(--inno-surface)] even:bg-slate-50/60">
 							{header.map((_, ci) => (
-								<td key={ci} className="border border-slate-200 px-2 py-1 align-top text-slate-600">
+								<td key={ci} className="border border-[var(--inno-border)] px-2 py-1 align-top text-[var(--inno-text-muted)]">
 									{r[ci] ?? ""}
 								</td>
 							))}
@@ -172,7 +172,7 @@ function CsvPreview({ name, content }: { name: string; content: string }) {
 					))}
 				</tbody>
 			</table>
-			<div className="mt-2 text-[10px] text-slate-400">{t("preview.tableRows", "{{count}} rows", { count: body.length })}</div>
+			<div className="mt-2 text-[10px] text-[var(--inno-text-subtle)]">{t("preview.tableRows", "{{count}} rows", { count: body.length })}</div>
 		</div>
 	);
 }
@@ -218,14 +218,14 @@ function OfficePreview({ file }: { file: WorkspaceFileDetail }) {
 	}, [file.url]);
 
 	if (loading) {
-		return <div className="flex h-full items-center justify-center text-sm text-slate-500">{t("preview.officeParsing", "Extracting document text...")}</div>;
+		return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.officeParsing", "Extracting document text...")}</div>;
 	}
 	if (error) {
 		return (
-			<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-slate-500">
-				<div className="font-medium text-slate-700">{file.name}</div>
+			<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[var(--inno-text-muted)]">
+				<div className="font-medium text-[var(--inno-text)]">{file.name}</div>
 				<div className="text-xs text-red-500">{error}</div>
-				<button className="flex items-center gap-1 rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-600 hover:bg-slate-50" onClick={downloadOriginal}>
+				<button className="flex items-center gap-1 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]" onClick={downloadOriginal}>
 					<Download size={12} />
 					{t("files.download", "Download")}
 				</button>
@@ -234,25 +234,25 @@ function OfficePreview({ file }: { file: WorkspaceFileDetail }) {
 	}
 	const pages = data?.pages?.length ? data.pages : (data ? [{ pageNumber: 1, text: data.text }] : []);
 	return (
-		<div className="workspace-scroll h-full overflow-auto bg-slate-50 p-4">
+		<div className="workspace-scroll h-full overflow-auto bg-[var(--inno-surface-muted)] p-4">
 			<div className="mb-3 flex items-center justify-between gap-2">
-				<div className="text-xs text-slate-500">
+				<div className="text-xs text-[var(--inno-text-muted)]">
 					{t("preview.officeNote", "Text extracted for preview · formatting may differ")} · {t("preview.pageCount", "{{count}} pages", { count: data?.pageCount ?? pages.length })}
 				</div>
-				<button className="flex shrink-0 items-center gap-1 rounded-md border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-600 hover:bg-slate-100" onClick={downloadOriginal}>
+				<button className="flex shrink-0 items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]" onClick={downloadOriginal}>
 					<Download size={12} />
 					{t("files.download", "Download")}
 				</button>
 			</div>
 			<div className="space-y-3">
 				{pages.map((p) => (
-					<div key={p.pageNumber} className="rounded-lg border border-slate-200 bg-white p-4">
+					<div key={p.pageNumber} className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
 						{pages.length > 1 ? (
-							<div className="mb-2 text-[10px] font-medium uppercase tracking-wide text-slate-400">
+							<div className="mb-2 text-[10px] font-medium uppercase tracking-wide text-[var(--inno-text-subtle)]">
 								{t("preview.page", "Page")} {p.pageNumber}
 							</div>
 						) : null}
-						<pre className="whitespace-pre-wrap break-words font-sans text-xs leading-relaxed text-slate-700">{p.text}</pre>
+						<pre className="whitespace-pre-wrap break-words font-sans text-xs leading-relaxed text-[var(--inno-text)]">{p.text}</pre>
 					</div>
 				))}
 			</div>
@@ -271,14 +271,14 @@ function HtmlPreview({ file }: { file: WorkspaceFileDetail }) {
     ? raw.replace(/<head([^>]*)>/i, `<head$1>${guardScript}`)
     : `<!doctype html><html><head>${guardScript}</head><body>${raw}</body></html>`;
 
-  return <iframe className="h-full w-full border-0 bg-white" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" srcDoc={html} title={file.name} />;
+  return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" srcDoc={html} title={file.name} />;
 }
 
 /* ---------- Preview (read-only) ---------- */
 
 function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: boolean }) {
 	const { t } = useTranslation();
-	if (isLoading) return <div className="flex h-full items-center justify-center text-sm text-slate-500">{t("preview.loadingFile")}</div>;
+	if (isLoading) return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.loadingFile")}</div>;
 	if (file.kind === "markdown") return <div className="workspace-scroll h-full overflow-y-auto p-5"><markdown-artifact content={file.content ?? ""} /></div>;
 		if (file.kind === "html") return <HtmlPreview file={file} />;
 	if (file.kind === "pdf") {
@@ -289,11 +289,11 @@ function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: bo
 		const pdfUrl = baseUrl
 			? `${baseUrl}${baseUrl.includes("#") ? "&" : "#"}view=FitH&zoom=page-width`
 			: "";
-		return <iframe className="h-full w-full border-0 bg-white" src={pdfUrl} title={file.name} />;
+		return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" src={pdfUrl} title={file.name} />;
 	}
 	if (file.kind === "image") {
 		return (
-			<div className="flex h-full items-center justify-center overflow-auto bg-slate-50 p-4">
+			<div className="flex h-full items-center justify-center overflow-auto bg-[var(--inno-surface-muted)] p-4">
 				<img className="max-h-full max-w-full object-contain" src={file.url ?? ""} alt={file.name} />
 			</div>
 		);
@@ -303,8 +303,8 @@ function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: bo
 	}
 	if (file.kind === "binary") {
 		return (
-			<div className="flex h-full flex-col items-center justify-center text-sm text-slate-500">
-				<div className="mb-2 text-lg font-medium text-slate-950">{file.name}</div>
+			<div className="flex h-full flex-col items-center justify-center text-sm text-[var(--inno-text-muted)]">
+				<div className="mb-2 text-lg font-medium text-[var(--inno-text)]">{file.name}</div>
 				<div>{t("preview.binaryFile")} · {formatSize(file.size)}</div>
 			</div>
 		);
@@ -386,10 +386,10 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 		return (
 			<div className="flex h-full flex-col">
 				{/* Editor toolbar */}
-				<div className="flex h-10 items-center justify-between border-b border-slate-200 bg-white px-3">
+				<div className="flex h-10 items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3">
 					<div className="min-w-0">
 						<div className="truncate text-sm font-medium">{state.file.name}</div>
-						<div className="truncate text-[10px] text-slate-500">{t("files.editing", "Editing")} · {state.file.path}</div>
+						<div className="truncate text-[10px] text-[var(--inno-text-muted)]">{t("files.editing", "Editing")} · {state.file.path}</div>
 					</div>
 					<div className="flex items-center gap-1.5">
 						<button
@@ -402,7 +402,7 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 						</button>
 						<button
 							disabled={state.isSaving}
-							className="flex h-7 items-center gap-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-600 hover:bg-slate-50 disabled:opacity-50"
+							className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] disabled:opacity-50"
 							onClick={() => workspaceStore.cancelEditing()}
 						>
 							<X size={12} />
@@ -425,10 +425,10 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 	// Read-only view
 	return (
 		<div className="flex h-full flex-col">
-			<div className="flex h-10 items-center justify-between border-b border-slate-200 bg-white px-3">
+			<div className="flex h-10 items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3">
 				<div className="flex min-w-0 flex-1 items-center gap-2">
 					<button
-						className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-slate-400 hover:bg-slate-100 hover:text-slate-700"
+						className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 						onClick={onToggleSidebar}
 						title={sidebarOpen ? t("common.collapseSidebar", "Collapse sidebar") : t("common.expandSidebar", "Expand sidebar")}
 					>
@@ -436,7 +436,7 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 					</button>
 					<div className="min-w-0">
 						<div className="truncate text-sm font-medium">{state.file?.name ?? t("preview.noFile", "No file selected")}</div>
-						<div className="truncate text-[10px] text-slate-500">
+						<div className="truncate text-[10px] text-[var(--inno-text-muted)]">
 							{state.file ? `${state.file.path} · ${formatSize(state.file.size)}` : t("preview.selectFile", "Select a file to preview")}
 						</div>
 					</div>
@@ -445,7 +445,7 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 					{state.file && !simpleMode ? <RunButton filePath={state.file.path} /> : null}
 					{canEdit && (
 						<button
-							className="flex h-7 items-center gap-1 rounded-md border border-slate-200 px-2.5 text-xs text-slate-600 hover:bg-slate-100 hover:text-slate-950"
+							className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 							onClick={() => workspaceStore.startEditing()}
 						>
 							<Pencil size={12} />
@@ -457,7 +457,7 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 			<div className="workspace-scroll min-h-0 flex-1 overflow-auto">
 				{state.error ? <div className="p-4 text-sm text-red-500">{state.error}</div> : null}
 				{!state.error && state.file ? <Preview file={state.file} isLoading={state.isLoadingFile} /> : null}
-				{!state.error && !state.file ? <div className="flex h-full items-center justify-center text-sm text-slate-500">{t("preview.noPreview", "Nothing to preview")}</div> : null}
+				{!state.error && !state.file ? <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.noPreview", "Nothing to preview")}</div> : null}
 			</div>
 		</div>
 	);
@@ -474,7 +474,7 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 			ref={dragHandle}
 			style={style}
 			className={`group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer select-none ${
-				selected ? "bg-blue-50 text-blue-700 ring-1 ring-blue-100" : "text-slate-600 hover:bg-slate-100/85 hover:text-slate-950"
+				selected ? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100" : "text-[var(--inno-text-muted)] hover:bg-slate-100/85 hover:text-[var(--inno-text)]"
 			}`}
 			onClick={(e) => {
 				e.stopPropagation();
@@ -492,13 +492,13 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 				e.currentTarget.dispatchEvent(ev);
 			}}
 		>
-			<span className="flex h-4 w-4 shrink-0 items-center justify-center text-slate-400">
+			<span className="flex h-4 w-4 shrink-0 items-center justify-center text-[var(--inno-text-subtle)]">
 				{nodeIcon(node.data.name, isDir, node.isOpen)}
 			</span>
 			{node.isEditing ? (
 				<input
 					autoFocus
-					className="min-w-0 flex-1 rounded border border-blue-300 bg-white px-1 py-0.5 text-xs outline-none focus:ring-1 focus:ring-blue-200"
+					className="min-w-0 flex-1 rounded border border-blue-300 bg-[var(--inno-surface)] px-1 py-0.5 text-xs outline-none focus:ring-1 focus:ring-blue-200"
 					defaultValue={node.data.name}
 					onFocus={(e) => {
 						const val = e.currentTarget.value;
@@ -556,11 +556,11 @@ function ContextMenu({ state, onClose, treeRef, workspaceId }: { state: CtxMenuS
 	return (
 		<>
 			<div className="fixed inset-0 z-40" onClick={onClose} />
-			<div className="fixed z-50 min-w-[140px] rounded-lg border border-slate-200 bg-white py-1 shadow-lg" style={{ left: state.x, top: state.y }}>
+			<div className="fixed z-50 min-w-[140px] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] py-1 shadow-lg" style={{ left: state.x, top: state.y }}>
 				{items.map((item) => (
 					<button
 						key={item.label}
-						className="flex w-full items-center px-3 py-1.5 text-left text-xs text-slate-700 hover:bg-slate-100"
+						className="flex w-full items-center px-3 py-1.5 text-left text-xs text-[var(--inno-text)] hover:bg-[var(--inno-surface-muted)]"
 						onClick={() => { item.action(); onClose(); }}
 					>
 						{item.label}
@@ -579,13 +579,13 @@ function DeleteConfirm({ paths, onConfirm, onCancel }: { paths: string[]; onConf
 	return (
 		<>
 			<div className="fixed inset-0 z-40 bg-black/20" onClick={onCancel} />
-			<div className="fixed left-1/2 top-1/2 z-50 w-80 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-slate-200 bg-white p-5 shadow-xl">
-				<div className="mb-3 text-sm font-medium text-slate-950">{t("files.confirmDelete", "Delete?")}</div>
-				<div className="mb-4 text-xs text-slate-500">
+			<div className="fixed left-1/2 top-1/2 z-50 w-80 -translate-x-1/2 -translate-y-1/2 rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] p-5 shadow-xl">
+				<div className="mb-3 text-sm font-medium text-[var(--inno-text)]">{t("files.confirmDelete", "Delete?")}</div>
+				<div className="mb-4 text-xs text-[var(--inno-text-muted)]">
 					{names.length === 1 ? names[0] : `${names.length} items`}
 				</div>
 				<div className="flex justify-end gap-2">
-					<button className="rounded-md border border-slate-200 px-3 py-1.5 text-xs text-slate-700 hover:bg-slate-50" onClick={onCancel}>
+					<button className="rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text)] hover:bg-[var(--inno-surface-muted)]" onClick={onCancel}>
 						{t("common.cancel", "Cancel")}
 					</button>
 					<button className="rounded-md bg-red-500 px-3 py-1.5 text-xs text-white hover:bg-red-600" onClick={onConfirm}>
@@ -797,22 +797,22 @@ export function WorkspaceBrowser() {
 		<div ref={rootRef} className={`grid h-full min-h-0 gap-3 bg-transparent p-3 transition-[grid-template-columns] duration-200 ${showContent ? (sidebarOpen ? "grid-cols-[260px_minmax(0,1fr)]" : "grid-cols-[0px_minmax(0,1fr)]") : "grid-cols-[minmax(0,1fr)]"}`}>
 			{/* --- Tree pane --- */}
 			<aside
-				className={`inno-workspace-card relative flex min-h-0 flex-col overflow-hidden rounded-lg transition-opacity duration-200 ${isDragOver ? "border-blue-400 bg-blue-50" : ""} ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
+				className={`inno-workspace-card relative flex min-h-0 flex-col overflow-hidden rounded-lg transition-opacity duration-200 ${isDragOver ? "border-blue-400 bg-[var(--inno-accent-soft)]" : ""} ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
 				onDragOver={handleDragOver}
 				onDragLeave={handleDragLeave}
 				onDrop={handleDrop}
 			>
 				{/* Toolbar */}
-				<div className="flex h-10 items-center gap-1 border-b border-slate-200 bg-slate-50 px-2">
+				<div className="flex h-10 items-center gap-1 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2">
 					<div className="min-w-0 flex-1">
-						<span className="block max-w-[220px] truncate px-1 text-xs font-medium text-slate-700" title={activeWorkspaceName}>
+						<span className="block max-w-[220px] truncate px-1 text-xs font-medium text-[var(--inno-text)]" title={activeWorkspaceName}>
 							{activeWorkspaceName || "工作区"}
 						</span>
 					</div>
-					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-slate-400 transition-colors hover:bg-violet-100 hover:text-violet-600 disabled:opacity-40" title={t("files.uploadSkill", "上传技能包 (.zip/.md) 到 .skills")} onClick={() => skillUploadRef.current?.click()}>
+					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] transition-colors hover:bg-violet-100 hover:text-violet-600 disabled:opacity-40" title={t("files.uploadSkill", "上传技能包 (.zip/.md) 到 .skills")} onClick={() => skillUploadRef.current?.click()}>
 						<Sparkles size={13} />
 					</button>
-					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-slate-400 transition-colors hover:bg-slate-200 hover:text-slate-700 disabled:opacity-40" title={t("preview.refresh", "Refresh")} onClick={() => void workspaceStore.loadTree()}>
+					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] transition-colors hover:bg-slate-200 hover:text-[var(--inno-text)] disabled:opacity-40" title={t("preview.refresh", "Refresh")} onClick={() => void workspaceStore.loadTree()}>
 						<RefreshCw size={13} />
 					</button>
 					<input ref={skillUploadRef} type="file" multiple accept=".zip,application/zip,.md,text/markdown" className="hidden" onChange={handleSkillUploadChange} />
@@ -829,7 +829,7 @@ export function WorkspaceBrowser() {
 					}}
 				>
 					{state.isLoadingTree && !arboristData.length ? (
-						<div className="p-3 text-xs text-slate-500">{t("preview.loading", "Loading...")}</div>
+						<div className="p-3 text-xs text-[var(--inno-text-muted)]">{t("preview.loading", "Loading...")}</div>
 					) : (
 						<>
 							{/* Always mount the Tree (even when empty) so treeRef is available
@@ -852,7 +852,7 @@ export function WorkspaceBrowser() {
 								{Node}
 							</Tree>
 							{!arboristData.length && (
-								<div className="pointer-events-none absolute left-0 top-0 p-3 text-xs text-slate-500">
+								<div className="pointer-events-none absolute left-0 top-0 p-3 text-xs text-[var(--inno-text-muted)]">
 									{t("preview.empty", "Empty workspace")}
 								</div>
 							)}
@@ -862,8 +862,8 @@ export function WorkspaceBrowser() {
 
 				{/* Drag overlay */}
 				{isDragOver && (
-					<div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg bg-blue-50">
-						<div className="rounded-lg bg-white px-4 py-2 text-xs font-medium text-blue-600 shadow-sm">{t("files.dropToUpload", "Drop files to upload")}</div>
+					<div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg bg-[var(--inno-accent-soft)]">
+						<div className="rounded-lg bg-[var(--inno-surface)] px-4 py-2 text-xs font-medium text-[var(--inno-accent)] shadow-sm">{t("files.dropToUpload", "Drop files to upload")}</div>
 					</div>
 				)}
 			</aside>

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -95,7 +95,7 @@ export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChan
 		return (
 			<aside className="relative h-full w-0 overflow-visible">
 				<button
-					className="absolute right-2 top-2 z-20 flex h-8 w-8 items-center justify-center rounded-lg text-slate-400 transition-colors hover:bg-white/90 hover:text-slate-700 hover:shadow-sm"
+					className="absolute right-2 top-2 z-20 flex h-8 w-8 items-center justify-center rounded-lg text-[var(--inno-text-subtle)] transition-colors hover:bg-white/90 hover:text-[var(--inno-text)] hover:shadow-sm"
 					title={t("workspace.openWorkspace") ?? ""}
 					onClick={() => onModeChange("half")}
 				>
@@ -118,7 +118,7 @@ export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChan
 				/>
 			) : null}
 
-			<div className="flex h-10 items-center gap-1 border-b border-slate-200 bg-[var(--inno-workspace-chrome)] px-2">
+			<div className="flex h-10 items-center gap-1 border-b border-[var(--inno-border)] bg-[var(--inno-workspace-chrome)] px-2">
 				<div className="flex min-w-0 flex-1 items-center gap-0.5 overflow-hidden">
 					{tabs.map((tab) => {
 						const label = t(`workspace.tabs.${tab}`);
@@ -126,7 +126,7 @@ export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChan
 						return (
 							<button
 								key={tab}
-								className={`inno-workspace-tab flex h-7 shrink-0 items-center gap-1 whitespace-nowrap rounded-md transition-colors ${compact ? "w-7 justify-center px-0" : "px-2"} ${isActive ? "bg-white font-medium text-blue-700 shadow-sm ring-1 ring-slate-200" : "text-slate-500 hover:bg-white hover:text-slate-950"}`}
+								className={`inno-workspace-tab flex h-7 shrink-0 items-center gap-1 whitespace-nowrap rounded-md transition-colors ${compact ? "w-7 justify-center px-0" : "px-2"} ${isActive ? "bg-[var(--inno-surface)] font-medium text-[var(--inno-accent)] shadow-sm ring-1 ring-slate-200" : "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
 								title={compact ? label : undefined}
 								aria-label={compact ? label : undefined}
 								onClick={() => onTabChange(tab)}
@@ -137,16 +137,16 @@ export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChan
 						);
 					})}
 				</div>
-				<div className="ml-1 flex shrink-0 items-center gap-1 border-l border-slate-200 pl-1">
+				<div className="ml-1 flex shrink-0 items-center gap-1 border-l border-[var(--inno-border)] pl-1">
 					<button
-						className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-white hover:text-slate-600"
+						className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text-muted)]"
 						title={mode === "full" ? (t("workspace.half") ?? "") : (t("workspace.full") ?? "")}
 						onClick={() => onModeChange(mode === "full" ? "half" : "full")}
 					>
 						{mode === "full" ? <Columns2 size={14} /> : <Maximize2 size={14} />}
 					</button>
 					<button
-						className="flex h-7 w-7 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-white hover:text-slate-600"
+						className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text-muted)]"
 						title={t("workspace.collapse") ?? ""}
 						onClick={() => onModeChange("collapsed")}
 					>

--- a/apps/inno-agent/web/src/react/jobs/ScheduleEditor.tsx
+++ b/apps/inno-agent/web/src/react/jobs/ScheduleEditor.tsx
@@ -24,12 +24,12 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 	const timeStr = `${pad2(value.hour)}:${pad2(value.minute)}`;
 
 	return (
-		<div className="flex flex-col gap-3 rounded-lg border border-slate-200 bg-slate-50 p-3">
+		<div className="flex flex-col gap-3 rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
 			<div className="grid grid-cols-2 gap-2">
 				<label className="block text-sm">
-					<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.frequency")}</span>
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.frequency")}</span>
 					<select
-						className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 						value={value.frequency}
 						onChange={(e) => patch({ frequency: e.target.value as Frequency })}
 					>
@@ -42,10 +42,10 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 				</label>
 				{value.frequency !== "custom" ? (
 					<label className="block text-sm">
-						<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.time")}</span>
+						<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.time")}</span>
 						<input
 							type="time"
-							className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+							className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 							value={timeStr}
 							onChange={(e) => {
 								const [h, m] = e.target.value.split(":").map(Number);
@@ -58,7 +58,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 
 			{value.frequency === "weekly" ? (
 				<div className="text-sm">
-					<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.weekdays")}</span>
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.weekdays")}</span>
 					<div className="flex flex-wrap gap-1.5">
 						{WEEKDAYS.map((d) => {
 							const active = value.weekdays.includes(d);
@@ -69,7 +69,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 									className={`rounded-full px-3 py-1 text-xs transition-colors ${
 										active
 											? "bg-slate-900 text-white"
-											: "bg-white text-slate-600 ring-1 ring-slate-200 hover:bg-slate-100"
+											: "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-slate-200 hover:bg-[var(--inno-surface-muted)]"
 									}`}
 									onClick={() => {
 										const next = active
@@ -88,9 +88,9 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 
 			{value.frequency === "monthly" ? (
 				<label className="block text-sm">
-					<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.dayOfMonth")}</span>
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.dayOfMonth")}</span>
 					<select
-						className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 						value={String(value.day)}
 						onChange={(e) => patch({ day: Number(e.target.value) })}
 					>
@@ -106,10 +106,10 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 
 			{value.frequency === "once" ? (
 				<label className="block text-sm">
-					<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.onceDate")}</span>
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.onceDate")}</span>
 					<input
 						type="date"
-						className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 						value={value.date}
 						onChange={(e) => patch({ date: e.target.value })}
 					/>
@@ -118,14 +118,14 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 
 			{value.frequency === "custom" ? (
 				<label className="block text-sm">
-					<span className="mb-1 block font-medium text-slate-700">{t("jobs.form.customCron")}</span>
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.customCron")}</span>
 					<input
-						className="w-full rounded-md border border-slate-200 bg-white px-3 py-2 font-mono text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 font-mono text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
 						placeholder={t("jobs.form.cronPlaceholder") ?? ""}
 						value={value.cron}
 						onChange={(e) => patch({ cron: e.target.value })}
 					/>
-					<span className="mt-1 block text-xs text-slate-500">{t("jobs.form.cronHint")}</span>
+					<span className="mt-1 block text-xs text-[var(--inno-text-muted)]">{t("jobs.form.cronHint")}</span>
 				</label>
 			) : null}
 

--- a/apps/inno-agent/web/src/react/jobs/ScheduleEditor.tsx
+++ b/apps/inno-agent/web/src/react/jobs/ScheduleEditor.tsx
@@ -66,11 +66,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 								<button
 									type="button"
 									key={d}
-									className={`rounded-full px-3 py-1 text-xs transition-colors ${
-										active
-											? "bg-slate-900 text-white"
-											: "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-slate-200 hover:bg-[var(--inno-surface-muted)]"
-									}`}
+									className={`rounded-full px-3 py-1 text-xs transition-colors ${ active ? "inno-primary-button" : "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-slate-200 hover:bg-[var(--inno-surface-muted)]" }`}
 									onClick={() => {
 										const next = active
 											? value.weekdays.filter((x) => x !== d)

--- a/apps/inno-agent/web/src/react/notebook/GraphView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/GraphView.tsx
@@ -388,7 +388,7 @@ export function GraphView() {
 						) : null}
 						{displayNode.type !== "tag" ? (
 							<button
-								className="ml-auto shrink-0 rounded bg-slate-900 px-2 py-0.5 text-xs text-white hover:bg-slate-800"
+								className="ml-auto shrink-0 rounded inno-primary-button px-2 py-0.5 text-xs text-white"
 								onClick={() => void notebookStore.selectPage(displayNode.id)}
 							>
 								{t("notebook.inspector.openPage")}

--- a/apps/inno-agent/web/src/react/notebook/GraphView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/GraphView.tsx
@@ -330,21 +330,21 @@ export function GraphView() {
 
 	return (
 		<div className="relative flex h-full min-h-0 flex-col">
-			<div className="@container flex items-center gap-2 border-b border-slate-200 bg-white px-3 py-2 text-xs text-slate-500">
-				<button className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 hover:bg-slate-100 hover:text-slate-950" onClick={fit} title={t("notebook.graph.fit")}>
+			<div className="@container flex items-center gap-2 border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
+				<button className="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={fit} title={t("notebook.graph.fit")}>
 					<Scan size={13} />
 					<span className="hidden @[680px]:inline">{t("notebook.graph.fit")}</span>
 				</button>
-				<button className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 hover:bg-slate-100 hover:text-slate-950" onClick={reLayout} title={t("notebook.graph.relayout")}>
+				<button className="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={reLayout} title={t("notebook.graph.relayout")}>
 					<Shuffle size={13} />
 					<span className="hidden @[680px]:inline">{t("notebook.graph.relayout")}</span>
 				</button>
-				<button className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 hover:bg-slate-100 hover:text-slate-950" onClick={() => void notebookStore.loadGraph()} title={t("notebook.graph.refresh")}>
+				<button className="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void notebookStore.loadGraph()} title={t("notebook.graph.refresh")}>
 					<RefreshCw size={13} />
 					<span className="hidden @[680px]:inline">{t("notebook.graph.refresh")}</span>
 				</button>
 				<div className="mx-1 h-4 w-px bg-slate-200" />
-				<span className="text-slate-400">{t("notebook.graph.show")}</span>
+				<span className="text-[var(--inno-text-subtle)]">{t("notebook.graph.show")}</span>
 				{ALL_CATEGORIES.map((cat) => {
 					const active = visibleCategories.has(cat);
 					const color = TYPE_COLORS[cat];
@@ -355,8 +355,8 @@ export function GraphView() {
 							onClick={() => toggleCategory(cat)}
 							className={`flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs transition ${
 								active
-									? "border-slate-300 bg-white text-slate-700 hover:bg-slate-50"
-									: "border-slate-200 bg-slate-50 text-slate-400 line-through hover:bg-slate-100"
+									? "border-[var(--inno-border-strong)] bg-[var(--inno-surface)] text-[var(--inno-text)] hover:bg-[var(--inno-surface-muted)]"
+									: "border-[var(--inno-border)] bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)] line-through hover:bg-[var(--inno-surface-muted)]"
 							}`}
 							title={t(`notebook.types.${cat}`)}
 						>
@@ -374,15 +374,15 @@ export function GraphView() {
 			</div>
 			<div ref={containerRef} className="relative min-h-0 flex-1 bg-[var(--inno-workspace-bg,#fafafa)]">
 				{displayNode ? (
-					<div className="absolute inset-x-0 top-0 z-10 flex items-center gap-2 border-b border-slate-200 bg-white px-3 py-1.5 text-xs">
+					<div className="absolute inset-x-0 top-0 z-10 flex items-center gap-2 border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-xs">
 						<span
 							className="inline-block h-2.5 w-2.5 shrink-0 rounded-full"
 							style={{ backgroundColor: TYPE_COLORS[displayNode.type] ?? "#8b949e" }}
 						/>
-						<span className="truncate font-medium text-slate-950">{displayNode.title || displayNode.id}</span>
-						<span className="text-slate-400">{t(`notebook.types.${displayNode.type}`)}</span>
+						<span className="truncate font-medium text-[var(--inno-text)]">{displayNode.title || displayNode.id}</span>
+						<span className="text-[var(--inno-text-subtle)]">{t(`notebook.types.${displayNode.type}`)}</span>
 						{displayNode.tags.length > 0 ? (
-							<span className="truncate text-slate-400">
+							<span className="truncate text-[var(--inno-text-subtle)]">
 								{displayNode.tags.map((tag) => `#${tag}`).join(" ")}
 							</span>
 						) : null}
@@ -398,13 +398,13 @@ export function GraphView() {
 				) : null}
 			</div>
 			{state.isLoading ? (
-				<div className="absolute inset-0 flex items-center justify-center bg-white/40 text-sm text-slate-500">
+				<div className="absolute inset-0 flex items-center justify-center bg-white/40 text-sm text-[var(--inno-text-muted)]">
 					<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
 					{t("common.loading")}
 				</div>
 			) : null}
 			{!state.isLoading && state.nodes.length === 0 ? (
-				<div className="absolute inset-0 flex items-center justify-center text-sm text-slate-500">
+				<div className="absolute inset-0 flex items-center justify-center text-sm text-[var(--inno-text-muted)]">
 					{t("notebook.graph.empty")}
 				</div>
 			) : null}

--- a/apps/inno-agent/web/src/react/notebook/NodeInspector.tsx
+++ b/apps/inno-agent/web/src/react/notebook/NodeInspector.tsx
@@ -38,7 +38,7 @@ export function NodeInspector() {
 				</div>
 			) : null}
 			<button
-				className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800 disabled:opacity-50"
+				className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white disabled:opacity-50"
 				disabled={node.type === "tag"}
 				onClick={() => void notebookStore.selectPage(node.id)}
 			>

--- a/apps/inno-agent/web/src/react/notebook/NodeInspector.tsx
+++ b/apps/inno-agent/web/src/react/notebook/NodeInspector.tsx
@@ -12,25 +12,25 @@ export function NodeInspector() {
 
 	if (!node) {
 		return (
-			<aside className="flex h-full flex-col overflow-y-auto border-l border-slate-200 bg-white p-3 text-sm text-slate-500">
-				<div className="mb-2 text-xs font-medium uppercase tracking-wide text-slate-500">{t("notebook.inspector.title")}</div>
+			<aside className="flex h-full flex-col overflow-y-auto border-l border-[var(--inno-border)] bg-[var(--inno-surface)] p-3 text-sm text-[var(--inno-text-muted)]">
+				<div className="mb-2 text-xs font-medium uppercase tracking-wide text-[var(--inno-text-muted)]">{t("notebook.inspector.title")}</div>
 				<p>{t("notebook.inspector.empty")}</p>
 			</aside>
 		);
 	}
 	return (
-		<aside className="flex h-full flex-col overflow-y-auto border-l border-slate-200 bg-white p-3">
-			<div className="mb-1 truncate text-sm font-medium text-slate-950">{node.title}</div>
-			<div className="mb-2 truncate text-xs text-slate-500">{node.id}</div>
-			<div className="mb-3 inline-block rounded bg-slate-100 px-2 py-0.5 text-xs text-slate-600">
+		<aside className="flex h-full flex-col overflow-y-auto border-l border-[var(--inno-border)] bg-[var(--inno-surface)] p-3">
+			<div className="mb-1 truncate text-sm font-medium text-[var(--inno-text)]">{node.title}</div>
+			<div className="mb-2 truncate text-xs text-[var(--inno-text-muted)]">{node.id}</div>
+			<div className="mb-3 inline-block rounded bg-[var(--inno-surface-muted)] px-2 py-0.5 text-xs text-[var(--inno-text-muted)]">
 				{t(`notebook.types.${node.type}`)}
 			</div>
 			{node.tags.length > 0 ? (
 				<div className="mb-3">
-					<div className="mb-1 text-xs font-medium text-slate-500">{t("notebook.inspector.tags")}</div>
+					<div className="mb-1 text-xs font-medium text-[var(--inno-text-muted)]">{t("notebook.inspector.tags")}</div>
 					<div className="flex flex-wrap gap-1">
 						{node.tags.map((tag) => (
-							<span key={tag} className="rounded-full bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700">
+							<span key={tag} className="rounded-full bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-xs text-[var(--inno-accent)]">
 								#{tag}
 							</span>
 						))}

--- a/apps/inno-agent/web/src/react/notebook/PageView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/PageView.tsx
@@ -95,7 +95,7 @@ export function PageView() {
 					/>
 				</div>
 				<div className="flex gap-2 border-t border-[var(--inno-border)] p-3">
-					<button className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800" onClick={() => void notebookStore.savePage()}>
+					<button className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white" onClick={() => void notebookStore.savePage()}>
 						{t("common.save")}
 					</button>
 					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={() => notebookStore.cancelEditing()}>
@@ -113,7 +113,7 @@ export function PageView() {
 				<markdown-artifact content={parsed.body} />
 			</div>
 			<div className="flex gap-2 border-t border-[var(--inno-border)] p-3">
-				<button className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800" onClick={() => notebookStore.startEditing()}>
+				<button className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white" onClick={() => notebookStore.startEditing()}>
 					{t("common.edit")}
 				</button>
 				<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={() => notebookStore.setView("graph")}>

--- a/apps/inno-agent/web/src/react/notebook/PageView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/PageView.tsx
@@ -11,7 +11,7 @@ import "@uiw/react-markdown-preview/markdown.css";
 function typeColor(type?: WikiPageType): string {
 	switch (type) {
 		case "source-summary":
-			return "bg-blue-50 text-blue-700 ring-1 ring-blue-100";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100";
 		case "entity":
 			return "bg-green-50 text-green-700 ring-1 ring-green-100";
 		case "concept":
@@ -19,7 +19,7 @@ function typeColor(type?: WikiPageType): string {
 		case "analysis":
 			return "bg-purple-50 text-purple-700 ring-1 ring-purple-100";
 		default:
-			return "bg-slate-100 text-slate-500";
+			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 	}
 }
 
@@ -37,19 +37,19 @@ function FrontmatterHeader({ frontmatter }: { frontmatter: WikiPageFrontmatter }
 	};
 
 	return (
-		<div className="border-b border-slate-200 bg-white px-4 py-3">
-			<h3 className="mb-1.5 truncate text-base font-medium text-slate-950">{frontmatter.title}</h3>
+		<div className="border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-4 py-3">
+			<h3 className="mb-1.5 truncate text-base font-medium text-[var(--inno-text)]">{frontmatter.title}</h3>
 			<div className="flex flex-wrap items-center gap-2 text-xs">
 				<span className={`rounded px-1.5 py-0.5 ${typeColor(frontmatter.type)}`}>{t(`notebook.types.${frontmatter.type}`)}</span>
 				<span className={`rounded px-1.5 py-0.5 ${statusColors[frontmatter.status] ?? ""}`}>{t(`notebook.status.${frontmatter.status}`)}</span>
 				<span className={`rounded px-1.5 py-0.5 ${confidenceColors[frontmatter.confidence] ?? ""}`}>{t(`notebook.confidence.${frontmatter.confidence}`)}</span>
 				{frontmatter.contested ? <span className="rounded bg-red-50 px-1.5 py-0.5 text-red-700 ring-1 ring-red-100">{t("notebook.contested")}</span> : null}
-				<span className="text-slate-500">{frontmatter.updated}</span>
+				<span className="text-[var(--inno-text-muted)]">{frontmatter.updated}</span>
 			</div>
 			{frontmatter.tags.length > 0 ? (
 				<div className="mt-2 flex flex-wrap gap-1">
 					{frontmatter.tags.map((tag) => (
-						<span key={tag} className="rounded-full bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700 ring-1 ring-blue-100">
+						<span key={tag} className="rounded-full bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-xs text-[var(--inno-accent)] ring-1 ring-blue-100">
 							#{tag}
 						</span>
 					))}
@@ -71,13 +71,13 @@ export function PageView() {
 
 	if (state.isLoading) {
 		return (
-			<div className="flex h-full items-center justify-center text-slate-500">
+			<div className="flex h-full items-center justify-center text-[var(--inno-text-muted)]">
 				<span className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
 			</div>
 		);
 	}
 	if (!state.currentPage || !parsed) {
-		return <div className="flex h-full items-center justify-center text-sm text-slate-500">{t("notebook.page.empty")}</div>;
+		return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("notebook.page.empty")}</div>;
 	}
 
 	if (state.isEditing) {
@@ -94,11 +94,11 @@ export function PageView() {
 						style={{ height: "100%" }}
 					/>
 				</div>
-				<div className="flex gap-2 border-t border-slate-200 p-3">
+				<div className="flex gap-2 border-t border-[var(--inno-border)] p-3">
 					<button className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800" onClick={() => void notebookStore.savePage()}>
 						{t("common.save")}
 					</button>
-					<button className="rounded-md bg-slate-100 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-200 hover:text-slate-950" onClick={() => notebookStore.cancelEditing()}>
+					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={() => notebookStore.cancelEditing()}>
 						{t("common.cancel")}
 					</button>
 				</div>
@@ -112,11 +112,11 @@ export function PageView() {
 			<div className="min-h-0 flex-1 overflow-y-auto p-4">
 				<markdown-artifact content={parsed.body} />
 			</div>
-			<div className="flex gap-2 border-t border-slate-200 p-3">
+			<div className="flex gap-2 border-t border-[var(--inno-border)] p-3">
 				<button className="rounded-md bg-slate-900 px-3 py-1.5 text-sm text-white hover:bg-slate-800" onClick={() => notebookStore.startEditing()}>
 					{t("common.edit")}
 				</button>
-				<button className="rounded-md bg-slate-100 px-3 py-1.5 text-sm text-slate-500 hover:bg-slate-200 hover:text-slate-950" onClick={() => notebookStore.setView("graph")}>
+				<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={() => notebookStore.setView("graph")}>
 					{t("notebook.page.backToGraph")}
 				</button>
 			</div>

--- a/apps/inno-agent/web/src/react/terminal/RunButton.tsx
+++ b/apps/inno-agent/web/src/react/terminal/RunButton.tsx
@@ -32,7 +32,7 @@ export function RunButton({ filePath, className }: RunButtonProps) {
 			onClick={handleClick}
 			className={
 				className ??
-				"flex h-7 items-center gap-1 rounded-md border border-slate-200 bg-white px-2 text-xs font-medium text-slate-700 transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700"
+				"flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 text-xs font-medium text-[var(--inno-text)] transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700"
 			}
 			title={`Run: ${command}`}
 		>

--- a/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
+++ b/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
@@ -140,7 +140,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 								<button
 									onClick={() => void handleArchive()}
 									disabled={archiveBusy}
-									className="flex h-6 items-center gap-1 rounded-md bg-slate-800 px-2 text-[11px] font-medium text-white transition-colors hover:bg-slate-700 disabled:opacity-50"
+									className="flex h-6 items-center gap-1 rounded-md inno-primary-button px-2 text-[11px] font-medium text-white transition-colors disabled:opacity-50"
 								>
 									<Archive size={11} />
 									{archiveBusy ? "归档中…" : "归档为笔记"}

--- a/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
+++ b/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
@@ -10,7 +10,7 @@ interface RunsPanelProps {
 }
 
 function statusBadge(code: number | null | undefined): { text: string; cls: string } {
-	if (code === null || code === undefined) return { text: "未完成", cls: "bg-slate-100 text-slate-600 ring-1 ring-slate-200" };
+	if (code === null || code === undefined) return { text: "未完成", cls: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] ring-1 ring-slate-200" };
 	if (code === 0) return { text: "✓ 0", cls: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100" };
 	return { text: `✗ ${code}`, cls: "bg-red-50 text-red-700 ring-1 ring-red-100" };
 }
@@ -78,21 +78,21 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 	}, [detail]);
 
 	return (
-		<div className="flex h-full min-h-0 flex-1 flex-col bg-white text-slate-700">
-			<div className="flex h-8 items-center gap-2 border-b border-slate-200 bg-[var(--inno-workspace-chrome)] px-2 text-xs text-slate-600">
-				<span className="font-medium text-slate-800">运行历史</span>
-				<span className="text-[11px] text-slate-400">{runs.length} 条</span>
+		<div className="flex h-full min-h-0 flex-1 flex-col bg-[var(--inno-surface)] text-[var(--inno-text)]">
+			<div className="flex h-8 items-center gap-2 border-b border-[var(--inno-border)] bg-[var(--inno-workspace-chrome)] px-2 text-xs text-[var(--inno-text-muted)]">
+				<span className="font-medium text-[var(--inno-text)]">运行历史</span>
+				<span className="text-[11px] text-[var(--inno-text-subtle)]">{runs.length} 条</span>
 				<button
 					onClick={() => void load()}
 					disabled={loading}
-					className="ml-auto flex h-6 w-6 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-white hover:text-slate-700 disabled:opacity-40"
+					className="ml-auto flex h-6 w-6 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)] disabled:opacity-40"
 					title="刷新"
 				>
 					<RefreshCw size={12} className={loading ? "animate-spin" : ""} />
 				</button>
 				<button
 					onClick={onClose}
-					className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-white hover:text-slate-700"
+					className="flex h-6 w-6 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"
 					title="关闭"
 				>
 					<X size={12} />
@@ -103,7 +103,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 				{/* List */}
 				<div className="min-h-0 overflow-y-auto bg-[var(--inno-workspace-bg)]">
 					{runs.length === 0 && !loading ? (
-						<div className="p-3 text-center text-xs text-slate-400">暂无运行记录</div>
+						<div className="p-3 text-center text-xs text-[var(--inno-text-subtle)]">暂无运行记录</div>
 					) : null}
 					{runs.map((r) => {
 						const badge = statusBadge(r.exitCode);
@@ -112,31 +112,31 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 							<button
 								key={r.id}
 								onClick={() => setSelectedId(r.id)}
-								className={`flex w-full items-start gap-2 border-b border-slate-100 px-2 py-1.5 text-left text-[11px] transition-colors ${selected ? "bg-white ring-1 ring-inset ring-slate-200" : "hover:bg-white"}`}
+								className={`flex w-full items-start gap-2 border-b border-[var(--inno-border)] px-2 py-1.5 text-left text-[11px] transition-colors ${selected ? "bg-[var(--inno-surface)] ring-1 ring-inset ring-slate-200" : "hover:bg-[var(--inno-surface)]"}`}
 							>
 								<span className={`shrink-0 rounded px-1 py-0.5 font-mono ${badge.cls}`}>{badge.text}</span>
 								<div className="min-w-0 flex-1">
-									<div className="truncate font-mono text-slate-800" title={r.command}>{r.command}</div>
-									<div className="truncate text-[10px] text-slate-400">{formatTime(r.startedAt)} · {formatDuration(r.startedAt, r.endedAt)}{r.sourceFile ? ` · ${r.sourceFile}` : ""}</div>
+									<div className="truncate font-mono text-[var(--inno-text)]" title={r.command}>{r.command}</div>
+									<div className="truncate text-[10px] text-[var(--inno-text-subtle)]">{formatTime(r.startedAt)} · {formatDuration(r.startedAt, r.endedAt)}{r.sourceFile ? ` · ${r.sourceFile}` : ""}</div>
 								</div>
-								<ChevronRight size={10} className="mt-0.5 shrink-0 text-slate-400" />
+								<ChevronRight size={10} className="mt-0.5 shrink-0 text-[var(--inno-text-subtle)]" />
 							</button>
 						);
 					})}
 				</div>
 
 				{/* Detail */}
-				<div className="flex min-h-0 min-w-0 flex-col bg-white">
+				<div className="flex min-h-0 min-w-0 flex-col bg-[var(--inno-surface)]">
 					{detail ? (
 						<>
-							<div className="border-b border-slate-200 bg-[var(--inno-workspace-chrome)] p-2 text-[11px]">
-								<div className="mb-1 break-all font-mono text-slate-900">{detail.command}</div>
-								<div className="text-slate-500">
+							<div className="border-b border-[var(--inno-border)] bg-[var(--inno-workspace-chrome)] p-2 text-[11px]">
+								<div className="mb-1 break-all font-mono text-[var(--inno-text)]">{detail.command}</div>
+								<div className="text-[var(--inno-text-muted)]">
 									exit={detail.exitCode ?? "(none)"} · {formatDuration(detail.startedAt, detail.endedAt)} · {detail.sourceFile ? `源: ${detail.sourceFile}` : "无源文件"}
 								</div>
-								<div className="truncate text-[10px] text-slate-400" title={detail.cwd}>cwd: {detail.cwd}</div>
+								<div className="truncate text-[10px] text-[var(--inno-text-subtle)]" title={detail.cwd}>cwd: {detail.cwd}</div>
 							</div>
-							<div className="flex items-center gap-2 border-b border-slate-200 bg-white px-2 py-1">
+							<div className="flex items-center gap-2 border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1">
 								<button
 									onClick={() => void handleArchive()}
 									disabled={archiveBusy}
@@ -145,14 +145,14 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 									<Archive size={11} />
 									{archiveBusy ? "归档中…" : "归档为笔记"}
 								</button>
-								{archiveMsg ? <span className="text-[10px] text-slate-500">{archiveMsg}</span> : null}
+								{archiveMsg ? <span className="text-[10px] text-[var(--inno-text-muted)]">{archiveMsg}</span> : null}
 							</div>
 							<pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words bg-[#0f172a] p-3 font-mono text-[11px] leading-snug text-slate-100">
 								{detail.outputTail || "(无输出)"}
 							</pre>
 						</>
 					) : (
-						<div className="flex h-full items-center justify-center text-xs text-slate-400">选择左侧一条记录查看详情</div>
+						<div className="flex h-full items-center justify-center text-xs text-[var(--inno-text-subtle)]">选择左侧一条记录查看详情</div>
 					)}
 				</div>
 			</div>

--- a/apps/inno-agent/web/src/react/terminal/TerminalDrawer.tsx
+++ b/apps/inno-agent/web/src/react/terminal/TerminalDrawer.tsx
@@ -63,11 +63,11 @@ export function TerminalDrawer() {
 	}, [sess.currentSessionId, ws.activeWorkspaceId]);
 
 	return (
-		<div className={`flex flex-col border-t border-slate-200 bg-[var(--inno-workspace-bg)] ${term.isOpen ? "min-h-[220px]" : ""}`}>
-			<div className="flex h-8 items-center gap-2 border-b border-slate-200 bg-[var(--inno-workspace-chrome)] px-2 text-xs text-slate-600">
+		<div className={`flex flex-col border-t border-[var(--inno-border)] bg-[var(--inno-workspace-bg)] ${term.isOpen ? "min-h-[220px]" : ""}`}>
+			<div className="flex h-8 items-center gap-2 border-b border-[var(--inno-border)] bg-[var(--inno-workspace-chrome)] px-2 text-xs text-[var(--inno-text-muted)]">
 				<button
 					onClick={toggle}
-					className="flex items-center gap-1.5 rounded-md px-1.5 py-0.5 text-slate-500 transition-colors hover:bg-white hover:text-slate-900"
+					className="flex items-center gap-1.5 rounded-md px-1.5 py-0.5 text-[var(--inno-text-muted)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"
 					title={term.isOpen ? "收起终端" : "展开终端"}
 				>
 					<TerminalIcon size={12} />
@@ -79,21 +79,21 @@ export function TerminalDrawer() {
 					title={STATUS_LABEL[term.status]}
 					aria-label={STATUS_LABEL[term.status]}
 				/>
-				{term.cwd ? <span className="truncate text-[11px] text-slate-400" title={term.cwd}>{term.cwd}</span> : null}
+				{term.cwd ? <span className="truncate text-[11px] text-[var(--inno-text-subtle)]" title={term.cwd}>{term.cwd}</span> : null}
 				{term.error ? <span className="text-[11px] text-red-600">{term.error}</span> : null}
 				<div className="ml-auto flex items-center gap-1">
 					{term.isOpen && sess.currentSessionId ? (
 						<>
 							<button
 								onClick={toggleHistory}
-								className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${showHistory ? "bg-white text-slate-900 ring-1 ring-slate-200" : "text-slate-400 hover:bg-white hover:text-slate-700"}`}
+								className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${showHistory ? "bg-[var(--inno-surface)] text-[var(--inno-text)] ring-1 ring-slate-200" : "text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
 								title="历史"
 							>
 								<History size={12} />
 							</button>
 							<button
 								onClick={() => void restart()}
-								className="flex h-6 w-6 items-center justify-center rounded-md text-slate-400 transition-colors hover:bg-white hover:text-slate-700"
+								className="flex h-6 w-6 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"
 								title="重启终端"
 							>
 								<RotateCcw size={12} />
@@ -110,7 +110,7 @@ export function TerminalDrawer() {
 						</div>
 					) : (
 						<div className="flex-1 min-h-0 p-2">
-							<div className="h-full overflow-hidden rounded-md border border-slate-200 bg-[#0f172a] p-1.5 shadow-inner">
+							<div className="h-full overflow-hidden rounded-md border border-[var(--inno-border)] bg-[#0f172a] p-1.5 shadow-inner">
 								<TerminalView
 									key={`${sess.currentSessionId}:${ws.activeWorkspaceId ?? "default"}`}
 									innoSessionId={sess.currentSessionId}
@@ -121,7 +121,7 @@ export function TerminalDrawer() {
 						</div>
 					)
 				) : (
-					<div className="flex h-[120px] items-center justify-center text-xs text-slate-500">
+					<div className="flex h-[120px] items-center justify-center text-xs text-[var(--inno-text-muted)]">
 						请先打开或新建一个会话
 					</div>
 				)

--- a/apps/inno-agent/web/src/react/terminal/TerminalView.tsx
+++ b/apps/inno-agent/web/src/react/terminal/TerminalView.tsx
@@ -1,15 +1,52 @@
 import { useEffect, useRef } from "react";
 import { Terminal } from "@xterm/xterm";
+import type { ITheme } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
 import { terminalStore } from "../../stores/terminal-store.js";
+import { themeStore, type ThemeId } from "../../stores/theme-store.js";
 
 interface TerminalViewProps {
 	innoSessionId: string;
 	workspaceId?: string;
 	className?: string;
 }
+
+// Per-theme xterm color schemes. Light themes use a light terminal palette;
+// dark themes use a dark one. Keys match ThemeId values.
+const TERMINAL_THEMES: Record<ThemeId, ITheme> = {
+	light: {
+		background: "#ffffff",
+		foreground: "#1e293b",
+		cursor: "#334155",
+		cursorAccent: "#ffffff",
+		selectionBackground: "#cbd5e1",
+		black: "#1e293b", red: "#dc2626", green: "#16a34a", yellow: "#d97706",
+		blue: "#2563eb", magenta: "#9333ea", cyan: "#0891b2", white: "#475569",
+		brightBlack: "#64748b", brightRed: "#ef4444", brightGreen: "#22c55e",
+		brightYellow: "#f59e0b", brightBlue: "#3b82f6", brightMagenta: "#a855f7",
+		brightCyan: "#06b6d4", brightWhite: "#1e293b",
+	},
+	warm: {
+		background: "#fffefa", foreground: "#2c2418", cursor: "#7a6b5a",
+		cursorAccent: "#fffefa", selectionBackground: "#e5ddd4",
+		black: "#2c2418", red: "#dc2626", green: "#16a34a", yellow: "#d97706",
+		blue: "#0d9488", magenta: "#9333ea", cyan: "#0891b2", white: "#7a6b5a",
+		brightBlack: "#9a8b7a", brightRed: "#ef4444", brightGreen: "#22c55e",
+		brightYellow: "#f59e0b", brightBlue: "#14b8a6", brightMagenta: "#a855f7",
+		brightCyan: "#06b6d4", brightWhite: "#2c2418",
+	},
+	ocean: {
+		background: "#f8fafb", foreground: "#1a2c3d", cursor: "#5a7088",
+		cursorAccent: "#f8fafb", selectionBackground: "#d0dae4",
+		black: "#1a2c3d", red: "#dc2626", green: "#059669", yellow: "#d97706",
+		blue: "#0891b2", magenta: "#9333ea", cyan: "#0d9488", white: "#5a7088",
+		brightBlack: "#7a92a8", brightRed: "#ef4444", brightGreen: "#10b981",
+		brightYellow: "#f59e0b", brightBlue: "#06b6d4", brightMagenta: "#a855f7",
+		brightCyan: "#14b8a6", brightWhite: "#1a2c3d",
+	},
+};
 
 /**
  * Mounts an xterm.js instance and wires it to the global terminalStore.
@@ -28,29 +65,7 @@ export function TerminalView({ innoSessionId, workspaceId, className }: Terminal
 			fontSize: 13,
 			cursorBlink: true,
 			convertEol: true,
-			theme: {
-				background: "#0f172a",
-				foreground: "#e2e8f0",
-				cursor: "#cbd5e1",
-				cursorAccent: "#0f172a",
-				selectionBackground: "#334155",
-				black: "#1e293b",
-				red: "#f87171",
-				green: "#34d399",
-				yellow: "#fbbf24",
-				blue: "#60a5fa",
-				magenta: "#c084fc",
-				cyan: "#22d3ee",
-				white: "#e2e8f0",
-				brightBlack: "#475569",
-				brightRed: "#fca5a5",
-				brightGreen: "#6ee7b7",
-				brightYellow: "#fcd34d",
-				brightBlue: "#93c5fd",
-				brightMagenta: "#d8b4fe",
-				brightCyan: "#67e8f9",
-				brightWhite: "#f1f5f9",
-			},
+			theme: TERMINAL_THEMES[themeStore.current],
 			scrollback: 5000,
 		});
 		const fit = new FitAddon();
@@ -84,9 +99,15 @@ export function TerminalView({ innoSessionId, workspaceId, className }: Terminal
 		});
 		ro.observe(host);
 
+		// React to theme switches live.
+		const offTheme = themeStore.on("change", () => {
+			term.options.theme = TERMINAL_THEMES[themeStore.current];
+		});
+
 		return () => {
 			ro.disconnect();
 			offOutput();
+			offTheme();
 			inputSub.dispose();
 			term.dispose();
 		};

--- a/apps/inno-agent/web/src/react/terminal/TerminalView.tsx
+++ b/apps/inno-agent/web/src/react/terminal/TerminalView.tsx
@@ -46,6 +46,15 @@ const TERMINAL_THEMES: Record<ThemeId, ITheme> = {
 		brightYellow: "#f59e0b", brightBlue: "#06b6d4", brightMagenta: "#a855f7",
 		brightCyan: "#14b8a6", brightWhite: "#1a2c3d",
 	},
+	innospark: {
+		background: "#ffffff", foreground: "#191922", cursor: "#555aff",
+		cursorAccent: "#ffffff", selectionBackground: "#edeeff",
+		black: "#191922", red: "#dc2626", green: "#22a06b", yellow: "#d99a08",
+		blue: "#555aff", magenta: "#7c5cff", cyan: "#6a7cff", white: "#545469",
+		brightBlack: "#9d9da9", brightRed: "#ef4444", brightGreen: "#2bbf7b",
+		brightYellow: "#f5b62f", brightBlue: "#6b70ff", brightMagenta: "#8b70ff",
+		brightCyan: "#8291ff", brightWhite: "#191922",
+	},
 };
 
 /**

--- a/apps/inno-agent/web/src/stores/theme-store.ts
+++ b/apps/inno-agent/web/src/stores/theme-store.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from "./event-emitter.js";
 
-export type ThemeId = "light" | "warm" | "ocean";
+export type ThemeId = "light" | "warm" | "ocean" | "innospark";
 
-export const THEME_IDS: ThemeId[] = ["light", "warm", "ocean"];
+export const THEME_IDS: ThemeId[] = ["light", "warm", "ocean", "innospark"];
 const DARK_THEMES: Set<ThemeId> = new Set();
 const STORAGE_KEY = "inno.theme";
 
@@ -11,6 +11,7 @@ export const THEME_PREVIEW_COLORS: Record<ThemeId, string> = {
 	light: "#ffffff",
 	warm: "#faf8f5",
 	ocean: "#f0f4f8",
+	innospark: "#555aff",
 };
 
 interface ThemeStoreEvents {

--- a/apps/inno-agent/web/src/stores/theme-store.ts
+++ b/apps/inno-agent/web/src/stores/theme-store.ts
@@ -1,0 +1,78 @@
+import { EventEmitter } from "./event-emitter.js";
+
+export type ThemeId = "light" | "warm" | "ocean";
+
+export const THEME_IDS: ThemeId[] = ["light", "warm", "ocean"];
+const DARK_THEMES: Set<ThemeId> = new Set();
+const STORAGE_KEY = "inno.theme";
+
+/** Preview swatch colors for the theme picker UI. */
+export const THEME_PREVIEW_COLORS: Record<ThemeId, string> = {
+	light: "#ffffff",
+	warm: "#faf8f5",
+	ocean: "#f0f4f8",
+};
+
+interface ThemeStoreEvents {
+	change: void;
+}
+
+function isValidTheme(v: string | null): v is ThemeId {
+	return v !== null && THEME_IDS.includes(v as ThemeId);
+}
+
+function getInitialTheme(): ThemeId {
+	const saved = localStorage.getItem(STORAGE_KEY);
+	if (isValidTheme(saved)) return saved;
+	return "light";
+}
+
+function applyThemeToDOM(id: ThemeId): void {
+	const html = document.documentElement;
+	html.setAttribute("data-theme", id);
+	if (DARK_THEMES.has(id)) {
+		html.classList.add("dark");
+	} else {
+		html.classList.remove("dark");
+	}
+}
+
+class ThemeStoreImpl extends EventEmitter<ThemeStoreEvents> {
+	current: ThemeId = getInitialTheme();
+	isSaving = false;
+
+	/** Apply theme locally (DOM + localStorage) without persisting to backend. */
+	apply(id: ThemeId): void {
+		if (!isValidTheme(id)) return;
+		this.current = id;
+		applyThemeToDOM(id);
+		localStorage.setItem(STORAGE_KEY, id);
+		this.emit("change", undefined);
+	}
+
+	/** Apply + persist to backend (best-effort). */
+	async save(id: ThemeId): Promise<void> {
+		this.apply(id);
+		this.isSaving = true;
+		this.emit("change", undefined);
+		try {
+			const { saveThemeSettings } = await import("../api/settings.js");
+			await saveThemeSettings(id);
+		} catch {
+			// best-effort — localStorage is the real source of truth
+		} finally {
+			this.isSaving = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	/** Returns true if the given theme is a dark variant. */
+	isDark(id?: ThemeId): boolean {
+		return DARK_THEMES.has(id ?? this.current);
+	}
+}
+
+export const themeStore = new ThemeStoreImpl();
+
+// Apply immediately on module load (before first render)
+applyThemeToDOM(themeStore.current);

--- a/apps/inno-agent/web/src/stores/theme-store.ts
+++ b/apps/inno-agent/web/src/stores/theme-store.ts
@@ -2,13 +2,13 @@ import { EventEmitter } from "./event-emitter.js";
 
 export type ThemeId = "light" | "warm" | "ocean" | "innospark";
 
-export const THEME_IDS: ThemeId[] = ["light", "warm", "ocean", "innospark"];
+export const THEME_IDS: ThemeId[] = ["light", "innospark", "warm", "ocean"];
 const DARK_THEMES: Set<ThemeId> = new Set();
 const STORAGE_KEY = "inno.theme";
 
 /** Preview swatch colors for the theme picker UI. */
 export const THEME_PREVIEW_COLORS: Record<ThemeId, string> = {
-	light: "#ffffff",
+	light: "#f1f1f2",
 	warm: "#faf8f5",
 	ocean: "#f0f4f8",
 	innospark: "#555aff",

--- a/apps/inno-agent/web/src/themes.css
+++ b/apps/inno-agent/web/src/themes.css
@@ -1,0 +1,97 @@
+/*
+ * Theme presets — each [data-theme] block overrides the --inno-* variables.
+ * :root in app.css provides the fallback (= light theme).
+ */
+
+/* ─── Light (default) ─── */
+:root[data-theme="light"] {
+	--inno-background: #f7f8fa;
+	--inno-surface: #ffffff;
+	--inno-surface-muted: #f3f4f6;
+	--inno-surface-raised: #fafafa;
+	--inno-sidebar-bg: #eceff3;
+	--inno-sidebar-active: #dde2e8;
+	--inno-chat-bg: #ffffff;
+	--inno-workspace-bg: #f8fafc;
+	--inno-workspace-chrome: #f1f5f9;
+	--inno-border: #e5e7eb;
+	--inno-border-strong: #c9d0d9;
+	--inno-text: #171a1f;
+	--inno-text-muted: #667085;
+	--inno-text-subtle: #8a94a3;
+	--inno-accent: #2563eb;
+	--inno-accent-soft: #dbeafe;
+	--inno-tech: #06b6d4;
+	--inno-success: #16a34a;
+	--inno-warning: #d97706;
+	--inno-danger: #dc2626;
+	--inno-shadow-soft: 0 1px 2px rgba(15, 23, 42, 0.05), 0 10px 28px rgba(15, 23, 42, 0.04);
+	--inno-ring: 0 0 0 3px rgba(37, 99, 235, 0.13);
+	--inno-scrollbar-thumb: rgba(0, 0, 0, 0.12);
+	--inno-scrollbar-thumb-hover: rgba(0, 0, 0, 0.22);
+	--inno-selection-bg: rgba(37, 99, 235, 0.15);
+	--inno-grid-color: rgba(37, 99, 235, 0.035);
+	color-scheme: light;
+}
+
+/* ─── Warm ─── */
+:root[data-theme="warm"] {
+	--inno-background: #faf8f5;
+	--inno-surface: #fffefa;
+	--inno-surface-muted: #f5f0ea;
+	--inno-surface-raised: #faf6f1;
+	--inno-sidebar-bg: #f0ebe4;
+	--inno-sidebar-active: #e6dfd6;
+	--inno-chat-bg: #fffefa;
+	--inno-workspace-bg: #faf7f3;
+	--inno-workspace-chrome: #f3ede6;
+	--inno-border: #e5ddd4;
+	--inno-border-strong: #d4c9bc;
+	--inno-text: #2c2418;
+	--inno-text-muted: #7a6b5a;
+	--inno-text-subtle: #9a8b7a;
+	--inno-accent: #d97706;
+	--inno-accent-soft: rgba(217, 119, 6, 0.12);
+	--inno-tech: #0d9488;
+	--inno-success: #16a34a;
+	--inno-warning: #ca8a04;
+	--inno-danger: #dc2626;
+	--inno-shadow-soft: 0 1px 2px rgba(44, 36, 24, 0.05), 0 10px 28px rgba(44, 36, 24, 0.04);
+	--inno-ring: 0 0 0 3px rgba(217, 119, 6, 0.13);
+	--inno-scrollbar-thumb: rgba(44, 36, 24, 0.12);
+	--inno-scrollbar-thumb-hover: rgba(44, 36, 24, 0.22);
+	--inno-selection-bg: rgba(217, 119, 6, 0.12);
+	--inno-grid-color: rgba(217, 119, 6, 0.035);
+	color-scheme: light;
+}
+
+/* ─── Ocean ─── */
+:root[data-theme="ocean"] {
+	--inno-background: #f0f4f8;
+	--inno-surface: #f8fafb;
+	--inno-surface-muted: #e8eef4;
+	--inno-surface-raised: #f2f6f9;
+	--inno-sidebar-bg: #e4ebf2;
+	--inno-sidebar-active: #d6e0ea;
+	--inno-chat-bg: #f8fafb;
+	--inno-workspace-bg: #f2f6f9;
+	--inno-workspace-chrome: #e8eef4;
+	--inno-border: #d0dae4;
+	--inno-border-strong: #b8c8d6;
+	--inno-text: #1a2c3d;
+	--inno-text-muted: #5a7088;
+	--inno-text-subtle: #7a92a8;
+	--inno-accent: #0d9488;
+	--inno-accent-soft: rgba(13, 148, 136, 0.12);
+	--inno-tech: #0891b2;
+	--inno-success: #059669;
+	--inno-warning: #d97706;
+	--inno-danger: #dc2626;
+	--inno-shadow-soft: 0 1px 2px rgba(26, 44, 61, 0.05), 0 10px 28px rgba(26, 44, 61, 0.04);
+	--inno-ring: 0 0 0 3px rgba(13, 148, 136, 0.13);
+	--inno-scrollbar-thumb: rgba(26, 44, 61, 0.12);
+	--inno-scrollbar-thumb-hover: rgba(26, 44, 61, 0.22);
+	--inno-selection-bg: rgba(13, 148, 136, 0.12);
+	--inno-grid-color: rgba(13, 148, 136, 0.035);
+	color-scheme: light;
+}

--- a/apps/inno-agent/web/src/themes.css
+++ b/apps/inno-agent/web/src/themes.css
@@ -5,32 +5,32 @@
 
 /* ─── Light (default) ─── */
 :root[data-theme="light"] {
-	--inno-background: #f7f8fa;
+	--inno-background: #f7f7f8;
 	--inno-surface: #ffffff;
-	--inno-surface-muted: #f3f4f6;
-	--inno-surface-raised: #fafafa;
-	--inno-sidebar-bg: #eceff3;
-	--inno-sidebar-active: #dde2e8;
+	--inno-surface-muted: #f1f1f2;
+	--inno-surface-raised: #fbfbfb;
+	--inno-sidebar-bg: #f3f4f4;
+	--inno-sidebar-active: #e8e8e9;
 	--inno-chat-bg: #ffffff;
-	--inno-workspace-bg: #f8fafc;
-	--inno-workspace-chrome: #f1f5f9;
-	--inno-border: #e5e7eb;
-	--inno-border-strong: #c9d0d9;
-	--inno-text: #171a1f;
-	--inno-text-muted: #667085;
-	--inno-text-subtle: #8a94a3;
-	--inno-accent: #2563eb;
-	--inno-accent-soft: #dbeafe;
-	--inno-tech: #06b6d4;
+	--inno-workspace-bg: #f8f8f8;
+	--inno-workspace-chrome: #f1f1f2;
+	--inno-border: #e3e3e4;
+	--inno-border-strong: #c8c8ca;
+	--inno-text: #202123;
+	--inno-text-muted: #6f7377;
+	--inno-text-subtle: #92969a;
+	--inno-accent: #34363a;
+	--inno-accent-soft: #ededee;
+	--inno-tech: #111827;
 	--inno-success: #16a34a;
 	--inno-warning: #d97706;
 	--inno-danger: #dc2626;
-	--inno-shadow-soft: 0 1px 2px rgba(15, 23, 42, 0.05), 0 10px 28px rgba(15, 23, 42, 0.04);
-	--inno-ring: 0 0 0 3px rgba(37, 99, 235, 0.13);
-	--inno-scrollbar-thumb: rgba(0, 0, 0, 0.12);
-	--inno-scrollbar-thumb-hover: rgba(0, 0, 0, 0.22);
-	--inno-selection-bg: rgba(37, 99, 235, 0.15);
-	--inno-grid-color: rgba(37, 99, 235, 0.035);
+	--inno-shadow-soft: 0 1px 2px rgba(0, 0, 0, 0.04), 0 10px 28px rgba(0, 0, 0, 0.035);
+	--inno-ring: 0 0 0 3px rgba(52, 54, 58, 0.14);
+	--inno-scrollbar-thumb: rgba(32, 33, 35, 0.14);
+	--inno-scrollbar-thumb-hover: rgba(32, 33, 35, 0.24);
+	--inno-selection-bg: rgba(52, 54, 58, 0.12);
+	--inno-grid-color: rgba(32, 33, 35, 0.025);
 	color-scheme: light;
 }
 

--- a/apps/inno-agent/web/src/themes.css
+++ b/apps/inno-agent/web/src/themes.css
@@ -95,3 +95,34 @@
 	--inno-grid-color: rgba(13, 148, 136, 0.035);
 	color-scheme: light;
 }
+
+/* ─── InnoSpark / 启创 ─── */
+:root[data-theme="innospark"] {
+	--inno-background: #f7f7fa;
+	--inno-surface: #ffffff;
+	--inno-surface-muted: #f1f1ff;
+	--inno-surface-raised: #fbfbff;
+	--inno-sidebar-bg: #f3f3f7;
+	--inno-sidebar-active: #ffffff;
+	--inno-chat-bg: #ffffff;
+	--inno-workspace-bg: #fbfbff;
+	--inno-workspace-chrome: #f5f5fb;
+	--inno-border: #e5e4f4;
+	--inno-border-strong: #d2d0ec;
+	--inno-text: #191922;
+	--inno-text-muted: #545469;
+	--inno-text-subtle: #9d9da9;
+	--inno-accent: #555aff;
+	--inno-accent-soft: #edeeff;
+	--inno-tech: #7c5cff;
+	--inno-success: #22a06b;
+	--inno-warning: #d99a08;
+	--inno-danger: #dc2626;
+	--inno-shadow-soft: 0 1px 2px rgba(85, 90, 255, 0.08), 0 14px 34px rgba(85, 90, 255, 0.12);
+	--inno-ring: 0 0 0 3px rgba(85, 90, 255, 0.18);
+	--inno-scrollbar-thumb: rgba(85, 90, 255, 0.16);
+	--inno-scrollbar-thumb-hover: rgba(85, 90, 255, 0.28);
+	--inno-selection-bg: rgba(85, 90, 255, 0.16);
+	--inno-grid-color: rgba(85, 90, 255, 0.028);
+	color-scheme: light;
+}

--- a/apps/inno-agent/web/src/types/settings.ts
+++ b/apps/inno-agent/web/src/types/settings.ts
@@ -91,4 +91,5 @@ export interface InnoSettings {
 	};
 	memory?: { l1Enabled: boolean; l2Enabled: boolean; l3Enabled: boolean };
 	simpleMode?: { enabled: boolean };
+	ui?: { theme: string };
 }


### PR DESCRIPTION
## Summary
- 4 visual theme presets: Light, Warm, Ocean, InnoSpark
- CSS variables (`--inno-*`) override via `:root[data-theme="..."]` selectors
- FOWT prevention via inline `<script>` in `index.html`
- Theme state managed in `theme-store.ts` (EventEmitter), persisted to `localStorage` + backend `config.json`
- Theme picker UI in SettingsPanel with color swatches
- xterm.js terminal gets theme-aware palettes per preset
- All hardcoded Tailwind colors migrated to `var(--inno-*)` references (~20 files)

## Key files
| File | Action |
|---|---|
| `web/src/themes.css` | New — 4 theme blocks |
| `web/src/stores/theme-store.ts` | New — theme state + DOM sync |
| `web/src/react/SettingsPanel.tsx` | Theme picker swatches |
| `web/src/react/terminal/TerminalView.tsx` | Dynamic xterm palette |
| `web/index.html` | FOWT inline script |
| `web/src/app.css` | Import themes.css |
| `src/server.ts` | `PUT /api/settings/theme` |
| `src/config.ts` | `InnoConfig.ui` schema |
| `web/src/i18n/locales/*.json` | Theme labels |
| ~20 component files | Hardcoded color → CSS var migration |