### PR TITLE
feat(feishu): add QR scan-to-bind registration flow

### DIFF
--- a/apps/inno-agent/src/channels/feishu/feishu-registration.ts
+++ b/apps/inno-agent/src/channels/feishu/feishu-registration.ts
@@ -1,0 +1,157 @@
+/**
+ * Feishu device-flow app registration.
+ *
+ * Uses the accounts.feishu.cn endpoint to provision a "PersonalAgent"
+ * self-built app by having the user scan a QR code with the Feishu mobile app.
+ * Same flow as larksuite/cli.
+ */
+
+import { logger } from "../../logger.js";
+
+const FEISHU_ACCOUNTS_URL =
+  "https://accounts.feishu.cn/oauth/v1/app/registration";
+
+export interface FeishuRegistrationBeginResult {
+  deviceCode: string;
+  userCode: string;
+  verificationUri: string; // URL to encode as QR
+  expiresIn: number; // seconds until QR expires
+  interval: number; // recommended poll interval (seconds)
+}
+
+export interface FeishuRegistrationPollResult {
+  status: "pending" | "confirmed" | "expired" | "denied" | "slow_down";
+  appId?: string;
+  appSecret?: string;
+  openId?: string;
+}
+
+/**
+ * Step 1: Begin the device-flow registration.
+ * Returns a verification URI that should be rendered as a QR code.
+ */
+export async function feishuRegistrationBegin(): Promise<FeishuRegistrationBeginResult> {
+  const body = new URLSearchParams({
+    action: "begin",
+    archetype: "PersonalAgent",
+    auth_method: "client_secret",
+    request_user_info: "open_id",
+  });
+
+  const resp = await fetch(FEISHU_ACCOUNTS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    logger.error(
+      { status: resp.status, body: text },
+      "[feishu-reg] begin request failed"
+    );
+    throw new Error(
+      `Feishu registration begin failed: ${resp.status} ${text}`
+    );
+  }
+
+  const data = (await resp.json()) as {
+    device_code?: string;
+    user_code?: string;
+    verification_uri_complete?: string;
+    verification_uri?: string;
+    expires_in?: number;
+    interval?: number;
+  };
+
+  if (!data.device_code) {
+    throw new Error("Feishu registration begin: missing device_code in response");
+  }
+
+  const verificationUri =
+    data.verification_uri_complete || data.verification_uri || "";
+
+  logger.info(
+    { userCode: data.user_code, expiresIn: data.expires_in },
+    "[feishu-reg] begin success"
+  );
+
+  return {
+    deviceCode: data.device_code,
+    userCode: data.user_code || "",
+    verificationUri,
+    expiresIn: data.expires_in || 600,
+    interval: data.interval || 5,
+  };
+}
+
+/**
+ * Step 2: Poll the registration status.
+ * Call this every `interval` seconds until status is no longer "pending".
+ */
+export async function feishuRegistrationPoll(
+  deviceCode: string
+): Promise<FeishuRegistrationPollResult> {
+  const body = new URLSearchParams({
+    action: "poll",
+    device_code: deviceCode,
+  });
+
+  const resp = await fetch(FEISHU_ACCOUNTS_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+    signal: AbortSignal.timeout(15_000),
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => "");
+    logger.warn(
+      { status: resp.status, body: text },
+      "[feishu-reg] poll request failed"
+    );
+    throw new Error(`Feishu registration poll failed: ${resp.status}`);
+  }
+
+  const data = (await resp.json()) as {
+    error?: string;
+    client_id?: string;
+    client_secret?: string;
+    user_info?: { open_id?: string; tenant_brand?: string };
+  };
+
+  // Error states
+  if (data.error) {
+    switch (data.error) {
+      case "authorization_pending":
+        return { status: "pending" };
+      case "expired_token":
+        return { status: "expired" };
+      case "access_denied":
+        return { status: "denied" };
+      case "slow_down":
+        return { status: "slow_down" };
+      default:
+        logger.warn({ error: data.error }, "[feishu-reg] unknown poll error");
+        return { status: "pending" };
+    }
+  }
+
+  // Success — credentials returned
+  if (data.client_id && data.client_secret) {
+    logger.info(
+      { appId: data.client_id, openId: data.user_info?.open_id },
+      "[feishu-reg] registration confirmed"
+    );
+    return {
+      status: "confirmed",
+      appId: data.client_id,
+      appSecret: data.client_secret,
+      openId: data.user_info?.open_id,
+    };
+  }
+
+  // Unexpected shape — treat as pending
+  return { status: "pending" };
+}

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -31,6 +31,7 @@ import type { ImageContent } from "@earendil-works/pi-ai";
 import { ChannelRegistry } from "./channels/channel.js";
 import type { ChannelStreamEvent } from "./channels/channel.js";
 import { FeishuChannel } from "./channels/feishu/feishu-channel.js";
