### PR TITLE
fix: switching sessions no longer kills the backend task

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -511,13 +511,12 @@ export async function reloadResources(): Promise<void> {
 
 /**
  * Switch active runtime to a persisted session file path.
+ * NOTE: We intentionally do NOT abort the current prompt here — switching
+ * sessions is a UI-level navigation action. The backend task continues
+ * running and the client can reconnect to its event stream later.
  */
 export async function switchSessionFile(sessionPath: string): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
-	// Defensively abort any in-flight prompt FIRST (outside the queue, like
-	// switchModel does) so this switch can't get stuck behind a still-streaming
-	// turn holding the shared queue.
-	await abortCurrentPrompt();
 	await enqueue(async () => {
 		await switchToSession(sessionPath);
 	});
@@ -538,13 +537,12 @@ export async function applyWorkspaceCwd(sessionPath: string): Promise<void> {
 
 /**
  * Create and switch to a new session.
+ * NOTE: We intentionally do NOT abort the current prompt here — the backend
+ * task for the previous session continues running in the background.
+ * The client can reconnect to its event stream when switching back.
  */
 export async function createNewSession(): Promise<string> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
-	// Defensively abort any in-flight prompt FIRST (outside the queue) so opening
-	// a new conversation can't get stuck behind a still-streaming turn holding the
-	// shared queue.
-	await abortCurrentPrompt();
 	return enqueue(async () => {
 		await _runtime!.newSession();
 		const sessionId = getCurrentSessionId();

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -104,6 +104,59 @@ let bootstrapped = false;
 let bootstrapPromise: Promise<void> | null = null;
 let bridgeToken: string | undefined;
 
+// ---------------------------------------------------------------------------
+// Session Event Broadcaster — allows clients to reconnect to in-progress
+// streams after navigating away and back.
+// ---------------------------------------------------------------------------
+
+class SessionEventBroadcaster {
+	private history: unknown[] = [];
+	private subscribers = new Set<(event: unknown) => void>();
+	private _closed = false;
+
+	publish(event: unknown): void {
+		if (this._closed) return;
+		this.history.push(event);
+		for (const sub of this.subscribers) sub(event);
+	}
+
+	subscribe(cb: (event: unknown) => void): () => void {
+		for (const event of this.history) cb(event);
+		if (!this._closed) this.subscribers.add(cb);
+		return () => { this.subscribers.delete(cb); };
+	}
+
+	close(): void { this._closed = true; this.subscribers.clear(); }
+	get closed(): boolean { return this._closed; }
+}
+
+const sessionBroadcasters = new Map<string, SessionEventBroadcaster>();
+
+function piEventToSseEvent(event: any): unknown | null {
+	switch (event.type) {
+		case "message_update": {
+			const ev = event.assistantMessageEvent;
+			if (ev.type === "text_delta") return { type: "text_delta", delta: ev.delta };
+			if (ev.type === "thinking_delta") return { type: "thinking_delta", delta: ev.delta };
+			if (ev.type === "error") return { type: "error", message: ev.error.errorMessage || `LLM API error (stopReason: ${ev.error.stopReason})` };
+			return null;
+		}
+		case "message_end": {
+			const msg = event.message;
+			if (msg && typeof msg === "object" && "stopReason" in msg && msg.stopReason === "error") {
+				return { type: "error", message: msg.errorMessage || "The model request failed." };
+			}
+			return null;
+		}
+		case "tool_execution_start":
+			return { type: "tool_start", toolCallId: event.toolCallId, toolName: event.toolName, args: event.args };
+		case "tool_execution_end":
+			return { type: "tool_end", toolCallId: event.toolCallId, toolName: event.toolName, result: event.result, isError: event.isError };
+		default:
+			return null;
+	}
+}
+
 /**
  * One-shot lazy bootstrap. Idempotent — concurrent requests while the first
  * bootstrap is still in-flight all await the same promise.
@@ -3494,6 +3547,41 @@ const server = createServer(async (req, res) => {
 			return;
 		}
 
+		// --- Chat Events Reconnect (SSE) ---
+		// Allows a client that navigated away to reconnect to an in-progress
+		// session's event stream and replay all events from the beginning.
+		const chatEventsMatch = matchRoute("GET", method, url, "/api/chat/events/:id");
+		if (chatEventsMatch) {
+			const sessionId = chatEventsMatch.id;
+			const bc = sessionBroadcasters.get(sessionId);
+			if (!bc) {
+				json(res, 404, { error: "No active stream" });
+				return;
+			}
+			res.writeHead(200, {
+				"Content-Type": "text/event-stream",
+				"Cache-Control": "no-cache",
+				"Connection": "keep-alive",
+				"X-Accel-Buffering": "no",
+			});
+			let ended = false;
+			const unsub = bc.subscribe((event: unknown) => {
+				if (ended) return;
+				res.write(`data: ${JSON.stringify(event)}\n\n`);
+				if ((event as any).type === "done" || ((event as any).type === "error" && !(event as any).toolCallId)) {
+					res.write("data: [DONE]\n\n");
+					ended = true;
+					res.end();
+				}
+			});
+			if (bc.closed && !ended) {
+				res.write("data: [DONE]\n\n");
+				res.end();
+			}
+			req.on("close", unsub);
+			return;
+		}
+
 		// --- Chat Streaming (SSE) ---
 		if (method === "POST" && url === "/api/chat/stream") {
 			const body = (await readBody(req)) as Record<string, unknown>;
@@ -3536,10 +3624,14 @@ const server = createServer(async (req, res) => {
 				aborted = true;
 				questionBridge.setEmitter(null);
 				questionBridge.cancel();
-				void abortCurrentPrompt();
 			});
 
 			questionBridge.setEmitter(sseWrite);
+
+			// Create a broadcaster for this session so clients can reconnect
+			// to the event stream after navigating away.
+			const broadcaster = new SessionEventBroadcaster();
+			sessionBroadcasters.set(capturedSessionId, broadcaster);
 
 			// Track whether the model API surfaced an error this turn. The PI SDK
 			// does NOT throw on model API errors (e.g. HTTP 413 from an over-long
@@ -3550,18 +3642,13 @@ const server = createServer(async (req, res) => {
 			let emittedError = false;
 			let promptStartTime = 0;
 			const onEvent = (event: import("@earendil-works/pi-coding-agent").AgentSessionEvent) => {
-				if (aborted) return;
+				// Logging regardless of aborted state
 				switch (event.type) {
 					case "message_update": {
 						const ev = event.assistantMessageEvent;
-						if (ev.type === "text_delta") {
-							sseWrite({ type: "text_delta", delta: ev.delta });
-						} else if (ev.type === "thinking_delta") {
-							sseWrite({ type: "thinking_delta", delta: ev.delta });
-						} else if (ev.type === "error") {
+						if (ev.type === "error") {
 							const errorMsg = ev.error.errorMessage || `LLM API error (stopReason: ${ev.error.stopReason})`;
 							logger.error({ errorMessage: errorMsg, stopReason: ev.error.stopReason, elapsedMs: Date.now() - promptStartTime }, "LLM API stream error event");
-							sseWrite({ type: "error", message: errorMsg });
 						}
 						break;
 					}
@@ -3575,7 +3662,6 @@ const server = createServer(async (req, res) => {
 							const detail = (msg as { errorMessage?: string }).errorMessage;
 							const errorMsg = detail || "The model request failed.";
 							logger.error({ stopReason: "error", errorMessage: errorMsg, message: msg, elapsedMs: Date.now() - promptStartTime }, "Model request failed (message_end stopReason=error)");
-							sseWrite({ type: "error", message: errorMsg });
 						}
 						break;
 					}
@@ -3584,12 +3670,6 @@ const server = createServer(async (req, res) => {
 							{ toolName: event.toolName, toolCallId: event.toolCallId },
 							"tool call started: %s", event.toolName,
 						);
-						sseWrite({
-							type: "tool_start",
-							toolCallId: event.toolCallId,
-							toolName: event.toolName,
-							args: event.args,
-						});
 						break;
 					case "tool_execution_end":
 						if (event.isError) {
@@ -3608,13 +3688,6 @@ const server = createServer(async (req, res) => {
 								"tool call completed: %s", event.toolName,
 							);
 						}
-						sseWrite({
-							type: "tool_end",
-							toolCallId: event.toolCallId,
-							toolName: event.toolName,
-							result: event.result,
-							isError: event.isError,
-						});
 						break;
 					case "auto_retry_start":
 						logger.warn({ attempt: event.attempt, maxAttempts: event.maxAttempts, delayMs: event.delayMs, errorMessage: event.errorMessage, elapsedMs: Date.now() - promptStartTime }, "LLM API call failed, auto-retrying...");
@@ -3628,6 +3701,13 @@ const server = createServer(async (req, res) => {
 						logger.info({ eventType: (event as { type?: string }).type }, "unhandled SSE event type: %s", (event as { type?: string }).type);
 						break;
 				}
+
+				// Convert to SSE event and publish to broadcaster + live client
+				const sseEvent = piEventToSseEvent(event);
+				if (sseEvent) {
+					broadcaster.publish(sseEvent);
+					if (!aborted) sseWrite(sseEvent);
+				}
 			};
 
 			promptStartTime = Date.now();
@@ -3637,15 +3717,19 @@ const server = createServer(async (req, res) => {
 				const fullText = targetSessionPath
 					? await runPromptStreamingInSession(targetSessionPath, prompt, onEvent, imageArgs)
 					: await runPromptStreaming(prompt, onEvent, imageArgs);
-				if (!aborted) sseWrite({ type: "done", fullText });
+				const doneEvent = { type: "done", fullText };
+				broadcaster.publish(doneEvent);
+				if (!aborted) sseWrite(doneEvent);
 				// Skip topic auto-generation when the turn errored — there is no
 				// meaningful assistant reply to summarize and the model API is
 				// likely still failing (which would just block again).
 				if (!emittedError) maybeAutoGenerateTopic(capturedSessionId);
 			} catch (err) {
 				logger.error({ err }, "SSE stream error");
+				const errorEvent = { type: "error", message: err instanceof Error ? err.message : "Unknown error" };
+				broadcaster.publish(errorEvent);
 				if (!aborted) {
-					sseWrite({ type: "error", message: err instanceof Error ? err.message : "Unknown error" });
+					sseWrite(errorEvent);
 				}
 			} finally {
 				// Always attribute this turn to the web channel — even on abort or
@@ -3660,6 +3744,14 @@ const server = createServer(async (req, res) => {
 				// session stays in the sidebar and can be reopened. No-op when an
 				// assistant message already exists (normal/errored turns).
 				persistPendingUserTurn(capturedSessionId);
+				// Keep the broadcaster alive for 60s so reconnecting clients can
+				// replay the full event history, then clean up.
+				setTimeout(() => {
+					if (sessionBroadcasters.get(capturedSessionId) === broadcaster) {
+						broadcaster.close();
+						sessionBroadcasters.delete(capturedSessionId);
+					}
+				}, 60_000);
 			}
 			if (!aborted) {
 				res.write("data: [DONE]\n\n");

--- a/apps/inno-agent/web/src/api/chat.ts
+++ b/apps/inno-agent/web/src/api/chat.ts
@@ -1,4 +1,4 @@
-import { apiFetch, streamSSE } from "./client.js";
+import { apiFetch, streamSSE, streamSSEGet } from "./client.js";
 import type { ChatStreamEvent } from "../types/chat.js";
 
 export interface InlineImage {
@@ -29,4 +29,12 @@ export async function abortChat(): Promise<void> {
 	} catch {
 		// best-effort — the SSE close handler is a fallback
 	}
+}
+
+/**
+ * Reconnect to an in-progress session's event stream. Returns silently
+ * if the session has no active stream (404).
+ */
+export function streamSessionEvents(sessionId: string, signal?: AbortSignal): AsyncGenerator<ChatStreamEvent> {
+	return streamSSEGet<ChatStreamEvent>(`/api/chat/events/${encodeURIComponent(sessionId)}`, signal);
 }

--- a/apps/inno-agent/web/src/api/client.ts
+++ b/apps/inno-agent/web/src/api/client.ts
@@ -25,28 +25,10 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
 }
 
 /**
- * SSE stream parser. Yields parsed JSON objects from `data:` lines.
- * Pass an AbortSignal to allow callers to stop the stream early (e.g. user
- * clicks Stop). When aborted the generator returns normally instead of
- * surfacing the underlying AbortError.
+ * Shared SSE body-reading loop. Yields parsed JSON objects from `data:` lines.
+ * When the signal is aborted the generator returns normally.
  */
-export async function* streamSSE<T>(url: string, body: unknown, signal?: AbortSignal): AsyncGenerator<T> {
-	let res: Response;
-	try {
-		res = await fetch(url, {
-			method: "POST",
-			headers: { "Content-Type": "application/json" },
-			body: JSON.stringify(body),
-			signal,
-		});
-	} catch (err) {
-		if (signal?.aborted) return;
-		throw err;
-	}
-	if (!res.ok) {
-		const errBody = await res.json().catch(() => ({}));
-		throw new ApiError(res.status, (errBody as Record<string, string>).error || res.statusText);
-	}
+async function* readSSEStream<T>(res: Response, signal?: AbortSignal): AsyncGenerator<T> {
 	const reader = res.body!.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
@@ -83,4 +65,50 @@ export async function* streamSSE<T>(url: string, body: unknown, signal?: AbortSi
 			// already closed
 		}
 	}
+}
+
+/**
+ * SSE stream parser. Yields parsed JSON objects from `data:` lines.
+ * Pass an AbortSignal to allow callers to stop the stream early (e.g. user
+ * clicks Stop). When aborted the generator returns normally instead of
+ * surfacing the underlying AbortError.
+ */
+export async function* streamSSE<T>(url: string, body: unknown, signal?: AbortSignal): AsyncGenerator<T> {
+	let res: Response;
+	try {
+		res = await fetch(url, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify(body),
+			signal,
+		});
+	} catch (err) {
+		if (signal?.aborted) return;
+		throw err;
+	}
+	if (!res.ok) {
+		const errBody = await res.json().catch(() => ({}));
+		throw new ApiError(res.status, (errBody as Record<string, string>).error || res.statusText);
+	}
+	yield* readSSEStream<T>(res, signal);
+}
+
+/**
+ * SSE stream via GET. Returns silently on 404 (no active stream).
+ * Yields parsed JSON objects from `data:` lines.
+ */
+export async function* streamSSEGet<T>(url: string, signal?: AbortSignal): AsyncGenerator<T> {
+	let res: Response;
+	try {
+		res = await fetch(url, { method: "GET", signal });
+	} catch (err) {
+		if (signal?.aborted) return;
+		throw err;
+	}
+	if (res.status === 404) return;
+	if (!res.ok) {
+		const errBody = await res.json().catch(() => ({}));
+		throw new ApiError(res.status, (errBody as Record<string, string>).error || res.statusText);
+	}
+	yield* readSSEStream<T>(res, signal);
 }

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -572,7 +572,7 @@ inno-workspace-panel textarea {
 }
 
 :root[data-theme="innospark"] .inno-sidebar-scope [role="button"]:hover,
-:root[data-theme="innospark"] .inno-sidebar-scope button:hover:not(:disabled):not(.inno-channel-filter-chip) {
+:root[data-theme="innospark"] .inno-sidebar-scope button:hover:not(:disabled):not(.inno-channel-filter-chip):not(.inno-primary-button):not(.inno-primary-icon-button) {
 	background: rgba(255, 255, 255, 0.86);
 	box-shadow: 0 1px 2px rgba(85, 90, 255, 0.05);
 }

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -673,8 +673,8 @@ inno-workspace-panel textarea {
 }
 
 :root[data-theme="innospark"] .inno-workspace-card,
-:root[data-theme="innospark"] .inno-workspace-scope .rounded-lg,
-:root[data-theme="innospark"] .inno-workspace-scope .rounded {
+:root[data-theme="innospark"] .inno-workspace-scope .rounded-lg:not(.inno-primary-button):not(.inno-primary-icon-button),
+:root[data-theme="innospark"] .inno-workspace-scope .rounded:not(.inno-primary-button):not(.inno-primary-icon-button) {
 	border-color: rgba(85, 90, 255, 0.12);
 	background-color: rgba(255, 255, 255, 0.86);
 }

--- a/apps/inno-agent/web/src/components/chat/chat-center.ts
+++ b/apps/inno-agent/web/src/components/chat/chat-center.ts
@@ -3,6 +3,7 @@ import { customElement, state, query } from "lit/decorators.js";
 import { chatStore } from "../../stores/chat-store.js";
 import type { ChatMessage } from "../../types/chat.js";
 import { uploadRawFile, type RawUploadResult } from "../../api/uploads.js";
+import { normalizeMarkdownMath } from "../../utils/markdown-math.js";
 
 // Import Pi SDK markdown renderer
 import "@earendil-works/pi-web-ui";
@@ -113,7 +114,7 @@ export class ChatCenter extends LitElement {
 		return html`
 			<div class="flex justify-start">
 				<div class="max-w-[76%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] leading-relaxed text-[var(--inno-text)]">
-					<markdown-artifact .content=${msg.content}></markdown-artifact>
+					<markdown-artifact .content=${normalizeMarkdownMath(msg.content)}></markdown-artifact>
 				</div>
 			</div>
 		`;
@@ -158,7 +159,7 @@ export class ChatCenter extends LitElement {
 				? html`
 						<div class="flex justify-start">
 							<div class="max-w-[76%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] leading-relaxed text-[var(--inno-text)]">
-								<markdown-artifact .content=${this._streamingText}></markdown-artifact>
+								<markdown-artifact .content=${normalizeMarkdownMath(this._streamingText)}></markdown-artifact>
 							</div>
 						</div>
 					`

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -14,6 +14,7 @@ import type { CreateSessionInput } from "../api/sessions.js";
 import { listRemotePresets } from "../api/presets.js";
 import type { PresetMeta } from "../types/presets.js";
 import { uploadRawFile, type RawUploadResult } from "../api/uploads.js";
+import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { QuestionDialog } from "./QuestionDialog.js";
 import "@earendil-works/pi-web-ui";
@@ -160,7 +161,7 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 						) : null}
 					</details>
 				) : null}
-				<markdown-artifact content={message.content} />
+				<markdown-artifact content={normalizeMarkdownMath(message.content)} />
 				{message.error ? (
 					<div className={message.content.trim() ? "mt-2" : ""}>
 						<ErrorBlock error={message.error} />
@@ -826,7 +827,7 @@ export function ChatCenter() {
 							transition={{ duration: 0.2, ease: "easeOut" }}
 						>
 							<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
-								<markdown-artifact content={chat.streamingText} />
+								<markdown-artifact content={normalizeMarkdownMath(chat.streamingText)} />
 							</div>
 						</motion.div>
 					) : null}

--- a/apps/inno-agent/web/src/react/JobsPanel.tsx
+++ b/apps/inno-agent/web/src/react/JobsPanel.tsx
@@ -214,7 +214,7 @@ export function JobsPanel() {
 
 									<div className="mt-2 flex flex-wrap gap-1.5">
 										<button
-											className={`flex items-center gap-1 rounded inno-primary-button px-2 py-1 text-xs text-white ${isRunning ? "cursor-wait opacity-50" : ""}`}
+											className={`flex items-center gap-1 rounded-md inno-primary-button px-2 py-1 text-xs text-white ${isRunning ? "cursor-wait opacity-50" : ""}`}
 											disabled={isRunning}
 											title={t("jobs.actions.run")}
 											onClick={() => void jobsStore.run(job.id)}

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -731,7 +731,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 				{/* Footer: new chat (mode switch lives on the IA logo above) */}
 				<div className="border-t border-slate-200/70 p-2">
 					<button
-						className="inno-sidebar-text flex w-full items-center justify-center gap-2 rounded-lg inno-primary-button px-3 py-1.5 font-medium text-white shadow-sm transition-colors"
+						className="inno-sidebar-text inno-new-chat-button flex w-full items-center justify-center gap-2 rounded-lg inno-primary-button px-3 py-1.5 font-medium text-white shadow-sm transition-colors"
 						onClick={newChat}
 					>
 						<Plus size={14} /> 新建对话
@@ -939,7 +939,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 			{/* Footer */}
 			<div className="border-t border-slate-200/70 p-2">
 				<button
-					className="inno-sidebar-text flex w-full items-center justify-center gap-2 rounded-lg inno-primary-button px-3 py-1.5 font-medium text-white shadow-sm transition-colors"
+					className="inno-sidebar-text inno-new-chat-button flex w-full items-center justify-center gap-2 rounded-lg inno-primary-button px-3 py-1.5 font-medium text-white shadow-sm transition-colors"
 					onClick={newChat}
 				>
 					<Plus size={14} /> 新建对话

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -23,6 +23,7 @@ import { skillRawUrl } from '../api/skills.js';
 import type { SkillInfo } from "../types/skills.js";
 import type { WorkspaceFileDetail, WorkspaceFileKind } from "../types/workspace.js";
 import { type ArboristNode, toArboristNodes } from "../types/workspace.js";
+import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 import { useStoreSnapshot } from "./hooks.js";
 import "@earendil-works/pi-web-ui";
 import "@uiw/react-md-editor/markdown-editor.css";
@@ -97,7 +98,7 @@ function SkillHtmlPreview({ file }: { file: WorkspaceFileDetail }) {
 function FilePreview({ file, skillName, isLoading }: { file: WorkspaceFileDetail; skillName: string; isLoading: boolean }) {
 	const { t } = useTranslation();
 	if (isLoading) return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.loadingFile", "Loading...")}</div>;
-	if (file.kind === "markdown") return <div className="h-full overflow-y-auto p-5"><markdown-artifact content={file.content ?? ""} /></div>;
+	if (file.kind === "markdown") return <div className="h-full overflow-y-auto p-5"><markdown-artifact content={normalizeMarkdownMath(file.content ?? "")} /></div>;
 	if (file.kind === "html") return <SkillHtmlPreview file={file} />;
 	if (file.kind === "pdf") return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" src={file.url ?? skillRawUrl(skillName, file.path)} title={file.name} />;
 	if (file.kind === "image") {

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -28,6 +28,7 @@ import { TerminalDrawer } from "./terminal/TerminalDrawer.js";
 import { RunButton } from "./terminal/RunButton.js";
 import type { WorkspaceFileDetail, WorkspaceFileKind } from "../types/workspace.js";
 import { type ArboristNode, toArboristNodes } from "../types/workspace.js";
+import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 import { useStoreSnapshot } from "./hooks.js";
 import "@earendil-works/pi-web-ui";
 import "@uiw/react-md-editor/markdown-editor.css";
@@ -279,7 +280,7 @@ function HtmlPreview({ file }: { file: WorkspaceFileDetail }) {
 function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: boolean }) {
 	const { t } = useTranslation();
 	if (isLoading) return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.loadingFile")}</div>;
-	if (file.kind === "markdown") return <div className="workspace-scroll h-full overflow-y-auto p-5"><markdown-artifact content={file.content ?? ""} /></div>;
+	if (file.kind === "markdown") return <div className="workspace-scroll h-full overflow-y-auto p-5"><markdown-artifact content={normalizeMarkdownMath(file.content ?? "")} /></div>;
 		if (file.kind === "html") return <HtmlPreview file={file} />;
 	if (file.kind === "pdf") {
 		// Default to fit-width so the PDF fills the preview panel horizontally.

--- a/apps/inno-agent/web/src/react/notebook/GraphView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/GraphView.tsx
@@ -388,7 +388,7 @@ export function GraphView() {
 						) : null}
 						{displayNode.type !== "tag" ? (
 							<button
-								className="ml-auto shrink-0 rounded inno-primary-button px-2 py-0.5 text-xs text-white"
+								className="ml-auto shrink-0 rounded-md inno-primary-button px-2 py-0.5 text-xs text-white"
 								onClick={() => void notebookStore.selectPage(displayNode.id)}
 							>
 								{t("notebook.inspector.openPage")}

--- a/apps/inno-agent/web/src/react/notebook/PageView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/PageView.tsx
@@ -3,6 +3,7 @@ import MDEditor from "@uiw/react-md-editor";
 import { notebookStore } from "../../stores/notebook-store.js";
 import type { WikiPageFrontmatter, WikiPageType } from "../../types/wiki.js";
 import { parseFrontmatter } from "../../utils/frontmatter.js";
+import { normalizeMarkdownMath } from "../../utils/markdown-math.js";
 import { useStoreSnapshot } from "../hooks.js";
 import "@earendil-works/pi-web-ui";
 import "@uiw/react-md-editor/markdown-editor.css";
@@ -110,7 +111,7 @@ export function PageView() {
 		<div className="flex h-full flex-col">
 			{parsed.frontmatter ? <FrontmatterHeader frontmatter={parsed.frontmatter} /> : null}
 			<div className="min-h-0 flex-1 overflow-y-auto p-4">
-				<markdown-artifact content={parsed.body} />
+				<markdown-artifact content={normalizeMarkdownMath(parsed.body)} />
 			</div>
 			<div className="flex gap-2 border-t border-[var(--inno-border)] p-3">
 				<button className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white" onClick={() => notebookStore.startEditing()}>

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "./event-emitter.js";
-import { streamChat, abortChat } from "../api/chat.js";
+import { streamChat, abortChat, streamSessionEvents } from "../api/chat.js";
 import type { InlineImage } from "../api/chat.js";
 import type { ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult } from "../types/chat.js";
 import { notebookStore } from "./notebook-store.js";
@@ -27,10 +27,12 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	/** Pending question from agent's ask_user_question tool */
 	pendingQuestion: PendingQuestion | null = null;
 	private abortController: AbortController | null = null;
+	private detachMode = false;
 	private wikiInvalidated = false;
 
 	async send(prompt: string, images?: InlineImage[]): Promise<void> {
 		if ((!prompt.trim() && !images?.length) || this.isSending) return;
+		this.detachMode = false;
 
 		// Capture the target session at send time to prevent misalignment
 		// if the user switches sessions while the request is queued.
@@ -67,7 +69,9 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			// Finalize: add accumulated text as assistant message. Also finalize
 			// when the turn produced only an error (no text), so the error is
 			// preserved in history instead of vanishing when streaming state resets.
-			if (this.streamingText || this.streamingError || aborted) {
+			if (this.detachMode) {
+				// skip — backend still running, loadHistory will show final result
+			} else if (this.streamingText || this.streamingError || aborted) {
 				this.messages = [
 					...this.messages,
 					{
@@ -98,6 +102,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			this.activeTools = [];
 			this.completedTools = [];
 			this.abortController = null;
+			this.detachMode = false;
 			this.pendingQuestion = null;
 			const shouldRefreshWiki = this.wikiInvalidated;
 			this.wikiInvalidated = false;
@@ -117,7 +122,10 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		}
 	}
 
-	/** Abort the in-flight stream. */
+	/**
+	 * Abort the in-flight stream. Called when user clicks the stop button —
+	 * the only path that actually stops the backend task.
+	 */
 	cancel(): void {
 		const wasSending = this.isSending;
 		this.abortController?.abort();
@@ -126,6 +134,72 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		// This releases the server's shared prompt queue immediately, preventing
 		// new-session / switch-session from blocking behind a still-running turn.
 		if (wasSending) void abortChat();
+	}
+
+	/**
+	 * Detach from the current stream without stopping the backend task.
+	 * Used when the user navigates to a different session.
+	 */
+	detach(): void {
+		this.detachMode = true;
+		this.abortController?.abort();
+		this.abortController = null;
+	}
+
+	/**
+	 * Reconnect to an in-progress session's backend event stream.
+	 * Replays history and continues receiving live events.
+	 */
+	async resumeStream(sessionId: string): Promise<void> {
+		if (this.isSending) return;
+		this.isSending = true;
+		this.streamingText = "";
+		this.streamingThinking = "";
+		this.streamingError = "";
+		this.activeTools = [];
+		this.completedTools = [];
+		this.detachMode = false;
+		const controller = new AbortController();
+		this.abortController = controller;
+		this.emit("change", undefined);
+
+		try {
+			for await (const event of streamSessionEvents(sessionId, controller.signal)) {
+				this._handleStreamEvent(event);
+			}
+			// Finalize assistant message from accumulated streaming text
+			if (this.detachMode) {
+				// detached again — skip finalize
+			} else if (this.streamingText || this.streamingError) {
+				this.messages = [
+					...this.messages,
+					{
+						role: "assistant",
+						content: this.streamingText,
+						timestamp: Date.now(),
+						thinking: this.streamingThinking || undefined,
+						tools: this.completedTools.length > 0 ? this.completedTools : undefined,
+						error: this.streamingError || undefined,
+					},
+				];
+			}
+		} catch (err) {
+			if (!controller.signal.aborted) {
+				console.warn("[chat-store] resumeStream error:", err);
+			}
+		} finally {
+			this.isSending = false;
+			this.streamingText = "";
+			this.streamingThinking = "";
+			this.streamingError = "";
+			this.activeTools = [];
+			this.completedTools = [];
+			this.abortController = null;
+			this.detachMode = false;
+			this.pendingQuestion = null;
+			this.emit("change", undefined);
+			void import("./sessions-store.js").then((m) => m.sessionsStore.refresh());
+		}
 	}
 
 	/** Re-send the last user prompt. No-op while a send is in flight. */
@@ -237,6 +311,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	}
 
 	loadHistory(messages: ChatMessage[]) {
+		this.isLoadingHistory = false;
 		this.messages = messages;
 		this.isSending = false;
 		this.streamingText = "";

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -68,6 +68,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	preselectedWorkspaceId: string | null = null;
 	private _openRequestId = 0;
 	private _messageCache = new Map<string, Awaited<ReturnType<typeof getSession>>["messages"]>();
+	private _backgroundRunningSessions = new Set<string>();
 
 	/**
 	 * Single source of truth for whether the chat center shows the welcome
@@ -170,14 +171,26 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 
 	async openSession(id: string): Promise<void> {
 		const requestId = ++this._openRequestId;
+		const prevSessionId = this.currentSessionId;
+
+		// Track background sessions: if the previous session was still streaming,
+		// preserve its state so we can resume when switching back.
+		if (prevSessionId && prevSessionId !== id) {
+			if (chatStore.isSending) {
+				this._backgroundRunningSessions.add(prevSessionId);
+				this._messageCache.set(prevSessionId, chatStore.messages);
+			} else {
+				this._messageCache.delete(prevSessionId);
+			}
+		}
+
 		this.currentSessionId = id;
 		this.openingSessionId = id;
 		this.pendingNewSession = false;
 		this.emit("change", undefined);
 
-		// Abort any in-flight chat stream tied to the previous session so its
-		// events can't leak into this one (and keep isSending=true forever).
-		chatStore.cancel();
+		// Detach from the current stream without stopping the backend task.
+		chatStore.detach();
 		// Drop any terminal bound to the previous session.
 		void terminalStore.disconnect();
 
@@ -203,12 +216,25 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		try {
 			const session = await getSession(id);
 			if (requestId !== this._openRequestId) return;
-			this._messageCache.set(id, session.messages);
-			chatStore.loadHistory(session.messages);
+
+			const isBackground = this._backgroundRunningSessions.has(id);
+			const cachedMessages = this._messageCache.get(id);
+
+			if (isBackground && cachedMessages && cachedMessages.length > session.messages.length) {
+				chatStore.loadHistory(cachedMessages);
+			} else {
+				this._messageCache.set(id, session.messages);
+				chatStore.loadHistory(session.messages);
+			}
 
 			void activateSession(id).catch((err) => {
 				console.warn(`[sessions] failed to activate ${id}: ${err instanceof Error ? err.message : String(err)}`);
 			});
+
+			if (isBackground) {
+				this._backgroundRunningSessions.delete(id);
+				void chatStore.resumeStream(id);
+			}
 		} finally {
 			if (requestId === this._openRequestId) {
 				this.openingSessionId = null;
@@ -222,14 +248,20 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	 * Enter "new session" mode without yet creating a backend session.
 	 * The actual session is created when the user chooses a workspace.
 	 *
-	 * Also aborts any in-flight chat stream so a stuck/streaming turn can't
-	 * keep `chatStore.isSending` true and block the chooser / input.
+	 * Also detaches from any in-flight chat stream so a stuck/streaming turn
+	 * can't keep `chatStore.isSending` true and block the chooser / input.
 	 */
 	beginNewSession(): void {
+		if (this.currentSessionId && chatStore.isSending) {
+			this._backgroundRunningSessions.add(this.currentSessionId);
+			this._messageCache.set(this.currentSessionId, chatStore.messages);
+		} else if (this.currentSessionId) {
+			this._messageCache.delete(this.currentSessionId);
+		}
 		this.currentSessionId = null;
 		this.pendingNewSession = true;
 		this.preselectedWorkspaceId = null;
-		chatStore.cancel();
+		chatStore.detach();
 		chatStore.clear();
 		void terminalStore.disconnect();
 		this.emit("change", undefined);
@@ -260,7 +292,11 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		this.pendingNewSession = false;
 		this.preselectedWorkspaceId = null;
 		// Make sure no previous stream / terminal lingers.
-		chatStore.cancel();
+		if (this.currentSessionId && chatStore.isSending) {
+			this._backgroundRunningSessions.add(this.currentSessionId);
+			this._messageCache.set(this.currentSessionId, chatStore.messages);
+		}
+		chatStore.detach();
 		void terminalStore.disconnect();
 		this.emit("change", undefined);
 		try {
@@ -313,6 +349,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	async deleteSession(id: string): Promise<void> {
 		const result = await deleteSession(id);
 		this._messageCache.delete(id);
+		this._backgroundRunningSessions.delete(id);
 		this.sessions = this.sessions.filter((session) => session.id !== id);
 		if (this.currentSessionId === id) {
 			this.currentSessionId = result.newActiveId;

--- a/apps/inno-agent/web/src/utils/markdown-math.ts
+++ b/apps/inno-agent/web/src/utils/markdown-math.ts
@@ -1,0 +1,138 @@
+const FENCE_RE = /^ {0,3}(`{3,}|~{3,})/;
+
+function normalizeMathExpression(source: string): string {
+	// MarkdownBlock escapes raw "<" before KaTeX runs, so use TeX relations.
+	return source
+		.replace(/&amp;(lt|gt|le|ge|ne|times|divide|plusmn|minus|nbsp);/gi, "&$1;")
+		.replace(/&#0*60;|&#x0*3c;/gi, "\\lt ")
+		.replace(/&#0*62;|&#x0*3e;/gi, "\\gt ")
+		.replace(/&lt;/gi, "\\lt ")
+		.replace(/&gt;/gi, "\\gt ")
+		.replace(/&le;|&leq;/gi, "\\le ")
+		.replace(/&ge;|&geq;/gi, "\\ge ")
+		.replace(/&ne;|&neq;/gi, "\\ne ")
+		.replace(/&times;/gi, "\\times ")
+		.replace(/&divide;/gi, "\\div ")
+		.replace(/&plusmn;/gi, "\\pm ")
+		.replace(/&minus;/gi, "-")
+		.replace(/&nbsp;/gi, " ")
+		.replace(/&amp;/gi, "&")
+		.replace(/</g, "\\lt ");
+}
+
+function isEscaped(source: string, index: number): boolean {
+	let slashCount = 0;
+	for (let i = index - 1; i >= 0 && source[i] === "\\"; i -= 1) slashCount += 1;
+	return slashCount % 2 === 1;
+}
+
+function findClosingDollar(source: string, start: number): number {
+	for (let i = start; i < source.length; i += 1) {
+		if (source[i] === "\n") return -1;
+		if (source[i] === "$" && !isEscaped(source, i)) return i;
+	}
+	return -1;
+}
+
+function normalizeDelimitedMath(source: string): string {
+	let output = "";
+	let index = 0;
+
+	while (index < source.length) {
+		if (source[index] === "`") {
+			const match = /^`+/.exec(source.slice(index));
+			const fence = match?.[0] ?? "`";
+			const end = source.indexOf(fence, index + fence.length);
+			if (end === -1) {
+				output += source.slice(index);
+				break;
+			}
+			output += source.slice(index, end + fence.length);
+			index = end + fence.length;
+			continue;
+		}
+
+		if (source.startsWith("$$", index) && !isEscaped(source, index)) {
+			const end = source.indexOf("$$", index + 2);
+			if (end !== -1) {
+				output += `$$${normalizeMathExpression(source.slice(index + 2, end))}$$`;
+				index = end + 2;
+				continue;
+			}
+		}
+
+		if (source[index] === "$" && !source.startsWith("$$", index) && !isEscaped(source, index)) {
+			const end = findClosingDollar(source, index + 1);
+			if (end !== -1) {
+				output += `$${normalizeMathExpression(source.slice(index + 1, end))}$`;
+				index = end + 1;
+				continue;
+			}
+		}
+
+		if ((source.startsWith("\\(", index) || source.startsWith("\\[", index)) && !isEscaped(source, index)) {
+			const close = source[index + 1] === "(" ? "\\)" : "\\]";
+			const end = source.indexOf(close, index + 2);
+			if (end !== -1) {
+				output += `${source.slice(index, index + 2)}${normalizeMathExpression(source.slice(index + 2, end))}${close}`;
+				index = end + 2;
+				continue;
+			}
+		}
+
+		output += source[index];
+		index += 1;
+	}
+
+	return output;
+}
+
+function normalizeOutsideFencedCode(content: string): string {
+	const lines = content.split(/(\n)/);
+	let inFence = false;
+	let fenceMarker = "";
+	let output = "";
+	let pending = "";
+
+	const flushPending = () => {
+		if (pending) {
+			output += normalizeDelimitedMath(pending);
+			pending = "";
+		}
+	};
+
+	for (let i = 0; i < lines.length; i += 1) {
+		const part = lines[i];
+		const isLine = part !== "\n";
+		if (!isLine) {
+			if (inFence) output += part;
+			else pending += part;
+			continue;
+		}
+
+		const fenceMatch = FENCE_RE.exec(part);
+		if (fenceMatch && (!inFence || fenceMatch[1][0] === fenceMarker[0])) {
+			if (!inFence) {
+				flushPending();
+				inFence = true;
+				fenceMarker = fenceMatch[1];
+			} else if (fenceMatch[1].length >= fenceMarker.length) {
+				inFence = false;
+				fenceMarker = "";
+			}
+			output += part;
+			continue;
+		}
+
+		if (inFence) output += part;
+		else pending += part;
+	}
+
+	flushPending();
+	return output;
+}
+
+export function normalizeMarkdownMath(content: string): string {
+	if (!content || !/[<&$\\]/.test(content)) return content;
+	return normalizeOutsideFencedCode(content);
+}


### PR DESCRIPTION
## Summary

- 切换对话不再终止后端任务,只有点击终止按钮才会停止
- 切回正在生成的对话时,流式显示自动续接(通过 SSE 重连 + 事件回放)
- 多次快速切换不会导致状态卡死或消息丢失

## Changes

- **后端 broadcaster**: 新增 `SessionEventBroadcaster` 记录每轮 prompt 的所有 SSE 事件,支持重连客户端回放历史 + 接收实时事件
- **重连路由**: `GET /api/chat/events/:sessionId` — 订阅 broadcaster,回放 + 推送
- **req.on("close") 不再 abort**: SSE 断开不杀任务,任务继续在后台跑
- **switchSessionFile/createNewSession 不再 abort**: 排队等当前 turn 完成
- **前端 detach()**: 只断本地 fetch,不通知后端终止
- **前端 resumeStream()**: 切回时重连后端事件流,恢复流式显示
- **状态管理修复**: detachMode 防泄漏、isLoadingHistory 防卡住、消息缓存保留 user prompt

## Test plan

- [ ] 对话 A 发送 → 切到 B → 切回 A → 流式文本续接显示
- [ ] 对话 A 发送 → 点终止按钮 → 立即停止
- [ ] 快速 A→B→A→B→A 切换 → 无 stuck loading,无消息丢失
- [ ] 对话 A 发送 → 切到 B → 等 A 完成 → 切回 A → 看到完整结果
- [ ] 跨标签页:标签 A 跑任务,标签 B 切对话 → 标签 A 不受影响