### PR TITLE
Add skill/preset category metadata + fix half-width toolbar overlap

### DIFF
--- a/apps/inno-agent/presets/lesson-plan/preset.json
+++ b/apps/inno-agent/presets/lesson-plan/preset.json
@@ -2,5 +2,6 @@
 	"id": "lesson-plan",
 	"name": "教案生成",
 	"description": "根据课题、学段与课时,生成结构化教案:教学目标、重难点、教学流程与作业设计。",
-	"icon": "book-open"
+	"icon": "book-open",
+	"category": "教学"
 }

--- a/apps/inno-agent/presets/ppt-creation/preset.json
+++ b/apps/inno-agent/presets/ppt-creation/preset.json
@@ -2,5 +2,6 @@
 	"id": "ppt-creation",
 	"name": "PPT 制作",
 	"description": "从主题或资料一键生成结构化演示文稿:大纲、每页标题与要点、演讲者备注,并可导出到工作区。",
-	"icon": "presentation"
+	"icon": "presentation",
+	"category": "演示"
 }

--- a/apps/inno-agent/presets/scenario-explain/preset.json
+++ b/apps/inno-agent/presets/scenario-explain/preset.json
@@ -2,5 +2,6 @@
 	"id": "scenario-explain",
 	"name": "情景化讲题",
 	"description": "把题目放进贴近生活的情景中讲解:拆解思路、分步引导、生成同类变式与练习。",
-	"icon": "lightbulb"
+	"icon": "lightbulb",
+	"category": "教学"
 }

--- a/apps/inno-agent/src/presets/preset-store.ts
+++ b/apps/inno-agent/src/presets/preset-store.ts
@@ -29,6 +29,7 @@ export interface PresetMeta {
 	name: string;
 	description: string;
 	icon?: string;
+	category?: string;
 }
 
 /** Only simple, single-segment ids — blocks path traversal. */
@@ -71,6 +72,7 @@ function parsePresetMeta(rawText: string, id: string): PresetMeta | null {
 			name,
 			description: (raw.description ?? "").trim(),
 			icon: raw.icon?.trim() || undefined,
+			category: raw.category?.trim() || undefined,
 		};
 	} catch (err) {
 		logger.warn({ err, id }, "failed to parse preset.json; skipping");
@@ -123,6 +125,7 @@ export async function listRemotePresets(source: RemoteContentSource, forceRefres
 					name: m.name.trim(),
 					description: typeof m.description === "string" ? m.description.trim() : "",
 					icon: typeof m.icon === "string" && m.icon.trim() ? m.icon.trim() : undefined,
+					category: typeof m.category === "string" && m.category.trim() ? m.category.trim() : undefined,
 				};
 			}
 			// GitHub: read the preset.json file.

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -928,6 +928,8 @@ interface SkillLibraryItem {
 	description: string;
 	/** Whether a skill with this slug already exists locally. */
 	installed: boolean;
+	/** Optional `category` from SKILL.md frontmatter; surfaces grouping in the UI. */
+	category?: string;
 }
 
 let contentSource: RemoteContentSource | null = null;
@@ -957,33 +959,41 @@ function invalidateContentSource(): void {
 }
 
 /**
- * Extract the `description` field from a SKILL.md frontmatter block. Supports
- * both single-line and YAML folded/literal block scalars (`>-`, `|`).
+ * Extract the `description` and `category` fields from a SKILL.md frontmatter
+ * block. Supports both single-line and YAML folded/literal block scalars
+ * (`>-`, `|`). Returns `""` for any missing field.
  */
