### PR TITLE
feat(feishu): add streaming card mode for agent responses

### DIFF
--- a/apps/inno-agent/src/channels/channel.ts
+++ b/apps/inno-agent/src/channels/channel.ts
@@ -22,6 +22,43 @@ export interface ChatChannel {
 	sendFile?(target: PushTarget, filePath: string, fileName?: string): Promise<void>;
 }
 
+/**
+ * A streaming event forwarded from the agent loop to the channel during streaming reply.
+ */
+export interface ChannelStreamEvent {
+	type: "text_delta" | "thinking_delta" | "tool_start" | "tool_end" | "error" | "done";
+	delta?: string;
+	toolCallId?: string;
+	toolName?: string;
+	isError?: boolean;
+	summary?: string;
+	message?: string;
+}
+
+/**
+ * Channels that support progressive/streaming card updates implement this interface.
+ * The dispatcher uses it to send real-time updates instead of waiting for the full response.
+ */
+export interface StreamingReplyChannel extends ChatChannel {
+	readonly supportsStreamingReply: boolean;
+	/**
+	 * Begin a streaming reply. Sends an initial placeholder card and returns
+	 * a handle that accepts streaming events and a finalize method.
+	 */
+	beginStreamingReply(message: IncomingMessage): Promise<StreamingReplyHandle>;
+}
+
+export interface StreamingReplyHandle {
+	/** Forward a streaming event to update the card. */
+	onEvent(event: ChannelStreamEvent): void;
+	/** Finalize the card after all events are done. Must be called. */
+	finalize(): Promise<void>;
+}
+
+export function isStreamingChannel(ch: ChatChannel): ch is StreamingReplyChannel {
+	return "supportsStreamingReply" in ch && (ch as StreamingReplyChannel).supportsStreamingReply;
+}
+
 export type MessageHandler = (msg: IncomingMessage) => Promise<void> | void;
 
 export interface RealtimeChatChannel extends ChatChannel {

--- a/apps/inno-agent/src/channels/feishu/feishu-api.ts
+++ b/apps/inno-agent/src/channels/feishu/feishu-api.ts
@@ -8,6 +8,24 @@ export interface FeishuConfig {
 	appSecret: string;
 }
 
+// ─── Streaming Card Types ────────────────────────────────────────────────────
+
+export interface StreamingCardState {
+	answerText: string;
+	thinkingText: string;
+	toolCalls: Array<{ name: string; status: "running" | "done" | "error"; summary?: string }>;
+	isComplete: boolean;
+	error?: string;
+}
+
+export type CardHeaderTemplate =
+	| "blue" | "wathet" | "turquoise" | "green" | "yellow"
+	| "orange" | "red" | "carmine" | "violet" | "purple"
+	| "indigo" | "grey";
+
+// Feishu card element limits
+const CARD_CONTENT_MAX_CHARS = 28000; // safe limit for card total content
+
 /** Map a file extension to a Feishu file_type. Unknown types fall back to "stream". */
 function feishuFileType(fileName: string): "opus" | "mp4" | "pdf" | "doc" | "xls" | "ppt" | "stream" {
 	const ext = extname(fileName).toLowerCase().replace(/^\./, "");
@@ -257,5 +275,183 @@ export class FeishuAPI {
 			pieces.push(current.join("\n"));
 		}
 		return pieces.length > 0 ? pieces : [block];
+	}
+
+	// ─── Interactive Card Methods ──────────────────────────────────────────────
+
+	/**
+	 * Send an interactive card as a reply to a message. Returns the sent message_id
+	 * for subsequent updates via patchCard().
+	 */
+	async replyCard(messageId: string, card: object): Promise<string> {
+		const resp = await this.client.im.v1.message.reply({
+			path: { message_id: messageId },
+			data: {
+				content: JSON.stringify(card),
+				msg_type: "interactive",
+			},
+		});
+		if (resp.code !== 0) {
+			throw new Error(`Feishu card reply failed: ${resp.msg} (code: ${resp.code})`);
+		}
+		return (resp.data?.message_id as string) ?? "";
+	}
+
+	/**
+	 * Send an interactive card to a chat. Returns the sent message_id.
+	 */
+	async sendCard(chatId: string, card: object): Promise<string> {
+		const resp = await this.client.im.v1.message.create({
+			params: { receive_id_type: "chat_id" },
+			data: {
+				receive_id: chatId,
+				content: JSON.stringify(card),
+				msg_type: "interactive",
+			},
+		});
+		if (resp.code !== 0) {
+			throw new Error(`Feishu card send failed: ${resp.msg} (code: ${resp.code})`);
+		}
+		return (resp.data?.message_id as string) ?? "";
+	}
+
+	/**
+	 * Update (PATCH) an existing interactive card message.
+	 * Requires `update_multi: true` in the card config.
+	 */
+	async patchCard(messageId: string, card: object): Promise<void> {
+		const resp = await this.client.im.v1.message.patch({
+			path: { message_id: messageId },
+			data: {
+				content: JSON.stringify(card),
+			},
+		});
+		if ((resp as any).code !== 0) {
+			const r = resp as any;
+			logger.warn({ code: r.code, msg: r.msg, messageId }, "Feishu card patch failed");
+		}
+	}
+
+	/**
+	 * Build a streaming-style interactive card from the current state.
+	 */
+	buildStreamingCard(state: StreamingCardState): object {
+		const elements: object[] = [];
+
+		// Thinking section (collapsible, only if there's thinking content)
+		if (state.thinkingText) {
+			const thinkingContent = this.truncateForCard(state.thinkingText, 3000);
+			elements.push({
+				tag: "collapsible_panel",
+				expanded: false,
+				header: {
+					title: {
+						tag: "plain_text",
+						content: "💭 思考过程",
+					},
+				},
+				border: { color: "grey" },
+				elements: [
+					{
+						tag: "markdown",
+						content: thinkingContent,
+					},
+				],
+			});
+		}
+
+		// Tool calls section (only if there are tool calls)
+		if (state.toolCalls.length > 0) {
+			const toolLines = state.toolCalls.map((tc) => {
+				const icon = tc.status === "running" ? "⏳" : tc.status === "error" ? "❌" : "✅";
+				const summary = tc.summary ? ` — ${tc.summary}` : "";
+				return `${icon} \`${tc.name}\`${summary}`;
+			});
+			elements.push({
+				tag: "collapsible_panel",
+				expanded: state.toolCalls.some((tc) => tc.status === "running"),
+				header: {
+					title: {
+						tag: "plain_text",
+						content: `🔧 工具调用 (${state.toolCalls.length})`,
+					},
+				},
+				border: { color: "grey" },
+				elements: [
+					{
+						tag: "markdown",
+						content: toolLines.join("\n"),
+					},
+				],
+			});
+		}
+
+		// Divider between meta sections and answer
+		if (elements.length > 0 && state.answerText) {
+			elements.push({ tag: "hr" });
+		}
+
+		// Answer content (main body)
+		if (state.answerText) {
+			const answerContent = this.truncateForCard(state.answerText, CARD_CONTENT_MAX_CHARS - 2000);
+			elements.push({
+				tag: "markdown",
+				content: answerContent,
+			});
+		} else if (!state.isComplete) {
+			// Placeholder while waiting for answer
+			elements.push({
+				tag: "markdown",
+				content: state.thinkingText ? "等待回复中..." : "思考中...",
+			});
+		}
+
+		// Error display
+		if (state.error) {
+			elements.push({ tag: "hr" });
+			elements.push({
+				tag: "markdown",
+				content: `❗ **错误**: ${state.error}`,
+			});
+		}
+
+		// Footer with status
+		if (state.isComplete) {
+			elements.push({
+				tag: "note",
+				elements: [
+					{
+						tag: "plain_text",
+						content: "✓ 回复完成",
+					},
+				],
+			});
+		}
+
+		// Determine header color based on state
+		let template: CardHeaderTemplate = "blue";
+		if (state.error) {
+			template = "red";
+		} else if (state.isComplete) {
+			template = "green";
+		} else if (state.toolCalls.some((tc) => tc.status === "running")) {
+			template = "turquoise";
+		}
+
+		const headerTitle = state.isComplete ? "Inno Agent" : "Inno Agent ⟳";
+
+		return {
+			config: { update_multi: true, wide_screen_mode: true },
+			header: {
+				template,
+				title: { tag: "plain_text", content: headerTitle },
+			},
+			elements,
+		};
+	}
+
+	private truncateForCard(text: string, maxLen: number): string {
+		if (text.length <= maxLen) return text;
+		return text.slice(0, maxLen) + "\n\n... *(内容过长已截断)*";
 	}
 }

