### PR TITLE
fix: notebook wiki 删除 + 对话框粘贴/滚动/问卷提示

### DIFF
--- a/apps/inno-agent/src/memory/l2/manifest-store.ts
+++ b/apps/inno-agent/src/memory/l2/manifest-store.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { appendJsonl, readJsonl } from "../../storage/file-store.js";
+import { appendJsonl, readJsonl, writeText } from "../../storage/file-store.js";
 import type { ManifestEntry } from "./types.js";
 
 const MANIFEST_FILE = "manifest.jsonl";
@@ -14,6 +14,28 @@ export function appendManifest(l2DataDir: string, entry: ManifestEntry): void {
 
 export function readManifest(l2DataDir: string): ManifestEntry[] {
 	return readJsonl<ManifestEntry>(getManifestPath(l2DataDir));
+}
+
+/**
+ * Remove a wiki page path from every manifest entry's `wikiPages` list.
+ * Rewrites the JSONL file in place. Keeps entries even if their `wikiPages`
+ * becomes empty (the source record is still valid).
+ * Returns true if any entry was modified.
+ */
+export function removeWikiPathFromManifest(l2DataDir: string, wikiPath: string): boolean {
+	const entries = readManifest(l2DataDir);
+	let changed = false;
+	for (const entry of entries) {
+		if (entry.wikiPages.includes(wikiPath)) {
+			entry.wikiPages = entry.wikiPages.filter((p) => p !== wikiPath);
+			changed = true;
+		}
+	}
+	if (changed) {
+		const lines = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+		writeText(getManifestPath(l2DataDir), lines);
+	}
+	return changed;
 }
 
 export function findManifestById(l2DataDir: string, id: string): ManifestEntry | undefined {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -42,7 +42,7 @@ import { executeJob } from "./scheduler/job-runner.js";
 import { CronScheduler } from "./scheduler/cron-scheduler.js";
 import { validateCron } from "./scheduler/cron-utils.js";
 import { parseFrontmatter, serializeFrontmatter } from "./memory/l2/wiki-maintainer.js";
-import { readManifest } from "./memory/l2/manifest-store.js";
+import { readManifest, removeWikiPathFromManifest } from "./memory/l2/manifest-store.js";
 import { loadProfile, saveProfile } from "./memory/learner/profile-store.js";
 import type { LearnerProfile, LearningGoal, KnowledgeState, Misconception, LearnerPreferences } from "./memory/learner/types.js";
 import { randomUUID } from "node:crypto";
@@ -2583,6 +2583,33 @@ const server = createServer(async (req, res) => {
 			}
 			writeText(fullPath, content);
 			json(res, 200, { path, saved: true });
+			return;
+		}
+
+		if (method === "DELETE" && url.startsWith("/api/wiki/page?")) {
+			const params = new URL(url, "http://localhost").searchParams;
+			const path = params.get("path");
+			if (!path) {
+				json(res, 400, { error: "Missing path parameter" });
+				return;
+			}
+			const fullPath = safeJoin(l2DataDir, path);
+			if (!fullPath) {
+				json(res, 400, { error: "Invalid wiki path" });
+				return;
+			}
+			if (!existsSync(fullPath)) {
+				json(res, 404, { error: "Wiki page not found" });
+				return;
+			}
+			try {
+				rmSync(fullPath);
+				removeWikiPathFromManifest(l2DataDir, path);
+				json(res, 200, { path, deleted: true });
+			} catch (err) {
+				logger.warn({ err }, "failed to delete wiki page");
+				json(res, 500, { error: "Failed to delete wiki page" });
+			}
 			return;
 		}
 

--- a/apps/inno-agent/web/src/api/wiki.ts
+++ b/apps/inno-agent/web/src/api/wiki.ts
@@ -16,6 +16,12 @@ export async function updateWikiPage(path: string, content: string): Promise<voi
 	});
 }
 
+export async function deleteWikiPage(path: string): Promise<void> {
+	await apiFetch(`/api/wiki/page?path=${encodeURIComponent(path)}`, {
+		method: "DELETE",
+	});
+}
+
 export async function getWikiGraph(): Promise<WikiGraphData> {
 	return apiFetch<WikiGraphData>("/api/wiki/graph");
 }

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -36,7 +36,11 @@
 		"saving": "Saving…",
 		"saved": "Saved",
 		"remove": "Remove",
