### PR TITLE
fix: Feishu channel hot-reload and auto-discover target

### DIFF
--- a/apps/inno-agent/src/channels/feishu/feishu-channel.ts
+++ b/apps/inno-agent/src/channels/feishu/feishu-channel.ts
@@ -18,6 +18,7 @@ export class FeishuChannel implements RealtimeChatChannel {
 	private downloadDir: string;
 	private personalOnly: boolean;
 	private allowedUserIds: Set<string> | null;
+	private cleanupTimer: ReturnType<typeof setInterval> | null = null;
 
 	constructor(
 		feishuConfig: FeishuConfig,
@@ -38,7 +39,7 @@ export class FeishuChannel implements RealtimeChatChannel {
 			? new Set(channelConfig.allowedUserIds)
 			: null;
 
-		setInterval(() => {
+		this.cleanupTimer = setInterval(() => {
 			if (this.processedMessages.size > 1000) {
 				this.processedMessages.clear();
 			}
@@ -61,6 +62,52 @@ export class FeishuChannel implements RealtimeChatChannel {
 
 		this.wsClient.start({ eventDispatcher });
 		logger.info("[feishu] WebSocket client started");
+	}
+
+	async stop(): Promise<void> {
+		try {
+			this.wsClient.close();
+		} catch (err) {
+			logger.warn({ err }, "[feishu] error closing WebSocket client");
+		}
+		if (this.cleanupTimer) {
+			clearInterval(this.cleanupTimer);
+			this.cleanupTimer = null;
+		}
+		this.processedMessages.clear();
+		logger.info("[feishu] channel stopped");
+	}
+
+	/**
+	 * Auto-discover the bot's p2p chats and return the first one as a PushTarget.
+	 * This eliminates the chicken-and-egg problem where the user must send a
+	 * message FROM Feishu before the agent can send TO Feishu.
+	 */
+	async discoverDefaultTarget(): Promise<PushTarget | null> {
+		try {
+			const resp = await this.api.client.im.v1.chat.list({
+				params: { page_size: 20 },
+			});
+			if (resp.code !== 0) {
+				logger.warn({ code: resp.code, msg: resp.msg }, "[feishu] chat.list failed");
+				return null;
+			}
+			const items = resp.data?.items;
+			if (!items || items.length === 0) return null;
+
+			// Find a p2p chat (direct message with a user)
+			const p2pChat = items.find((item: Record<string, unknown>) => item.chat_mode === "p2p");
+			if (!p2pChat) return null;
+
+			const chatId = (p2pChat as Record<string, unknown>).chat_id as string | undefined;
+			if (!chatId) return null;
+
+			logger.info({ chatId }, "[feishu] auto-discovered default p2p target");
+			return { channel: "feishu", chatId };
+		} catch (err) {
+			logger.warn({ err }, "[feishu] discoverDefaultTarget failed");
+			return null;
+		}
 	}
 
 	private async parseEvent(data: Record<string, unknown>): Promise<IncomingMessage | null> {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -283,6 +283,18 @@ async function ensureBootstrapped(): Promise<void> {
 		if (feishuChannel) {
 			feishuChannel.onMessage((msg) => dispatcher!.handle(feishuChannel!, msg));
 			feishuChannel.start();
+
+			// Auto-discover default target on first boot if none persisted
+			if (!channelRegistry.getDefaultTarget("feishu")) {
+				feishuChannel.discoverDefaultTarget().then((target) => {
+					if (target) {
+						channelRegistry.setDefaultTarget(target);
+						logger.info({ chatId: target.chatId }, "[feishu] auto-set default target from chat list");
+					}
+				}).catch((err) => {
+					logger.warn({ err }, "[feishu] initial target discovery failed");
+				});
+			}
 		}
 		if (wechatChannel) {
 			wechatChannel.onMessage((msg) => dispatcher!.handle(wechatChannel!, msg));
@@ -304,6 +316,48 @@ async function ensureBootstrapped(): Promise<void> {
 	});
 
 	return bootstrapPromise;
+}
+
+// ---------------------------------------------------------------------------
+// Channel hot-reload
+// ---------------------------------------------------------------------------
+
+/**
+ * Stop the current Feishu channel (if any) and reinitialize it from the
+ * current in-memory config. Called after PUT /api/settings/channels so that
+ * new credentials take effect without a server restart.
+ */
+async function reloadFeishuChannel(): Promise<void> {
+	// Tear down existing instance
+	if (feishuChannel) {
+		try { await feishuChannel.stop(); } catch { /* best effort */ }
+		feishuChannel = null;
+	}
+
+	// If feishu is now configured and enabled, create a new instance
+	if (!config.feishu?.appId || !config.channels?.feishu?.enabled) {
+		logger.info("[feishu] channel disabled or not configured, skipping reload");
+		return;
+	}
+
+	feishuChannel = new FeishuChannel(config.feishu, dataDir, config.channels.feishu);
+	channelRegistry.register(feishuChannel);
+
+	if (dispatcher) {
+		feishuChannel.onMessage((msg) => dispatcher!.handle(feishuChannel!, msg));
+	}
+	feishuChannel.start();
+	logger.info("[feishu] channel hot-reloaded with new credentials");
+
+	// Auto-discover default target if none exists yet (fixes first-time setup
+	// chicken-and-egg: user had to send FROM Feishu before agent could send TO it)
+	if (!channelRegistry.getDefaultTarget("feishu")) {
+		const target = await feishuChannel.discoverDefaultTarget();
+		if (target) {
+			channelRegistry.setDefaultTarget(target);
+			logger.info({ chatId: target.chatId }, "[feishu] auto-set default target from chat list");
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -3375,6 +3429,14 @@ const server = createServer(async (req, res) => {
 				json(res, 400, { error: err instanceof Error ? err.message : String(err) });
 				return;
 			}
+
+			// Hot-reload Feishu channel: stop old instance, create new one if configured.
+			try {
+				await reloadFeishuChannel();
+			} catch (err) {
+				logger.warn({ err }, "feishu channel hot-reload failed");
+			}
+
 			json(res, 200, buildSafeSettings());
 			return;
 		}


### PR DESCRIPTION
## Summary
- Feishu channel now activates immediately after saving appId/appSecret in settings UI (no restart needed)
- First-time setup no longer requires sending a message FROM Feishu before the agent can send TO Feishu — the bot auto-discovers its p2p chat target via `im.v1.chat.list`

## Changes
- `feishu-channel.ts`: Added `stop()` method (closes WSClient, clears timer) and `discoverDefaultTarget()` (lists bot's p2p chats to find a push target)
- `server.ts`: Added `reloadFeishuChannel()` helper called after `PUT /api/settings/channels`; also runs auto-discovery on initial bootstrap

## Test plan
- [ ] Configure Feishu appId + appSecret in settings UI for the first time → channel should connect without restart
- [ ] Change Feishu credentials → old WebSocket disconnects, new one connects
- [ ] Disable Feishu in settings → channel stops
- [ ] First-time setup: if user has an existing p2p chat with the bot in Feishu, agent can send messages without needing to receive one first