-function extractFrontmatterDescription(content: string): string {
+function extractFrontmatterFields(content: string): { description: string; category: string } {
 	const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 	const fmMatch = normalized.match(/^---\n([\s\S]*?)\n---/);
-	if (!fmMatch) return "";
+	if (!fmMatch) return { description: "", category: "" };
 	const lines = fmMatch[1].split("\n");
-	for (let i = 0; i < lines.length; i++) {
-		const m = lines[i].match(/^description:\s*(.*)$/);
-		if (!m) continue;
-		const inline = m[1].trim();
-		// Block scalar (>- , |, > , |- ...) → gather indented continuation lines.
-		if (/^[>|][+-]?\s*$/.test(inline)) {
-			const block: string[] = [];
-			for (let j = i + 1; j < lines.length; j++) {
-				if (/^\s+\S/.test(lines[j]) || lines[j].trim() === "") {
-					block.push(lines[j].trim());
-				} else {
-					break;
+	const extractField = (key: string): string => {
+		const re = new RegExp(`^${key}:\\s*(.*)$`);
+		for (let i = 0; i < lines.length; i++) {
+			const m = lines[i].match(re);
+			if (!m) continue;
+			const inline = m[1].trim();
+			// Block scalar (>- , |, > , |- ...) → gather indented continuation lines.
+			if (/^[>|][+-]?\s*$/.test(inline)) {
+				const block: string[] = [];
+				for (let j = i + 1; j < lines.length; j++) {
+					if (/^\s+\S/.test(lines[j]) || lines[j].trim() === "") {
+						block.push(lines[j].trim());
+					} else {
+						break;
+					}
 				}
+				return block.join(" ").replace(/\s+/g, " ").trim();
 			}
-			return block.join(" ").replace(/\s+/g, " ").trim();
+			return inline.replace(/^["']|["']$/g, "").trim();
 		}
-		return inline.replace(/^["']|["']$/g, "").trim();
-	}
-	return "";
+		return "";
+	};
+	return {
+		description: extractField("description"),
+		category: extractField("category"),
+	};
 }
 
 /**
@@ -1004,13 +1014,19 @@ async function listSkillLibrary(forceRefresh = false): Promise<SkillLibraryItem[
 		items.map(async (item): Promise<SkillLibraryItem> => {
 			// Prefer inline meta (bundle service); otherwise read SKILL.md frontmatter.
 			let description = typeof item.meta?.description === "string" ? item.meta.description : "";
-			if (!description) {
+			let category = typeof item.meta?.category === "string" ? item.meta.category.trim() : "";
+			if (!description || !category) {
 				const md = await source.readItemTextFile("skills", item.name, "SKILL.md");
-				if (md) description = extractFrontmatterDescription(md);
+				if (md) {
+					const fields = extractFrontmatterFields(md);
+					if (!description) description = fields.description;
+					if (!category) category = fields.category;
+				}
 			}
 			return {
 				name: item.name,
 				description,
+				category: category || undefined,
 				installed: localNames.has(slugifySkillName(item.name)),
 			};
 		}),
@@ -1123,9 +1139,11 @@ function listProjectSkills(): unknown[] {
 			const content = existsSync(filePath) ? readText(filePath) : "";
 			const stat = existsSync(filePath) ? statSync(filePath) : statSync(join(skillsDir, name));
 			const loadedSkill = loadedByPath.get(resolve(filePath));
+			const fields = extractFrontmatterFields(content);
 			return {
 				name,
-				description: extractFrontmatterDescription(content),
+				description: fields.description,
+				category: fields.category || undefined,
 				enabled: !disabled.has(name),
 				loaded: Boolean(loadedSkill),
 				filePath: relative(paths.workspaceDir, filePath),

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -314,7 +314,17 @@
 		"import": "Import",
 		"importing": "Importing…",
 		"installed": "Installed",
-		"libraryError": "Failed to load skills library"
+		"libraryError": "Failed to load skills library",
+		"searchPlaceholder": "Search by name, description, or category…",
+		"uncategorized": "Uncategorized",
+		"noResults": "No matching skills"
+	},
+	"presets": {
+		"simpleModeHeader": "Ready to go · pick one to start",
+		"searchPlaceholder": "Search presets…",
+		"uncategorized": "Uncategorized",
+		"noResults": "No matching presets",
+		"opening": "Opening…"
 	},
 	"settings": {
 		"title": "Settings",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -314,7 +314,17 @@
 		"import": "导入",
 		"importing": "导入中…",
 		"installed": "已安装",
-		"libraryError": "加载技能库失败"
+		"libraryError": "加载技能库失败",
+		"searchPlaceholder": "按名称、描述或分类搜索…",
+		"uncategorized": "未分类",
+		"noResults": "无匹配技能"
+	},
+	"presets": {
+		"simpleModeHeader": "开箱即用 · 选一个开始",
+		"searchPlaceholder": "搜索预设…",
+		"uncategorized": "未分类",
+		"noResults": "无匹配预设",
+		"opening": "正在打开…"
 	},
 	"settings": {
 		"title": "设置",

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "motion/react";
-import { Paperclip, X, SendHorizonal, Square, RotateCcw, Image, AlertTriangle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Paperclip, X, SendHorizonal, Square, RotateCcw, Image, AlertTriangle, Search } from "lucide-react";
 import type { ChatMessage } from "../types/chat.js";
 import type { InlineImage } from "../api/chat.js";
 import { chatStore } from "../stores/chat-store.js";
@@ -15,6 +16,7 @@ import { listRemotePresets } from "../api/presets.js";
 import type { PresetMeta } from "../types/presets.js";
 import { uploadRawFile, type RawUploadResult } from "../api/uploads.js";
 import { normalizeMarkdownMath } from "../utils/markdown-math.js";
+import { groupByCategory, matchesQuery } from "../utils/category-grouping.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { QuestionDialog } from "./QuestionDialog.js";
 import "@earendil-works/pi-web-ui";
@@ -217,7 +219,112 @@ function ModeChip({ selected, onClick, disabled, children }: { selected: boolean
 	);
 }
 
+/**
+ * Simple Mode preset grid: searchable, grouped by `category`, vertically
+ * bounded so a long preset list doesn't push the composer off-screen.
+ * The search input only appears when there are enough presets to make it
+ * useful (≥ 4); the scroll container caps height at ~50vh.
+ */
+function PresetPicker({
+	presets,
+	openingPresetId,
+	onOpen,
+	query,
+	onQueryChange,
+	t,
+}: {
+	presets: PresetMeta[];
+	openingPresetId: string | null;
+	onOpen: (id: string) => void;
+	query: string;
+	onQueryChange: (v: string) => void;
+	t: (key: string) => string;
+}) {
+	const uncategorizedLabel = t("presets.uncategorized");
+	const groups = useMemo(
+		() => groupByCategory(presets.filter((p) => matchesQuery(p, query)), uncategorizedLabel),
+		[presets, query, uncategorizedLabel],
+	);
+	const totalMatched = useMemo(() => groups.reduce((sum, [, items]) => sum + items.length, 0), [groups]);
+	const showSearch = presets.length >= 4;
+
+	return (
+		<div className="mt-5">
+			<div className="mb-2 flex items-center gap-2">
+				<div className="text-xs font-medium text-[var(--inno-text-muted)]">{t("presets.simpleModeHeader")}</div>
+				<span className="text-[10px] text-[var(--inno-text-subtle)]">· {presets.length}</span>
+			</div>
+
+			{showSearch ? (
+				<div className="mb-2 flex items-center gap-2 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5">
+					<Search size={13} className="shrink-0 text-[var(--inno-text-subtle)]" />
+					<input
+						type="text"
+						value={query}
+						onChange={(e) => onQueryChange(e.target.value)}
+						placeholder={t("presets.searchPlaceholder")}
+						className="min-w-0 flex-1 bg-transparent text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:outline-none"
+					/>
+					{query ? (
+						<button
+							type="button"
+							className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+							onClick={() => onQueryChange("")}
+						>
+							<X size={12} />
+						</button>
+					) : null}
+				</div>
+			) : null}
+
+			<div className="max-h-[50vh] overflow-y-auto rounded-md">
+				{totalMatched === 0 ? (
+					<div className="py-6 text-center text-xs text-[var(--inno-text-muted)]">{t("presets.noResults")}</div>
+				) : (
+					groups.map(([category, items]) => (
+						<div key={category} className="mb-3 last:mb-0">
+							{/* Only show the group header when at least one categorized group exists
+							    AND there is more than one group — keeps the single-bucket flat layout
+							    when nothing has been categorized yet. */}
+							{groups.length > 1 ? (
+								<div className="mb-1.5 px-0.5 text-[10px] font-medium uppercase tracking-wide text-[var(--inno-text-subtle)]">
+									{category} <span className="ml-1 text-[var(--inno-text-subtle)]">· {items.length}</span>
+								</div>
+							) : null}
+							<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+								{items.map((preset) => (
+									<button
+										key={preset.id}
+										type="button"
+										disabled={openingPresetId !== null}
+										onClick={() => onOpen(preset.id)}
+										title={preset.description}
+										className="group flex flex-col items-start rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2.5 text-left transition-colors hover:border-blue-300 hover:bg-blue-50/40 disabled:opacity-50"
+									>
+										<span className="text-sm font-medium text-[var(--inno-text)] group-hover:text-[var(--inno-accent)]">
+											{preset.name}
+										</span>
+										{preset.description ? (
+											<span className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-[var(--inno-text-muted)]">
+												{preset.description}
+											</span>
+										) : null}
+										{openingPresetId === preset.id ? (
+											<span className="mt-1 text-[10px] text-[var(--inno-accent)]">{t("presets.opening")}</span>
+										) : null}
+									</button>
+								))}
+							</div>
+						</div>
+					))
+				)}
+			</div>
+		</div>
+	);
+}
+
 export function ChatCenter() {
+	const { t } = useTranslation();
 	const inputRef = useRef<HTMLTextAreaElement | null>(null);
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const imageInputRef = useRef<HTMLInputElement | null>(null);
@@ -239,6 +346,7 @@ export function ChatCenter() {
 	const [presets, setPresets] = useState<PresetMeta[]>([]);
 	const [openingPresetId, setOpeningPresetId] = useState<string | null>(null);
 	const [togglingMode, setTogglingMode] = useState(false);
+	const [presetQuery, setPresetQuery] = useState("");
 
 	// Toggle between Simple and Normal mode from the welcome screen. The IA icon
 	// plays a flip animation keyed on the resulting mode.
@@ -663,33 +771,14 @@ export function ChatCenter() {
 						{renderComposer("有什么想学习或实践的?发送消息开始…")}
 
 						{simpleMode && presets.length > 0 ? (
-							<div className="mt-5">
-								<div className="mb-2 text-xs font-medium text-[var(--inno-text-muted)]">开箱即用 · 选一个开始</div>
-								<div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-									{presets.map((preset) => (
-										<button
-											key={preset.id}
-											type="button"
-											disabled={openingPresetId !== null}
-											onClick={() => openPreset(preset.id)}
-											title={preset.description}
-											className="group flex flex-col items-start rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2.5 text-left transition-colors hover:border-blue-300 hover:bg-blue-50/40 disabled:opacity-50"
-										>
-											<span className="text-sm font-medium text-[var(--inno-text)] group-hover:text-[var(--inno-accent)]">
-												{preset.name}
-											</span>
-											{preset.description ? (
-												<span className="mt-0.5 line-clamp-2 text-[11px] leading-relaxed text-[var(--inno-text-muted)]">
-													{preset.description}
-												</span>
-											) : null}
-											{openingPresetId === preset.id ? (
-												<span className="mt-1 text-[10px] text-[var(--inno-accent)]">正在打开…</span>
-											) : null}
-										</button>
-									))}
-								</div>
-							</div>
+							<PresetPicker
+								presets={presets}
+								openingPresetId={openingPresetId}
+								onOpen={openPreset}
+								query={presetQuery}
+								onQueryChange={setPresetQuery}
+								t={t}
+							/>
 						) : null}
 
 						{simpleMode ? null : preselectedWs ? (

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -17,13 +17,14 @@ import { cpp } from "@codemirror/lang-cpp";
 import { rust } from "@codemirror/lang-rust";
 import { go } from "@codemirror/lang-go";
 import type { Extension } from "@codemirror/state";
-import { RefreshCw, Upload, Trash2, ChevronLeft, File, FileText, FileType, Folder, FolderOpen, Globe, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Library, Download, Check, FileCode2 } from "lucide-react";
+import { RefreshCw, Upload, Trash2, ChevronLeft, File, FileText, FileType, Folder, FolderOpen, Globe, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Library, Download, Check, FileCode2, Search } from "lucide-react";
 import { skillsStore } from "../stores/skills-store.js";
 import { skillRawUrl } from '../api/skills.js';
 import type { SkillInfo } from "../types/skills.js";
 import type { WorkspaceFileDetail, WorkspaceFileKind } from "../types/workspace.js";
 import { type ArboristNode, toArboristNodes } from "../types/workspace.js";
 import { normalizeMarkdownMath } from "../utils/markdown-math.js";
+import { groupByCategory, matchesQuery } from "../utils/category-grouping.js";
 import { useStoreSnapshot } from "./hooks.js";
 import "@earendil-works/pi-web-ui";
 import "@uiw/react-md-editor/markdown-editor.css";
@@ -381,6 +382,14 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 		error: skillsStore.libraryError,
 		importing: skillsStore.importing,
 	}));
+	const [query, setQuery] = useState("");
+
+	const uncategorizedLabel = t("skills.uncategorized");
+	const groups = useMemo(
+		() => groupByCategory(state.library.filter((item) => matchesQuery(item, query)), uncategorizedLabel),
+		[state.library, query, uncategorizedLabel],
+	);
+	const totalMatched = useMemo(() => groups.reduce((sum, [, items]) => sum + items.length, 0), [groups]);
 
 	return (
 		<div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-900/40 p-4" onClick={onClose}>
@@ -414,6 +423,27 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 					</div>
 				</div>
 
+				{/* Search */}
+				<div className="flex items-center gap-2 border-b border-[var(--inno-border)] px-4 py-2">
+					<Search size={14} className="shrink-0 text-[var(--inno-text-subtle)]" />
+					<input
+						type="text"
+						value={query}
+						onChange={(e) => setQuery(e.target.value)}
+						placeholder={t("skills.searchPlaceholder")}
+						className="min-w-0 flex-1 bg-transparent text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:outline-none"
+					/>
+					{query ? (
+						<button
+							className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+							onClick={() => setQuery("")}
+							title={t("common.clear", "Clear")}
+						>
+							<X size={12} />
+						</button>
+					) : null}
+				</div>
+
 				{state.error ? <div className="border-b border-[var(--inno-border)] bg-red-50 px-4 py-2 text-xs text-red-700">{state.error}</div> : null}
 
 				{/* Body */}
@@ -427,32 +457,43 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 						<div className="flex h-full flex-col items-center justify-center py-12 text-center text-sm text-[var(--inno-text-muted)]">
 							{t("skills.libraryEmpty")}
 						</div>
+					) : totalMatched === 0 ? (
+						<div className="flex h-full flex-col items-center justify-center py-12 text-center text-sm text-[var(--inno-text-muted)]">
+							{t("skills.noResults")}
+						</div>
 					) : (
-						state.library.map((item) => {
-							const isImporting = state.importing.has(item.name);
-							return (
-								<div key={item.name} className="flex items-start gap-3 border-b border-[var(--inno-border)] px-4 py-3">
-									<div className="min-w-0 flex-1">
-										<div className="truncate text-sm font-medium text-[var(--inno-text)]">{item.name}</div>
-										{item.description && <div className="mt-0.5 line-clamp-3 text-xs leading-relaxed text-[var(--inno-text-muted)]">{item.description}</div>}
-									</div>
-									{item.installed ? (
-										<span className="flex shrink-0 items-center gap-1 rounded-md bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 ring-1 ring-green-100">
-											<Check size={12} /> {t("skills.installed")}
-										</span>
-									) : (
-										<button
-											disabled={isImporting}
-											className="flex h-7 shrink-0 items-center gap-1 rounded-md inno-primary-button px-2.5 text-xs text-white disabled:opacity-50"
-											onClick={() => void skillsStore.importFromLibrary(item.name)}
-										>
-											<Download size={12} />
-											{isImporting ? t("skills.importing") : t("skills.import")}
-										</button>
-									)}
+						groups.map(([category, items]) => (
+							<div key={category}>
+								<div className="sticky top-0 z-10 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)]/95 px-4 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--inno-text-muted)] backdrop-blur">
+									{category} <span className="ml-1 text-[var(--inno-text-subtle)]">· {items.length}</span>
 								</div>
-							);
-						})
+								{items.map((item) => {
+									const isImporting = state.importing.has(item.name);
+									return (
+										<div key={item.name} className="flex items-start gap-3 border-b border-[var(--inno-border)] px-4 py-3">
+											<div className="min-w-0 flex-1">
+												<div className="truncate text-sm font-medium text-[var(--inno-text)]">{item.name}</div>
+												{item.description && <div className="mt-0.5 line-clamp-3 text-xs leading-relaxed text-[var(--inno-text-muted)]">{item.description}</div>}
+											</div>
+											{item.installed ? (
+												<span className="flex shrink-0 items-center gap-1 rounded-md bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 ring-1 ring-green-100">
+													<Check size={12} /> {t("skills.installed")}
+												</span>
+											) : (
+												<button
+													disabled={isImporting}
+													className="flex h-7 shrink-0 items-center gap-1 rounded-md inno-primary-button px-2.5 text-xs text-white disabled:opacity-50"
+													onClick={() => void skillsStore.importFromLibrary(item.name)}
+												>
+													<Download size={12} />
+													{isImporting ? t("skills.importing") : t("skills.import")}
+												</button>
+											)}
+										</div>
+									);
+								})}
+							</div>
+						))
 					)}
 				</div>
 			</div>
@@ -473,6 +514,7 @@ export function SkillsPanel() {
 		error: skillsStore.error,
 		libraryOpen: skillsStore.libraryOpen,
 	}));
+	const [query, setQuery] = useState("");
 
 	useEffect(() => {
 		void skillsStore.load();
@@ -486,6 +528,13 @@ export function SkillsPanel() {
 	}
 
 	const activeSkill = state.selectedSkill ? state.skills.find((s) => s.name === state.selectedSkill) : null;
+
+	const uncategorizedLabel = t("skills.uncategorized");
+	const groups = useMemo(
+		() => groupByCategory(state.skills.filter((s) => matchesQuery(s, query)), uncategorizedLabel),
+		[state.skills, query, uncategorizedLabel],
+	);
+	const totalMatched = useMemo(() => groups.reduce((sum, [, items]) => sum + items.length, 0), [groups]);
 
 	// Detail view — file browser
 	if (activeSkill) {
@@ -520,6 +569,30 @@ export function SkillsPanel() {
 						</button>
 					</div>
 				</div>
+
+				{/* Search (visible when there's anything to search through) */}
+				{state.skills.length > 0 ? (
+					<div className="flex items-center gap-2 border-b border-[var(--inno-border)] px-3 py-2">
+						<Search size={13} className="shrink-0 text-[var(--inno-text-subtle)]" />
+						<input
+							type="text"
+							value={query}
+							onChange={(e) => setQuery(e.target.value)}
+							placeholder={t("skills.searchPlaceholder")}
+							className="min-w-0 flex-1 bg-transparent text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:outline-none"
+						/>
+						{query ? (
+							<button
+								className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+								onClick={() => setQuery("")}
+								title={t("common.clear", "Clear")}
+							>
+								<X size={12} />
+							</button>
+						) : null}
+					</div>
+				) : null}
+
 				{state.error ? <div className="border-b border-[var(--inno-border)] bg-red-50 px-3 py-2 text-xs text-red-700">{state.error}</div> : null}
 
 				{/* Skills list */}
@@ -534,9 +607,20 @@ export function SkillsPanel() {
 							<div className="text-base font-medium text-[var(--inno-text)]">{t("skills.empty")}</div>
 							<p className="mt-1 max-w-sm text-xs">{t("skills.emptyDesc")}</p>
 						</div>
+					) : totalMatched === 0 ? (
+						<div className="flex h-full flex-col items-center justify-center py-12 text-center text-sm text-[var(--inno-text-muted)]">
+							{t("skills.noResults")}
+						</div>
 					) : (
-						state.skills.map((skill) => (
-							<SkillRow key={skill.name} skill={skill} onClick={() => void skillsStore.selectSkill(skill.name)} />
+						groups.map(([category, items]) => (
+							<div key={category}>
+								<div className="sticky top-0 z-10 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)]/95 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--inno-text-muted)] backdrop-blur">
+									{category} <span className="ml-1 text-[var(--inno-text-subtle)]">· {items.length}</span>
+								</div>
+								{items.map((skill) => (
+									<SkillRow key={skill.name} skill={skill} onClick={() => void skillsStore.selectSkill(skill.name)} />
+								))}
+							</div>
 						))
 					)}
 				</div>

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -464,7 +464,7 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 					) : (
 						groups.map(([category, items]) => (
 							<div key={category}>
-								<div className="sticky top-0 z-10 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)]/95 px-4 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--inno-text-muted)] backdrop-blur">
+								<div className="sticky top-0 z-10 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-4 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--inno-text-muted)]">
 									{category} <span className="ml-1 text-[var(--inno-text-subtle)]">· {items.length}</span>
 								</div>
 								{items.map((item) => {
@@ -550,22 +550,22 @@ export function SkillsPanel() {
 	// List view — one skill per row
 	return (
 		<div className="relative flex h-full flex-col p-3">
-			<div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
+			<div className="@container/skillspanel flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
 				{/* Toolbar */}
-				<div className="flex items-center justify-between gap-3 border-b border-[var(--inno-border)] px-3 py-2.5">
-					<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("skills.title")}</h3>
-					<div className="flex shrink-0 items-center gap-2">
+				<div className="flex flex-wrap items-center justify-between gap-x-2 gap-y-1.5 border-b border-[var(--inno-border)] px-3 py-2">
+					<h3 className="min-w-0 truncate text-sm font-medium text-[var(--inno-text)]">{t("skills.title")}</h3>
+					<div className="flex shrink-0 items-center gap-1.5">
 						<input ref={uploadRef} type="file" className="hidden" accept=".zip,application/zip,.md,text/markdown,text/plain" onChange={handleUpload} />
-						<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => skillsStore.openLibrary()}>
+						<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("skills.library")} onClick={() => skillsStore.openLibrary()}>
 							<Library size={13} />
-							{t("skills.library")}
+							<span className="hidden @[26rem]/skillspanel:inline">{t("skills.library")}</span>
 						</button>
-						<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void skillsStore.reload()}>
+						<button className="flex h-7 w-7 items-center justify-center rounded-md border border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("preview.refresh", "Refresh")} onClick={() => void skillsStore.reload()}>
 							<RefreshCw size={13} />
 						</button>
-						<button className="flex h-7 items-center gap-1 rounded-md inno-primary-button px-2.5 text-xs text-white disabled:opacity-50" disabled={state.isUploading} onClick={() => uploadRef.current?.click()}>
+						<button className="flex h-7 items-center gap-1 rounded-md inno-primary-button px-2 text-xs text-white disabled:opacity-50" disabled={state.isUploading} title={state.isUploading ? t("skills.uploading") : t("skills.upload")} onClick={() => uploadRef.current?.click()}>
 							<Upload size={13} />
-							{state.isUploading ? t("skills.uploading") : t("skills.upload")}
+							<span className="hidden @[26rem]/skillspanel:inline">{state.isUploading ? t("skills.uploading") : t("skills.upload")}</span>
 						</button>
 					</div>
 				</div>
@@ -614,7 +614,7 @@ export function SkillsPanel() {
 					) : (
 						groups.map(([category, items]) => (
 							<div key={category}>
-								<div className="sticky top-0 z-10 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)]/95 px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--inno-text-muted)] backdrop-blur">
+								<div className="sticky top-0 z-10 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3 py-1.5 text-[11px] font-medium uppercase tracking-wide text-[var(--inno-text-muted)]">
 									{category} <span className="ml-1 text-[var(--inno-text-subtle)]">· {items.length}</span>
 								</div>
 								{items.map((skill) => (

--- a/apps/inno-agent/web/src/types/presets.ts
+++ b/apps/inno-agent/web/src/types/presets.ts
@@ -3,4 +3,5 @@ export interface PresetMeta {
 	name: string;
 	description: string;
 	icon?: string;
+	category?: string;
 }

--- a/apps/inno-agent/web/src/types/skills.ts
+++ b/apps/inno-agent/web/src/types/skills.ts
@@ -7,10 +7,12 @@ export interface SkillInfo {
 	size: number;
 	updatedAt: string;
 	diagnostics: string[];
+	category?: string;
 }
 
 export interface SkillLibraryItem {
 	name: string;
 	description: string;
 	installed: boolean;
+	category?: string;
 }

--- a/apps/inno-agent/web/src/utils/category-grouping.ts
+++ b/apps/inno-agent/web/src/utils/category-grouping.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared helpers for client-side search + category-based grouping used by the
+ * Skills panel (local + library) and the Simple Mode preset grid.
+ */
+
+/** Substring match (case-insensitive) on any of name / description / category. */
+export function matchesQuery(item: { name: string; description?: string; category?: string }, query: string): boolean {
+	if (!query) return true;
+	const q = query.toLowerCase();
+	return (
+		item.name.toLowerCase().includes(q) ||
+		(item.description?.toLowerCase().includes(q) ?? false) ||
+		(item.category?.toLowerCase().includes(q) ?? false)
+	);
+}
+
+/**
+ * Group items by category. Items without a category land under `fallback`
+ * (the localized "Uncategorized" label). Returns the entries pre-sorted with
+ * the fallback group last so categorized items lead the list.
+ */
+export function groupByCategory<T extends { category?: string }>(items: T[], fallback: string): [string, T[]][] {
+	const map = new Map<string, T[]>();
+	for (const item of items) {
+		const key = item.category?.trim() || fallback;
+		const list = map.get(key);
+		if (list) list.push(item);
+		else map.set(key, [item]);
+	}
+	const entries = Array.from(map.entries());
+	entries.sort(([a], [b]) => {
+		if (a === fallback) return 1;
+		if (b === fallback) return -1;
+		return a.localeCompare(b);
+	});
+	return entries;
+}


### PR DESCRIPTION
## Summary

- Add `category` metadata support to skills and presets, with grouped scroll + search in both the local skills panel and the Skill Library modal (commit 589cf69).
- Fix the regression where the SkillsPanel toolbar overlapped its own title at half-screen / quarter-screen widths after the category feature shipped (commit da26de0).

## Details

**Category feature (589cf69)**
- Surface `category` from skill frontmatter and preset.json.
- Group skills/presets by category in the right panel and in the Skill Library modal.
- Add a search input that filters across name + description + category.
- Sticky category headers inside the scroll area.

**Toolbar overlap fix (da26de0)**
- Wrap toolbar parent with `@container/skillspanel` + `flex-wrap` so the button cluster reflows instead of overlapping when the container is narrow.
- Add `min-w-0 truncate` to the title.
- Hide Library / Upload button labels below 26rem container width via `@[26rem]/skillspanel:inline`; keep `title=` for tooltip access.
- Make Refresh an icon-only square button (h-7 w-7).
- Replace translucent `/95 + backdrop-blur` sticky category headers (which showed ghosts of rows scrolling underneath) with an opaque `bg-[var(--inno-surface-muted)]` in both the local list and the Skill Library modal.

## Test plan

- [ ] Verify skills/presets grouped by category and searchable in the right panel.
- [ ] Switch right panel to half / quarter mode — toolbar title and buttons no longer overlap; Library/Upload labels collapse to icon-only below ~26rem, tooltips still work.
- [ ] Scroll past a sticky category header — no translucent ghost of underlying rows shows through.
- [ ] `npm run build` clean.