### PR TITLE
fix(workspace): allow editing dotfiles as text

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1259,13 +1259,20 @@ function contentTypeForWorkspaceFile(filePath: string): string {
 	if (ext === ".docx") return "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 	if (ext === ".xlsx") return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 	if (ext === ".pptx") return "application/vnd.openxmlformats-officedocument.presentationml.presentation";
-	return TEXT_PREVIEW_EXTENSIONS.has(ext) ? "text/plain; charset=utf-8" : "application/octet-stream";
+	if (TEXT_PREVIEW_EXTENSIONS.has(ext)) return "text/plain; charset=utf-8";
+	if (isDotfileText(filePath)) return "text/plain; charset=utf-8";
+	return "application/octet-stream";
 }
 
 const TEXT_NOEXT_NAMES = new Set(["makefile", "dockerfile", "gemfile", "rakefile", "procfile", "vagrantfile"]);
 
 /** Office document extensions previewable via LiteParse text extraction. */
 const OFFICE_PREVIEW_EXTENSIONS = new Set([".docx", ".xlsx", ".pptx"]);
+
+/** Whether a file looks like a dotfile config (almost always text). */
+function isDotfileText(filePath: string): boolean {
+	return basename(filePath).startsWith(".");
+}
 
 function workspaceFileKind(filePath: string): "markdown" | "html" | "pdf" | "image" | "office" | "text" | "binary" {
 	const ext = extname(filePath).toLowerCase();
@@ -1276,6 +1283,8 @@ function workspaceFileKind(filePath: string): "markdown" | "html" | "pdf" | "ima
 	if (OFFICE_PREVIEW_EXTENSIONS.has(ext)) return "office";
 	if (TEXT_PREVIEW_EXTENSIONS.has(ext)) return "text";
 	if (!ext && TEXT_NOEXT_NAMES.has(basename(filePath).toLowerCase())) return "text";
+	// Dotfiles (.env, .env.local, .npmrc, .gitconfig, etc.) are text config files
+	if (isDotfileText(filePath)) return "text";
 	return "binary";
 }
 