-		"open": "Open"
+		"open": "Open",
+		"pasteCollapsed": "«Pasted {{count}} lines»",
+		"pasteCollapsedUndo": "Undo paste",
+		"questionPending": "Please answer the question above before continuing",
+		"questionPendingJump": "View question"
 	},
 	"notebook": {
 		"title": "Notebook",

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -84,6 +84,10 @@
 			"openInNotebook": "Open page",
 			"backToGraph": "Back to graph"
 		},
+		"delete": {
+			"button": "Delete",
+			"confirm": "Delete \"{{title}}\"? This page will be permanently removed."
+		},
 		"inspector": {
 			"title": "Node",
 			"empty": "Select a node to inspect. Double-click a non-tag node to open its page.",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -84,6 +84,10 @@
 			"openInNotebook": "在笔记本中查看",
 			"backToGraph": "返回图谱"
 		},
+		"delete": {
+			"button": "删除",
+			"confirm": "确定删除「{{title}}」吗？该页面将被永久移除。"
+		},
 		"inspector": {
 			"title": "节点详情",
 			"empty": "选择节点查看详细信息。双击非标签节点可打开页面。",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -36,7 +36,11 @@
 		"saving": "保存中…",
 		"saved": "已保存",
 		"remove": "移除",
-		"open": "打开"
+		"open": "打开",
+		"pasteCollapsed": "«已粘贴 {{count}} 行»",
+		"pasteCollapsedUndo": "撤销粘贴",
+		"questionPending": "请完成上方问卷后再继续对话",
+		"questionPendingJump": "查看问卷"
 	},
 	"notebook": {
 		"title": "笔记本",

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -22,6 +22,12 @@ import { useStoreSnapshot } from "./hooks.js";
 import { QuestionDialog } from "./QuestionDialog.js";
 import "@earendil-works/pi-web-ui";
 
+// Thresholds for collapsing a large paste into a placeholder chip. A paste
+// crossing EITHER threshold is collapsed. Tuned so normal multi-line typing
+// (a few paragraphs) stays inline, but dumping a whole file collapses.
+const PASTE_COLLAPSE_LINES = 20;
+const PASTE_COLLAPSE_CHARS = 2000;
+
 const CHANNEL_BADGE_CLASS: Record<string, string> = {
 	cli: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]",
 	web: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]",