+import { feishuRegistrationBegin, feishuRegistrationPoll } from "./channels/feishu/feishu-registration.js";
 import { PersonalChannelDispatcher } from "./channels/personal-dispatcher.js";
 import { BridgeChannel } from "./channels/bridge/bridge-channel.js";
 import { handleBridgeMessage } from "./channels/bridge/bridge-server.js";
@@ -1856,6 +1857,51 @@ const server = createServer(async (req, res) => {
 				json(res, 200, health);
 			} else {
 				json(res, 200, { channel: channel.name, mode: "native", healthy: true, checkedAt: new Date().toISOString() });
+			}
+			return;
+		}
+
+		// Feishu QR device-flow registration
+		if (method === "POST" && url === "/api/channels/feishu/qr-register") {
+			try {
+				const result = await feishuRegistrationBegin();
+				json(res, 200, {
+					deviceCode: result.deviceCode,
+					qrUrl: result.verificationUri,
+					expiresIn: result.expiresIn,
+					interval: result.interval,
+				});
+			} catch (err) {
+				logger.error({ err }, "[feishu] QR registration begin failed");
+				json(res, 502, { error: err instanceof Error ? err.message : "Failed to start Feishu registration" });
+			}
+			return;
+		}
+
+		if (method === "GET" && url.startsWith("/api/channels/feishu/qr-status")) {
+			const deviceCode = new URL(url, "http://localhost").searchParams.get("deviceCode");
+			if (!deviceCode) {
+				json(res, 400, { error: "Missing deviceCode" });
+				return;
+			}
+			try {
+				const result = await feishuRegistrationPoll(deviceCode);
+				if (result.status === "confirmed" && result.appId && result.appSecret) {
+					// Save credentials to config and start channel
+					config.feishu = { appId: result.appId, appSecret: result.appSecret };
+					if (!config.channels) config.channels = {};
+					config.channels.feishu = {
+						enabled: true,
+						personalOnly: true,
+						allowedUserIds: result.openId ? [result.openId] : [],
+					};
+					config = saveConfig(paths.configPath, config);
+					await reloadFeishuChannel();
+				}
+				json(res, 200, { status: result.status });
+			} catch (err) {
+				logger.error({ err }, "[feishu] QR registration poll failed");
+				json(res, 502, { error: err instanceof Error ? err.message : "Failed to poll Feishu registration" });
 			}
 			return;
 		}

--- a/apps/inno-agent/web/src/api/settings.ts
+++ b/apps/inno-agent/web/src/api/settings.ts
@@ -91,6 +91,16 @@ export async function saveThemeSettings(theme: string): Promise<InnoSettings> {
 	});
 }
 
+export async function feishuQrRegister(): Promise<{ deviceCode: string; qrUrl: string; expiresIn: number; interval: number }> {
+	return apiFetch<{ deviceCode: string; qrUrl: string; expiresIn: number; interval: number }>("/api/channels/feishu/qr-register", {
+		method: "POST",
+	});
+}
+
+export async function feishuQrStatus(deviceCode: string): Promise<{ status: string }> {
+	return apiFetch<{ status: string }>(`/api/channels/feishu/qr-status?deviceCode=${encodeURIComponent(deviceCode)}`);
+}
+
 export async function wechatQrLogin(): Promise<{ qrId: string; qrUrl: string }> {
 	return apiFetch<{ qrId: string; qrUrl: string }>("/api/channels/wechat/qr-login", {
 		method: "POST",

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -455,6 +455,16 @@
 			"desc": "The skill library and preset workspaces are fetched from here. Defaults to the public repo; switch to a private GitHub repo or a self-hosted service.",
 			"bundle": "Self-hosted service",
 			"tokenPlaceholder": "Access token (private repo / higher limit, optional)"
+		},
+		"feishu": {
+			"qrRegister": "Scan to Bind",
+			"qrTitle": "Feishu QR Registration",
+			"qrSubtitle": "Open Feishu on your phone, scan the QR code to create a bot application.",
+			"qrExpired": "QR code expired",
+			"qrDenied": "Authorization denied",
+			"qrConfirmed": "Binding successful",
+			"qrWaiting": "Waiting for scan...",
+			"qrRegenerate": "Regenerate"
 		}
 	}
 }

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -455,6 +455,16 @@
 			"desc": "技能库和预设工作区从这里拉取。默认公共仓库,可改为私有 GitHub 仓库或自托管服务。",
 			"bundle": "自托管服务",
 			"tokenPlaceholder": "访问令牌(私有仓库 / 提额,可选)"