@@ -2124,7 +2133,8 @@ const server = createServer(async (req, res) => {
 			}
 			const st = statSync(fullPath);
 			const kind = workspaceFileKind(fullPath);
-			if (kind === "binary" || kind === "pdf" || kind === "image") {
+			const forceText = params.get("forceText") === "1";
+			if (!forceText && (kind === "binary" || kind === "pdf" || kind === "image")) {
 				json(res, 200, {
 					path: relative(skillDir, fullPath),
 					name: basename(fullPath),
@@ -2140,8 +2150,8 @@ const server = createServer(async (req, res) => {
 			json(res, 200, {
 				path: relative(skillDir, fullPath),
 				name: basename(fullPath),
-				kind,
-				mimeType: contentTypeForWorkspaceFile(fullPath),
+				kind: forceText ? "text" : kind,
+				mimeType: forceText ? "text/plain; charset=utf-8" : contentTypeForWorkspaceFile(fullPath),
 				size: st.size,
 				updatedAt: st.mtime.toISOString(),
 				content: readFileSync(fullPath, "utf-8"),
@@ -2722,7 +2732,8 @@ const server = createServer(async (req, res) => {
 			const stat = statSync(filePath);
 			const kind = workspaceFileKind(filePath);
 			const contentType = contentTypeForWorkspaceFile(filePath);
-			if (kind === "binary" || kind === "pdf" || kind === "image" || kind === "office") {
+			const forceText = params.get("forceText") === "1";
+			if (!forceText && (kind === "binary" || kind === "pdf" || kind === "image" || kind === "office")) {
 				const relPath = workspaceRelativePath(root, filePath);
 				const rawUrl = `/api/workspace/raw?workspaceId=${encodeURIComponent(wsId)}&path=${encodeURIComponent(relPath)}`;
 				json(res, 200, {
@@ -2747,8 +2758,8 @@ const server = createServer(async (req, res) => {
 			json(res, 200, {
 				path: workspaceRelativePath(root, filePath),
 				name: basename(filePath),
-				kind,
-				mimeType: contentType,
+				kind: forceText ? "text" : kind,
+				mimeType: forceText ? "text/plain; charset=utf-8" : contentType,
 				size: stat.size,
 				updatedAt: stat.mtime.toISOString(),
 				content: readFileSync(filePath, "utf-8"),

--- a/apps/inno-agent/web/src/api/skills.ts
+++ b/apps/inno-agent/web/src/api/skills.ts
@@ -68,8 +68,10 @@ export async function getSkillTree(name: string): Promise<{ name: string; childr
 	return apiFetch<{ name: string; children: WorkspaceTreeNode[] }>(`/api/skills/${encodeURIComponent(name)}/tree`);
 }
 
-export async function getSkillFile(name: string, path: string): Promise<WorkspaceFileDetail> {
-	return apiFetch<WorkspaceFileDetail>(`/api/skills/${encodeURIComponent(name)}/file?path=${encodeURIComponent(path)}`);
+export async function getSkillFile(name: string, path: string, forceText = false): Promise<WorkspaceFileDetail> {
+	const params = new URLSearchParams({ path });
+	if (forceText) params.set("forceText", "1");
+	return apiFetch<WorkspaceFileDetail>(`/api/skills/${encodeURIComponent(name)}/file?${params.toString()}`);
 }
 
 export async function saveSkillFile(name: string, path: string, content: string): Promise<{ path: string; saved: boolean }> {

--- a/apps/inno-agent/web/src/api/workspace.ts
+++ b/apps/inno-agent/web/src/api/workspace.ts
@@ -13,9 +13,10 @@ export async function getWorkspaceTree(workspaceId?: string): Promise<WorkspaceT
 	return apiFetch<WorkspaceTree>(`/api/workspace/tree${qs(workspaceId)}`);
 }
 
-export async function getWorkspaceFile(path: string, workspaceId?: string): Promise<WorkspaceFileDetail> {
+export async function getWorkspaceFile(path: string, workspaceId?: string, forceText = false): Promise<WorkspaceFileDetail> {
 	const params = new URLSearchParams({ path });
 	if (workspaceId) params.set("workspaceId", workspaceId);
+	if (forceText) params.set("forceText", "1");
 	return apiFetch<WorkspaceFileDetail>(`/api/workspace/file?${params.toString()}`);
 }
 

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -123,6 +123,7 @@
 		"selectFile": "Select a file from the workspace",
 		"noPreview": "No preview",
 		"binaryFile": "Binary file",
+		"openAsText": "Open as Text",
 		"emptyTable": "Empty table",
 		"tableRows": "{{count}} rows",
 		"officeParsing": "Extracting document text...",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -123,6 +123,7 @@
 		"selectFile": "从左侧选择一个文件",
 		"noPreview": "暂无预览",
 		"binaryFile": "二进制文件",
+		"openAsText": "以文本打开",
 		"emptyTable": "空表格",
 		"tableRows": "{{count}} 行",
 		"officeParsing": "正在提取文档文本…",

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -17,7 +17,7 @@ import { cpp } from "@codemirror/lang-cpp";
 import { rust } from "@codemirror/lang-rust";
 import { go } from "@codemirror/lang-go";
 import type { Extension } from "@codemirror/state";
-import { RefreshCw, Upload, Trash2, ChevronLeft, File, FileText, FileType, Folder, FolderOpen, Globe, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Library, Download, Check } from "lucide-react";
+import { RefreshCw, Upload, Trash2, ChevronLeft, File, FileText, FileType, Folder, FolderOpen, Globe, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Library, Download, Check, FileCode2 } from "lucide-react";
 import { skillsStore } from "../stores/skills-store.js";
 import { skillRawUrl } from '../api/skills.js';
 import type { SkillInfo } from "../types/skills.js";
@@ -110,9 +110,16 @@ function FilePreview({ file, skillName, isLoading }: { file: WorkspaceFileDetail
 	}
 	if (file.kind === "binary") {
 		return (
-			<div className="flex h-full flex-col items-center justify-center text-sm text-[var(--inno-text-muted)]">
-				<div className="mb-2 text-lg font-medium text-[var(--inno-text)]">{file.name}</div>
+			<div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-[var(--inno-text-muted)]">
+				<div className="text-lg font-medium text-[var(--inno-text)]">{file.name}</div>
 				<div>{t("preview.binaryFile", "Binary file")} · {formatSize(file.size)}</div>
+				<button
+					className="mt-2 flex items-center gap-1.5 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
+					onClick={() => skillsStore.openAsText()}
+				>
+					<FileCode2 size={13} />
+					{t("preview.openAsText", "Open as Text")}
+				</button>
 			</div>
 		);
 	}

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -17,7 +17,7 @@ import { cpp } from "@codemirror/lang-cpp";
 import { rust } from "@codemirror/lang-rust";
 import { go } from "@codemirror/lang-go";
 import type { Extension } from "@codemirror/state";
-import { RefreshCw, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Sparkles, Download } from "lucide-react";
+import { RefreshCw, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Sparkles, Download, FileCode2 } from "lucide-react";
 import { workspaceStore } from "../stores/workspace-store.js";
 import { workspaceFileUrl, workspaceFolderZipUrl, triggerDownload } from "../api/workspace.js";
 import { workspacesStore } from "../stores/workspaces-store.js";
@@ -304,9 +304,16 @@ function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: bo
 	}
 	if (file.kind === "binary") {
 		return (
-			<div className="flex h-full flex-col items-center justify-center text-sm text-[var(--inno-text-muted)]">
-				<div className="mb-2 text-lg font-medium text-[var(--inno-text)]">{file.name}</div>
+			<div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-[var(--inno-text-muted)]">
+				<div className="text-lg font-medium text-[var(--inno-text)]">{file.name}</div>
 				<div>{t("preview.binaryFile")} · {formatSize(file.size)}</div>
+				<button
+					className="mt-2 flex items-center gap-1.5 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
+					onClick={() => workspaceStore.openAsText()}
+				>
+					<FileCode2 size={13} />
+					{t("preview.openAsText", "Open as Text")}
+				</button>
 			</div>
 		);
 	}

--- a/apps/inno-agent/web/src/stores/skills-store.ts
+++ b/apps/inno-agent/web/src/stores/skills-store.ts
@@ -185,6 +185,22 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 		this.emit("change", undefined);
 	}
 
+	/** Re-fetch the current file forcing text mode (for binary files the user wants to edit). */
+	async openAsText() {
+		if (!this.selectedSkill || !this.currentFile) return;
+		this.isLoadingFile = true;
+		this.emit("change", undefined);
+		try {
+			const file = await getSkillFile(this.selectedSkill, this.currentFile.path, true);
+			this.currentFile = file;
+		} catch {
+			// keep current file on failure
+		} finally {
+			this.isLoadingFile = false;
+			this.emit("change", undefined);
+		}
+	}
+
 	updateEditBuffer(value: string) {
 		this.editBuffer = value;
 		this.emit("change", undefined);

--- a/apps/inno-agent/web/src/stores/workspace-store.ts
+++ b/apps/inno-agent/web/src/stores/workspace-store.ts
@@ -93,6 +93,23 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 
 	/* --- Edit lifecycle --- */
 
+	/** Re-fetch the current file forcing text mode (for binary files the user wants to edit). */
+	async openAsText(): Promise<void> {
+		if (!this.currentFile) return;
+		this.isLoadingFile = true;
+		this.error = "";
+		this.emit("change", undefined);
+		try {
+			const file = await getWorkspaceFile(this.currentFile.path, this.wsId, true);
+			this.currentFile = file;
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : "Failed to load file as text";
+		} finally {
+			this.isLoadingFile = false;
+			this.emit("change", undefined);
+		}
+	}
+
 	startEditing(): void {
 		if (!this.currentFile || this.currentFile.content == null) return;
 		this.isEditing = true;


### PR DESCRIPTION
## Summary
- Dotfiles (`.env`, `.env.local`, `.npmrc`, `.gitconfig`, etc.) were incorrectly classified as "binary" because `path.extname` returns empty for these files, making them uneditable in the workspace browser
- Added `isDotfileText()` heuristic: files whose basename starts with `.` are now treated as text
- Added `?forceText=1` API param and "Open as Text" fallback button for any remaining unrecognized file types

## Test plan
- [ ] Open a workspace containing `.env` or `.env.local` — should display as editable text
- [ ] Open a truly binary file (e.g. `.png`) — should still show binary preview with "Open as Text" button
- [ ] Click "Open as Text" on a binary file — should re-render as text in CodeMirror
- [ ] Edit and save a dotfile — content persists correctly