@@ -333,6 +339,12 @@ export function ChatCenter() {
 	const [uploads, setUploads] = useState<{ fileName: string; path: string }[]>([]);
 	const [isUploading, setIsUploading] = useState(false);
 	const [inlineImages, setInlineImages] = useState<(InlineImage & { name: string; previewUrl: string })[]>([]);
+	// When the user pastes a large block of text (many lines / chars), we
+	// insert a short placeholder token (e.g. «已粘贴 N 行») into the textarea
+	// at the caret position and hold the real text here. The user can keep
+	// typing before/after the token. On send, the token is replaced by the
+	// real text.
+	const [pasteBlock, setPasteBlock] = useState<{ text: string; lineCount: number } | null>(null);
 
 	// Inline workspace chooser state (welcome screen only). Seeded from the
 	// user's last choice (P3) so a new chat resumes the workspace they were in
@@ -458,8 +470,14 @@ export function ChatCenter() {
 	const handleInput = useCallback(() => {
 		const el = inputRef.current;
 		if (!el) return;
+		const maxHeight = 200;
 		el.style.height = "auto";
-		el.style.height = `${Math.min(el.scrollHeight, 140)}px`;
+		const h = Math.min(el.scrollHeight, maxHeight);
+		el.style.height = `${h}px`;
+		// Only show a vertical scrollbar once content overflows the max height;
+		// never show a horizontal scrollbar (long lines wrap).
+		el.style.overflowY = el.scrollHeight > maxHeight ? "auto" : "hidden";
+		el.style.overflowX = "hidden";
 	}, []);
 
 	const buildSessionInput = useCallback((): CreateSessionInput | { __error: string } => {
@@ -505,7 +523,16 @@ export function ChatCenter() {
 	}, []);
 
 	const handleSend = useCallback(() => {
-		const input = inputRef.current?.value.trim() ?? "";
+		const rawValue = inputRef.current?.value ?? "";
+		// Replace any paste-placeholder tokens (e.g. «已粘贴 N 行» / «Pasted N lines»)
+		// with the real pasted text before sending.
+		const expandPaste = (s: string) => {
+			if (!pasteBlock) return s;
+			// Token format from common.pasteCollapsed: «已粘贴 N 行» (zh) or
+			// «Pasted N lines» (en). Replace every occurrence with the real text.
+			return s.replace(/«[^»]*»/g, pasteBlock.text);
+		};
+		const input = expandPaste(rawValue).trim();
 		if ((!input && uploads.length === 0 && inlineImages.length === 0) || chat.isSending || isUploading) return;
 
 		const uploadNote = uploads.length > 0
@@ -516,6 +543,15 @@ export function ChatCenter() {
 			? inlineImages.map(({ data, mimeType }) => ({ data, mimeType }))
 			: undefined;
 
+		const resetComposer = () => {
+			if (inputRef.current) {
+				inputRef.current.value = "";
+				inputRef.current.style.height = "auto";
+				inputRef.current.style.overflowY = "hidden";
+			}
+			setPasteBlock(null);
+		};
+
 		if (isWelcome) {
 			const wsInput = buildSessionInput();
 			if ("__error" in wsInput) {
@@ -525,10 +561,7 @@ export function ChatCenter() {
 			setWsError("");
 			// Remember the workspace choice so the next new chat resumes it (P3).
 			if (!simpleMode) rememberWsChoice(wsMode, wsExistingId);
-			if (inputRef.current) {
-				inputRef.current.value = "";
-				inputRef.current.style.height = "auto";
-			}
+			resetComposer();
 			setUploads([]);
 			setInlineImages([]);
 			void (async () => {
@@ -542,14 +575,11 @@ export function ChatCenter() {
 			return;
 		}
 
-		if (inputRef.current) {
-			inputRef.current.value = "";
-			inputRef.current.style.height = "auto";
-		}
+		resetComposer();
 		setUploads([]);
 		setInlineImages([]);
 		void chatStore.send(messageContent, imagesToSend);
-	}, [isWelcome, buildSessionInput, uploads, inlineImages, chat.isSending, isUploading, simpleMode, wsMode, wsExistingId]);
+	}, [isWelcome, buildSessionInput, uploads, inlineImages, chat.isSending, isUploading, simpleMode, wsMode, wsExistingId, pasteBlock]);
 
 	const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
 		// Don't fire Send while the user is composing with an IME (e.g. picking
@@ -587,12 +617,46 @@ export function ChatCenter() {
 	}, []);
 
 	const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+		// Image paste: keep existing behavior.
 		const imageItems = Array.from(e.clipboardData.items).filter((item) => item.type.startsWith("image/"));
-		if (imageItems.length === 0) return;
-		e.preventDefault();
-		const files = imageItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
-		addImageFiles(files);
-	}, [addImageFiles]);
+		if (imageItems.length > 0) {
+			e.preventDefault();
+			const files = imageItems.map((item) => item.getAsFile()).filter((f): f is File => f !== null);
+			addImageFiles(files);
+			return;
+		}
+		// Large text paste: insert a placeholder token at the caret and hold
+		// the real text in `pasteBlock`. The user can keep typing before/after
+		// the token. On send the token is replaced with the real text.
+		const text = e.clipboardData.getData("text/plain");
+		if (text) {
+			const lineCount = text.split(/\r\n|\r|\n/).length;
+			const charCount = text.length;
+			if (lineCount > PASTE_COLLAPSE_LINES || charCount > PASTE_COLLAPSE_CHARS) {
+				e.preventDefault();
+				const token = t("common.pasteCollapsed", { count: lineCount });
+				const el = inputRef.current;
+				if (el) {
+					const start = el.selectionStart;
+					const end = el.selectionEnd;
+					const before = el.value.slice(0, start);
+					const after = el.value.slice(end);
+					el.value = `${before}${token}${after}`;
+					// Place caret right after the inserted token.
+					const caret = start + token.length;
+					el.setSelectionRange(caret, caret);
+					el.dispatchEvent(new Event("input", { bubbles: true }));
+				}
+				// Merge into any existing paste block (rare: second large paste
+				// before sending the first). Keep total text + recompute lines.
+				setPasteBlock((prev) => {
+					if (!prev) return { text, lineCount };
+					const merged = `${prev.text}\n${text}`;
+					return { text: merged, lineCount: merged.split(/\r\n|\r|\n/).length };
+				});
+			}
+		}
+	}, [addImageFiles, t]);
 
 	const handleImageFiles = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
 		const files = Array.from(event.target.files ?? []).filter((f) => f.type.startsWith("image/"));
@@ -676,6 +740,24 @@ export function ChatCenter() {
 		) : null
 	);
 
+	const renderQuestionHint = () => (
+		chat.pendingQuestion ? (
+			<div className="mb-2 flex items-center gap-2 rounded-md border border-[var(--inno-border)] bg-[var(--inno-accent-soft)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)]">
+				<AlertTriangle size={14} className="shrink-0 text-[var(--inno-warning)]" />
+				<span>{t("common.questionPending")}</span>
+				<button
+					className="ml-auto shrink-0 rounded px-2 py-0.5 font-medium text-[var(--inno-warning)] hover:bg-[var(--inno-surface-muted)]"
+					onClick={() => {
+						const el = scrollRef.current;
+						if (el) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+					}}
+				>
+					{t("common.questionPendingJump")}
+				</button>
+			</div>
+		) : null
+	);
+
 	const renderComposer = (placeholder: string) => (
 		<div className="inno-composer flex items-end gap-2 rounded-lg p-2">
 			<input ref={fileInputRef} id="file-input" type="file" className="hidden" multiple onChange={handleFiles} />
@@ -689,7 +771,7 @@ export function ChatCenter() {
 			<textarea
 				ref={inputRef}
 				id="chat-input"
-				className="min-h-[36px] max-h-[140px] flex-1 resize-none overflow-hidden rounded-md border-0 bg-transparent px-2 py-2 text-sm leading-5 text-[var(--inno-text)] outline-none placeholder:text-[var(--inno-text-subtle)] disabled:opacity-60"
+				className="min-h-[36px] max-h-[200px] flex-1 resize-none overflow-hidden rounded-md border-0 bg-transparent px-2 py-2 text-sm leading-5 text-[var(--inno-text)] outline-none placeholder:text-[var(--inno-text-subtle)] disabled:opacity-60"
 				placeholder={placeholder}
 				rows={1}
 				onKeyDown={handleKeyDown}
@@ -785,6 +867,7 @@ export function ChatCenter() {
 
 						{renderUploadChips()}
 						{renderInlineImagePreviews()}
+						{renderQuestionHint()}
 						{renderComposer("有什么想学习或实践的?发送消息开始…")}
 
 						{simpleMode && presets.length > 0 ? (
@@ -974,6 +1057,7 @@ export function ChatCenter() {
 				<div className="mx-auto max-w-3xl">
 					{renderUploadChips()}
 					{renderInlineImagePreviews()}
+					{renderQuestionHint()}
 					{renderComposer("Type a message...")}
 				</div>
 			</div>

--- a/apps/inno-agent/web/src/react/Notebook.tsx
+++ b/apps/inno-agent/web/src/react/Notebook.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Network, FileText, PanelLeftClose, PanelLeftOpen } from "lucide-react";
+import { Network, FileText, PanelLeftClose, PanelLeftOpen, Trash2 } from "lucide-react";
 import { notebookStore } from "../stores/notebook-store.js";
 import type { WikiPageType } from "../types/wiki.js";
 import { useStoreSnapshot } from "./hooks.js";
@@ -35,7 +35,18 @@ export function Notebook() {
 		currentPagePath: notebookStore.currentPage?.path ?? null,
 		selectedNodeId: notebookStore.selectedNodeId,
 		isLoadingPages: notebookStore.isLoadingPages,
+		isDeletingPage: notebookStore.isDeletingPage,
 	}));
+
+	async function handleDelete(path: string, title: string) {
+		const ok = window.confirm(t("notebook.delete.confirm", { title }));
+		if (!ok) return;
+		try {
+			await notebookStore.deletePage(path);
+		} catch {
+			// store logs the error; nothing else to do
+		}
+	}
 
 	useEffect(() => {
 		void notebookStore.loadAll();
@@ -74,20 +85,36 @@ export function Notebook() {
 					) : null}
 					{state.pages.map((page) => {
 						const selected = state.currentPagePath === page.path || state.selectedNodeId === page.path;
+						const title = page.frontmatter?.title || page.path;
 						return (
-							<button
+							<div
 								key={page.path}
-								className={`w-full border-b border-[var(--inno-border)] px-3 py-2 text-left text-sm transition-colors ${selected ? "bg-[var(--inno-accent-soft)]" : "hover:bg-[var(--inno-surface-muted)]"}`}
-								onClick={() => void notebookStore.selectPage(page.path)}
+								className={`group relative border-b border-[var(--inno-border)] transition-colors ${selected ? "bg-[var(--inno-accent-soft)]" : "hover:bg-[var(--inno-surface-muted)]"}`}
 							>
-								<div className="truncate font-medium text-[var(--inno-text)]">{page.frontmatter?.title || page.path}</div>
-								<div className="mt-1 flex items-center gap-1.5">
-									<span className={`rounded px-1.5 text-xs ${typeColor(page.frontmatter?.type)}`}>
-										{page.frontmatter?.type ? t(`notebook.types.${page.frontmatter.type}`) : t("notebook.types.unknown")}
-									</span>
-									<span className="truncate text-xs text-[var(--inno-text-muted)]">{page.frontmatter?.updated || ""}</span>
-								</div>
-							</button>
+								<button
+									className="w-full px-3 py-2 pr-9 text-left text-sm"
+									onClick={() => void notebookStore.selectPage(page.path)}
+								>
+									<div className="truncate font-medium text-[var(--inno-text)]">{title}</div>
+									<div className="mt-1 flex items-center gap-1.5">
+										<span className={`rounded px-1.5 text-xs ${typeColor(page.frontmatter?.type)}`}>
+											{page.frontmatter?.type ? t(`notebook.types.${page.frontmatter.type}`) : t("notebook.types.unknown")}
+										</span>
+										<span className="truncate text-xs text-[var(--inno-text-muted)]">{page.frontmatter?.updated || ""}</span>
+									</div>
+								</button>
+								<button
+									className={`absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-muted)] hover:bg-red-50 hover:text-red-600 disabled:opacity-50 ${state.isDeletingPage ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
+									title={t("notebook.delete.button")}
+									disabled={state.isDeletingPage}
+									onClick={(e) => {
+										e.stopPropagation();
+										void handleDelete(page.path, title);
+									}}
+								>
+									<Trash2 size={13} />
+								</button>
+							</div>
 						);
 					})}
 				</div>

--- a/apps/inno-agent/web/src/stores/notebook-store.ts
+++ b/apps/inno-agent/web/src/stores/notebook-store.ts
@@ -3,6 +3,7 @@ import {
 	listWikiPages,
 	getWikiPage,
 	updateWikiPage,
+	deleteWikiPage,
 	getWikiGraph,
 } from "../api/wiki.js";
 import type {
@@ -27,6 +28,7 @@ class NotebookStoreImpl extends EventEmitter<NotebookStoreEvents> {
 	isLoadingGraph = false;
 	isLoadingPage = false;
 	isEditing = false;
+	isDeletingPage = false;
 	editBuffer = "";
 	filterType: WikiPageType | "all" = "all";
 	searchQuery = "";
@@ -161,6 +163,26 @@ class NotebookStoreImpl extends EventEmitter<NotebookStoreEvents> {
 			console.error("Failed to save wiki page:", err);
 		} finally {
 			this.isLoadingPage = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async deletePage(path: string): Promise<void> {
+		this.isDeletingPage = true;
+		this.emit("change", undefined);
+		try {
+			await deleteWikiPage(path);
+			if (this.currentPage?.path === path) {
+				this.currentPage = null;
+				this.isEditing = false;
+			}
+			this.selectedNodeId = null;
+			await Promise.all([this.loadPages(), this.loadGraph()]);
+		} catch (err) {
+			console.error("Failed to delete wiki page:", err);
+			throw err;
+		} finally {
+			this.isDeletingPage = false;
 			this.emit("change", undefined);
 		}
 	}


### PR DESCRIPTION
## Summary
- 笔记本面板支持手动删除 wiki 条目(侧边栏悬停删除按钮 + 确认弹窗,后端 DELETE /api/wiki/page 同步清理 manifest 引用)
- 对话输入框多行显示并随内容增高,到上限后纵向滚动(默认无滚动条,永不出现横向滚动条)
- 大段粘贴(>20 行或 >2000 字符)折叠为内联占位符 `«已粘贴 N 行»`,真实内容发送时替换;占位符前后可继续输入
- ask_user_question 问卷待答时,对话框上方显示主题适配的提示条 + 跳转按钮

## Test plan
- [ ] 笔记本侧边栏 hover 条目,点删除按钮,确认后页面消失且 manifest 引用清理
- [ ] 输入框敲多行,确认变厚到上限后纵向滚动,无横向滚动条
- [ ] 粘贴 >20 行内容,确认显示占位符且前后可继续输入,发送后后端收到真实内容
- [ ] 触发 ask_user_question,确认 composer 上方提示条出现且「查看问卷」可滚动定位
- [ ] 切换四个主题(light/warm/ocean/innospark)确认提示条配色协调