+		},
+		"feishu": {
+			"qrRegister": "扫码绑定",
+			"qrTitle": "飞书扫码注册",
+			"qrSubtitle": "打开手机飞书，扫描二维码以创建机器人应用。",
+			"qrExpired": "二维码已过期",
+			"qrDenied": "用户拒绝授权",
+			"qrConfirmed": "绑定成功",
+			"qrWaiting": "等待扫描…",
+			"qrRegenerate": "重新生成"
 		}
 	}
 }

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -5,7 +5,7 @@ import { QRCodeSVG } from "qrcode.react";
 import { getWikiStats } from "../api/wiki.js";
 import { settingsStore } from "../stores/settings-store.js";
 import { themeStore, THEME_IDS, THEME_PREVIEW_COLORS, type ThemeId } from "../stores/theme-store.js";
-import { wechatQrLogin, wechatQrStatus, wechatStatus } from "../api/settings.js";
+import { feishuQrRegister, feishuQrStatus, wechatQrLogin, wechatQrStatus, wechatStatus } from "../api/settings.js";
 import type { InnoModelInfo, InnoProviderModel as ProviderModel, InnoSettings, ChannelsSettingsPayload, PersonalBridgeChannelConfig } from "../types/settings.js";
 import type { WikiStats } from "../types/wiki.js";
 import { useStoreSnapshot } from "./hooks.js";
@@ -338,6 +338,54 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 		(settings.channels?.feishu?.allowedUserIds ?? []).join("\n"),
 	);
 
+	// Feishu QR registration state
+	const [feishuQrUrl, setFeishuQrUrl] = useState<string | null>(null);
+	const [feishuQrDeviceCode, setFeishuQrDeviceCode] = useState<string | null>(null);
+	const [feishuQrState, setFeishuQrState] = useState<string | null>(null); // waitingScan | confirmed | expired | denied
+	const [feishuQrError, setFeishuQrError] = useState<string | null>(null);
+	const feishuQrPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+	useEffect(() => {
+		return () => { if (feishuQrPollRef.current) clearInterval(feishuQrPollRef.current); };
+	}, []);
+
+	const startFeishuQrRegister = useCallback(async () => {
+		setFeishuQrState("scanning");
+		setFeishuQrUrl(null);
+		setFeishuQrError(null);
+		if (feishuQrPollRef.current) clearInterval(feishuQrPollRef.current);
+		try {
+			const { deviceCode, qrUrl, interval } = await feishuQrRegister();
+			setFeishuQrDeviceCode(deviceCode);
+			setFeishuQrUrl(qrUrl);
+			setFeishuQrState("waitingScan");
+			// Poll status
+			feishuQrPollRef.current = setInterval(async () => {
+				try {
+					const res = await feishuQrStatus(deviceCode);
+					if (res.status === "confirmed") {
+						setFeishuQrState("confirmed");
+						setFeishuEnabled(true);
+						if (feishuQrPollRef.current) clearInterval(feishuQrPollRef.current);
+						// Refresh settings to get new appId
+						settingsStore.load();
+					} else if (res.status === "expired") {
+						setFeishuQrState("expired");
+						if (feishuQrPollRef.current) clearInterval(feishuQrPollRef.current);
+					} else if (res.status === "denied") {
+						setFeishuQrState("denied");
+						if (feishuQrPollRef.current) clearInterval(feishuQrPollRef.current);
+					}
+				} catch {
+					// ignore poll errors
+				}
+			}, (interval || 5) * 1000);
+		} catch (err) {
+			setFeishuQrState(null);
+			setFeishuQrError(err instanceof Error ? err.message : "QR registration failed");
+		}
+	}, []);
+
 	// QQ
 	const qqConfig = settings.channels?.qq as PersonalBridgeChannelConfig | undefined;
 	const [qqEnabled, setQqEnabled] = useState(qqConfig?.enabled ?? false);