--- a/apps/inno-agent/src/channels/feishu/feishu-channel.ts
+++ b/apps/inno-agent/src/channels/feishu/feishu-channel.ts
@@ -1,16 +1,18 @@
 import * as Lark from "@larksuiteoapi/node-sdk";
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
-import type { RealtimeChatChannel, MessageHandler } from "../channel.js";
+import type { RealtimeChatChannel, MessageHandler, StreamingReplyChannel, StreamingReplyHandle, ChannelStreamEvent } from "../channel.js";
 import type { IncomingMessage, PushTarget, MessageAttachment } from "../types.js";
 import type { PersonalChannelConfig } from "../../config.js";
 import { FeishuAPI, type FeishuConfig } from "./feishu-api.js";
+import { createStreamingCardSession } from "./streaming-card.js";
 import { logger } from "../../logger.js";
 
 const SUPPORTED_TYPES = new Set(["text", "image", "file", "post"]);
 
-export class FeishuChannel implements RealtimeChatChannel {
+export class FeishuChannel implements RealtimeChatChannel, StreamingReplyChannel {
 	readonly name = "feishu";
+	readonly supportsStreamingReply = true;
 	private api: FeishuAPI;
 	private wsClient: Lark.WSClient;
 	private messageHandler: MessageHandler | null = null;
@@ -281,5 +283,50 @@ export class FeishuChannel implements RealtimeChatChannel {
 
 	async sendFile(target: PushTarget, filePath: string, fileName?: string): Promise<void> {
 		await this.api.sendFile(target.chatId, filePath, fileName);
+	}
+
+	/**
+	 * Begin a streaming reply: sends an initial "thinking..." card and returns
+	 * a handle for progressive updates.
+	 */
+	async beginStreamingReply(message: IncomingMessage): Promise<StreamingReplyHandle> {
+		// Send initial placeholder card
+		const initialState = {
+			answerText: "",
+			thinkingText: "",
+			toolCalls: [],
+			isComplete: false,
+		};
+		const initialCard = this.api.buildStreamingCard(initialState);
+		const cardMessageId = await this.api.replyCard(message.messageId, initialCard);
+
+		const session = createStreamingCardSession(this.api, cardMessageId);
+
+		return {
+			onEvent(event: ChannelStreamEvent): void {
+				switch (event.type) {
+					case "text_delta":
+						if (event.delta) session.appendAnswer(event.delta);
+						break;
+					case "thinking_delta":
+						if (event.delta) session.appendThinking(event.delta);
+						break;
+					case "tool_start":
+						session.toolStart(event.toolName ?? "unknown", event.toolCallId);
+						break;
+					case "tool_end":
+						if (event.toolCallId) {
+							session.toolEnd(event.toolCallId, event.isError, event.summary);
+						}
+						break;
+					case "error":
+						session.setError(event.message ?? "Unknown error");
+						break;
+				}
+			},
+			async finalize(): Promise<void> {
+				await session.finalize();
+			},
+		};
 	}
 }

--- a/apps/inno-agent/src/channels/feishu/streaming-card.ts
+++ b/apps/inno-agent/src/channels/feishu/streaming-card.ts
@@ -1,0 +1,118 @@
+/**
+ * Manages a single streaming card session for a Feishu message.
+ * Handles throttled updates, state accumulation, and graceful finalization.
+ */
+import { FeishuAPI, type StreamingCardState } from "./feishu-api.js";
+import { logger } from "../../logger.js";
+
+const UPDATE_INTERVAL_MS = 800; // throttle card patches to avoid rate limits (5 QPS)
+const MIN_DELTA_CHARS = 20; // don't update for trivial deltas
+
+export interface StreamingCardSession {
+	/** Append text to the answer section. */
+	appendAnswer(delta: string): void;
+	/** Append text to the thinking section. */
+	appendThinking(delta: string): void;
+	/** Record a tool call starting. */
+	toolStart(name: string, id?: string): void;
+	/** Record a tool call completed. */
+	toolEnd(id: string, isError?: boolean, summary?: string): void;
+	/** Mark the card as errored. */
+	setError(message: string): void;
+	/** Finalize the card (last update with complete state). */
+	finalize(): Promise<void>;
+}
+
+export function createStreamingCardSession(
+	api: FeishuAPI,
+	cardMessageId: string,
+): StreamingCardSession {
+	const state: StreamingCardState = {
+		answerText: "",
+		thinkingText: "",
+		toolCalls: [],
+		isComplete: false,
+	};
+
+	// Track tool calls by ID for matching start/end
+	const toolIdMap = new Map<string, number>(); // id -> index in toolCalls
+
+	let updateTimer: ReturnType<typeof setTimeout> | null = null;
+	let lastUpdateLen = 0;
+	let updateInFlight = false;
+
+	async function flushUpdate(): Promise<void> {
+		if (updateInFlight) return;
+		updateInFlight = true;
+		try {
+			const card = api.buildStreamingCard(state);
+			await api.patchCard(cardMessageId, card);
+			lastUpdateLen = state.answerText.length + state.thinkingText.length;
+		} catch (err) {
+			logger.warn({ err, cardMessageId }, "[feishu-streaming] card patch failed");
+		} finally {
+			updateInFlight = false;
+		}
+	}
+
+	function scheduleUpdate(): void {
+		if (updateTimer) return;
+		const currentLen = state.answerText.length + state.thinkingText.length;
+		if (currentLen - lastUpdateLen < MIN_DELTA_CHARS) return;
+
+		updateTimer = setTimeout(() => {
+			updateTimer = null;
+			void flushUpdate();
+		}, UPDATE_INTERVAL_MS);
+	}
+
+	return {
+		appendAnswer(delta: string): void {
+			state.answerText += delta;
+			scheduleUpdate();
+		},
+
+		appendThinking(delta: string): void {
+			state.thinkingText += delta;
+			scheduleUpdate();
+		},
+
+		toolStart(name: string, id?: string): void {
+			const idx = state.toolCalls.length;
+			state.toolCalls.push({ name, status: "running" });
+			if (id) toolIdMap.set(id, idx);
+			// Tool start is important — flush immediately
+			void flushUpdate();
+		},
+
+		toolEnd(id: string, isError?: boolean, summary?: string): void {
+			const idx = toolIdMap.get(id);
+			if (idx !== undefined && state.toolCalls[idx]) {
+				state.toolCalls[idx].status = isError ? "error" : "done";
+				if (summary) state.toolCalls[idx].summary = summary;
+			}
+			void flushUpdate();
+		},
+
+		setError(message: string): void {
+			state.error = message;
+			void flushUpdate();
+		},
+
+		async finalize(): Promise<void> {
+			// Clear any pending timer
+			if (updateTimer) {
+				clearTimeout(updateTimer);
+				updateTimer = null;
+			}
+			state.isComplete = true;
+			// Final update
+			try {
+				const card = api.buildStreamingCard(state);
+				await api.patchCard(cardMessageId, card);
+			} catch (err) {
+				logger.warn({ err, cardMessageId }, "[feishu-streaming] final card patch failed");
+			}
+		},
+	};
+}

--- a/apps/inno-agent/src/channels/personal-dispatcher.ts
+++ b/apps/inno-agent/src/channels/personal-dispatcher.ts
@@ -1,5 +1,6 @@
-import type { ChatChannel } from "./channel.js";
+import type { ChatChannel, ChannelStreamEvent } from "./channel.js";
 import type { ChannelRegistry } from "./channel.js";
+import { isStreamingChannel } from "./channel.js";
 import type { IncomingMessage } from "./types.js";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { DedupeStore } from "./dedupe-store.js";
@@ -11,12 +12,22 @@ import { logger } from "../logger.js";
 const NEW_SESSION_COMMANDS = new Set(["/new", "新建对话", "新建会话"]);
 const MAX_TEXT_LENGTH = 20_000;
 
+/** Callback type for streaming prompt execution. */
+export type StreamEventCallback = (event: ChannelStreamEvent) => void;
+
 export interface PersonalChannelDispatcherOptions {
 	channelRegistry: ChannelRegistry;
 	/** Plain runPrompt (runs in the current global session). */
 	runPrompt: (prompt: string, images?: ImageContent[]) => Promise<string>;
 	/** Atomically switch to sessionPath and run prompt in one enqueue slot. */
 	runPromptInSession: (sessionPath: string, prompt: string, images?: ImageContent[]) => Promise<string>;
+	/** Streaming variant: runs prompt and forwards events via callback. */
+	runPromptStreamingInSession?: (
+		sessionPath: string,
+		prompt: string,
+		onEvent: StreamEventCallback,
+		images?: ImageContent[],
+	) => Promise<string>;
 	createNewSession: () => Promise<string>;
 	getCurrentSessionId: () => string;
 	recordSessionChannel: (channel: string, explicitSessionId?: string) => void;
@@ -137,9 +148,34 @@ export class PersonalChannelDispatcher {
 		const startedAt = new Date();
 
 		try {
-			const output = targetSessionPath
-				? await this.opts.runPromptInSession(targetSessionPath, prompt, images.length > 0 ? images : undefined)
-				: await this.opts.runPrompt(prompt, images.length > 0 ? images : undefined);
+			let output: string;
+
+			// Use streaming path if channel supports it and streaming function is available
+			if (
+				isStreamingChannel(channel) &&
+				this.opts.runPromptStreamingInSession &&
+				targetSessionPath
+			) {
+				try {
+					output = await this.handleStreaming(channel, msg, targetSessionPath, prompt, images);
+				} catch (streamErr: any) {
+					// If streaming card creation itself failed (e.g. bot lacks interactive card
+					// permissions), fall back to non-streaming. We detect this by checking if
+					// the error came from beginStreamingReply (before prompt execution started).
+					if (streamErr?._streamingInitFailed) {
+						logger.warn({ err: streamErr }, "[dispatcher] streaming card init failed, falling back to non-streaming");
+						output = await this.opts.runPromptInSession(targetSessionPath, prompt, images.length > 0 ? images : undefined);
+						await this.safeReply(channel, msg, output);
+					} else {
+						throw streamErr;
+					}
+				}
+			} else {
+				output = targetSessionPath
+					? await this.opts.runPromptInSession(targetSessionPath, prompt, images.length > 0 ? images : undefined)
+					: await this.opts.runPrompt(prompt, images.length > 0 ? images : undefined);
+				await this.safeReply(channel, msg, output);
+			}
 
 			const sessionId = this.opts.getCurrentSessionId();
 			this.opts.recordSessionChannel(msg.channel, sessionId);
@@ -155,8 +191,6 @@ export class PersonalChannelDispatcher {
 				finishedAt: finishedAt.toISOString(),
 				durationMs: finishedAt.getTime() - startedAt.getTime(),
 			});
-
-			await this.safeReply(channel, msg, output);
 		} catch (err) {
 			const finishedAt = new Date();
 			this.runLog.append({
@@ -232,6 +266,47 @@ export class PersonalChannelDispatcher {
 			} catch (retryErr) {
 				logger.error({ err: retryErr }, "dispatcher reply retry also failed");
 			}
+		}
+	}
+
+	/**
+	 * Handle a message using the streaming path: creates a streaming card,
+	 * forwards events progressively, and finalizes on completion.
+	 */
+	private async handleStreaming(
+		channel: ChatChannel & { beginStreamingReply: (msg: IncomingMessage) => Promise<import("./channel.js").StreamingReplyHandle> },
+		msg: IncomingMessage,
+		sessionPath: string,
+		prompt: string,
+		images: ImageContent[],
+	): Promise<string> {
+		let handle: import("./channel.js").StreamingReplyHandle;
+		try {
+			handle = await channel.beginStreamingReply(msg);
+		} catch (err: any) {
+			// Tag the error so the caller can detect streaming init failure vs prompt failure
+			err._streamingInitFailed = true;
+			throw err;
+		}
+
+		try {
+			const output = await this.opts.runPromptStreamingInSession!(
+				sessionPath,
+				prompt,
+				(event: ChannelStreamEvent) => {
+					handle.onEvent(event);
+				},
+				images.length > 0 ? images : undefined,
+			);
+			await handle.finalize();
+			return output;
+		} catch (err) {
+			handle.onEvent({
+				type: "error",
+				message: err instanceof Error ? err.message : String(err),
+			});
+			await handle.finalize();
+			throw err;
 		}
 	}
 }

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -29,6 +29,7 @@ import {
 import { completePromptOnce, runPromptSerialized, runPromptStreaming, runPromptStreamingInSession, runPromptInSession, abortCurrentPrompt, persistPendingUserTurn } from "./agent/pi-runner.js";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { ChannelRegistry } from "./channels/channel.js";
+import type { ChannelStreamEvent } from "./channels/channel.js";
 import { FeishuChannel } from "./channels/feishu/feishu-channel.js";
 import { PersonalChannelDispatcher } from "./channels/personal-dispatcher.js";
 import { BridgeChannel } from "./channels/bridge/bridge-channel.js";
@@ -157,6 +158,34 @@ function piEventToSseEvent(event: any): unknown | null {
 	}
 }
 
+/** Convert a raw PI SDK event to a ChannelStreamEvent for channel streaming replies. */
+function piEventToChannelStreamEvent(event: any): ChannelStreamEvent | null {
+	switch (event.type) {
+		case "message_update": {
+			const ev = event.assistantMessageEvent;
+			if (ev.type === "text_delta") return { type: "text_delta", delta: ev.delta };
+			if (ev.type === "thinking_delta") return { type: "thinking_delta", delta: ev.delta };
+			if (ev.type === "error") return { type: "error", message: ev.error?.errorMessage || "LLM API error" };
+			return null;
+		}
+		case "message_end": {
+			const msg = event.message;
+			if (msg && typeof msg === "object" && "stopReason" in msg && msg.stopReason === "error") {
+				return { type: "error", message: msg.errorMessage || "The model request failed." };
+			}
+			return null;
+		}
+		case "tool_execution_start":
+			return { type: "tool_start", toolCallId: event.toolCallId, toolName: event.toolName };
+		case "tool_execution_end": {
+			const summary = typeof event.result === "string" ? event.result.slice(0, 80) : undefined;
+			return { type: "tool_end", toolCallId: event.toolCallId, toolName: event.toolName, isError: event.isError, summary };
+		}
+		default:
+			return null;
+	}
+}
+
 /**
  * One-shot lazy bootstrap. Idempotent — concurrent requests while the first
  * bootstrap is still in-flight all await the same promise.
@@ -264,6 +293,12 @@ async function ensureBootstrapped(): Promise<void> {
 			channelRegistry,
 			runPrompt: runPromptSerialized,
 			runPromptInSession,
+			runPromptStreamingInSession: (sessionPath, prompt, onEvent, images) => {
+				return runPromptStreamingInSession(sessionPath, prompt, (piEvent: any) => {
+					const channelEvent = piEventToChannelStreamEvent(piEvent);
+					if (channelEvent) onEvent(channelEvent);
+				}, images);
+			},
 			createNewSession,
 			getCurrentSessionId,
 			recordSessionChannel: (ch, sid?) => recordCurrentSessionChannel(ch as SessionChannel, sid, { setOriginIfEmpty: true }),


### PR DESCRIPTION
## Summary

- 为飞书频道新增流式交互卡片模式：Agent 回复过程中实时更新卡片，展示正文、思考过程与工具调用状态
- 引入 `StreamingReplyChannel` 抽象，`PersonalChannelDispatcher` 在支持流式的频道上走 `runPromptStreamingInSession` 路径
- 卡片初始化失败（如机器人缺少交互卡片权限）时自动回退为普通文本回复

## Test plan

- [ ] 在飞书私聊中发送消息，确认先出现「思考中...」占位卡片，随后逐步更新正文
- [ ] 触发工具调用时，卡片中展示工具名称与运行/完成状态
- [ ] 模型带 reasoning 时，思考过程出现在可折叠面板中
- [ ] 回复完成后卡片标题变为绿色「回复完成」
- [ ] 模拟卡片 API 失败场景，确认回退为普通文本回复
- [ ] `npm run build` 通过


Made with [Cursor](https://cursor.com)