@@ -496,6 +544,47 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								{t("settings.channels.enabled")}
 							</label>
 						</div>
+
+						{/* Feishu QR Registration */}
+						<div className="mb-3">
+							{feishuQrState === "waitingScan" && feishuQrUrl ? (
+								<div className="flex flex-col items-center gap-2 rounded-lg border border-[var(--inno-border)] bg-[var(--inno-bg-alt)] p-4">
+									<div className="text-xs font-medium text-[var(--inno-text)]">{t("settings.feishu.qrTitle")}</div>
+									<QRCodeSVG value={feishuQrUrl} size={192} />
+									<div className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.feishu.qrSubtitle")}</div>
+									<div className="text-[10px] text-[var(--inno-accent)]">{t("settings.feishu.qrWaiting")}</div>
+								</div>
+							) : feishuQrState === "confirmed" ? (
+								<div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3">
+									<CheckCircle className="h-4 w-4 text-green-600" />
+									<span className="text-xs text-green-700">{t("settings.feishu.qrConfirmed")}</span>
+								</div>
+							) : feishuQrState === "expired" ? (
+								<div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
+									<span className="text-xs text-amber-700">{t("settings.feishu.qrExpired")}</span>
+									<button className="ml-auto rounded bg-[var(--inno-accent)] px-2 py-0.5 text-[10px] text-white" onClick={startFeishuQrRegister}>{t("settings.feishu.qrRegenerate")}</button>
+								</div>
+							) : feishuQrState === "denied" ? (
+								<div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3">
+									<span className="text-xs text-red-700">{t("settings.feishu.qrDenied")}</span>
+									<button className="ml-auto rounded bg-[var(--inno-accent)] px-2 py-0.5 text-[10px] text-white" onClick={startFeishuQrRegister}>{t("settings.feishu.qrRegenerate")}</button>
+								</div>
+							) : feishuQrState === "scanning" ? (
+								<div className="text-center text-[10px] text-[var(--inno-text-subtle)] py-2">{t("settings.feishu.qrWaiting")}</div>
+							) : (
+								<button
+									className="w-full rounded border border-[var(--inno-border)] bg-[var(--inno-bg-alt)] px-3 py-2 text-xs text-[var(--inno-text)] hover:bg-[var(--inno-bg-hover)] flex items-center justify-center gap-2"
+									onClick={startFeishuQrRegister}
+								>
+									<QrCodeIcon className="h-3.5 w-3.5" />
+									{t("settings.feishu.qrRegister")}
+								</button>
+							)}
+							{feishuQrError && (
+								<div className="mt-1 rounded bg-red-50 px-2 py-1 text-[10px] text-red-600">{feishuQrError}</div>
+							)}
+						</div>
+
 						{feishuEnabled && (
 							<div className="grid grid-cols-2 gap-2">
 								<div>


### PR DESCRIPTION
## Summary

- Add device-flow QR code registration for Feishu channel (same flow as larksuite/cli)
- User scans QR with Feishu mobile app → PersonalAgent bot app auto-provisioned → credentials saved → channel started
- Manual appId/appSecret input remains as fallback

## Changes

- **New**: `apps/inno-agent/src/channels/feishu/feishu-registration.ts` — calls `accounts.feishu.cn/oauth/v1/app/registration` (begin + poll)
- **Backend**: `POST /api/channels/feishu/qr-register` and `GET /api/channels/feishu/qr-status` routes
- **Frontend**: QR scan UI in settings Feishu section (QRCodeSVG, status polling, state transitions)
- **i18n**: zh-CN + en keys for QR flow

## Test plan

- [ ] Open settings → Feishu section → click "扫码绑定" → verify QR code renders
- [ ] Scan with Feishu mobile app → verify status transitions to "绑定成功"
- [ ] Verify `runtime/config/config.json` gets populated with appId/appSecret
- [ ] Verify Feishu channel starts (server logs show `[feishu] channel hot-reloaded`)
- [ ] Verify manual appId/appSecret entry still works as fallback