### PR TITLE
Render office files without LibreOffice

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,5 +15,6 @@ docker-compose.yml
 electron/loading.html
 electron/main.js
 build
-scripts
+# Root-only: keep apps/inno-agent/scripts (vendored pptx→svg Python converter)
+/scripts
 docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN npm config set registry https://registry.npmmirror.com && npm ci
 
 # Copy source code
 COPY apps/inno-agent/src apps/inno-agent/src/
+COPY apps/inno-agent/scripts apps/inno-agent/scripts/
 COPY apps/inno-agent/web/src apps/inno-agent/web/src/
 COPY apps/inno-agent/web/vite.config.ts apps/inno-agent/web/index.html apps/inno-agent/web/
 
@@ -25,6 +26,13 @@ RUN npm run build
 # Stage 2: Production runtime — web UI mode
 FROM node:22-bookworm AS runtime
 WORKDIR /app
+
+# python3 is required at runtime for the pptx→svg preview converter
+# (apps/inno-agent/scripts/pptx_to_svg). Stdlib-only, no pip packages.
+RUN sed -i 's|http://deb.debian.org/debian|http://mirrors.tuna.tsinghua.edu.cn/debian|g' /etc/apt/sources.list.d/debian.sources \
+    && apt-get update && apt-get install -y ca-certificates python3 \
+    && sed -i 's|http://mirrors.tuna.tsinghua.edu.cn/debian|https://mirrors.tuna.tsinghua.edu.cn/debian|g' /etc/apt/sources.list.d/debian.sources \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV NODE_ENV=production \
     INNO_HOME=/var/lib/inno-agent \
@@ -44,6 +52,8 @@ COPY --from=build /app/apps/inno-agent/node_modules ./apps/inno-agent/node_modul
 # Copy compiled artifacts from build stage
 COPY --from=build /app/apps/inno-agent/dist ./apps/inno-agent/dist
 COPY --from=build /app/apps/inno-agent/web/dist ./apps/inno-agent/web/dist
+# Vendored Python pptx→svg converter (not compiled by tsc, copied verbatim)
+COPY --from=build /app/apps/inno-agent/scripts ./apps/inno-agent/scripts
 
 #COPY config.example.json /etc/inno-agent/config.json
 #RUN mkdir -p /var/lib/inno-agent/data /var/lib/inno-agent/skills /srv/inno-workspace

--- a/apps/inno-agent/scripts/README.md
+++ b/apps/inno-agent/scripts/README.md
@@ -1,0 +1,31 @@
+# Vendored scripts
+
+## `pptx_to_svg/` + `pptx_to_svg.py` + `console_encoding.py`
+
+Pure-Python PPTX → SVG converter, vendored from the
+[ppt-master](https://github.com/hugohe3/ppt-master) skill
+(`skills/ppt-master/scripts/`).
+
+Used by the backend `/api/workspace/pptx-preview` route (`src/server.ts`) to
+render PowerPoint slides as SVG **without LibreOffice**. Invoked as a
+subprocess:
+
+```
+python3 pptx_to_svg.py <file.pptx> --embed-images --inheritance-mode flat -o <outdir>
+```
+
+### Guarantees / notes
+
+- **Standard library only** — no `pip` dependencies. Reads the `.pptx` ZIP
+  directly and emits shape-level SVG (text, shapes, gradients, tables,
+  base64-embedded images).
+- `console_encoding.py` is imported by the CLI (`configure_utf8_stdio`) and
+  **must stay alongside** `pptx_to_svg.py`.
+- Optional: EMF/WMF assets shell out to ImageMagick (`magick`) if present, and
+  degrade gracefully when it is absent — not a hard dependency.
+- Do **not** edit the Python: internal imports are relative and the CLI does
+  `sys.path.insert(0, <script dir>)` to resolve both the package and the
+  helper from its own directory.
+
+Charts / SmartArt fall back to the PowerPoint-baked preview bitmap when
+present, otherwise a labelled placeholder box.

--- a/apps/inno-agent/scripts/console_encoding.py
+++ b/apps/inno-agent/scripts/console_encoding.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Console encoding helpers for PPT Master CLI scripts."""
+
+from __future__ import annotations
+
+import io
+import sys
+from typing import TextIO
+
+
+def _reconfigure_stream(stream: TextIO) -> TextIO:
+    try:
+        stream.reconfigure(encoding="utf-8", errors="replace")
+        return stream
+    except AttributeError:
+        buffer = getattr(stream, "buffer", None)
+        if buffer is None:
+            return stream
+        return io.TextIOWrapper(buffer, encoding="utf-8", errors="replace")
+    except (OSError, ValueError):
+        return stream
+
+
+def configure_utf8_stdio() -> None:
+    """Use UTF-8 for CLI stdout/stderr, including Windows non-UTF-8 locales."""
+    sys.stdout = _reconfigure_stream(sys.stdout)
+    sys.stderr = _reconfigure_stream(sys.stderr)

--- a/apps/inno-agent/scripts/pptx_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""CLI entry: convert a .pptx file to one SVG per slide.
+
+Usage:
+    python3 pptx_to_svg.py <pptx_file> [-o <output_dir>] [--embed-images]
+                                       [--media-subdir <name>] [--keep-hidden]
+                                       [--inheritance-mode {both,layered,flat}]
+
+Output structure (default --inheritance-mode both):
+    <output_dir>/
+        svg/                    layered machine input: masters/layouts/slides
+        svg-flat/               self-contained visual preview slides
+        <media_subdir>/         (default: assets/)
+            image1.png
+            image2.png
+            ...
+
+If -o is omitted, writes alongside the source file as <pptx_stem>_pptx_to_svg/.
+
+This is the reverse of svg_to_pptx.py: it reads OOXML directly and emits
+shape-level SVG without going through PowerPoint or PDF rendering.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running this script from anywhere
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from console_encoding import configure_utf8_stdio
+from pptx_to_svg import convert_pptx_to_svg
+from pptx_to_svg.converter import ConvertOptions
+
+configure_utf8_stdio()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert .pptx to per-slide SVG by reading OOXML directly.",
+    )
+    parser.add_argument("pptx_file", help="Path to the source .pptx file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="Output directory (default: <pptx_stem>_pptx_to_svg beside source)",
+    )
+    parser.add_argument(
+        "--media-subdir",
+        default="assets",
+        help="Subdirectory for extracted media (default: assets)",
+    )
+    parser.add_argument(
+        "--embed-images",
+        action="store_true",
+        help="Base64-embed images inline instead of writing files",
+    )
+    parser.add_argument(
+        "--keep-hidden",
+        action="store_true",
+        help='Include shapes marked hidden="1"',
+    )
+    parser.add_argument(
+        "--inheritance-mode",
+        choices=("both", "layered", "flat"),
+        default="both",
+        help=(
+            "How to render inheritance. 'both' (default) writes layered SVGs "
+            "under svg/ and complete preview slides under svg-flat/. "
+            "'layered' writes only svg/ plus inheritance.json. 'flat' writes "
+            "self-contained slides under svg/ for backward compatibility."
+        ),
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    pptx_path = Path(args.pptx_file).expanduser().resolve()
+    if not pptx_path.exists():
+        print(f"Error: file does not exist: {pptx_path}", file=sys.stderr)
+        return 1
+    if pptx_path.suffix.lower() != ".pptx":
+        print(f"Error: expected a .pptx file, got: {pptx_path.name}", file=sys.stderr)
+        return 1
+
+    output_dir = (
+        Path(args.output).expanduser().resolve()
+        if args.output
+        else pptx_path.with_name(f"{pptx_path.stem}_pptx_to_svg")
+    )
+
+    options = ConvertOptions(
+        media_subdir=args.media_subdir,
+        embed_images=args.embed_images,
+        keep_hidden=args.keep_hidden,
+        inheritance_mode=args.inheritance_mode,
+    )
+
+    result = convert_pptx_to_svg(pptx_path, output_dir, options)
+
+    print(f"Source: {pptx_path.name}")
+    print(f"Canvas: {result.canvas_px[0]:.0f} x {result.canvas_px[1]:.0f} px")
+    if result.theme_colors:
+        scheme = ", ".join(f"{k}={v}" for k, v in sorted(result.theme_colors.items()))
+        print(f"Theme colors: {scheme}")
+    if result.theme_fonts:
+        fonts = ", ".join(f"{k}={v}" for k, v in result.theme_fonts.items())
+        print(f"Theme fonts: {fonts}")
+    print(f"Slides converted: {len(result.slides)}")
+    print(f"Output: {output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/inno-agent/scripts/pptx_to_svg/__init__.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/__init__.py
@@ -1,0 +1,13 @@
+"""PPTX -> SVG semantic converter (reverse of svg_to_pptx).
+
+Reads OOXML (DrawingML) directly from a .pptx zip archive and emits SVG with
+shape-level fidelity: <p:sp prst="rect"> -> <rect>, <p:txBody> -> <text>, etc.
+
+Public entry: convert_pptx_to_svg().
+"""
+
+from __future__ import annotations
+
+from .converter import convert_pptx_to_svg
+
+__all__ = ["convert_pptx_to_svg"]

--- a/apps/inno-agent/scripts/pptx_to_svg/color_resolver.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/color_resolver.py
@@ -1,0 +1,347 @@
+"""DrawingML color resolution.
+
+Resolves any of the 6 OOXML color types (srgbClr, schemeClr, sysClr, prstClr,
+hslClr, scrgbClr) plus modifiers (tint/shade/lumMod/lumOff/satMod/satOff/
+hueMod/hueOff/alpha) into an (#RRGGBB, alpha) pair.
+
+Theme palette is resolved from the slide master's a:clrMap and theme1.xml's
+a:clrScheme.
+"""
+
+from __future__ import annotations
+
+import colorsys
+from xml.etree import ElementTree as ET
+
+from .emu_units import NS, percent_to_ratio
+from .ooxml_loader import PartRef
+
+
+# ---------------------------------------------------------------------------
+# Preset color names (DrawingML <a:prstClr val="...">)
+# ---------------------------------------------------------------------------
+
+# Source: ECMA-376 ST_PresetColorVal (subset — full list has ~140 entries).
+PRST_COLORS = {
+    "aliceBlue": "F0F8FF", "antiqueWhite": "FAEBD7", "aqua": "00FFFF",
+    "aquamarine": "7FFFD4", "azure": "F0FFFF", "beige": "F5F5DC",
+    "bisque": "FFE4C4", "black": "000000", "blanchedAlmond": "FFEBCD",
+    "blue": "0000FF", "blueViolet": "8A2BE2", "brown": "A52A2A",
+    "burlyWood": "DEB887", "cadetBlue": "5F9EA0", "chartreuse": "7FFF00",
+    "chocolate": "D2691E", "coral": "FF7F50", "cornflowerBlue": "6495ED",
+    "cornsilk": "FFF8DC", "crimson": "DC143C", "cyan": "00FFFF",
+    "darkBlue": "00008B", "darkCyan": "008B8B", "darkGoldenrod": "B8860B",
+    "darkGray": "A9A9A9", "darkGrey": "A9A9A9", "darkGreen": "006400",
+    "darkKhaki": "BDB76B", "darkMagenta": "8B008B", "darkOliveGreen": "556B2F",
+    "darkOrange": "FF8C00", "darkOrchid": "9932CC", "darkRed": "8B0000",
+    "darkSalmon": "E9967A", "darkSeaGreen": "8FBC8F", "darkSlateBlue": "483D8B",
+    "darkSlateGray": "2F4F4F", "darkSlateGrey": "2F4F4F",
+    "darkTurquoise": "00CED1", "darkViolet": "9400D3", "deepPink": "FF1493",
+    "deepSkyBlue": "00BFFF", "dimGray": "696969", "dimGrey": "696969",
+    "dkBlue": "00008B", "dkCyan": "008B8B", "dkGoldenrod": "B8860B",
+    "dkGray": "A9A9A9", "dkGrey": "A9A9A9", "dkGreen": "006400",
+    "dkKhaki": "BDB76B", "dkMagenta": "8B008B", "dkOliveGreen": "556B2F",
+    "dkOrange": "FF8C00", "dkOrchid": "9932CC", "dkRed": "8B0000",
+    "dkSalmon": "E9967A", "dkSeaGreen": "8FBC8F", "dkSlateBlue": "483D8B",
+    "dkSlateGray": "2F4F4F", "dkSlateGrey": "2F4F4F",
+    "dkTurquoise": "00CED1", "dkViolet": "9400D3",
+    "dodgerBlue": "1E90FF", "firebrick": "B22222", "floralWhite": "FFFAF0",
+    "forestGreen": "228B22", "fuchsia": "FF00FF", "gainsboro": "DCDCDC",
+    "ghostWhite": "F8F8FF", "gold": "FFD700", "goldenrod": "DAA520",
+    "gray": "808080", "grey": "808080", "green": "008000",
+    "greenYellow": "ADFF2F", "honeydew": "F0FFF0", "hotPink": "FF69B4",
+    "indianRed": "CD5C5C", "indigo": "4B0082", "ivory": "FFFFF0",
+    "khaki": "F0E68C", "lavender": "E6E6FA", "lavenderBlush": "FFF0F5",
+    "lawnGreen": "7CFC00", "lemonChiffon": "FFFACD",
+    "lightBlue": "ADD8E6", "lightCoral": "F08080", "lightCyan": "E0FFFF",
+    "lightGoldenrodYellow": "FAFAD2", "lightGray": "D3D3D3",
+    "lightGrey": "D3D3D3", "lightGreen": "90EE90", "lightPink": "FFB6C1",
+    "lightSalmon": "FFA07A", "lightSeaGreen": "20B2AA",
+    "lightSkyBlue": "87CEFA", "lightSlateGray": "778899",
+    "lightSlateGrey": "778899", "lightSteelBlue": "B0C4DE",
+    "lightYellow": "FFFFE0", "ltBlue": "ADD8E6", "ltCoral": "F08080",
+    "ltCyan": "E0FFFF", "ltGoldenrodYellow": "FAFAD2", "ltGray": "D3D3D3",
+    "ltGrey": "D3D3D3", "ltGreen": "90EE90", "ltPink": "FFB6C1",
+    "ltSalmon": "FFA07A", "ltSeaGreen": "20B2AA", "ltSkyBlue": "87CEFA",
+    "ltSlateGray": "778899", "ltSlateGrey": "778899",
+    "ltSteelBlue": "B0C4DE", "ltYellow": "FFFFE0",
+    "lime": "00FF00", "limeGreen": "32CD32", "linen": "FAF0E6",
+    "magenta": "FF00FF", "maroon": "800000", "medAquamarine": "66CDAA",
+    "medBlue": "0000CD", "medOrchid": "BA55D3", "medPurple": "9370DB",
+    "medSeaGreen": "3CB371", "medSlateBlue": "7B68EE",
+    "medSpringGreen": "00FA9A", "medTurquoise": "48D1CC",
+    "medVioletRed": "C71585", "mediumAquamarine": "66CDAA",
+    "mediumBlue": "0000CD", "mediumOrchid": "BA55D3", "mediumPurple": "9370DB",
+    "mediumSeaGreen": "3CB371", "mediumSlateBlue": "7B68EE",
+    "mediumSpringGreen": "00FA9A", "mediumTurquoise": "48D1CC",
+    "mediumVioletRed": "C71585",
+    "midnightBlue": "191970", "mintCream": "F5FFFA", "mistyRose": "FFE4E1",
+    "moccasin": "FFE4B5", "navajoWhite": "FFDEAD", "navy": "000080",
+    "oldLace": "FDF5E6", "olive": "808000", "oliveDrab": "6B8E23",
+    "orange": "FFA500", "orangeRed": "FF4500", "orchid": "DA70D6",
+    "paleGoldenrod": "EEE8AA", "paleGreen": "98FB98", "paleTurquoise": "AFEEEE",
+    "paleVioletRed": "DB7093", "papayaWhip": "FFEFD5", "peachPuff": "FFDAB9",
+    "peru": "CD853F", "pink": "FFC0CB", "plum": "DDA0DD",
+    "powderBlue": "B0E0E6", "purple": "800080", "red": "FF0000",
+    "rosyBrown": "BC8F8F", "royalBlue": "4169E1", "saddleBrown": "8B4513",
+    "salmon": "FA8072", "sandyBrown": "F4A460", "seaGreen": "2E8B57",
+    "seaShell": "FFF5EE", "sienna": "A0522D", "silver": "C0C0C0",
+    "skyBlue": "87CEEB", "slateBlue": "6A5ACD", "slateGray": "708090",
+    "slateGrey": "708090", "snow": "FFFAFA", "springGreen": "00FF7F",
+    "steelBlue": "4682B4", "tan": "D2B48C", "teal": "008080",
+    "thistle": "D8BFD8", "tomato": "FF6347", "turquoise": "40E0D0",
+    "violet": "EE82EE", "wheat": "F5DEB3", "white": "FFFFFF",
+    "whiteSmoke": "F5F5F5", "yellow": "FFFF00", "yellowGreen": "9ACD32",
+}
+
+
+# Scheme color name normalization
+SCHEME_ALIASES = {
+    "bg1": "lt1", "bg2": "lt2",
+    "tx1": "dk1", "tx2": "dk2",
+}
+
+
+# ---------------------------------------------------------------------------
+# ColorPalette
+# ---------------------------------------------------------------------------
+
+class ColorPalette:
+    """Resolves scheme colors via the master's a:clrMap + theme1's a:clrScheme.
+
+    a:clrMap remaps presentation-level scheme names (bg1/tx1) to theme-level
+    names (lt1/dk1) — this is rarely overridden but must be honored.
+    """
+
+    def __init__(self, master: PartRef | None, theme: PartRef | None) -> None:
+        self.scheme: dict[str, str] = {}
+        self.clr_map: dict[str, str] = {}
+        if theme is not None:
+            self._load_scheme(theme.xml)
+        if master is not None:
+            self._load_clr_map(master.xml)
+
+    def _load_scheme(self, theme_root: ET.Element) -> None:
+        clr_scheme = theme_root.find(".//a:clrScheme", NS)
+        if clr_scheme is None:
+            return
+        for child in list(clr_scheme):
+            if not isinstance(child.tag, str):
+                continue
+            name = child.tag.split("}", 1)[-1]
+            srgb = child.find("a:srgbClr", NS)
+            sys_clr = child.find("a:sysClr", NS)
+            if srgb is not None and srgb.attrib.get("val"):
+                self.scheme[name] = srgb.attrib["val"].upper()
+            elif sys_clr is not None:
+                last = sys_clr.attrib.get("lastClr")
+                if last:
+                    self.scheme[name] = last.upper()
+
+    def _load_clr_map(self, master_root: ET.Element) -> None:
+        clr_map = master_root.find("p:clrMap", NS)
+        if clr_map is None:
+            return
+        # Each attribute on clrMap is a remap: bg1="lt1" tx1="dk1" ...
+        for attr, val in clr_map.attrib.items():
+            self.clr_map[attr] = val
+
+    def resolve_scheme(self, name: str) -> str | None:
+        """scheme name (e.g. 'accent1', 'bg1') -> 'RRGGBB'. None on miss."""
+        # apply clrMap remap (bg1 -> lt1, tx1 -> dk1, etc.)
+        mapped = self.clr_map.get(name, name)
+        # canonical alias (bg1 -> lt1)
+        mapped = SCHEME_ALIASES.get(mapped, mapped)
+        return self.scheme.get(mapped)
+
+
+# ---------------------------------------------------------------------------
+# Color resolution
+# ---------------------------------------------------------------------------
+
+# All concrete color element names under the a: namespace.
+COLOR_TAGS = ("srgbClr", "schemeClr", "sysClr", "prstClr",
+              "hslClr", "scrgbClr")
+
+
+def find_color_elem(parent: ET.Element | None) -> ET.Element | None:
+    """Return the first child color element (any of the 6 OOXML color tags)."""
+    if parent is None:
+        return None
+    for tag in COLOR_TAGS:
+        elem = parent.find(f"a:{tag}", NS)
+        if elem is not None:
+            return elem
+    return None
+
+
+def resolve_color(
+    color_elem: ET.Element | None,
+    palette: ColorPalette | None,
+    *,
+    placeholder_hex: str | None = None,
+) -> tuple[str | None, float]:
+    """Resolve a color element to (#RRGGBB, alpha).
+
+    Args:
+        color_elem: a:srgbClr / a:schemeClr / etc. May be None.
+        palette: ColorPalette for resolving schemeClr.
+        placeholder_hex: when a child uses schemeClr val="phClr" (placeholder
+            color used inside theme styles), substitute this hex.
+
+    Returns:
+        (hex string with leading '#', alpha in [0,1]) or (None, 1.0) on failure.
+    """
+    if color_elem is None:
+        return None, 1.0
+
+    tag = color_elem.tag.split("}", 1)[-1]
+    base_hex: str | None = None
+    alpha: float = 1.0
+
+    if tag == "srgbClr":
+        val = color_elem.attrib.get("val", "")
+        base_hex = _normalize_hex(val)
+    elif tag == "schemeClr":
+        name = color_elem.attrib.get("val", "")
+        if name == "phClr":
+            base_hex = _normalize_hex(placeholder_hex) if placeholder_hex else None
+        elif palette is not None:
+            base_hex = palette.resolve_scheme(name)
+    elif tag == "sysClr":
+        last = color_elem.attrib.get("lastClr") or color_elem.attrib.get("val")
+        base_hex = _normalize_hex(last) if last else None
+    elif tag == "prstClr":
+        name = color_elem.attrib.get("val", "")
+        base_hex = PRST_COLORS.get(name)
+    elif tag == "hslClr":
+        # DrawingML hue is in 1/60000 deg ([0, 21_600_000) maps to [0°, 360°));
+        # _hsl_to_hex expects a fraction in [0, 1), so divide by 60000 * 360.
+        h = float(color_elem.attrib.get("hue", "0")) / 21_600_000.0
+        s = float(color_elem.attrib.get("sat", "0")) / 100000.0
+        lum = float(color_elem.attrib.get("lum", "0")) / 100000.0
+        base_hex = _hsl_to_hex(h, s, lum)
+    elif tag == "scrgbClr":
+        # 0..100000 per channel
+        r = float(color_elem.attrib.get("r", "0")) / 100000.0
+        g = float(color_elem.attrib.get("g", "0")) / 100000.0
+        b = float(color_elem.attrib.get("b", "0")) / 100000.0
+        base_hex = _rgb01_to_hex(r, g, b)
+
+    if base_hex is None:
+        return None, 1.0
+
+    # Apply modifiers (children of the color element).
+    base_hex, alpha = _apply_modifiers(base_hex, color_elem)
+    return f"#{base_hex}", alpha
+
+
+def _apply_modifiers(hex_color: str, color_elem: ET.Element) -> tuple[str, float]:
+    """Apply tint / shade / lumMod / lumOff / satMod / hueMod / alpha modifiers
+    in document order. DrawingML stacks these on the color in order.
+    """
+    r, g, b = _hex_to_rgb01(hex_color)
+    # Convert to HSL for luminance/saturation ops; convert back when emitting.
+    h, lum, sat = colorsys.rgb_to_hls(r, g, b)
+    alpha = 1.0
+
+    for child in list(color_elem):
+        if not isinstance(child.tag, str):
+            continue
+        tag = child.tag.split("}", 1)[-1]
+        val_ratio = percent_to_ratio(child.attrib.get("val"), default=0.0)
+
+        if tag == "tint":
+            # Tint blends toward white. r' = r + (1-r)*(1-val) is the common
+            # interpretation; OOXML actually defines tint on luminance.
+            # Use luminance-based tint per ECMA-376.
+            lum = lum * val_ratio + (1.0 - val_ratio)
+        elif tag == "shade":
+            # Shade blends toward black on luminance.
+            lum = lum * val_ratio
+        elif tag == "lumMod":
+            lum = lum * val_ratio
+        elif tag == "lumOff":
+            lum = lum + val_ratio
+        elif tag == "satMod":
+            sat = sat * val_ratio
+        elif tag == "satOff":
+            sat = sat + val_ratio
+        elif tag == "hueMod":
+            h = (h * val_ratio) % 1.0
+        elif tag == "hueOff":
+            # hueOff is in 1/60000 deg
+            try:
+                deg = float(child.attrib.get("val", "0")) / 60000.0
+            except ValueError:
+                deg = 0.0
+            h = (h + deg / 360.0) % 1.0
+        elif tag == "alpha":
+            alpha = max(0.0, min(1.0, val_ratio))
+        elif tag == "alphaMod":
+            alpha *= val_ratio
+        elif tag == "alphaOff":
+            alpha = max(0.0, min(1.0, alpha + val_ratio))
+        elif tag == "gray":
+            # Convert to grayscale based on luminance.
+            sat = 0.0
+        elif tag == "comp":
+            # Complement: hue rotated 180°
+            h = (h + 0.5) % 1.0
+        elif tag == "inv":
+            # RGB invert
+            rr, gg, bb = colorsys.hls_to_rgb(h, lum, sat)
+            rr, gg, bb = 1.0 - rr, 1.0 - gg, 1.0 - bb
+            h, lum, sat = colorsys.rgb_to_hls(rr, gg, bb)
+
+        # Clamp luminance / saturation to [0,1]
+        lum = max(0.0, min(1.0, lum))
+        sat = max(0.0, min(1.0, sat))
+
+    rr, gg, bb = colorsys.hls_to_rgb(h, lum, sat)
+    return _rgb01_to_hex(rr, gg, bb), alpha
+
+
+# ---------------------------------------------------------------------------
+# Hex / RGB / HSL helpers
+# ---------------------------------------------------------------------------
+
+def _normalize_hex(value: str | None) -> str | None:
+    """Strip '#' and validate 6-digit hex. Return uppercase or None on failure."""
+    if value is None:
+        return None
+    v = value.strip()
+    if v.startswith("#"):
+        v = v[1:]
+    if len(v) == 3:
+        v = "".join(c * 2 for c in v)
+    if len(v) != 6:
+        return None
+    try:
+        int(v, 16)
+    except ValueError:
+        return None
+    return v.upper()
+
+
+def _hex_to_rgb01(hex_color: str) -> tuple[float, float, float]:
+    h = _normalize_hex(hex_color) or "000000"
+    r = int(h[0:2], 16) / 255.0
+    g = int(h[2:4], 16) / 255.0
+    b = int(h[4:6], 16) / 255.0
+    return r, g, b
+
+
+def _rgb01_to_hex(r: float, g: float, b: float) -> str:
+    r = max(0.0, min(1.0, r))
+    g = max(0.0, min(1.0, g))
+    b = max(0.0, min(1.0, b))
+    return f"{int(round(r * 255)):02X}{int(round(g * 255)):02X}{int(round(b * 255)):02X}"
+
+
+def _hsl_to_hex(h: float, s: float, l: float) -> str:
+    h = h % 1.0 if h != 1.0 else 1.0
+    s = max(0.0, min(1.0, s))
+    l = max(0.0, min(1.0, l))
+    r, g, b = colorsys.hls_to_rgb(h, l, s)
+    return _rgb01_to_hex(r, g, b)

--- a/apps/inno-agent/scripts/pptx_to_svg/converter.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/converter.py
@@ -1,0 +1,443 @@
+"""Top-level orchestrator for PPTX -> SVG conversion.
+
+Public API: convert_pptx_to_svg(pptx_path, output_dir, options).
+
+Composes the per-slide pipeline:
+    OoxmlPackage -> shape_walker.walk_sp_tree
+                 -> per-shape dispatch (prstgeom / txbody / pic / ...)
+                 -> assembled SVG text + extracted media files
+
+Stages B-F will fill in the per-shape dispatch. For Stage A this entry just
+loads the package and reports basic per-slide structure to verify wiring.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+
+from .color_resolver import ColorPalette
+from .emu_units import NS
+from .ooxml_loader import OoxmlPackage, PartRef, SlideRef
+from .slide_to_svg import assemble_part_solo, assemble_slide
+
+
+def _extract_theme_info(
+    theme: PartRef,
+    palette: ColorPalette,
+) -> tuple[dict[str, str], dict[str, str]]:
+    from .color_resolver import find_color_elem, resolve_color
+
+    colors: dict[str, str] = {}
+    fonts: dict[str, str] = {}
+
+    scheme = theme.xml.find(".//a:clrScheme", NS)
+    if scheme is not None:
+        for child in list(scheme):
+            if not isinstance(child.tag, str):
+                continue
+            name = child.tag.split("}", 1)[-1]
+            color_elem = find_color_elem(child)
+            hex_, _ = resolve_color(color_elem, palette)
+            if hex_:
+                colors[name] = hex_
+
+    font_scheme = theme.xml.find(".//a:fontScheme", NS)
+    if font_scheme is not None:
+        for slot in ("majorFont", "minorFont"):
+            fnt = font_scheme.find(f"a:{slot}", NS)
+            if fnt is None:
+                continue
+            role_prefix = "major" if slot == "majorFont" else "minor"
+            latin = fnt.find("a:latin", NS)
+            if latin is not None and latin.attrib.get("typeface"):
+                fonts[f"{role_prefix}Latin"] = latin.attrib["typeface"]
+            ea = fnt.find("a:ea", NS)
+            if ea is not None and ea.attrib.get("typeface"):
+                fonts[f"{role_prefix}EastAsia"] = ea.attrib["typeface"]
+            cs = fnt.find("a:cs", NS)
+            if cs is not None and cs.attrib.get("typeface"):
+                fonts[f"{role_prefix}ComplexScript"] = cs.attrib["typeface"]
+
+    return colors, fonts
+
+
+@dataclass
+class ConvertOptions:
+    """Convert behavior knobs.
+
+    media_subdir: where to write media files relative to output_dir. SVG image
+        href will use './<media_subdir>/<filename>'.
+    embed_images: when True, base64-encode images inline instead of writing
+        files. Default False (matches svg_to_pptx default of external images).
+    keep_hidden: include shapes marked hidden="1". Default False.
+    inheritance_mode: how to render master/layout shapes per slide SVG.
+        - "both" (default): emit both views — layered under svg/ for template
+          designers (master/layout/slide as separate files) and flat under
+          svg-flat/ for previewers (each slide self-contained). Costs roughly
+          1.3-1.5× converter time and ~1.6-2× disk vs. either single mode.
+        - "layered": skip inherited shapes inside the slide. The orchestrator
+          renders every master and layout to its own SVG, plus
+          svg/inheritance.json describing the reuse graph. Optimised for
+          template authors who need to see "what is shared vs. unique".
+        - "flat": inline inherited shapes into every slide. Used by
+          svg_to_pptx round-trip and any caller that wants self-contained
+          slides (preview pages, screenshot pipelines).
+    """
+
+    media_subdir: str = "assets"
+    embed_images: bool = False
+    keep_hidden: bool = False
+    inheritance_mode: str = "both"
+    asset_name_map: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class PartArtifact:
+    """Result of converting a master or layout part to SVG (layered mode only)."""
+
+    role: str  # "master" | "layout"
+    part_path: str  # OOXML part path, e.g. "ppt/slideLayouts/slideLayout3.xml"
+    filename: str  # output svg filename, e.g. "layout_03_title.xml.svg"
+    svg: str
+    media_files: dict[str, bytes] = field(default_factory=dict)
+    parent_master_part_path: str | None = None
+    theme_part_path: str | None = None
+
+
+@dataclass
+class SlideArtifact:
+    """Result of converting a single slide."""
+
+    index: int  # 1-based
+    svg: str
+    media_files: dict[str, bytes] = field(default_factory=dict)
+    layout_part_path: str | None = None
+    master_part_path: str | None = None
+
+
+@dataclass
+class ConvertResult:
+    """Result of converting an entire .pptx.
+
+    ``slides`` holds the layered/primary view (or, in pure flat mode, the flat
+    view). ``flat_slides`` is populated only in ``"both"`` mode and contains
+    self-contained renderings of every slide; callers that don't care about
+    the flat view can ignore it.
+    """
+
+    slides: list[SlideArtifact] = field(default_factory=list)
+    canvas_px: tuple[float, float] = (1280.0, 720.0)
+    theme_colors: dict[str, str] = field(default_factory=dict)
+    theme_fonts: dict[str, str] = field(default_factory=dict)
+    layouts: list[PartArtifact] = field(default_factory=list)
+    masters: list[PartArtifact] = field(default_factory=list)
+    flat_slides: list[SlideArtifact] = field(default_factory=list)
+    master_themes: dict[str, dict[str, object]] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Entry
+# ---------------------------------------------------------------------------
+
+def convert_pptx_to_svg(
+    pptx_path: Path,
+    output_dir: Path | None = None,
+    options: ConvertOptions | None = None,
+) -> ConvertResult:
+    """Convert a .pptx file to one SVG per slide.
+
+    Args:
+        pptx_path: Source .pptx file.
+        output_dir: When given, write svg/<slide_NN>.svg + media files there.
+            When None, files are not written; callers can read SlideArtifact.svg.
+        options: ConvertOptions; defaults to ConvertOptions().
+
+    Returns:
+        ConvertResult with per-slide SVG strings and resolved theme info.
+    """
+    options = options or ConvertOptions()
+    if options.inheritance_mode not in {"flat", "layered", "both"}:
+        raise ValueError(
+            f"inheritance_mode must be 'flat', 'layered', or 'both', "
+            f"got {options.inheritance_mode!r}"
+        )
+    emit_layered = options.inheritance_mode in {"layered", "both"}
+    emit_flat = options.inheritance_mode in {"flat", "both"}
+    result = ConvertResult()
+
+    with OoxmlPackage(pptx_path) as pkg:
+        result.canvas_px = pkg.slide_size_px
+
+        # Default theme summary is kept for compatibility; conversion itself
+        # resolves palette/fonts per slide master.
+        first_slide = pkg.get_slide(1)
+        default_master = first_slide.master if first_slide else None
+        default_theme = pkg.resolve_theme(default_master)
+        palette = ColorPalette(default_master, default_theme)
+        if default_theme is not None:
+            result.theme_colors, result.theme_fonts = _extract_theme_info(default_theme, palette)
+
+        for master in pkg.iter_all_masters():
+            theme = pkg.resolve_theme(master) or default_theme
+            pal = ColorPalette(master, theme)
+            colors, fonts = _extract_theme_info(theme, pal) if theme is not None else ({}, {})
+            result.master_themes[master.path] = {
+                "themePath": theme.path if theme is not None else None,
+                "colors": colors,
+                "fonts": fonts,
+            }
+
+        # Per-slide conversion. The primary view is layered when emitted
+        # (template designers care most about that one); the flat view is
+        # rendered alongside when needed.
+        primary_mode = "layered" if emit_layered else "flat"
+        for slide in pkg.iter_slides():
+            slide_theme = pkg.resolve_theme(slide.master) or default_theme
+            slide_palette = ColorPalette(slide.master, slide_theme)
+            _colors, slide_fonts = _extract_theme_info(slide_theme, slide_palette) if slide_theme is not None else ({}, result.theme_fonts)
+            artifact = _convert_slide(
+                pkg, slide, slide_palette, options, slide_fonts,
+                inheritance_mode=primary_mode,
+            )
+            result.slides.append(artifact)
+        if emit_layered and emit_flat:
+            for slide in pkg.iter_slides():
+                slide_theme = pkg.resolve_theme(slide.master) or default_theme
+                slide_palette = ColorPalette(slide.master, slide_theme)
+                _colors, slide_fonts = _extract_theme_info(slide_theme, slide_palette) if slide_theme is not None else ({}, result.theme_fonts)
+                artifact = _convert_slide(
+                    pkg, slide, slide_palette, options, slide_fonts,
+                    inheritance_mode="flat",
+                )
+                result.flat_slides.append(artifact)
+
+        # Layered mode: also render each master / layout once.
+        if emit_layered:
+            _convert_inheritance_parts(pkg, default_theme, options, result)
+
+    if output_dir is not None:
+        _write_artifacts(output_dir, result, options)
+
+    return result
+
+
+def _convert_slide(
+    pkg: OoxmlPackage,
+    slide: SlideRef,
+    palette: ColorPalette,
+    options: ConvertOptions,
+    theme_fonts: dict[str, str] | None = None,
+    *,
+    inheritance_mode: str | None = None,
+) -> SlideArtifact:
+    """Convert a single slide via the full shape pipeline.
+
+    ``inheritance_mode`` overrides ``options.inheritance_mode`` so the
+    orchestrator can render the same slide twice (once layered, once flat)
+    when the user asked for ``"both"``. Pass ``"flat"`` or ``"layered"``;
+    ``None`` falls back to ``options.inheritance_mode`` (used by direct
+    callers that want a single mode).
+    """
+    mode = inheritance_mode or options.inheritance_mode
+    if mode == "both":
+        mode = "layered"  # primary view in both-mode
+    svg, media = assemble_slide(
+        pkg, slide, palette,
+        theme_fonts=theme_fonts,
+        media_subdir=options.media_subdir,
+        embed_images=options.embed_images,
+        keep_hidden=options.keep_hidden,
+        inheritance_mode=mode,
+        asset_name_map=options.asset_name_map,
+    )
+    return SlideArtifact(
+        index=slide.index,
+        svg=svg,
+        media_files=media,
+        layout_part_path=slide.layout.path if slide.layout else None,
+        master_part_path=slide.master.path if slide.master else None,
+    )
+
+
+def _convert_inheritance_parts(
+    pkg: OoxmlPackage,
+    default_theme: PartRef | None,
+    options: ConvertOptions,
+    result: ConvertResult,
+) -> None:
+    """Render every master and layout in the deck to its own SVG (layered mode).
+
+    We deliberately render *all* masters / layouts, not only the ones a slide
+    references. Multi-style template packages routinely ship more design
+    surfaces than the embedded sample slides exercise, and dropping unused
+    ones discards the bulk of the template's design intent.
+    """
+    # Collect unique parts in document order so output filenames are
+    # deterministic for a given .pptx.
+    seen_masters: dict[str, PartRef] = {}
+    for master in pkg.iter_all_masters():
+        if master.path not in seen_masters:
+            seen_masters[master.path] = master
+
+    layouts_with_parent: list[tuple[PartRef, PartRef]] = []
+    seen_layout_paths: set[str] = set()
+    for layout, parent_master in pkg.iter_all_layouts_with_parent():
+        if layout.path in seen_layout_paths:
+            continue
+        seen_layout_paths.add(layout.path)
+        layouts_with_parent.append((layout, parent_master))
+
+    for seq, part in enumerate(seen_masters.values(), start=1):
+        theme = pkg.resolve_theme(part) or default_theme
+        palette = ColorPalette(part, theme)
+        _colors, fonts = _extract_theme_info(theme, palette) if theme is not None else ({}, result.theme_fonts)
+        result.masters.append(_render_part(
+            pkg, part, palette, options, fonts,
+            role="master", seq=seq, theme_part=theme,
+        ))
+    for seq, (layout, parent_master) in enumerate(layouts_with_parent, start=1):
+        theme = pkg.resolve_theme(parent_master) or default_theme
+        palette = ColorPalette(parent_master, theme)
+        _colors, fonts = _extract_theme_info(theme, palette) if theme is not None else ({}, result.theme_fonts)
+        result.layouts.append(_render_part(
+            pkg, layout, palette, options, fonts,
+            role="layout", seq=seq, parent_master=parent_master,
+            theme_part=theme,
+        ))
+
+
+def _render_part(
+    pkg: OoxmlPackage,
+    part: PartRef,
+    palette: ColorPalette,
+    options: ConvertOptions,
+    theme_fonts: dict[str, str],
+    *,
+    role: str,
+    seq: int,
+    parent_master: PartRef | None = None,
+    theme_part: PartRef | None = None,
+) -> PartArtifact:
+    """Render a master/layout part, returning a PartArtifact with output filename."""
+    svg, media = assemble_part_solo(
+        pkg, part, palette,
+        role=role,
+        parent_master=parent_master,
+        theme_fonts=theme_fonts,
+        media_subdir=options.media_subdir,
+        embed_images=options.embed_images,
+        keep_hidden=options.keep_hidden,
+        asset_name_map=options.asset_name_map,
+    )
+    stem = PurePosixPath(part.path).stem  # e.g. "slideLayout3"
+    safe_stem = re.sub(r"[^A-Za-z0-9_-]+", "_", stem).strip("_") or role
+    filename = f"{role}_{seq:02d}_{safe_stem}.svg"
+    return PartArtifact(
+        role=role,
+        part_path=part.path,
+        filename=filename,
+        svg=svg,
+        media_files=media,
+        parent_master_part_path=parent_master.path if parent_master is not None else None,
+        theme_part_path=theme_part.path if theme_part is not None else None,
+    )
+
+
+def _write_artifacts(output_dir: Path, result: ConvertResult,
+                     options: ConvertOptions) -> None:
+    """Write SVG + media files to output_dir.
+
+    Layout:
+      - ``svg/``        primary view (layered when emitted, otherwise flat)
+      - ``svg-flat/``   self-contained per-slide renders (only in "both" mode)
+      - ``<media_subdir>/`` shared image assets, referenced by both views
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    svg_dir = output_dir / "svg"
+    svg_dir.mkdir(exist_ok=True)
+    media_dir = output_dir / options.media_subdir
+    media_written: set[str] = set()
+
+    def _write_media(media: dict[str, bytes]) -> None:
+        for filename, blob in media.items():
+            if filename in media_written:
+                continue
+            media_dir.mkdir(parents=True, exist_ok=True)
+            target = media_dir / filename
+            if target.exists():
+                if target.read_bytes() != blob:
+                    raise RuntimeError(f"Asset filename collision with different bytes: {filename}")
+            else:
+                target.write_bytes(blob)
+            media_written.add(filename)
+
+    # Layered mode: write masters and layouts first so they sort ahead of slides.
+    for art in result.masters:
+        (svg_dir / art.filename).write_text(art.svg, encoding="utf-8")
+        _write_media(art.media_files)
+    for art in result.layouts:
+        (svg_dir / art.filename).write_text(art.svg, encoding="utf-8")
+        _write_media(art.media_files)
+
+    # Slides (primary view).
+    for art in result.slides:
+        target = svg_dir / f"slide_{art.index:02d}.svg"
+        target.write_text(art.svg, encoding="utf-8")
+        _write_media(art.media_files)
+
+    # Inheritance graph alongside the layered SVGs (only meaningful when we
+    # actually emitted a layered view).
+    if options.inheritance_mode in {"layered", "both"}:
+        _write_inheritance_json(svg_dir, result)
+
+    # Flat companion view (only when result.flat_slides is populated).
+    if result.flat_slides:
+        flat_dir = output_dir / "svg-flat"
+        flat_dir.mkdir(exist_ok=True)
+        for art in result.flat_slides:
+            target = flat_dir / f"slide_{art.index:02d}.svg"
+            target.write_text(art.svg, encoding="utf-8")
+            _write_media(art.media_files)
+
+
+def _write_inheritance_json(svg_dir: Path, result: ConvertResult) -> None:
+    """Record which layout/master each slide consumes (layered mode only)."""
+    layout_by_path = {art.part_path: art.filename for art in result.layouts}
+    master_by_path = {art.part_path: art.filename for art in result.masters}
+
+    inheritance = {
+        "masters": [
+            {
+                "file": art.filename,
+                "partPath": art.part_path,
+                "themePath": art.theme_part_path,
+            }
+            for art in result.masters
+        ],
+        "layouts": [
+            {
+                "file": art.filename,
+                "partPath": art.part_path,
+                "master": master_by_path.get(art.parent_master_part_path or ""),
+                "parentPartPath": art.parent_master_part_path,
+                "themePath": art.theme_part_path,
+            }
+            for art in result.layouts
+        ],
+        "slides": [
+            {
+                "file": f"slide_{slide.index:02d}.svg",
+                "index": slide.index,
+                "layout": layout_by_path.get(slide.layout_part_path or ""),
+                "master": master_by_path.get(slide.master_part_path or ""),
+            }
+            for slide in result.slides
+        ],
+    }
+    (svg_dir / "inheritance.json").write_text(
+        json.dumps(inheritance, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )

--- a/apps/inno-agent/scripts/pptx_to_svg/custgeom_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/custgeom_to_svg.py
@@ -1,0 +1,192 @@
+"""DrawingML <a:custGeom> -> SVG <path d="..."> conversion.
+
+Reverse of svg_to_pptx/drawingml_paths.path_commands_to_drawingml.
+
+Path command mapping:
+    <a:moveTo>      -> M
+    <a:lnTo>        -> L
+    <a:cubicBezTo>  -> C
+    <a:quadBezTo>   -> Q
+    <a:arcTo>       -> A   (DrawingML uses center + sweep angles; we convert
+                            to SVG endpoint parameterization)
+    <a:close/>      -> Z
+
+DrawingML <a:path w="..." h="..."> defines a local EMU coordinate system. We
+remap path coordinates from path-local to slide-absolute pixels using the
+shape's xfrm.
+"""
+
+from __future__ import annotations
+
+import math
+from xml.etree import ElementTree as ET
+
+from .emu_units import NS, Xfrm, emu_to_px, fmt_num
+
+
+def convert_custom_geom(
+    cust_geom: ET.Element,
+    xfrm: Xfrm,
+) -> str | None:
+    """Return an SVG path d="..." string in slide-absolute coordinates, or None.
+    """
+    path_lst = cust_geom.find("a:pathLst", NS)
+    if path_lst is None:
+        return None
+
+    paths = path_lst.findall("a:path", NS)
+    if not paths:
+        return None
+
+    d_segments: list[str] = []
+    for path_elem in paths:
+        d = _convert_one_path(path_elem, xfrm)
+        if d:
+            d_segments.append(d)
+
+    if not d_segments:
+        return None
+    return " ".join(d_segments)
+
+
+def _convert_one_path(path_elem: ET.Element, xfrm: Xfrm) -> str:
+    """Convert a single <a:path> to SVG path commands (slide-absolute coords)."""
+    try:
+        path_w_emu = int(path_elem.attrib.get("w", "0"))
+        path_h_emu = int(path_elem.attrib.get("h", "0"))
+    except ValueError:
+        return ""
+    path_w_px = emu_to_px(path_w_emu) if path_w_emu else xfrm.w
+    path_h_px = emu_to_px(path_h_emu) if path_h_emu else xfrm.h
+    if path_w_px <= 0 or path_h_px <= 0:
+        return ""
+    sx = xfrm.w / path_w_px if path_w_px else 1.0
+    sy = xfrm.h / path_h_px if path_h_px else 1.0
+
+    def map_pt(x_emu: float, y_emu: float) -> tuple[float, float]:
+        x = emu_to_px(x_emu) * sx + xfrm.x
+        y = emu_to_px(y_emu) * sy + xfrm.y
+        return x, y
+
+    # Track current point so a:arcTo (center-based) can compute its endpoint
+    cx, cy = 0.0, 0.0  # slide-absolute pixels
+
+    parts: list[str] = []
+    for child in list(path_elem):
+        if not isinstance(child.tag, str):
+            continue
+        local = child.tag.split("}", 1)[-1]
+        if local == "moveTo":
+            pt = child.find("a:pt", NS)
+            if pt is None:
+                continue
+            x, y = _read_pt(pt, map_pt)
+            parts.append(f"M {fmt_num(x)} {fmt_num(y)}")
+            cx, cy = x, y
+        elif local == "lnTo":
+            pt = child.find("a:pt", NS)
+            if pt is None:
+                continue
+            x, y = _read_pt(pt, map_pt)
+            parts.append(f"L {fmt_num(x)} {fmt_num(y)}")
+            cx, cy = x, y
+        elif local == "cubicBezTo":
+            pts = child.findall("a:pt", NS)
+            if len(pts) < 3:
+                continue
+            p1 = _read_pt(pts[0], map_pt)
+            p2 = _read_pt(pts[1], map_pt)
+            p3 = _read_pt(pts[2], map_pt)
+            parts.append(
+                f"C {fmt_num(p1[0])} {fmt_num(p1[1])} "
+                f"{fmt_num(p2[0])} {fmt_num(p2[1])} "
+                f"{fmt_num(p3[0])} {fmt_num(p3[1])}"
+            )
+            cx, cy = p3
+        elif local == "quadBezTo":
+            pts = child.findall("a:pt", NS)
+            if len(pts) < 2:
+                continue
+            p1 = _read_pt(pts[0], map_pt)
+            p2 = _read_pt(pts[1], map_pt)
+            parts.append(
+                f"Q {fmt_num(p1[0])} {fmt_num(p1[1])} "
+                f"{fmt_num(p2[0])} {fmt_num(p2[1])}"
+            )
+            cx, cy = p2
+        elif local == "arcTo":
+            arc_d, end_x, end_y = _arc_to_svg(child, cx, cy, sx, sy)
+            if arc_d:
+                parts.append(arc_d)
+                cx, cy = end_x, end_y
+        elif local == "close":
+            parts.append("Z")
+            # SVG semantics: Z returns to subpath start; we don't track that
+            # explicitly here. cx/cy stays as-is — subsequent moveTo will reset.
+
+    return " ".join(parts)
+
+
+def _read_pt(pt_elem: ET.Element, mapper) -> tuple[float, float]:
+    try:
+        x = float(pt_elem.attrib.get("x", "0"))
+        y = float(pt_elem.attrib.get("y", "0"))
+    except ValueError:
+        x = 0.0
+        y = 0.0
+    return mapper(x, y)
+
+
+def _arc_to_svg(
+    arc_elem: ET.Element,
+    cx: float, cy: float,
+    sx: float, sy: float,
+) -> tuple[str, float, float]:
+    """Convert <a:arcTo wR hR stAng swAng/> to an SVG A command.
+
+    DrawingML semantics: starting at the current point, draw an elliptical arc
+    where the ellipse has radii (wR, hR) in path-local EMU. stAng/swAng are
+    1/60000 degrees, with 0° = +x axis, increasing clockwise.
+
+    The center of the ellipse is at:
+        center.x = cur.x - wR * cos(stAng)
+        center.y = cur.y - hR * sin(stAng)
+    The end point is on the same ellipse at angle (stAng + swAng).
+
+    We emit a single SVG A command. SVG's sweep_flag = 1 means clockwise; the
+    DrawingML convention is also clockwise so we pass sweep_flag = 1 when
+    swAng > 0.
+    """
+    try:
+        wR_emu = float(arc_elem.attrib.get("wR", "0"))
+        hR_emu = float(arc_elem.attrib.get("hR", "0"))
+        st_ang = float(arc_elem.attrib.get("stAng", "0"))
+        sw_ang = float(arc_elem.attrib.get("swAng", "0"))
+    except ValueError:
+        return "", cx, cy
+
+    if wR_emu <= 0 or hR_emu <= 0:
+        return "", cx, cy
+
+    rx = emu_to_px(wR_emu) * sx
+    ry = emu_to_px(hR_emu) * sy
+    st_rad = math.radians(st_ang / 60000.0)
+    sw_rad = math.radians(sw_ang / 60000.0)
+    end_rad = st_rad + sw_rad
+
+    # Center of the ellipse in slide-absolute coords
+    arc_cx = cx - rx * math.cos(st_rad)
+    arc_cy = cy - ry * math.sin(st_rad)
+    end_x = arc_cx + rx * math.cos(end_rad)
+    end_y = arc_cy + ry * math.sin(end_rad)
+
+    abs_sw = abs(sw_ang) / 60000.0
+    large_arc = 1 if abs_sw > 180.0 else 0
+    sweep = 1 if sw_ang >= 0 else 0
+
+    return (
+        f"A {fmt_num(rx)} {fmt_num(ry)} 0 {large_arc} {sweep} "
+        f"{fmt_num(end_x)} {fmt_num(end_y)}",
+        end_x,
+        end_y,
+    )

--- a/apps/inno-agent/scripts/pptx_to_svg/effect_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/effect_to_svg.py
@@ -1,0 +1,210 @@
+"""DrawingML <a:effectLst> -> SVG <filter> conversion.
+
+Reverse of svg_to_pptx/drawingml_styles.build_effect_xml.
+
+Covers the most common DrawingML effects:
+- <a:outerShdw>  -> feDropShadow (or feGaussianBlur+feOffset+feFlood)
+- <a:innerShdw>  -> approximated via inverted SourceAlpha pipeline
+- <a:glow>       -> outer glow (no offset, uses flood color)
+- <a:blur>       -> feGaussianBlur on whole shape
+- <a:softEdge>   -> feGaussianBlur (approximation; SVG has no direct match)
+
+Output: each call returns (filter_id, defs_xml). Caller adds filter="url(#id)"
+to the shape and accumulates defs_xml into the slide's <defs>.
+"""
+
+from __future__ import annotations
+
+import math
+from xml.etree import ElementTree as ET
+
+from .color_resolver import ColorPalette, find_color_elem, resolve_color
+from .emu_units import NS, emu_to_px, fmt_num
+
+
+def convert_effects(
+    sp_pr: ET.Element | None,
+    palette: ColorPalette | None,
+    *,
+    id_prefix: str = "fx",
+    id_seq: list[int] | None = None,
+) -> tuple[str | None, list[str]]:
+    """Inspect <p:spPr> for <a:effectLst> and return (filter_id, defs_xml).
+
+    If no effect is present returns (None, []). Multiple effects are layered
+    inside one <filter> using SVG primitive results.
+    """
+    if sp_pr is None:
+        return None, []
+    effect_lst = sp_pr.find("a:effectLst", NS)
+    if effect_lst is None:
+        return None, []
+    if len(list(effect_lst)) == 0:
+        return None, []
+
+    if id_seq is None:
+        id_seq = [0]
+    id_seq[0] += 1
+    filter_id = f"{id_prefix}{id_seq[0]}"
+
+    primitives: list[str] = []
+    last_result = "SourceGraphic"
+    # Filter region needs to extend beyond the bounding box to render shadows
+    # and glows; choose generous defaults.
+    filter_x = "-25%"
+    filter_y = "-25%"
+    filter_w = "150%"
+    filter_h = "150%"
+
+    for child in list(effect_lst):
+        if not isinstance(child.tag, str):
+            continue
+        local = child.tag.split("}", 1)[-1]
+        prim, last_result = _convert_one_effect(child, last_result, palette)
+        if prim:
+            primitives.append(prim)
+
+    if not primitives:
+        return None, []
+
+    defs_xml = (
+        f'<filter id="{filter_id}" x="{filter_x}" y="{filter_y}" '
+        f'width="{filter_w}" height="{filter_h}">'
+        + "".join(primitives)
+        + "</filter>"
+    )
+    return filter_id, [defs_xml]
+
+
+# ---------------------------------------------------------------------------
+# Per-effect conversion
+# ---------------------------------------------------------------------------
+
+def _convert_one_effect(
+    elem: ET.Element,
+    last_result: str,
+    palette: ColorPalette | None,
+) -> tuple[str, str]:
+    """Convert one effect to SVG filter primitives.
+
+    Returns (primitives_xml, new_last_result_name).
+    """
+    local = elem.tag.split("}", 1)[-1]
+    if local == "outerShdw":
+        return _outer_shadow(elem, last_result, palette)
+    if local == "innerShdw":
+        return _inner_shadow(elem, last_result, palette)
+    if local == "glow":
+        return _glow(elem, last_result, palette)
+    if local == "blur":
+        return _blur(elem, last_result)
+    if local == "softEdge":
+        return _soft_edge(elem, last_result)
+    if local == "reflection":
+        # v1 approximation: skip (would require feImage + feFlood + transform)
+        return "", last_result
+    return "", last_result
+
+
+def _color_alpha(elem: ET.Element, palette: ColorPalette | None) -> tuple[str, float]:
+    color = find_color_elem(elem)
+    hex_, alpha = resolve_color(color, palette)
+    return hex_ or "#000000", alpha
+
+
+def _direction_offset(elem: ET.Element) -> tuple[float, float]:
+    """Read dir / dist into (dx, dy) px."""
+    try:
+        direction_units = float(elem.attrib.get("dir", "0"))
+        dist_emu = float(elem.attrib.get("dist", "0"))
+    except ValueError:
+        return 0.0, 0.0
+    direction_deg = direction_units / 60000.0
+    dist_px = emu_to_px(dist_emu)
+    rad = math.radians(direction_deg)
+    return dist_px * math.cos(rad), dist_px * math.sin(rad)
+
+
+def _blur_radius(elem: ET.Element, attr: str = "blurRad", default_emu: float = 0.0) -> float:
+    try:
+        v = float(elem.attrib.get(attr, str(default_emu)))
+    except ValueError:
+        return 0.0
+    return emu_to_px(v)
+
+
+def _outer_shadow(elem: ET.Element, last_result: str,
+                  palette: ColorPalette | None) -> tuple[str, str]:
+    dx, dy = _direction_offset(elem)
+    blur = _blur_radius(elem, "blurRad")
+    color, alpha = _color_alpha(elem, palette)
+    # std deviation ~= blur radius / 2 (rough; PowerPoint shadows are larger)
+    std = max(blur / 2.0, 0.1)
+    # Use feDropShadow for compactness — it's well-supported in modern browsers.
+    return (
+        f'<feDropShadow dx="{fmt_num(dx)}" dy="{fmt_num(dy)}" '
+        f'stdDeviation="{fmt_num(std)}" '
+        f'flood-color="{color}" flood-opacity="{fmt_num(alpha, 4)}"/>',
+        "shadow",
+    )
+
+
+def _inner_shadow(elem: ET.Element, last_result: str,
+                  palette: ColorPalette | None) -> tuple[str, str]:
+    """Inner shadow via inverted alpha + offset + blur + composite-in.
+
+    Approximation: produces a darkened inner edge similar to PowerPoint.
+    """
+    dx, dy = _direction_offset(elem)
+    blur = _blur_radius(elem, "blurRad")
+    color, alpha = _color_alpha(elem, palette)
+    std = max(blur / 2.0, 0.1)
+    # Pipeline:
+    #   feFlood (color) -> compose with inverted alpha -> blur -> offset ->
+    #   composite-in original alpha
+    return (
+        f'<feFlood flood-color="{color}" flood-opacity="{fmt_num(alpha, 4)}" result="flood"/>'
+        f'<feComposite in="flood" in2="SourceAlpha" operator="out" result="inverted"/>'
+        f'<feGaussianBlur in="inverted" stdDeviation="{fmt_num(std)}" result="blurred"/>'
+        f'<feOffset in="blurred" dx="{fmt_num(dx)}" dy="{fmt_num(dy)}" result="offset"/>'
+        f'<feComposite in="offset" in2="SourceAlpha" operator="in" result="innerShadow"/>'
+        f'<feMerge><feMergeNode in="SourceGraphic"/><feMergeNode in="innerShadow"/></feMerge>',
+        "innerShadow",
+    )
+
+
+def _glow(elem: ET.Element, last_result: str,
+          palette: ColorPalette | None) -> tuple[str, str]:
+    rad = _blur_radius(elem, "rad")
+    color, alpha = _color_alpha(elem, palette)
+    std = max(rad / 2.0, 0.1)
+    return (
+        f'<feMorphology operator="dilate" radius="{fmt_num(rad / 4.0)}" '
+        f'in="SourceAlpha" result="dilated"/>'
+        f'<feGaussianBlur in="dilated" stdDeviation="{fmt_num(std)}" result="blurred"/>'
+        f'<feFlood flood-color="{color}" flood-opacity="{fmt_num(alpha, 4)}" result="flood"/>'
+        f'<feComposite in="flood" in2="blurred" operator="in" result="glow"/>'
+        f'<feMerge><feMergeNode in="glow"/><feMergeNode in="SourceGraphic"/></feMerge>',
+        "glow",
+    )
+
+
+def _blur(elem: ET.Element, last_result: str) -> tuple[str, str]:
+    rad = _blur_radius(elem, "rad")
+    std = max(rad / 2.0, 0.1)
+    return (
+        f'<feGaussianBlur stdDeviation="{fmt_num(std)}"/>',
+        "blurred",
+    )
+
+
+def _soft_edge(elem: ET.Element, last_result: str) -> tuple[str, str]:
+    # softEdge fades the edges; approximate with an alpha-only Gaussian blur
+    # then composite-in. v1 just outputs a gentle blur.
+    rad = _blur_radius(elem, "rad")
+    std = max(rad / 4.0, 0.1)
+    return (
+        f'<feGaussianBlur in="SourceAlpha" stdDeviation="{fmt_num(std)}" result="softEdge"/>'
+        f'<feComposite in="SourceGraphic" in2="softEdge" operator="in"/>',
+        "softEdge",
+    )

--- a/apps/inno-agent/scripts/pptx_to_svg/emu_units.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/emu_units.py
@@ -1,0 +1,223 @@
+"""EMU <-> pixel conversion and DrawingML unit constants.
+
+Mirrors svg_to_pptx/drawingml_utils.py and pptx_dimensions.py, in reverse.
+
+DrawingML unit conventions:
+- Coordinates / sizes: EMU (English Metric Unit). 914400 EMU = 1 inch = 96 px.
+- Font size: hundredths of a point. 1 px = 0.75 pt = 75 hundredths-of-a-point.
+- Angle: 60000ths of a degree.
+- Color tint/shade/lumMod/lumOff/satMod: percent in 1000ths (100% = 100000).
+- srcRect / fillRect: percent in 1000ths of the unit rect.
+"""
+
+from __future__ import annotations
+
+from xml.etree import ElementTree as ET
+
+EMU_PER_INCH = 914400
+EMU_PER_PX = 9525  # 96 dpi
+HUNDREDTHS_PT_PER_PX = 75  # 1 px = 0.75 pt = 75 hundredths
+ANGLE_UNIT = 60000  # 1 degree = 60000 angle units
+PERCENT_UNIT = 100000  # 100% = 100000 (DrawingML "ST_PositivePercentage")
+SRCRECT_UNIT = 100000  # srcRect l/t/r/b are in 1000ths of percent (i.e. 100000 = 100%)
+
+
+# Namespaces used throughout OOXML
+NS = {
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+    "rel": "http://schemas.openxmlformats.org/package/2006/relationships",
+    "ct": "http://schemas.openxmlformats.org/package/2006/content-types",
+    "asvg": "http://schemas.microsoft.com/office/drawing/2016/SVG/main",
+    "mc": "http://schemas.openxmlformats.org/markup-compatibility/2006",
+}
+
+# Register so ET output emits clean prefixes (writers normally don't need this
+# since the SVG output uses the SVG namespace, but keep it consistent).
+for prefix, uri in NS.items():
+    try:
+        ET.register_namespace(prefix, uri)
+    except (ValueError, AttributeError):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Length conversions
+# ---------------------------------------------------------------------------
+
+def emu_to_px(emu: float | int | None, default: float = 0.0) -> float:
+    """Convert EMU to SVG px (96 dpi). None / unparsable -> default."""
+    if emu is None:
+        return default
+    try:
+        return float(emu) / EMU_PER_PX
+    except (ValueError, TypeError):
+        return default
+
+
+def emu_attr_to_px(elem: ET.Element | None, attr: str, default: float = 0.0) -> float:
+    """Read EMU integer attribute and return px."""
+    if elem is None:
+        return default
+    return emu_to_px(elem.get(attr), default)
+
+
+def hundredths_pt_to_px(val: float | int | str | None, default: float = 0.0) -> float:
+    """Convert font size (a:rPr@sz) to px. 100 = 1 pt = 4/3 px."""
+    if val is None:
+        return default
+    try:
+        return float(val) / HUNDREDTHS_PT_PER_PX
+    except (ValueError, TypeError):
+        return default
+
+
+def angle_to_deg(val: float | int | str | None, default: float = 0.0) -> float:
+    """Convert DrawingML angle (1/60000 deg) to plain degrees."""
+    if val is None:
+        return default
+    try:
+        return float(val) / ANGLE_UNIT
+    except (ValueError, TypeError):
+        return default
+
+
+def percent_to_ratio(val: float | int | str | None, default: float = 0.0) -> float:
+    """DrawingML positive percent (100000 = 100%) -> ratio in [0, 1]."""
+    if val is None:
+        return default
+    try:
+        return float(val) / PERCENT_UNIT
+    except (ValueError, TypeError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# xfrm / transform parsing
+# ---------------------------------------------------------------------------
+
+class Xfrm:
+    """Resolved <a:xfrm> in pixel space.
+
+    Attributes:
+        x, y: top-left position (px).
+        w, h: size (px).
+        rot: rotation in degrees, clockwise around the shape center.
+        flip_h: bool — horizontal flip.
+        flip_v: bool — vertical flip.
+        ch_x, ch_y, ch_w, ch_h: only set when this is a group <p:grpSpPr>'s
+            xfrm; describes the child coordinate frame (a:chOff / a:chExt).
+            None on leaf shapes.
+    """
+
+    __slots__ = ("x", "y", "w", "h", "rot", "flip_h", "flip_v",
+                 "ch_x", "ch_y", "ch_w", "ch_h")
+
+    def __init__(
+        self,
+        x: float = 0.0,
+        y: float = 0.0,
+        w: float = 0.0,
+        h: float = 0.0,
+        rot: float = 0.0,
+        flip_h: bool = False,
+        flip_v: bool = False,
+        ch_x: float | None = None,
+        ch_y: float | None = None,
+        ch_w: float | None = None,
+        ch_h: float | None = None,
+    ) -> None:
+        self.x = x
+        self.y = y
+        self.w = w
+        self.h = h
+        self.rot = rot
+        self.flip_h = flip_h
+        self.flip_v = flip_v
+        self.ch_x = ch_x
+        self.ch_y = ch_y
+        self.ch_w = ch_w
+        self.ch_h = ch_h
+
+    def __repr__(self) -> str:
+        parts = [f"x={self.x:.1f}", f"y={self.y:.1f}",
+                 f"w={self.w:.1f}", f"h={self.h:.1f}"]
+        if self.rot:
+            parts.append(f"rot={self.rot:.2f}")
+        if self.flip_h:
+            parts.append("flipH")
+        if self.flip_v:
+            parts.append("flipV")
+        return f"Xfrm({', '.join(parts)})"
+
+    def to_svg_transform(self) -> str | None:
+        """Build SVG transform attribute for rotation / flip around the center.
+
+        Returns None if no rotation / flip is needed.
+        """
+        if not self.rot and not self.flip_h and not self.flip_v:
+            return None
+        cx = self.x + self.w / 2.0
+        cy = self.y + self.h / 2.0
+        parts: list[str] = []
+        if self.rot:
+            parts.append(f"rotate({_fmt(self.rot)} {_fmt(cx)} {_fmt(cy)})")
+        if self.flip_h or self.flip_v:
+            sx = -1 if self.flip_h else 1
+            sy = -1 if self.flip_v else 1
+            # scale around shape center
+            parts.append(f"translate({_fmt(cx)} {_fmt(cy)})")
+            parts.append(f"scale({sx} {sy})")
+            parts.append(f"translate({_fmt(-cx)} {_fmt(-cy)})")
+        return " ".join(parts) if parts else None
+
+
+def parse_xfrm(xfrm_elem: ET.Element | None) -> Xfrm:
+    """Parse <a:xfrm> into an Xfrm object. None -> zero Xfrm."""
+    if xfrm_elem is None:
+        return Xfrm()
+
+    rot = angle_to_deg(xfrm_elem.get("rot"))
+    flip_h = xfrm_elem.get("flipH") == "1"
+    flip_v = xfrm_elem.get("flipV") == "1"
+
+    off = xfrm_elem.find("a:off", NS)
+    ext = xfrm_elem.find("a:ext", NS)
+    ch_off = xfrm_elem.find("a:chOff", NS)
+    ch_ext = xfrm_elem.find("a:chExt", NS)
+
+    x = emu_attr_to_px(off, "x")
+    y = emu_attr_to_px(off, "y")
+    w = emu_attr_to_px(ext, "cx")
+    h = emu_attr_to_px(ext, "cy")
+
+    ch_x = emu_attr_to_px(ch_off, "x") if ch_off is not None else None
+    ch_y = emu_attr_to_px(ch_off, "y") if ch_off is not None else None
+    ch_w = emu_attr_to_px(ch_ext, "cx") if ch_ext is not None else None
+    ch_h = emu_attr_to_px(ch_ext, "cy") if ch_ext is not None else None
+
+    return Xfrm(x=x, y=y, w=w, h=h, rot=rot,
+                flip_h=flip_h, flip_v=flip_v,
+                ch_x=ch_x, ch_y=ch_y, ch_w=ch_w, ch_h=ch_h)
+
+
+# ---------------------------------------------------------------------------
+# Number formatting for SVG output
+# ---------------------------------------------------------------------------
+
+def _fmt(val: float, ndigits: int = 2) -> str:
+    """Format a number for SVG attributes: trim trailing zeros, keep ints clean."""
+    if val == 0:
+        return "0"
+    rounded = round(val, ndigits)
+    if rounded == int(rounded):
+        return str(int(rounded))
+    s = f"{rounded:.{ndigits}f}"
+    # trim trailing zeros after decimal
+    if "." in s:
+        s = s.rstrip("0").rstrip(".")
+    return s
+
+
+fmt_num = _fmt

--- a/apps/inno-agent/scripts/pptx_to_svg/fill_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/fill_to_svg.py
@@ -1,0 +1,393 @@
+"""DrawingML fill -> SVG fill conversion.
+
+Handles:
+- <a:solidFill>     -> fill="#XXXXXX" (+ fill-opacity)
+- <a:noFill/>       -> fill="none"
+- <a:gradFill>      -> linearGradient/radialGradient in <defs>, fill="url(#id)"
+- <a:blipFill>      -> handled by pic_to_svg (this module short-circuits)
+
+Returned FillResult is a struct of attribute dict + optional <defs> XML so the
+slide assembler can collect gradient defs without conflicting IDs.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from xml.etree import ElementTree as ET
+
+from .color_resolver import ColorPalette, find_color_elem, resolve_color
+from .emu_units import NS, fmt_num, percent_to_ratio
+
+
+@dataclass
+class FillResult:
+    """Resolved fill: SVG attributes to apply + optional <defs> entries."""
+
+    attrs: dict[str, str] = field(default_factory=dict)
+    defs: list[str] = field(default_factory=list)  # XML strings of <linearGradient>/<radialGradient>
+
+    @classmethod
+    def none_fill(cls) -> "FillResult":
+        return cls(attrs={"fill": "none"})
+
+    @classmethod
+    def inherit(cls) -> "FillResult":
+        # No fill resolved — let caller decide whether to default
+        return cls()
+
+
+def resolve_fill(
+    sp_pr: ET.Element | None,
+    palette: ColorPalette | None,
+    *,
+    id_prefix: str = "g",
+    id_seq: list[int] | None = None,
+    placeholder_hex: str | None = None,
+) -> FillResult:
+    """Inspect <p:spPr>'s fill children and emit an SVG fill descriptor.
+
+    Args:
+        sp_pr: <p:spPr> or any element that may directly hold a fill child.
+        palette: ColorPalette for scheme color resolution.
+        id_prefix: prefix for generated gradient IDs.
+        id_seq: external counter (single-element list) so callers can share
+            unique gradient IDs across the whole slide.
+
+    Returns:
+        FillResult. If no recognized fill is found, result.attrs is empty —
+        the caller should apply its own default (typically transparent /
+        inherit from the source SVG).
+    """
+    if sp_pr is None:
+        return FillResult.inherit()
+
+    # Direct child fill (in priority order: explicit -> derived).
+    handlers = (
+        ("noFill", _resolve_no_fill),
+        ("solidFill", _resolve_solid_fill),
+        ("gradFill", _resolve_grad_fill),
+        ("blipFill", _resolve_blip_fill),
+        ("pattFill", _resolve_patt_fill),
+    )
+
+    local_name = sp_pr.tag.split("}", 1)[-1] if isinstance(sp_pr.tag, str) else ""
+    for tag, handler in handlers:
+        if local_name == tag:
+            return handler(sp_pr, palette, id_prefix, id_seq, placeholder_hex)
+
+    for tag, handler in handlers:
+        elem = sp_pr.find(f"a:{tag}", NS)
+        if elem is not None:
+            return handler(elem, palette, id_prefix, id_seq, placeholder_hex)
+
+    return FillResult.inherit()
+
+
+# ---------------------------------------------------------------------------
+# Per-fill handlers
+# ---------------------------------------------------------------------------
+
+def _resolve_no_fill(_elem, _palette, _prefix, _seq, _placeholder_hex) -> FillResult:
+    return FillResult.none_fill()
+
+
+def _resolve_solid_fill(elem: ET.Element, palette: ColorPalette | None,
+                        _prefix: str, _seq, placeholder_hex: str | None) -> FillResult:
+    color_elem = find_color_elem(elem)
+    hex_, alpha = resolve_color(color_elem, palette, placeholder_hex=placeholder_hex)
+    if hex_ is None:
+        return FillResult.inherit()
+    attrs: dict[str, str] = {"fill": hex_}
+    if alpha < 1.0:
+        attrs["fill-opacity"] = fmt_num(alpha, 4)
+    return FillResult(attrs=attrs)
+
+
+def _resolve_grad_fill(elem: ET.Element, palette: ColorPalette | None,
+                       prefix: str, seq, placeholder_hex: str | None) -> FillResult:
+    """Convert <a:gradFill> to an SVG linearGradient or radialGradient."""
+    if seq is None:
+        seq = [0]
+    seq[0] += 1
+    grad_id = f"{prefix}grad{seq[0]}"
+
+    # Stops
+    gs_lst = elem.find("a:gsLst", NS)
+    if gs_lst is None:
+        return FillResult.inherit()
+    stops_xml = []
+    for gs in gs_lst.findall("a:gs", NS):
+        pos_pct = percent_to_ratio(gs.attrib.get("pos"), default=0.0)
+        color_elem = find_color_elem(gs)
+        hex_, alpha = resolve_color(color_elem, palette, placeholder_hex=placeholder_hex)
+        if hex_ is None:
+            continue
+        opacity_attr = f' stop-opacity="{fmt_num(alpha, 4)}"' if alpha < 1.0 else ""
+        stops_xml.append(
+            f'<stop offset="{fmt_num(pos_pct, 4)}" stop-color="{hex_}"{opacity_attr}/>'
+        )
+    if not stops_xml:
+        return FillResult.inherit()
+
+    # Linear vs radial vs path
+    lin = elem.find("a:lin", NS)
+    rad = elem.find("a:path", NS)
+
+    if lin is not None:
+        # ang is 1/60000 deg. 0° = horizontal left-to-right.
+        try:
+            angle_deg = float(lin.attrib.get("ang", "0")) / 60000.0
+        except ValueError:
+            angle_deg = 0.0
+        x1, y1, x2, y2 = _angle_to_unit_endpoints(angle_deg)
+        defs_xml = (
+            f'<linearGradient id="{grad_id}" '
+            f'x1="{fmt_num(x1, 4)}" y1="{fmt_num(y1, 4)}" '
+            f'x2="{fmt_num(x2, 4)}" y2="{fmt_num(y2, 4)}">'
+            + "".join(stops_xml)
+            + "</linearGradient>"
+        )
+    elif rad is not None:
+        # Treat as radial regardless of path="circle" / "rect" / "shape" — SVG
+        # only has circle/ellipse, and path="circle" maps to fillToRect=center.
+        defs_xml = (
+            f'<radialGradient id="{grad_id}" cx="0.5" cy="0.5" r="0.5">'
+            + "".join(stops_xml)
+            + "</radialGradient>"
+        )
+    else:
+        # No direction specified — default to horizontal linear
+        defs_xml = (
+            f'<linearGradient id="{grad_id}" x1="0" y1="0" x2="1" y2="0">'
+            + "".join(stops_xml)
+            + "</linearGradient>"
+        )
+
+    return FillResult(
+        attrs={"fill": f"url(#{grad_id})"},
+        defs=[defs_xml],
+    )
+
+
+def _resolve_blip_fill(_elem, _palette, _prefix, _seq, _placeholder_hex) -> FillResult:
+    """blipFill on <p:spPr> means a shape filled with an image — handled at
+    pic_to_svg level. For now mark as transparent so the shape's outline
+    still draws and pic_to_svg can layer the image on top.
+    """
+    return FillResult.none_fill()
+
+
+def _resolve_patt_fill(elem: ET.Element, palette: ColorPalette | None,
+                       prefix, seq, placeholder_hex: str | None) -> FillResult:
+    """Pattern fills (<a:pattFill prst="..."/> with fg/bg colors)."""
+    fg = elem.find("a:fgClr", NS)
+    bg = elem.find("a:bgClr", NS)
+    fg_hex, fg_alpha = resolve_color(
+        find_color_elem(fg), palette, placeholder_hex=placeholder_hex,
+    )
+    bg_hex, bg_alpha = resolve_color(
+        find_color_elem(bg), palette, placeholder_hex=placeholder_hex,
+    )
+    if fg_hex is None:
+        return FillResult.inherit()
+
+    prst = elem.attrib.get("prst", "")
+    geom = _pattern_foreground(prst, fg_hex, fg_alpha)
+    if geom is None:
+        # Unsupported preset → degrade to solid fg color so the shape at
+        # least carries the right tone. Round-trip will lose the texture.
+        attrs: dict[str, str] = {"fill": fg_hex}
+        if fg_alpha < 1.0:
+            attrs["fill-opacity"] = fmt_num(fg_alpha, 4)
+        return FillResult(attrs=attrs)
+    tile_w, tile_h, fg_svg = geom
+
+    if seq is None:
+        seq = [0]
+    seq[0] += 1
+    pattern_id = f"{prefix}patt{seq[0]}"
+    bg_rect = ""
+    if bg_hex is not None:
+        bg_opacity = (
+            f' fill-opacity="{fmt_num(bg_alpha, 4)}"'
+            if bg_alpha < 1.0 else ""
+        )
+        bg_rect = (
+            f'<rect width="{tile_w}" height="{tile_h}" '
+            f'fill="{bg_hex}"{bg_opacity}/>'
+        )
+    # Tag with data attributes so the reverse exporter can rebuild <a:pattFill>
+    # faithfully (preset + fg/bg colors) instead of inferring from path geometry.
+    bg_attr = f' data-pptx-bg="{bg_hex}"' if bg_hex is not None else ""
+    pattern_xml = (
+        f'<pattern id="{pattern_id}" patternUnits="userSpaceOnUse" '
+        f'width="{tile_w}" height="{tile_h}" '
+        f'data-pptx-pattern="{prst}" data-pptx-fg="{fg_hex}"{bg_attr}>'
+        f'{bg_rect}{fg_svg}</pattern>'
+    )
+    return FillResult(
+        attrs={"fill": f"url(#{pattern_id})"},
+        defs=[pattern_xml],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-preset SVG geometry for <a:pattFill prst="...">
+#
+# Each handler returns (tile_w, tile_h, foreground_svg). The caller wraps with
+# the background rect + <pattern> element. None means "unsupported preset" and
+# the caller degrades to a solid fg color.
+# ---------------------------------------------------------------------------
+
+def _pattern_foreground(prst: str, fg: str,
+                        fg_alpha: float) -> tuple[int, int, str] | None:
+    stroke_op = (
+        f' stroke-opacity="{fmt_num(fg_alpha, 4)}"'
+        if fg_alpha < 1.0 else ""
+    )
+    fill_op = (
+        f' fill-opacity="{fmt_num(fg_alpha, 4)}"'
+        if fg_alpha < 1.0 else ""
+    )
+
+    # Diagonal stripes — tile size and stroke width pick the visual weight.
+    diag = {
+        "ltUpDiag":   (8,  1.0, "up", False),
+        "dkUpDiag":   (8,  2.0, "up", False),
+        "wdUpDiag":   (16, 1.0, "up", False),
+        "dashUpDiag": (8,  1.0, "up", True),
+        "ltDnDiag":   (8,  1.0, "dn", False),
+        "dkDnDiag":   (8,  2.0, "dn", False),
+        "wdDnDiag":   (16, 1.0, "dn", False),
+        "dashDnDiag": (8,  1.0, "dn", True),
+    }
+    if prst in diag:
+        tile, sw, direction, dashed = diag[prst]
+        dash = ' stroke-dasharray="3 2"' if dashed else ""
+        if direction == "up":
+            d = f"M -2 {tile} L {tile} -2 M 0 {tile + 2} L {tile + 2} 0"
+        else:
+            d = f"M -2 0 L {tile} {tile + 2} M 0 -2 L {tile + 2} {tile}"
+        return tile, tile, (
+            f'<path d="{d}" stroke="{fg}"{stroke_op} '
+            f'stroke-width="{fmt_num(sw)}" fill="none"{dash}/>'
+        )
+
+    # Horizontal / vertical lines.
+    line_specs = {
+        "horz":     ("h", 8, 1.0, False),
+        "ltHorz":   ("h", 8, 0.5, False),
+        "dkHorz":   ("h", 8, 2.0, False),
+        "narHorz":  ("h", 4, 1.0, False),
+        "dashHorz": ("h", 8, 1.0, True),
+        "vert":     ("v", 8, 1.0, False),
+        "ltVert":   ("v", 8, 0.5, False),
+        "dkVert":   ("v", 8, 2.0, False),
+        "narVert":  ("v", 4, 1.0, False),
+        "dashVert": ("v", 8, 1.0, True),
+    }
+    if prst in line_specs:
+        axis, tile, sw, dashed = line_specs[prst]
+        dash = ' stroke-dasharray="3 2"' if dashed else ""
+        mid = tile / 2.0
+        if axis == "h":
+            line = (
+                f'<line x1="0" y1="{fmt_num(mid)}" '
+                f'x2="{tile}" y2="{fmt_num(mid)}"'
+            )
+        else:
+            line = (
+                f'<line x1="{fmt_num(mid)}" y1="0" '
+                f'x2="{fmt_num(mid)}" y2="{tile}"'
+            )
+        return tile, tile, (
+            f'{line} stroke="{fg}"{stroke_op} '
+            f'stroke-width="{fmt_num(sw)}"{dash}/>'
+        )
+
+    # Grids / crosses.
+    if prst == "cross":
+        return 8, 8, (
+            f'<line x1="0" y1="4" x2="8" y2="4" stroke="{fg}"{stroke_op} stroke-width="1"/>'
+            f'<line x1="4" y1="0" x2="4" y2="8" stroke="{fg}"{stroke_op} stroke-width="1"/>'
+        )
+    if prst == "diagCross":
+        d = (
+            "M -2 8 L 8 -2 M 0 10 L 10 0 "
+            "M -2 0 L 8 10 M 0 -2 L 10 8"
+        )
+        return 8, 8, (
+            f'<path d="{d}" stroke="{fg}"{stroke_op} stroke-width="1" fill="none"/>'
+        )
+    if prst in ("smGrid", "lgGrid"):
+        tile = 4 if prst == "smGrid" else 16
+        # Lines along top + left edges; tiles together produce a uniform grid.
+        return tile, tile, (
+            f'<path d="M 0 0 L {tile} 0 M 0 0 L 0 {tile}" '
+            f'stroke="{fg}"{stroke_op} stroke-width="0.5" fill="none"/>'
+        )
+    if prst == "dotGrid":
+        # Dots at corners → tiling yields a uniform dot grid.
+        return 8, 8, (
+            f'<circle cx="0" cy="0" r="1" fill="{fg}"{fill_op}/>'
+        )
+    if prst == "dotDmnd":
+        return 8, 8, (
+            f'<circle cx="0" cy="0" r="1" fill="{fg}"{fill_op}/>'
+            f'<circle cx="4" cy="4" r="1" fill="{fg}"{fill_op}/>'
+        )
+
+    # Percentage shading — single centered dot whose area matches the target
+    # density. Approximates PowerPoint's stipple without per-tile artwork.
+    if prst.startswith("pct"):
+        try:
+            pct = float(prst[3:])
+        except ValueError:
+            return None
+        pct = max(0.0, min(pct, 100.0))
+        tile = 8
+        radius = math.sqrt(pct / 100.0 * tile * tile / math.pi)
+        radius = max(0.3, min(radius, tile / 2.0))
+        return tile, tile, (
+            f'<circle cx="{tile / 2}" cy="{tile / 2}" '
+            f'r="{fmt_num(radius, 3)}" fill="{fg}"{fill_op}/>'
+        )
+
+    return None
+
+
+def _hex_distance(a: str, b: str) -> float:
+    """Euclidean distance between two #RRGGBB colors."""
+    try:
+        ar, ag, ab = int(a[1:3], 16), int(a[3:5], 16), int(a[5:7], 16)
+        br, bg, bb = int(b[1:3], 16), int(b[3:5], 16), int(b[5:7], 16)
+    except (ValueError, IndexError):
+        return 255.0
+    return math.sqrt((ar - br) ** 2 + (ag - bg) ** 2 + (ab - bb) ** 2)
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+def _angle_to_unit_endpoints(angle_deg: float) -> tuple[float, float, float, float]:
+    """Convert a DrawingML linear gradient angle to SVG x1/y1/x2/y2 in unit box.
+
+    DrawingML 0° = horizontal pointing right; angle is clockwise.
+    SVG default linearGradient is also unit-box (objectBoundingBox).
+    """
+    rad = math.radians(angle_deg % 360)
+    cos_a = math.cos(rad)
+    sin_a = math.sin(rad)
+    # Center of unit box
+    cx, cy = 0.5, 0.5
+    # Half-extent in the direction of the angle vector.
+    # We project the unit box onto the angle direction; the line endpoints are
+    # the projections of the box corners.
+    half = abs(cos_a) * 0.5 + abs(sin_a) * 0.5
+    x1 = cx - cos_a * half
+    y1 = cy - sin_a * half
+    x2 = cx + cos_a * half
+    y2 = cy + sin_a * half
+    return x1, y1, x2, y2

--- a/apps/inno-agent/scripts/pptx_to_svg/ln_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/ln_to_svg.py
@@ -1,0 +1,234 @@
+"""DrawingML <a:ln> -> SVG stroke conversion.
+
+Reverse of svg_to_pptx/drawingml_styles.build_stroke_xml.
+
+Produces an SVG attribute dict with stroke / stroke-width / stroke-opacity /
+stroke-dasharray / stroke-linecap / stroke-linejoin / marker-start /
+marker-end (markers also need a <defs> entry which is returned alongside).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from xml.etree import ElementTree as ET
+
+from .color_resolver import ColorPalette, find_color_elem, resolve_color
+from .emu_units import NS, emu_to_px, fmt_num
+
+
+@dataclass
+class StrokeResult:
+    """Resolved stroke: SVG attributes to apply + optional <defs> for markers."""
+
+    attrs: dict[str, str] = field(default_factory=dict)
+    defs: list[str] = field(default_factory=list)
+
+
+# Reverse of svg_to_pptx DASH_PRESETS (preset name -> dasharray).
+PRST_DASH_TO_ARRAY = {
+    "solid": None,           # no dasharray
+    "dot": "1 3",
+    "dash": "4 4",
+    "lgDash": "8 4",
+    "dashDot": "4 4 1 4",
+    "lgDashDot": "8 4 2 4",
+    "lgDashDotDot": "8 4 2 4 2 4",
+    "sysDash": "3 3",
+    "sysDot": "1 3",
+    "sysDashDot": "3 3 1 3",
+    "sysDashDotDot": "3 3 1 3 1 3",
+}
+
+# DrawingML cap -> SVG stroke-linecap
+CAP_MAP = {
+    "rnd": "round",
+    "sq": "square",
+    "flat": "butt",
+}
+
+
+def resolve_stroke(
+    sp_pr: ET.Element | None,
+    palette: ColorPalette | None,
+    *,
+    id_prefix: str = "m",
+    id_seq: list[int] | None = None,
+    style_stroke_default: str | None = None,
+) -> StrokeResult:
+    """Resolve <a:ln> child of <p:spPr>.
+
+    Returns:
+        StrokeResult.attrs is empty if no <a:ln> present (caller falls back to
+        the spec default). If <a:ln> exists with <a:noFill/>, attrs has
+        stroke="none".
+    """
+    if sp_pr is None:
+        return StrokeResult()
+
+    ln = sp_pr.find("a:ln", NS)
+    if ln is None:
+        return StrokeResult()
+
+    attrs: dict[str, str] = {}
+    defs: list[str] = []
+
+    # Width (a:ln@w in EMU)
+    width_emu = ln.attrib.get("w")
+    if width_emu is not None:
+        try:
+            width_px = emu_to_px(int(width_emu))
+            attrs["stroke-width"] = fmt_num(width_px, 3)
+        except (ValueError, TypeError):
+            pass
+
+    # Cap
+    cap = ln.attrib.get("cap")
+    if cap and cap in CAP_MAP:
+        attrs["stroke-linecap"] = CAP_MAP[cap]
+
+    # Fill: noFill / solidFill / gradFill
+    no_fill = ln.find("a:noFill", NS)
+    if no_fill is not None:
+        attrs["stroke"] = "none"
+    else:
+        solid = ln.find("a:solidFill", NS)
+        if solid is not None:
+            color_elem = find_color_elem(solid)
+            hex_, alpha = resolve_color(color_elem, palette)
+            if hex_:
+                attrs["stroke"] = hex_
+                if alpha < 1.0:
+                    attrs["stroke-opacity"] = fmt_num(alpha, 4)
+        else:
+            grad = ln.find("a:gradFill", NS)
+            if grad is not None:
+                # Approximate gradient stroke as the first stop color (SVG
+                # supports gradient strokes via fill="url()" but it adds a lot
+                # of plumbing; first-stop is good enough for v1).
+                first_gs = grad.find("a:gsLst/a:gs", NS)
+                if first_gs is not None:
+                    color_elem = find_color_elem(first_gs)
+                    hex_, alpha = resolve_color(color_elem, palette)
+                    if hex_:
+                        attrs["stroke"] = hex_
+                        if alpha < 1.0:
+                            attrs["stroke-opacity"] = fmt_num(alpha, 4)
+
+    # Dash pattern
+    prst_dash = ln.find("a:prstDash", NS)
+    if prst_dash is not None:
+        preset = prst_dash.attrib.get("val", "")
+        dasharray = PRST_DASH_TO_ARRAY.get(preset)
+        if dasharray:
+            attrs["stroke-dasharray"] = dasharray
+    else:
+        cust_dash = ln.find("a:custDash", NS)
+        if cust_dash is not None:
+            ds_parts: list[str] = []
+            sw = float(attrs.get("stroke-width", "1") or "1") or 1.0
+            for ds in cust_dash.findall("a:ds", NS):
+                # d, sp are percentages of stroke width (1000ths)
+                try:
+                    d_pct = int(ds.attrib.get("d", "0"))
+                    sp_pct = int(ds.attrib.get("sp", "0"))
+                except ValueError:
+                    continue
+                ds_parts.append(fmt_num(d_pct / 100000.0 * sw, 2))
+                ds_parts.append(fmt_num(sp_pct / 100000.0 * sw, 2))
+            if ds_parts:
+                attrs["stroke-dasharray"] = " ".join(ds_parts)
+
+    # Join
+    if ln.find("a:round", NS) is not None:
+        attrs["stroke-linejoin"] = "round"
+    elif ln.find("a:bevel", NS) is not None:
+        attrs["stroke-linejoin"] = "bevel"
+    elif ln.find("a:miter", NS) is not None:
+        attrs["stroke-linejoin"] = "miter"
+
+    # Arrow markers (head / tail)
+    if id_seq is None:
+        id_seq = [0]
+    for which, attr in (("headEnd", "marker-start"), ("tailEnd", "marker-end")):
+        end_elem = ln.find(f"a:{which}", NS)
+        if end_elem is None:
+            continue
+        marker_color = attrs.get("stroke") or style_stroke_default or "#000000"
+        marker_id, marker_def = _build_arrow_marker(
+            end_elem,
+            marker_color,
+            id_prefix=id_prefix,
+            seq=id_seq,
+            reversed_=(which == "headEnd"),
+        )
+        if marker_id is None:
+            continue
+        defs.append(marker_def)
+        attrs[attr] = f"url(#{marker_id})"
+
+    return StrokeResult(attrs=attrs, defs=defs)
+
+
+# ---------------------------------------------------------------------------
+# Arrow marker generation
+# ---------------------------------------------------------------------------
+
+# Bucket -> markerWidth/markerHeight ratio (in stroke widths).
+# Tuned to roughly match PowerPoint's rendered arrowhead size; the spec is
+# under-defined but PowerPoint draws noticeably larger heads than 1.5–3.5×.
+SIZE_BUCKET = {"sm": 3.0, "med": 5.0, "lg": 7.0}
+
+
+def _build_arrow_marker(
+    end_elem: ET.Element,
+    stroke_color: str,
+    *,
+    id_prefix: str,
+    seq: list[int],
+    reversed_: bool,
+) -> tuple[str | None, str]:
+    """Build an SVG <marker> def for an <a:headEnd>/<a:tailEnd>."""
+    typ = end_elem.attrib.get("type", "")
+    if typ in ("none", ""):
+        return None, ""
+
+    w_b = end_elem.attrib.get("w", "med")
+    l_b = end_elem.attrib.get("len", "med")
+    mw = SIZE_BUCKET.get(l_b, 2.5)
+    mh = SIZE_BUCKET.get(w_b, 2.5)
+
+    seq[0] += 1
+    marker_id = f"{id_prefix}arrow{seq[0]}"
+
+    # SVG markers are drawn in their own viewBox; we use a 0..10 box and place
+    # the path so refX is at the line endpoint.
+    if typ == "triangle":
+        path = "M 0 0 L 10 5 L 0 10 z"
+    elif typ == "stealth":
+        path = "M 0 0 L 10 5 L 0 10 L 3 5 z"
+    elif typ == "arrow":
+        path = "M 0 0 L 10 5 L 0 10"
+    elif typ == "diamond":
+        path = "M 0 5 L 5 0 L 10 5 L 5 10 z"
+    elif typ == "oval":
+        path = ""  # use circle below
+    else:
+        # Unknown type — fall back to triangle so user still sees something
+        path = "M 0 0 L 10 5 L 0 10 z"
+
+    if typ == "oval":
+        body = f'<circle cx="5" cy="5" r="4" fill="{stroke_color}"/>'
+    else:
+        body = f'<path d="{path}" fill="{stroke_color}"/>'
+
+    orient = "auto-start-reverse" if reversed_ else "auto"
+    fill_attr = "" if typ == "arrow" else ""  # no extra
+    # Note: stroke="none" prevents marker from inheriting parent stroke.
+    marker_def = (
+        f'<marker id="{marker_id}" viewBox="0 0 10 10" '
+        f'refX="{"0" if reversed_ else "10"}" refY="5" '
+        f'markerWidth="{fmt_num(mw, 2)}" markerHeight="{fmt_num(mh, 2)}" '
+        f'orient="{orient}" markerUnits="strokeWidth">'
+        f"{body}</marker>"
+    )
+    return marker_id, marker_def

--- a/apps/inno-agent/scripts/pptx_to_svg/ooxml_loader.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/ooxml_loader.py
@@ -1,0 +1,375 @@
+"""OOXML loader: read .pptx zip package, resolve relationships, expose
+slide / layout / master / theme / media as a navigable structure.
+
+Mirrors what manifest.py does for analysis, but keeps the parsed XML roots
+accessible for downstream shape conversion.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Iterator
+from xml.etree import ElementTree as ET
+
+from .emu_units import NS, emu_attr_to_px
+
+
+# ---------------------------------------------------------------------------
+# Relationship parsing
+# ---------------------------------------------------------------------------
+
+REL_NS = NS["rel"]
+PACKAGE_REL = "_rels/.rels"
+PRESENTATION_REL_PREFIX = "ppt/_rels/presentation.xml.rels"
+
+
+def _normalize_part_path(target: str, base: str | None = None) -> str:
+    """Resolve a relationship target against its rels source.
+
+    PPTX rels typically use paths relative to the rels file's parent directory,
+    e.g. slide1.xml.rels says target="../theme/theme1.xml". The result is
+    normalized to a posix path with no leading slash and no '..'.
+    """
+    target = target.replace("\\", "/")
+    if target.startswith("/"):
+        return target.lstrip("/")
+    if base is None:
+        return target
+    base_dir = posixpath.dirname(base.rstrip("/"))
+    joined = posixpath.normpath(posixpath.join(base_dir, target))
+    return joined.lstrip("/")
+
+
+def _rels_path_for(part_path: str) -> str:
+    """Given a part path 'ppt/slides/slide1.xml', return its rels path."""
+    parent, name = posixpath.split(part_path)
+    if not parent:
+        return f"_rels/{name}.rels"
+    return f"{parent}/_rels/{name}.rels"
+
+
+def _parse_rels(zf: zipfile.ZipFile, rels_path: str) -> dict[str, dict[str, str]]:
+    """Parse a .rels file. Returns {rId: {'type': ..., 'target': absolute_part_path}}."""
+    if rels_path not in zf.namelist():
+        return {}
+    try:
+        root = ET.fromstring(zf.read(rels_path))
+    except ET.ParseError:
+        return {}
+
+    base = rels_path.replace("/_rels/", "/")  # source part path
+    base = base[:-len(".rels")]  # strip .rels suffix
+    rels: dict[str, dict[str, str]] = {}
+    for child in root.findall(f"{{{REL_NS}}}Relationship"):
+        rid = child.attrib.get("Id", "")
+        rtype = child.attrib.get("Type", "")
+        target = child.attrib.get("Target", "")
+        target_mode = child.attrib.get("TargetMode", "")
+        # External relationships (e.g. hyperlinks) keep the raw target.
+        if target_mode == "External":
+            rels[rid] = {"type": rtype, "target": target, "external": "1"}
+            continue
+        absolute = _normalize_part_path(target, base)
+        rels[rid] = {"type": rtype, "target": absolute}
+    return rels
+
+
+def _load_xml(zf: zipfile.ZipFile, part_path: str) -> ET.Element | None:
+    if part_path not in zf.namelist():
+        return None
+    try:
+        return ET.fromstring(zf.read(part_path))
+    except ET.ParseError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Data classes for navigable parts
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PartRef:
+    """A loaded XML part with its rels resolved."""
+
+    path: str
+    xml: ET.Element
+    rels: dict[str, dict[str, str]] = field(default_factory=dict)
+
+    def resolve_rel(self, rid: str) -> str | None:
+        """Resolve an rId to an absolute part path. Returns None if missing."""
+        info = self.rels.get(rid)
+        if info is None:
+            return None
+        if info.get("external"):
+            return None
+        return info.get("target")
+
+
+@dataclass
+class SlideRef:
+    """One slide, with its layout / master chain attached."""
+
+    index: int  # 1-based
+    part: PartRef
+    layout: PartRef | None
+    master: PartRef | None
+
+
+# ---------------------------------------------------------------------------
+# OoxmlPackage
+# ---------------------------------------------------------------------------
+
+# Relationship type constants
+REL_TYPES = {
+    "presentation": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument",
+    "slide": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide",
+    "slideLayout": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout",
+    "slideMaster": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideMaster",
+    "theme": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/theme",
+    "image": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/image",
+    "media": "http://schemas.openxmlformats.org/officeDocument/2006/relationships/media",
+}
+
+
+class OoxmlPackage:
+    """Loaded .pptx ready for shape walking.
+
+    Usage:
+        with OoxmlPackage(Path("foo.pptx")) as pkg:
+            for slide in pkg.iter_slides():
+                root = slide.part.xml
+                ...
+    """
+
+    def __init__(self, pptx_path: Path) -> None:
+        self.path = pptx_path
+        self.zip: zipfile.ZipFile | None = None
+        self.presentation: PartRef | None = None
+        self.slide_size_px: tuple[float, float] = (1280.0, 720.0)
+        self.slide_size_emu: tuple[int, int] = (12192000, 6858000)
+        self._slides: list[SlideRef] = []
+        self._layouts: dict[str, PartRef] = {}
+        self._masters: dict[str, PartRef] = {}
+        self._themes: dict[str, PartRef] = {}
+
+    # ------------------- context manager -------------------
+
+    def __enter__(self) -> "OoxmlPackage":
+        self.open()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self.close()
+
+    def open(self) -> None:
+        if self.zip is not None:
+            return
+        self.zip = zipfile.ZipFile(self.path, "r")
+        self._load_presentation()
+        self._load_slides()
+
+    def close(self) -> None:
+        if self.zip is not None:
+            self.zip.close()
+            self.zip = None
+
+    # ------------------- low-level helpers -------------------
+
+    def _load_part(self, part_path: str) -> PartRef | None:
+        assert self.zip is not None
+        xml = _load_xml(self.zip, part_path)
+        if xml is None:
+            return None
+        rels = _parse_rels(self.zip, _rels_path_for(part_path))
+        return PartRef(path=part_path, xml=xml, rels=rels)
+
+    def read_media(self, part_path: str) -> bytes | None:
+        """Return raw bytes of an embedded media part (e.g. ppt/media/image1.png)."""
+        assert self.zip is not None
+        if part_path not in self.zip.namelist():
+            return None
+        return self.zip.read(part_path)
+
+    def media_filename(self, part_path: str) -> str:
+        """Last segment of the media path, e.g. 'image1.png'."""
+        return PurePosixPath(part_path).name
+
+    # ------------------- loading sequence -------------------
+
+    def _load_presentation(self) -> None:
+        assert self.zip is not None
+        # /_rels/.rels -> presentation.xml
+        package_rels = _parse_rels(self.zip, PACKAGE_REL)
+        pres_path = None
+        for info in package_rels.values():
+            if info.get("type") == REL_TYPES["presentation"]:
+                pres_path = info["target"]
+                break
+        if pres_path is None:
+            pres_path = "ppt/presentation.xml"
+
+        self.presentation = self._load_part(pres_path)
+        if self.presentation is None:
+            raise RuntimeError(f"presentation.xml missing in {self.path}")
+
+        # slide size
+        size = self.presentation.xml.find("p:sldSz", NS)
+        if size is not None:
+            cx = int(size.attrib.get("cx", "12192000"))
+            cy = int(size.attrib.get("cy", "6858000"))
+            self.slide_size_emu = (cx, cy)
+            self.slide_size_px = (cx / 9525.0, cy / 9525.0)
+
+    def _load_slides(self) -> None:
+        assert self.zip is not None and self.presentation is not None
+        # presentation.xml has <p:sldIdLst><p:sldId r:id="rId..."/></p:sldIdLst>
+        # in document order.
+        sld_id_lst = self.presentation.xml.find("p:sldIdLst", NS)
+        if sld_id_lst is None:
+            return
+
+        for index, sld_id in enumerate(sld_id_lst.findall("p:sldId", NS), start=1):
+            rid = sld_id.attrib.get(f"{{{NS['r']}}}id")
+            if not rid:
+                continue
+            slide_path = self.presentation.resolve_rel(rid)
+            if not slide_path:
+                continue
+            slide_part = self._load_part(slide_path)
+            if slide_part is None:
+                continue
+            layout = self._resolve_layout(slide_part)
+            master = self._resolve_master(layout) if layout else None
+            self._slides.append(SlideRef(
+                index=index, part=slide_part, layout=layout, master=master,
+            ))
+
+    def _resolve_layout(self, slide: PartRef) -> PartRef | None:
+        for info in slide.rels.values():
+            if info.get("type") == REL_TYPES["slideLayout"]:
+                target = info["target"]
+                cached = self._layouts.get(target)
+                if cached is None:
+                    cached = self._load_part(target)
+                    if cached is not None:
+                        self._layouts[target] = cached
+                return cached
+        return None
+
+    def _resolve_master(self, layout: PartRef) -> PartRef | None:
+        for info in layout.rels.values():
+            if info.get("type") == REL_TYPES["slideMaster"]:
+                target = info["target"]
+                cached = self._masters.get(target)
+                if cached is None:
+                    cached = self._load_part(target)
+                    if cached is not None:
+                        self._masters[target] = cached
+                return cached
+        return None
+
+    def resolve_theme(self, master: PartRef | None) -> PartRef | None:
+        """Return the theme part referenced by a slide master."""
+        if master is None:
+            return None
+        for info in master.rels.values():
+            if info.get("type") == REL_TYPES["theme"]:
+                target = info["target"]
+                cached = self._themes.get(target)
+                if cached is None:
+                    cached = self._load_part(target)
+                    if cached is not None:
+                        self._themes[target] = cached
+                return cached
+        return None
+
+    # ------------------- public iteration -------------------
+
+    def iter_slides(self) -> Iterator[SlideRef]:
+        yield from self._slides
+
+    @property
+    def slide_count(self) -> int:
+        return len(self._slides)
+
+    def get_slide(self, index: int) -> SlideRef | None:
+        """1-based index lookup."""
+        if 1 <= index <= len(self._slides):
+            return self._slides[index - 1]
+        return None
+
+    def iter_all_masters(self) -> Iterator[PartRef]:
+        """Yield every slideMaster declared in presentation.xml, regardless of
+        whether any slide currently uses it.
+
+        Template decks routinely ship more masters than the visible sample
+        slides reference (one master per "style"). The slide-driven traversal
+        in ``_load_slides`` only caches masters that are actually consumed by
+        a slide — fine for an authoring deck, but it drops 90% of the design
+        intent for a multi-style template package. This iterator hits the
+        presentation's ``sldMasterIdLst`` directly so callers (e.g. the
+        layered template export) can preserve the full template library.
+        """
+        if self.presentation is None:
+            return
+        master_id_lst = self.presentation.xml.find("p:sldMasterIdLst", NS)
+        if master_id_lst is None:
+            return
+        for master_id in master_id_lst.findall("p:sldMasterId", NS):
+            rid = master_id.attrib.get(f"{{{NS['r']}}}id")
+            if not rid:
+                continue
+            target = self.presentation.resolve_rel(rid)
+            if not target:
+                continue
+            cached = self._masters.get(target)
+            if cached is None:
+                cached = self._load_part(target)
+                if cached is None:
+                    continue
+                self._masters[target] = cached
+            yield cached
+
+    def iter_all_layouts(self) -> Iterator[PartRef]:
+        """Yield every slideLayout reachable from any master, regardless of
+        slide usage. Layouts live under ``master.sldLayoutIdLst`` in document
+        order; we walk every master so the export reflects the full set.
+
+        See :meth:`iter_all_layouts_with_parent` when you need each layout's
+        owning master alongside the layout itself (e.g. for theme-fill
+        resolution during standalone rendering).
+        """
+        for layout, _master in self.iter_all_layouts_with_parent():
+            yield layout
+
+    def iter_all_layouts_with_parent(self) -> Iterator[tuple[PartRef, PartRef]]:
+        """Like :meth:`iter_all_layouts` but yields ``(layout, parent_master)``
+        pairs. The parent master is the one whose ``sldLayoutIdLst`` contains
+        the layout, which is the source of truth for theme-style resolution
+        (e.g. ``<p:bgRef idx=...>`` on the layout still hops through the
+        master's theme).
+        """
+        seen: set[str] = set()
+        for master in self.iter_all_masters():
+            layout_id_lst = master.xml.find("p:sldLayoutIdLst", NS)
+            if layout_id_lst is None:
+                continue
+            for layout_id in layout_id_lst.findall("p:sldLayoutId", NS):
+                rid = layout_id.attrib.get(f"{{{NS['r']}}}id")
+                if not rid:
+                    continue
+                target = master.resolve_rel(rid)
+                if not target or target in seen:
+                    continue
+                seen.add(target)
+                cached = self._layouts.get(target)
+                if cached is None:
+                    cached = self._load_part(target)
+                    if cached is None:
+                        continue
+                    self._layouts[target] = cached
+                yield cached, master
+

--- a/apps/inno-agent/scripts/pptx_to_svg/pic_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/pic_to_svg.py
@@ -1,0 +1,354 @@
+"""DrawingML <p:pic> -> SVG <image> conversion.
+
+Reverse of svg_to_pptx convert_image.
+
+DrawingML structure:
+    <p:pic>
+        <p:blipFill>
+            <a:blip r:embed="rIdN"/>
+            <a:srcRect l/t/r/b="1/100000"/>      (optional crop)
+            <a:stretch><a:fillRect/></a:stretch> (default: fill the shape)
+        </p:blipFill>
+        <p:spPr>
+            <a:xfrm/>
+            <a:prstGeom prst="rect"/>            (usually rect; can be other)
+        </p:spPr>
+    </p:pic>
+
+Strategy:
+- Default (no srcRect, plain stretch) -> a single <image> filling the box,
+  preserveAspectRatio="none".
+- With srcRect -> wrap the <image> in a nested <svg viewBox> in the unit
+  rectangle [0,1] x [0,1], so cropping is expressed as the visible viewBox
+  region. preserveAspectRatio="none" both inside and outside.
+- Image bytes are written through the result; the slide assembler decides
+  the href format (external file vs base64).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import io
+import mimetypes
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+try:
+    from PIL import Image, ImageEnhance
+except ImportError:  # pragma: no cover - optional visual enhancement dependency
+    Image = None
+    ImageEnhance = None
+
+from .emu_units import NS, Xfrm, fmt_num
+from .ooxml_loader import OoxmlPackage, PartRef
+
+
+@dataclass
+class PictureResult:
+    """Resolved picture: SVG element string + extracted media bytes."""
+
+    svg: str = ""
+    # Map of {filename: bytes} that the assembler should emit alongside
+    # the SVG. Filename is the basename inside the package's media dir.
+    media: dict[str, bytes] = field(default_factory=dict)
+
+
+class MediaResolutionError(RuntimeError):
+    """Raised when a PPTX media relationship cannot be reproduced as SVG."""
+
+
+def convert_blip_fill(
+    blip_fill_elem: ET.Element,
+    xfrm: Xfrm,
+    slide_part: PartRef,
+    pkg: OoxmlPackage,
+    *,
+    media_subdir: str = "assets",
+    embed_inline: bool = False,
+    asset_name_map: dict[str, str] | None = None,
+) -> PictureResult:
+    """Convert an <a:blipFill> element to SVG <image>.
+
+    Handles image fill for both:
+    - <p:pic><p:blipFill> (standard picture elements)
+    - <p:sp><p:spPr><a:blipFill> (shape with image fill, e.g. Canva exports)
+    """
+    blip = blip_fill_elem.find("a:blip", NS)
+    if blip is None:
+        return PictureResult()
+
+    rid = blip.attrib.get(f"{{{NS['r']}}}embed")
+    linked_rid = blip.attrib.get(f"{{{NS['r']}}}link")
+    if not rid:
+        if linked_rid:
+            raise MediaResolutionError(
+                "Linked image relationships are not supported; embed the image in PowerPoint first"
+            )
+        return PictureResult()
+
+    target = slide_part.resolve_rel(rid)
+    if not target:
+        raise MediaResolutionError(f"Image relationship {rid} cannot be resolved in {slide_part.path}")
+
+    # Read the bytes
+    img_bytes = pkg.read_media(target)
+    if img_bytes is None:
+        raise MediaResolutionError(f"Embedded image part is missing: {target}")
+
+    filename = (asset_name_map or {}).get(target, pkg.media_filename(target))
+    filename, img_bytes = _normalize_office_media(filename, img_bytes)
+    filename, img_bytes = _apply_blip_image_effects(filename, img_bytes, blip)
+    href = _build_href(filename, img_bytes, media_subdir, embed_inline)
+
+    # srcRect: l/t/r/b in 1/100000ths (so 50000 = 50%).
+    src_rect = blip_fill_elem.find("a:srcRect", NS)
+    crop = _parse_src_rect(src_rect)
+
+    # stretch / tile: default stretch+fillRect means "fill, ignore aspect ratio".
+    has_stretch = blip_fill_elem.find("a:stretch") is not None
+    if not has_stretch:
+        # tile mode is rare; for v1 fall back to plain image.
+        pass
+
+    if crop is None:
+        # Plain unclipped image
+        svg = (
+            f'<image href="{href}" x="{fmt_num(xfrm.x)}" y="{fmt_num(xfrm.y)}" '
+            f'width="{fmt_num(xfrm.w)}" height="{fmt_num(xfrm.h)}" '
+            f'preserveAspectRatio="none"/>'
+        )
+    else:
+        # Crop expressed as a unit-rectangle viewBox on a nested <svg>.
+        vb_l, vb_t, vb_w, vb_h = crop
+        svg = (
+            f'<svg x="{fmt_num(xfrm.x)}" y="{fmt_num(xfrm.y)}" '
+            f'width="{fmt_num(xfrm.w)}" height="{fmt_num(xfrm.h)}" '
+            f'viewBox="{fmt_num(vb_l, 5)} {fmt_num(vb_t, 5)} '
+            f'{fmt_num(vb_w, 5)} {fmt_num(vb_h, 5)}" '
+            f'preserveAspectRatio="none">'
+            f'<image href="{href}" x="0" y="0" width="1" height="1" '
+            f'preserveAspectRatio="none"/>'
+            f"</svg>"
+        )
+
+    media: dict[str, bytes] = {}
+    if not embed_inline:
+        media[filename] = img_bytes
+    return PictureResult(svg=svg, media=media)
+
+
+def convert_picture(
+    pic_elem: ET.Element,
+    xfrm: Xfrm,
+    slide_part: PartRef,
+    pkg: OoxmlPackage,
+    *,
+    media_subdir: str = "assets",
+    embed_inline: bool = False,
+    asset_name_map: dict[str, str] | None = None,
+) -> PictureResult:
+    """Translate <p:pic> to SVG <image> (or nested <svg>+<image> for cropping)."""
+    blip_fill = pic_elem.find("p:blipFill", NS)
+    if blip_fill is None:
+        return PictureResult()
+
+    return convert_blip_fill(
+        blip_fill, xfrm, slide_part, pkg,
+        media_subdir=media_subdir,
+        embed_inline=embed_inline,
+        asset_name_map=asset_name_map,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_OFFICE_VECTOR_EXTS = {".emf", ".wmf"}
+
+
+def _normalize_office_media(filename: str, img_bytes: bytes) -> tuple[str, bytes]:
+    """Convert Office-only vector image formats to browser-renderable PNG.
+
+    PPTX can contain EMF/WMF assets that PowerPoint renders natively but SVG
+    viewers generally do not. Keep the original asset in the manifest layer;
+    the SVG view uses a PNG preview when the local system can make one.
+    """
+    suffix = Path(filename).suffix.lower()
+    if suffix not in _OFFICE_VECTOR_EXTS:
+        return filename, img_bytes
+
+    converted = _convert_office_vector_to_png(filename, img_bytes)
+    if converted is None:
+        return filename, img_bytes
+    stem = Path(filename).stem
+    return f"{stem}_preview.png", converted
+
+
+def _convert_office_vector_to_png(filename: str, img_bytes: bytes) -> bytes | None:
+    magick = shutil.which("magick")
+    if not magick:
+        return None
+    suffix = Path(filename).suffix.lower() or ".bin"
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_dir = Path(tmp)
+        src = tmp_dir / f"source{suffix}"
+        dst = tmp_dir / "preview.png"
+        src.write_bytes(img_bytes)
+        try:
+            subprocess.run(
+                [magick, str(src), str(dst)],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except (OSError, subprocess.CalledProcessError):
+            return None
+        if not dst.exists():
+            return None
+        return dst.read_bytes()
+
+def _parse_src_rect(elem: ET.Element | None) -> tuple[float, float, float, float] | None:
+    """Convert <a:srcRect l t r b="1/100000"/> to (x, y, w, h) in unit space."""
+    if elem is None:
+        return None
+    if not (elem.attrib.keys() & {"l", "t", "r", "b"}):
+        return None
+    l = _pct_attr(elem, "l")
+    t = _pct_attr(elem, "t")
+    r = _pct_attr(elem, "r")
+    b = _pct_attr(elem, "b")
+    # All zero -> equivalent to no crop
+    if l == 0 and t == 0 and r == 0 and b == 0:
+        return None
+    vb_x = l
+    vb_y = t
+    vb_w = max(0.0, 1.0 - l - r)
+    vb_h = max(0.0, 1.0 - t - b)
+    if vb_w <= 0 or vb_h <= 0:
+        return None
+    return vb_x, vb_y, vb_w, vb_h
+
+
+def _apply_blip_image_effects(
+    filename: str,
+    img_bytes: bytes,
+    blip: ET.Element,
+) -> tuple[str, bytes]:
+    """Bake supported DrawingML blip effects into extracted image bytes.
+
+    Keeping the SVG as a plain <image> avoids introducing CSS filters that the
+    downstream native PPTX converter cannot reliably map back to DrawingML.
+    """
+    lum = blip.find("a:lum", NS)
+    if lum is None:
+        return filename, img_bytes
+
+    bright = _signed_pct_attr(lum, "bright")
+    contrast = _signed_pct_attr(lum, "contrast")
+    if bright is None and contrast is None:
+        return filename, img_bytes
+    if Image is None or ImageEnhance is None:
+        return filename, img_bytes
+
+    try:
+        image = Image.open(io.BytesIO(img_bytes))
+        output_format = image.format or _pil_format_from_filename(filename)
+        if image.mode not in ("RGB", "RGBA"):
+            image = image.convert("RGBA" if "A" in image.getbands() else "RGB")
+        if bright is not None:
+            image = ImageEnhance.Brightness(image).enhance(max(0.0, 1.0 + bright))
+        if contrast is not None:
+            image = ImageEnhance.Contrast(image).enhance(max(0.0, 1.0 + contrast))
+
+        out = io.BytesIO()
+        save_format = output_format or "PNG"
+        save_kwargs = {"quality": 95} if save_format.upper() in {"JPEG", "JPG"} else {}
+        image.save(out, format=save_format, **save_kwargs)
+        effect_key = f"lum-{bright}-{contrast}".encode("ascii")
+        digest = hashlib.sha1(effect_key).hexdigest()[:8]
+        return _effect_filename(filename, digest, save_format), out.getvalue()
+    except Exception:
+        return filename, img_bytes
+
+
+def _signed_pct_attr(elem: ET.Element, name: str) -> float | None:
+    val = elem.attrib.get(name)
+    if val is None:
+        return None
+    try:
+        return float(val) / 100000.0
+    except ValueError:
+        return None
+
+
+def _pil_format_from_filename(filename: str) -> str | None:
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if ext in {"jpg", "jpeg"}:
+        return "JPEG"
+    if ext == "png":
+        return "PNG"
+    if ext == "gif":
+        return "GIF"
+    if ext == "webp":
+        return "WEBP"
+    return None
+
+
+def _effect_filename(filename: str, digest: str, image_format: str) -> str:
+    stem, sep, ext = filename.rpartition(".")
+    if not sep:
+        ext = (image_format or "png").lower()
+        stem = filename
+    if ext.lower() == "jpg":
+        ext = "jpeg"
+    return f"{stem}_fx_{digest}.{ext}"
+
+
+def _pct_attr(elem: ET.Element, name: str) -> float:
+    val = elem.attrib.get(name)
+    if val is None:
+        return 0.0
+    try:
+        return float(val) / 100000.0
+    except ValueError:
+        return 0.0
+
+
+def _build_href(filename: str, img_bytes: bytes, subdir: str, embed: bool) -> str:
+    """Build an <image href=...> value (relative path or data URI).
+
+    The path is relative to the SVG file's location. The slide assembler writes
+    SVGs to <output>/svg/, so media files in <output>/<subdir>/ resolve via
+    a leading "../".
+    """
+    if embed:
+        mime = (
+            mimetypes.guess_type(filename)[0]
+            or _sniff_mime(img_bytes)
+            or "application/octet-stream"
+        )
+        encoded = base64.b64encode(img_bytes).decode("ascii")
+        return f"data:{mime};base64,{encoded}"
+    rel = f"../{subdir}/{filename}" if subdir else f"../{filename}"
+    return rel
+
+
+def _sniff_mime(data: bytes) -> str | None:
+    """Best-effort MIME sniffing for embedded images."""
+    if data.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if data.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if data.startswith(b"GIF87a") or data.startswith(b"GIF89a"):
+        return "image/gif"
+    if data.startswith(b"<svg") or data.startswith(b"<?xml"):
+        return "image/svg+xml"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    return None

--- a/apps/inno-agent/scripts/pptx_to_svg/prstgeom_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/prstgeom_to_svg.py
@@ -1,0 +1,670 @@
+"""DrawingML <a:prstGeom> -> SVG geometry conversion.
+
+svg_to_pptx only emits 4 prstGeom presets (rect / roundRect / ellipse / line);
+everything else goes through custGeom. So the reverse pipeline only needs
+strong support for those four to handle round-tripped decks. We additionally
+include an extended preset map covering the most common PowerPoint-authored
+shapes (triangle, diamond, hexagon, parallelogram, arrow, star, etc.) so
+hand-built decks like muban.pptx don't fall through to a placeholder.
+
+Each handler returns a SHAPE_TAG + attribute dict that the slide assembler
+wraps with fill/stroke/effect attributes plus the absolute (x, y) translation.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from xml.etree import ElementTree as ET
+
+from .emu_units import NS, Xfrm, fmt_num
+
+
+# ---------------------------------------------------------------------------
+# GeomResult
+# ---------------------------------------------------------------------------
+
+@dataclass
+class GeomResult:
+    """Result of converting a prst preset to SVG.
+
+    `tag` is the SVG element tag (rect / ellipse / line / polygon / path /
+    polyline). `attrs` are absolute SVG coordinates already in slide space.
+    `path_d` (when tag == 'path') is the d attribute. The slide assembler
+    merges fill/stroke attrs from fill_to_svg/ln_to_svg.
+    """
+
+    tag: str
+    attrs: dict[str, str] = field(default_factory=dict)
+    # When tag == 'path' use path_d for the d attribute.
+    path_d: str | None = None
+    # When tag == 'polygon' / 'polyline' use points for the points attribute.
+    points: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Adjustment helper
+# ---------------------------------------------------------------------------
+
+def _adj_value(sp_pr: ET.Element | None, adj_name: str = "adj",
+               default_pct: float = 0.0) -> float:
+    """Read an adjustment value from <a:avLst><a:gd name="..." fmla="val N"/>.
+
+    Returns the value as a fraction in [0, 1] of the relevant dimension. If
+    the gd is absent or the formula is unparseable, returns default_pct.
+    """
+    if sp_pr is None:
+        return default_pct
+    av_lst = sp_pr.find(".//a:avLst", NS)
+    if av_lst is None:
+        return default_pct
+    for gd in av_lst.findall("a:gd", NS):
+        if gd.attrib.get("name") == adj_name:
+            fmla = gd.attrib.get("fmla", "")
+            if fmla.startswith("val "):
+                try:
+                    return float(fmla[4:]) / 100000.0
+                except ValueError:
+                    return default_pct
+    return default_pct
+
+
+def _adj_int_value(sp_pr: ET.Element | None, adj_name: str,
+                   default: int) -> int:
+    """Read an adjustment value as the original DrawingML integer."""
+    if sp_pr is None:
+        return default
+    av_lst = sp_pr.find(".//a:avLst", NS)
+    if av_lst is None:
+        return default
+    for gd in av_lst.findall("a:gd", NS):
+        if gd.attrib.get("name") == adj_name:
+            fmla = gd.attrib.get("fmla", "")
+            if fmla.startswith("val "):
+                try:
+                    return int(float(fmla[4:]))
+                except ValueError:
+                    return default
+    return default
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+def convert_prst_geom(
+    prst: str,
+    xfrm: Xfrm,
+    sp_pr: ET.Element | None,
+) -> GeomResult | None:
+    """Convert <a:prstGeom prst="..."> to a GeomResult.
+
+    Returns None if the preset has no v1 mapping; the caller can then choose
+    to render a fallback rect.
+    """
+    # Line-style presets accept zero width OR zero height (axis-aligned lines).
+    if prst in ("line", "straightConnector1"):
+        if xfrm.w == 0 and xfrm.h == 0:
+            return None
+        return _line(xfrm, sp_pr)
+    if xfrm.w <= 0 or xfrm.h <= 0:
+        return None
+    handler = _PRESET_HANDLERS.get(prst)
+    if handler is None:
+        return None
+    return handler(xfrm, sp_pr)
+
+
+# ---------------------------------------------------------------------------
+# Per-preset handlers
+# ---------------------------------------------------------------------------
+
+def _rect(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    return GeomResult(
+        tag="rect",
+        attrs={
+            "x": fmt_num(xfrm.x),
+            "y": fmt_num(xfrm.y),
+            "width": fmt_num(xfrm.w),
+            "height": fmt_num(xfrm.h),
+        },
+    )
+
+
+def _round_rect(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """roundRect adj = ratio of corner radius to half of shorter side.
+
+    DrawingML default adj = 16667 (16.667%) when avLst is absent.
+    """
+    adj = _adj_value(sp_pr, "adj", default_pct=0.16667)
+    short = min(xfrm.w, xfrm.h)
+    radius = adj * short / 2.0  # adj is fraction of "half shorter side"
+    # Actually DrawingML "adj" for roundRect is fraction of the shorter side
+    # itself (i.e. up to 50000 = half side = capsule). svg_to_pptx writes
+    # adj = radius / shorterSide * 100000, so we invert: radius = adj * shorter.
+    radius = adj * short
+    radius = min(radius, short / 2.0)
+    return GeomResult(
+        tag="rect",
+        attrs={
+            "x": fmt_num(xfrm.x),
+            "y": fmt_num(xfrm.y),
+            "width": fmt_num(xfrm.w),
+            "height": fmt_num(xfrm.h),
+            "rx": fmt_num(radius),
+            "ry": fmt_num(radius),
+        },
+    )
+
+
+def _round_2_diag_rect(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """Rectangle with two diagonal rounded corners.
+
+    DrawingML's round2DiagRect rounds the top-left and bottom-right corners.
+    SVG has no direct primitive for per-corner radii, so emit a native-friendly
+    path with quadratic curves.
+    """
+    adj = _adj_value(sp_pr, "adj", default_pct=0.16667)
+    r = min(adj * min(xfrm.w, xfrm.h), min(xfrm.w, xfrm.h) / 2.0)
+    x, y, w, h = xfrm.x, xfrm.y, xfrm.w, xfrm.h
+    d = (
+        f"M {fmt_num(x + r)} {fmt_num(y)} "
+        f"L {fmt_num(x + w)} {fmt_num(y)} "
+        f"L {fmt_num(x + w)} {fmt_num(y + h - r)} "
+        f"Q {fmt_num(x + w)} {fmt_num(y + h)} {fmt_num(x + w - r)} {fmt_num(y + h)} "
+        f"L {fmt_num(x)} {fmt_num(y + h)} "
+        f"L {fmt_num(x)} {fmt_num(y + r)} "
+        f"Q {fmt_num(x)} {fmt_num(y)} {fmt_num(x + r)} {fmt_num(y)} Z"
+    )
+    return GeomResult(tag="path", path_d=d)
+
+
+def _round_2_same_rect(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """Rectangle with top and bottom same-side corner adjustments.
+
+    Mirrors the OOXML preset definition: adj1 controls the top pair of corners,
+    adj2 controls the bottom pair. A common title-tab setting is adj1=0 and
+    adj2=50000, yielding square top corners and a capsule-like bottom edge.
+    """
+    x, y, w, h = xfrm.x, xfrm.y, xfrm.w, xfrm.h
+    ss = min(w, h)
+    adj1 = _adj_int_value(sp_pr, "adj1", 16667)
+    adj2 = _adj_int_value(sp_pr, "adj2", 0)
+    tx = min(adj1 / 100000.0, 0.5) * ss
+    bx = min(adj2 / 100000.0, 0.5) * ss
+    parts = [
+        f"M {fmt_num(x + tx)} {fmt_num(y)}",
+        f"L {fmt_num(x + w - tx)} {fmt_num(y)}",
+    ]
+    if tx > 0:
+        parts.append(
+            f"A {fmt_num(tx)} {fmt_num(tx)} 0 0 1 "
+            f"{fmt_num(x + w)} {fmt_num(y + tx)}"
+        )
+    parts.append(f"L {fmt_num(x + w)} {fmt_num(y + h - bx)}")
+    if bx > 0:
+        parts.append(
+            f"A {fmt_num(bx)} {fmt_num(bx)} 0 0 1 "
+            f"{fmt_num(x + w - bx)} {fmt_num(y + h)}"
+        )
+    else:
+        parts.append(f"L {fmt_num(x + w)} {fmt_num(y + h)}")
+    parts.append(f"L {fmt_num(x + bx)} {fmt_num(y + h)}")
+    if bx > 0:
+        parts.append(
+            f"A {fmt_num(bx)} {fmt_num(bx)} 0 0 1 "
+            f"{fmt_num(x)} {fmt_num(y + h - bx)}"
+        )
+    else:
+        parts.append(f"L {fmt_num(x)} {fmt_num(y + h)}")
+    parts.append(f"L {fmt_num(x)} {fmt_num(y + tx)}")
+    if tx > 0:
+        parts.append(
+            f"A {fmt_num(tx)} {fmt_num(tx)} 0 0 1 "
+            f"{fmt_num(x + tx)} {fmt_num(y)}"
+        )
+    d = " ".join(parts) + " Z"
+    return GeomResult(
+        tag="path",
+        attrs={
+            "data-pptx-prst": "round2SameRect",
+            "data-pptx-adj1": str(adj1),
+            "data-pptx-adj2": str(adj2),
+        },
+        path_d=d,
+    )
+
+
+def _ellipse(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    cx = xfrm.x + xfrm.w / 2.0
+    cy = xfrm.y + xfrm.h / 2.0
+    rx = xfrm.w / 2.0
+    ry = xfrm.h / 2.0
+    return GeomResult(
+        tag="ellipse",
+        attrs={
+            "cx": fmt_num(cx), "cy": fmt_num(cy),
+            "rx": fmt_num(rx), "ry": fmt_num(ry),
+        },
+    )
+
+
+def _line(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    # cxnSp line endpoints: x1,y1 = (x, y); x2,y2 = (x+w, y+h). flipH/flipV
+    # already baked into the xfrm via to_svg_transform.
+    return GeomResult(
+        tag="line",
+        attrs={
+            "x1": fmt_num(xfrm.x), "y1": fmt_num(xfrm.y),
+            "x2": fmt_num(xfrm.x + xfrm.w), "y2": fmt_num(xfrm.y + xfrm.h),
+        },
+    )
+
+
+# ---------- Polygon-based shapes ----------
+
+def _polygon(points: list[tuple[float, float]]) -> GeomResult:
+    pts = " ".join(f"{fmt_num(x)},{fmt_num(y)}" for x, y in points)
+    return GeomResult(tag="polygon", points=pts)
+
+
+def _triangle(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """Isoceles triangle. adj controls apex x position (default 50%)."""
+    adj = _adj_value(sp_pr, "adj", default_pct=0.5)
+    apex_x = xfrm.x + adj * xfrm.w
+    return _polygon([
+        (apex_x, xfrm.y),
+        (xfrm.x + xfrm.w, xfrm.y + xfrm.h),
+        (xfrm.x, xfrm.y + xfrm.h),
+    ])
+
+
+def _rt_triangle(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    return _polygon([
+        (xfrm.x, xfrm.y),
+        (xfrm.x, xfrm.y + xfrm.h),
+        (xfrm.x + xfrm.w, xfrm.y + xfrm.h),
+    ])
+
+
+def _diamond(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    cx = xfrm.x + xfrm.w / 2.0
+    cy = xfrm.y + xfrm.h / 2.0
+    return _polygon([
+        (cx, xfrm.y),
+        (xfrm.x + xfrm.w, cy),
+        (cx, xfrm.y + xfrm.h),
+        (xfrm.x, cy),
+    ])
+
+
+def _parallelogram(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """adj = horizontal skew offset as fraction of width (default 25%)."""
+    adj = _adj_value(sp_pr, "adj", default_pct=0.25)
+    skew = adj * xfrm.w
+    return _polygon([
+        (xfrm.x + skew, xfrm.y),
+        (xfrm.x + xfrm.w, xfrm.y),
+        (xfrm.x + xfrm.w - skew, xfrm.y + xfrm.h),
+        (xfrm.x, xfrm.y + xfrm.h),
+    ])
+
+
+def _trapezoid(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """OOXML trapezoid: x1 = ss * adj / 200000 (ss = min(w, h)).
+
+    adj default 25000; maxAdj caps at 50000 * w / ss so the top can't invert.
+    """
+    adj = _adj_int_value(sp_pr, "adj", 25000)
+    ss = min(xfrm.w, xfrm.h)
+    if ss <= 0:
+        return _rect(xfrm, sp_pr)
+    max_adj = 50000.0 * xfrm.w / ss
+    a = max(0.0, min(float(adj), max_adj))
+    inset = ss * a / 200000.0
+    return _polygon([
+        (xfrm.x + inset, xfrm.y),
+        (xfrm.x + xfrm.w - inset, xfrm.y),
+        (xfrm.x + xfrm.w, xfrm.y + xfrm.h),
+        (xfrm.x, xfrm.y + xfrm.h),
+    ])
+
+
+def _chevron(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """OOXML chevron: dx = ss * adj / 100000 (ss = min(w, h)), default adj=50000.
+
+    Both the right-pointing tip length and the left back-notch depth equal dx,
+    which is what lets a series of chevrons tile flush.
+    """
+    adj = _adj_int_value(sp_pr, "adj", 50000)
+    x, y, w, h = xfrm.x, xfrm.y, xfrm.w, xfrm.h
+    ss = min(w, h)
+    if ss <= 0:
+        return _rect(xfrm, sp_pr)
+    max_adj = 100000.0 * w / ss
+    a = max(0.0, min(float(adj), max_adj))
+    dx = ss * a / 100000.0
+    cy = y + h / 2.0
+    return _polygon([
+        (x, y),
+        (x + w - dx, y),
+        (x + w, cy),
+        (x + w - dx, y + h),
+        (x, y + h),
+        (x + dx, cy),
+    ])
+
+
+def _home_plate(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """OOXML homePlate: tip length = ss * adj / 100000; body fills 0..(w - tip).
+
+    Same dx as chevron so a homePlate→chevron series tiles seamlessly.
+    """
+    adj = _adj_int_value(sp_pr, "adj", 50000)
+    x, y, w, h = xfrm.x, xfrm.y, xfrm.w, xfrm.h
+    ss = min(w, h)
+    if ss <= 0:
+        return _rect(xfrm, sp_pr)
+    max_adj = 100000.0 * w / ss
+    a = max(0.0, min(float(adj), max_adj))
+    dx = ss * a / 100000.0
+    split = w - dx
+    cy = y + h / 2.0
+    return _polygon([
+        (x, y),
+        (x + split, y),
+        (x + w, cy),
+        (x + split, y + h),
+        (x, y + h),
+    ])
+
+
+def _flow_chart_extract(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    """Flowchart "Extract": upward-pointing isoceles triangle."""
+    return _polygon([
+        (xfrm.x + xfrm.w / 2.0, xfrm.y),
+        (xfrm.x + xfrm.w, xfrm.y + xfrm.h),
+        (xfrm.x, xfrm.y + xfrm.h),
+    ])
+
+
+def _flow_chart_merge(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    """Flowchart "Merge": downward-pointing isoceles triangle."""
+    return _polygon([
+        (xfrm.x, xfrm.y),
+        (xfrm.x + xfrm.w, xfrm.y),
+        (xfrm.x + xfrm.w / 2.0, xfrm.y + xfrm.h),
+    ])
+
+
+def _regular_polygon(xfrm: Xfrm, n_sides: int, *, rot_deg: float = -90.0) -> GeomResult:
+    """Regular polygon inscribed in the bounding box."""
+    cx = xfrm.x + xfrm.w / 2.0
+    cy = xfrm.y + xfrm.h / 2.0
+    rx = xfrm.w / 2.0
+    ry = xfrm.h / 2.0
+    pts: list[tuple[float, float]] = []
+    for i in range(n_sides):
+        ang = math.radians(rot_deg + i * 360.0 / n_sides)
+        pts.append((cx + rx * math.cos(ang), cy + ry * math.sin(ang)))
+    return _polygon(pts)
+
+
+def _pentagon(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    return _regular_polygon(xfrm, 5)
+
+
+def _hexagon(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    return _regular_polygon(xfrm, 6, rot_deg=0)
+
+
+def _heptagon(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    return _regular_polygon(xfrm, 7)
+
+
+def _octagon(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    return _regular_polygon(xfrm, 8, rot_deg=22.5)
+
+
+def _decagon(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    return _regular_polygon(xfrm, 10)
+
+
+def _dodecagon(xfrm: Xfrm, _sp_pr) -> GeomResult:
+    return _regular_polygon(xfrm, 12)
+
+
+def _star(n_points: int):
+    def handler(xfrm: Xfrm, _sp_pr) -> GeomResult:
+        cx = xfrm.x + xfrm.w / 2.0
+        cy = xfrm.y + xfrm.h / 2.0
+        r_outer_x = xfrm.w / 2.0
+        r_outer_y = xfrm.h / 2.0
+        # Inner radius: classic 5-pointed star uses ~0.382 of outer.
+        inner_ratio = 0.382 if n_points == 5 else 0.5
+        r_inner_x = r_outer_x * inner_ratio
+        r_inner_y = r_outer_y * inner_ratio
+        pts: list[tuple[float, float]] = []
+        for i in range(n_points * 2):
+            angle = math.radians(-90 + i * (360.0 / (n_points * 2)))
+            rx = r_outer_x if i % 2 == 0 else r_inner_x
+            ry = r_outer_y if i % 2 == 0 else r_inner_y
+            pts.append((cx + rx * math.cos(angle), cy + ry * math.sin(angle)))
+        return _polygon(pts)
+    return handler
+
+
+# ---------- Arrow shapes ----------
+
+def _right_arrow(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """Right-pointing block arrow. adj1 = head width / shape height (50%);
+    adj2 = head length / shape width (50%)."""
+    adj1 = _adj_value(sp_pr, "adj1", default_pct=0.5)
+    adj2 = _adj_value(sp_pr, "adj2", default_pct=0.5)
+    head_h = xfrm.h * adj1
+    head_w = xfrm.w * adj2
+    body_y_top = xfrm.y + (xfrm.h - head_h) / 2.0
+    body_y_bot = xfrm.y + (xfrm.h + head_h) / 2.0
+    head_x = xfrm.x + xfrm.w - head_w
+    return _polygon([
+        (xfrm.x, body_y_top),
+        (head_x, body_y_top),
+        (head_x, xfrm.y),
+        (xfrm.x + xfrm.w, xfrm.y + xfrm.h / 2.0),
+        (head_x, xfrm.y + xfrm.h),
+        (head_x, body_y_bot),
+        (xfrm.x, body_y_bot),
+    ])
+
+
+def _left_arrow(xfrm: Xfrm, sp_pr) -> GeomResult:
+    adj1 = _adj_value(sp_pr, "adj1", default_pct=0.5)
+    adj2 = _adj_value(sp_pr, "adj2", default_pct=0.5)
+    head_h = xfrm.h * adj1
+    head_w = xfrm.w * adj2
+    body_y_top = xfrm.y + (xfrm.h - head_h) / 2.0
+    body_y_bot = xfrm.y + (xfrm.h + head_h) / 2.0
+    head_x = xfrm.x + head_w
+    return _polygon([
+        (xfrm.x + xfrm.w, body_y_top),
+        (head_x, body_y_top),
+        (head_x, xfrm.y),
+        (xfrm.x, xfrm.y + xfrm.h / 2.0),
+        (head_x, xfrm.y + xfrm.h),
+        (head_x, body_y_bot),
+        (xfrm.x + xfrm.w, body_y_bot),
+    ])
+
+
+def _down_arrow(xfrm: Xfrm, sp_pr) -> GeomResult:
+    adj1 = _adj_value(sp_pr, "adj1", default_pct=0.5)
+    adj2 = _adj_value(sp_pr, "adj2", default_pct=0.5)
+    head_w = xfrm.w * adj1
+    head_h = xfrm.h * adj2
+    body_x_l = xfrm.x + (xfrm.w - head_w) / 2.0
+    body_x_r = xfrm.x + (xfrm.w + head_w) / 2.0
+    head_y = xfrm.y + xfrm.h - head_h
+    return _polygon([
+        (body_x_l, xfrm.y),
+        (body_x_l, head_y),
+        (xfrm.x, head_y),
+        (xfrm.x + xfrm.w / 2.0, xfrm.y + xfrm.h),
+        (xfrm.x + xfrm.w, head_y),
+        (body_x_r, head_y),
+        (body_x_r, xfrm.y),
+    ])
+
+
+def _up_arrow(xfrm: Xfrm, sp_pr) -> GeomResult:
+    adj1 = _adj_value(sp_pr, "adj1", default_pct=0.5)
+    adj2 = _adj_value(sp_pr, "adj2", default_pct=0.5)
+    head_w = xfrm.w * adj1
+    head_h = xfrm.h * adj2
+    body_x_l = xfrm.x + (xfrm.w - head_w) / 2.0
+    body_x_r = xfrm.x + (xfrm.w + head_w) / 2.0
+    head_y = xfrm.y + head_h
+    return _polygon([
+        (body_x_l, xfrm.y + xfrm.h),
+        (body_x_l, head_y),
+        (xfrm.x, head_y),
+        (xfrm.x + xfrm.w / 2.0, xfrm.y),
+        (xfrm.x + xfrm.w, head_y),
+        (body_x_r, head_y),
+        (body_x_r, xfrm.y + xfrm.h),
+    ])
+
+
+# ---------- Decorative shapes ----------
+
+def _plaque(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """Approximate DrawingML plaque with concave curved corner cuts."""
+    adj = _adj_value(sp_pr, "adj", default_pct=0.16667)
+    r = min(adj * min(xfrm.w, xfrm.h), min(xfrm.w, xfrm.h) / 2.0)
+    x, y, w, h = xfrm.x, xfrm.y, xfrm.w, xfrm.h
+    d = (
+        f"M {fmt_num(x + r)} {fmt_num(y)} "
+        f"L {fmt_num(x + w - r)} {fmt_num(y)} "
+        f"Q {fmt_num(x + w - r)} {fmt_num(y + r)} {fmt_num(x + w)} {fmt_num(y + r)} "
+        f"L {fmt_num(x + w)} {fmt_num(y + h - r)} "
+        f"Q {fmt_num(x + w - r)} {fmt_num(y + h - r)} {fmt_num(x + w - r)} {fmt_num(y + h)} "
+        f"L {fmt_num(x + r)} {fmt_num(y + h)} "
+        f"Q {fmt_num(x + r)} {fmt_num(y + h - r)} {fmt_num(x)} {fmt_num(y + h - r)} "
+        f"L {fmt_num(x)} {fmt_num(y + r)} "
+        f"Q {fmt_num(x + r)} {fmt_num(y + r)} {fmt_num(x + r)} {fmt_num(y)} Z"
+    )
+    return GeomResult(tag="path", path_d=d)
+
+
+# ---------- Pie / chord / arc (path-based) ----------
+
+def _pie(xfrm: Xfrm, sp_pr) -> GeomResult:
+    """Pie slice. adj1 = start angle, adj2 = end angle (1/60000 deg)."""
+    adj1 = _adj_value(sp_pr, "adj1", default_pct=0.0)  # default 0°
+    adj2 = _adj_value(sp_pr, "adj2", default_pct=270.0 / 360.0)  # default 270°
+    # adj is in 100000ths of percent → degrees by * 360
+    start_deg = adj1 * 360.0
+    end_deg = adj2 * 360.0
+    return _arc_path(xfrm, start_deg, end_deg, mode="pie")
+
+
+def _chord(xfrm: Xfrm, sp_pr) -> GeomResult:
+    adj1 = _adj_value(sp_pr, "adj1", default_pct=0.0)
+    adj2 = _adj_value(sp_pr, "adj2", default_pct=270.0 / 360.0)
+    return _arc_path(xfrm, adj1 * 360.0, adj2 * 360.0, mode="chord")
+
+
+def _arc(xfrm: Xfrm, sp_pr) -> GeomResult:
+    adj1 = _adj_value(sp_pr, "adj1", default_pct=270.0 / 360.0)
+    adj2 = _adj_value(sp_pr, "adj2", default_pct=0.0)
+    return _arc_path(xfrm, adj1 * 360.0, adj2 * 360.0, mode="arc")
+
+
+def _arc_path(xfrm: Xfrm, start_deg: float, end_deg: float, *, mode: str) -> GeomResult:
+    cx = xfrm.x + xfrm.w / 2.0
+    cy = xfrm.y + xfrm.h / 2.0
+    rx = xfrm.w / 2.0
+    ry = xfrm.h / 2.0
+    sa = math.radians(start_deg)
+    ea = math.radians(end_deg)
+    sx = cx + rx * math.cos(sa)
+    sy = cy + ry * math.sin(sa)
+    ex = cx + rx * math.cos(ea)
+    ey = cy + ry * math.sin(ea)
+    # Sweep direction: PowerPoint draws clockwise; SVG arc sweep_flag = 1 = clockwise.
+    delta = (end_deg - start_deg) % 360.0
+    large_arc = 1 if delta > 180 else 0
+    sweep = 1
+    parts = [f"M {fmt_num(sx)} {fmt_num(sy)}",
+             f"A {fmt_num(rx)} {fmt_num(ry)} 0 {large_arc} {sweep} {fmt_num(ex)} {fmt_num(ey)}"]
+    if mode == "pie":
+        parts.append(f"L {fmt_num(cx)} {fmt_num(cy)}")
+        parts.append("Z")
+    elif mode == "chord":
+        parts.append("Z")
+    return GeomResult(tag="path", path_d=" ".join(parts))
+
+
+# ---------------------------------------------------------------------------
+# Preset table
+# ---------------------------------------------------------------------------
+
+_PRESET_HANDLERS = {
+    # Core 4 (svg_to_pptx round-trip)
+    "rect": _rect,
+    "roundRect": _round_rect,
+    "round2DiagRect": _round_2_diag_rect,
+    "round2SameRect": _round_2_same_rect,
+    "ellipse": _ellipse,
+    "line": _line,
+    # Straight connector: same geometry as a `line` preset; head/tail markers
+    # come from <a:ln>.
+    "straightConnector1": _line,
+
+    # Polygons
+    "triangle": _triangle,
+    "rtTriangle": _rt_triangle,
+    "diamond": _diamond,
+    "parallelogram": _parallelogram,
+    "trapezoid": _trapezoid,
+    "chevron": _chevron,
+    "homePlate": _home_plate,
+    "flowChartExtract": _flow_chart_extract,
+    "flowChartMerge": _flow_chart_merge,
+    "pentagon": _pentagon,
+    "hexagon": _hexagon,
+    "heptagon": _heptagon,
+    "octagon": _octagon,
+    "decagon": _decagon,
+    "dodecagon": _dodecagon,
+
+    # Stars
+    "star4": _star(4),
+    "star5": _star(5),
+    "star6": _star(6),
+    "star7": _star(7),
+    "star8": _star(8),
+    "star10": _star(10),
+    "star12": _star(12),
+    "star16": _star(16),
+    "star24": _star(24),
+    "star32": _star(32),
+
+    # Arrows
+    "rightArrow": _right_arrow,
+    "leftArrow": _left_arrow,
+    "downArrow": _down_arrow,
+    "upArrow": _up_arrow,
+
+    # Decorative
+    "plaque": _plaque,
+
+    # Pie / chord / arc
+    "pie": _pie,
+    "chord": _chord,
+    "arc": _arc,
+}
+
+
+def supported_presets() -> set[str]:
+    """Return the set of recognized prst values for diagnostics."""
+    return set(_PRESET_HANDLERS.keys())

--- a/apps/inno-agent/scripts/pptx_to_svg/shape_walker.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/shape_walker.py
@@ -1,0 +1,392 @@
+"""Shape tree walker.
+
+Reads <p:spTree> from a slide / layout / master and emits a normalized
+ShapeNode tree that downstream converters can dispatch on.
+
+Handles:
+- <p:sp>           -> SHAPE
+- <p:pic>          -> PICTURE
+- <p:cxnSp>        -> CONNECTOR
+- <p:grpSp>        -> GROUP (recurses; resolves a:chOff/a:chExt frame)
+- <p:graphicFrame> -> GRAPHIC (table / chart / SmartArt — emitted as opaque
+                     placeholder for v1 so callers can decide a fallback)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from xml.etree import ElementTree as ET
+
+from .emu_units import NS, Xfrm, parse_xfrm
+
+
+# ---------------------------------------------------------------------------
+# ShapeNode
+# ---------------------------------------------------------------------------
+
+SHAPE = "sp"
+PICTURE = "pic"
+CONNECTOR = "cxnSp"
+GROUP = "grpSp"
+GRAPHIC = "graphicFrame"
+
+_TITLE_PLACEHOLDER_TYPES = {"title", "ctrTitle"}
+_BODY_PLACEHOLDER_TYPES = {"body", "subTitle"}
+_TX_STYLE_TITLE_KEY = ("__txStyleTitle", None)
+_TX_STYLE_BODY_KEY = ("__txStyleBody", None)
+_TX_STYLE_OTHER_KEY = ("__txStyleOther", None)
+
+
+@dataclass
+class PlaceholderInfo:
+    """Resolved <p:ph> attributes for a shape if any."""
+
+    type: str | None = None  # title / body / ctrTitle / subTitle / ftr / dt / ...
+    idx: str | None = None
+    sz: str | None = None  # full / half / quarter
+    orient: str | None = None
+
+
+@dataclass
+class ShapeNode:
+    """Normalized shape entry produced by the walker."""
+
+    kind: str  # one of SHAPE / PICTURE / CONNECTOR / GROUP / GRAPHIC
+    xml: ET.Element  # original element
+    xfrm: Xfrm  # resolved geometry in absolute slide pixel space
+    name: str = ""
+    spid: str = ""
+    hidden: bool = False
+    placeholder: PlaceholderInfo | None = None
+    inherited_lst_styles: tuple[ET.Element, ...] = ()
+    # GROUP only: children, in z-order
+    children: list["ShapeNode"] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Walker
+# ---------------------------------------------------------------------------
+
+def _read_nv_sp_pr(parent: ET.Element, nv_tag: str) -> tuple[str, str, bool, PlaceholderInfo | None]:
+    """Extract name/id/hidden/placeholder from an nvXXXPr container.
+
+    nv_tag is one of nvSpPr / nvPicPr / nvCxnSpPr / nvGrpSpPr / nvGraphicFramePr.
+    """
+    container = parent.find(f"p:{nv_tag}", NS)
+    name = ""
+    spid = ""
+    hidden = False
+    ph: PlaceholderInfo | None = None
+    if container is None:
+        return name, spid, hidden, ph
+
+    cnv = container.find("p:cNvPr", NS)
+    if cnv is not None:
+        name = cnv.attrib.get("name", "")
+        spid = cnv.attrib.get("id", "")
+        if cnv.attrib.get("hidden") == "1":
+            hidden = True
+
+    nv_pr = container.find("p:nvPr", NS)
+    if nv_pr is not None:
+        ph_elem = nv_pr.find("p:ph", NS)
+        if ph_elem is not None:
+            ph = PlaceholderInfo(
+                type=ph_elem.attrib.get("type"),
+                idx=ph_elem.attrib.get("idx"),
+                sz=ph_elem.attrib.get("sz"),
+                orient=ph_elem.attrib.get("orient"),
+            )
+
+    return name, spid, hidden, ph
+
+
+def _resolve_xfrm(shape: ET.Element, kind: str) -> ET.Element | None:
+    """Find the <a:xfrm> element under the right spPr / grpSpPr container."""
+    if kind == GROUP:
+        sp_pr = shape.find("p:grpSpPr", NS)
+    elif kind == GRAPHIC:
+        # graphicFrame uses p:xfrm directly (no a: namespace)
+        return shape.find("p:xfrm", NS)
+    else:
+        sp_pr = shape.find("p:spPr", NS)
+    if sp_pr is None:
+        return None
+    return sp_pr.find("a:xfrm", NS)
+
+
+def _adjust_for_group(child_xfrm: Xfrm, group_xfrm: Xfrm) -> Xfrm:
+    """Map a child shape's xfrm from group's child coordinate space into the
+    parent (group) coordinate space.
+
+    DrawingML group rule: a child's a:off/a:ext is in the group's chOff/chExt
+    coordinate system. We map to the group's actual off/ext on the slide.
+
+    If the group has no chOff/chExt, fall back to identity translation.
+    """
+    if (group_xfrm.ch_w is None or group_xfrm.ch_h is None
+            or group_xfrm.ch_w == 0 or group_xfrm.ch_h == 0):
+        # No child frame — children already in slide space; just translate.
+        return child_xfrm
+
+    # Linear map: child-frame -> group's (off..off+ext)
+    sx = group_xfrm.w / group_xfrm.ch_w if group_xfrm.ch_w else 1.0
+    sy = group_xfrm.h / group_xfrm.ch_h if group_xfrm.ch_h else 1.0
+    ch_x = group_xfrm.ch_x or 0.0
+    ch_y = group_xfrm.ch_y or 0.0
+
+    new_x = group_xfrm.x + (child_xfrm.x - ch_x) * sx
+    new_y = group_xfrm.y + (child_xfrm.y - ch_y) * sy
+    new_w = child_xfrm.w * sx
+    new_h = child_xfrm.h * sy
+
+    return Xfrm(
+        x=new_x, y=new_y, w=new_w, h=new_h,
+        rot=child_xfrm.rot,
+        flip_h=child_xfrm.flip_h,
+        flip_v=child_xfrm.flip_v,
+        ch_x=child_xfrm.ch_x, ch_y=child_xfrm.ch_y,
+        ch_w=child_xfrm.ch_w, ch_h=child_xfrm.ch_h,
+    )
+
+
+# Mapping from element tag -> kind / nv tag.
+_KIND_MAP = {
+    "sp": (SHAPE, "nvSpPr"),
+    "pic": (PICTURE, "nvPicPr"),
+    "cxnSp": (CONNECTOR, "nvCxnSpPr"),
+    "grpSp": (GROUP, "nvGrpSpPr"),
+    "graphicFrame": (GRAPHIC, "nvGraphicFramePr"),
+}
+
+
+def _walk_container(
+    container: ET.Element,
+    parent_group_xfrm: Xfrm | None,
+    placeholder_xfrms: dict[tuple[str | None, str | None], Xfrm] | None = None,
+    placeholder_lst_styles: dict[
+        tuple[str | None, str | None],
+        list[ET.Element],
+    ] | None = None,
+) -> list[ShapeNode]:
+    """Walk a p:spTree or p:grpSp subtree. Children kept in document (z) order.
+    """
+    nodes: list[ShapeNode] = []
+    for child in list(container):
+        if not isinstance(child.tag, str):
+            continue
+        local = child.tag.split("}", 1)[-1]
+        kind_info = _KIND_MAP.get(local)
+        if kind_info is None:
+            continue
+        kind, nv_tag = kind_info
+
+        name, spid, hidden, ph = _read_nv_sp_pr(child, nv_tag)
+        xfrm = parse_xfrm(_resolve_xfrm(child, kind))
+
+        # Placeholders without their own xfrm inherit geometry from a matching
+        # placeholder in the layout, then the master. This is what PowerPoint
+        # itself does when rendering the slide. Without this fallback such
+        # shapes get a 0×0 box and convert_txbody wraps every glyph onto its
+        # own line — visually a vertical strip of single characters.
+        if (ph is not None and placeholder_xfrms
+                and (xfrm.w == 0 and xfrm.h == 0)):
+            inherited = _lookup_placeholder_xfrm(ph, placeholder_xfrms)
+            if inherited is not None:
+                xfrm = Xfrm(
+                    x=inherited.x, y=inherited.y,
+                    w=inherited.w, h=inherited.h,
+                    rot=xfrm.rot, flip_h=xfrm.flip_h, flip_v=xfrm.flip_v,
+                    ch_x=xfrm.ch_x, ch_y=xfrm.ch_y,
+                    ch_w=xfrm.ch_w, ch_h=xfrm.ch_h,
+                )
+
+        # If we're inside a group, remap to slide-absolute coordinates
+        if parent_group_xfrm is not None:
+            xfrm = _adjust_for_group(xfrm, parent_group_xfrm)
+
+        inherited_lst_styles: tuple[ET.Element, ...] = ()
+        if ph is not None and placeholder_lst_styles:
+            inherited_lst_styles = _lookup_placeholder_lst_styles(
+                ph, placeholder_lst_styles,
+            )
+
+        node = ShapeNode(
+            kind=kind, xml=child, xfrm=xfrm,
+            name=name, spid=spid, hidden=hidden, placeholder=ph,
+            inherited_lst_styles=inherited_lst_styles,
+        )
+
+        if kind == GROUP:
+            node.children = _walk_container(
+                child, xfrm,
+                placeholder_xfrms=placeholder_xfrms,
+                placeholder_lst_styles=placeholder_lst_styles,
+            )
+
+        nodes.append(node)
+    return nodes
+
+
+def _lookup_placeholder_xfrm(
+    ph: PlaceholderInfo,
+    table: dict[tuple[str | None, str | None], Xfrm],
+) -> Xfrm | None:
+    """Find an inherited xfrm for a placeholder. PowerPoint matches first by
+    (type, idx) exactly, then by type alone, then by idx alone — so a slide
+    body with idx="1" can pull from a layout body that omits idx, and a slide
+    title with no idx can pull from a master title that has idx="0"."""
+    for key in (
+        (ph.type, ph.idx),
+        (ph.type, None),
+        (None, ph.idx),
+    ):
+        hit = table.get(key)
+        if hit is not None and (hit.w > 0 or hit.h > 0):
+            return hit
+    return None
+
+
+def _lookup_placeholder_lst_styles(
+    ph: PlaceholderInfo,
+    table: dict[tuple[str | None, str | None], list[ET.Element]],
+) -> tuple[ET.Element, ...]:
+    """Find inherited txBody/lstStyle elements for a placeholder."""
+    styles: list[ET.Element] = []
+    seen: set[int] = set()
+    for key in (
+        (ph.type, ph.idx),
+        (ph.type, None),
+        (None, ph.idx),
+        _placeholder_tx_style_key(ph),
+    ):
+        for style in table.get(key, []):
+            marker = id(style)
+            if marker in seen:
+                continue
+            styles.append(style)
+            seen.add(marker)
+    return tuple(styles)
+
+
+def _placeholder_tx_style_key(
+    ph: PlaceholderInfo,
+) -> tuple[str | None, str | None]:
+    if ph.type in _TITLE_PLACEHOLDER_TYPES:
+        return _TX_STYLE_TITLE_KEY
+    if ph.type in _BODY_PLACEHOLDER_TYPES:
+        return _TX_STYLE_BODY_KEY
+    return _TX_STYLE_OTHER_KEY
+
+
+def _build_placeholder_xfrm_table(
+    *parts: ET.Element | None,
+) -> dict[tuple[str | None, str | None], Xfrm]:
+    """Index placeholders that *do* have explicit geometry, in priority order.
+
+    Pass parts most-specific to least-specific (layout first, master second);
+    the first writer for a given key wins so layout overrides master, which is
+    what PowerPoint's inheritance chain expects.
+    """
+    table: dict[tuple[str | None, str | None], Xfrm] = {}
+    for part_xml in parts:
+        if part_xml is None:
+            continue
+        sp_tree = part_xml.find("p:cSld/p:spTree", NS)
+        if sp_tree is None:
+            continue
+        for sp in sp_tree.iter():
+            if not isinstance(sp.tag, str) or sp.tag.split("}", 1)[-1] != "sp":
+                continue
+            ph_elem = sp.find("p:nvSpPr/p:nvPr/p:ph", NS)
+            if ph_elem is None:
+                continue
+            xfrm_elem = sp.find("p:spPr/a:xfrm", NS)
+            if xfrm_elem is None:
+                continue
+            xfrm = parse_xfrm(xfrm_elem)
+            if xfrm.w <= 0 and xfrm.h <= 0:
+                continue
+            ph_type = ph_elem.attrib.get("type")
+            ph_idx = ph_elem.attrib.get("idx")
+            for key in ((ph_type, ph_idx),
+                        (ph_type, None),
+                        (None, ph_idx)):
+                table.setdefault(key, xfrm)
+    return table
+
+
+def _build_placeholder_lst_style_table(
+    *parts: ET.Element | None,
+) -> dict[tuple[str | None, str | None], list[ET.Element]]:
+    """Index placeholder txBody/lstStyle elements in priority order."""
+    table: dict[tuple[str | None, str | None], list[ET.Element]] = {}
+    for part_xml in parts:
+        if part_xml is None:
+            continue
+        sp_tree = part_xml.find("p:cSld/p:spTree", NS)
+        if sp_tree is None:
+            continue
+        for sp in sp_tree.iter():
+            if not isinstance(sp.tag, str) or sp.tag.split("}", 1)[-1] != "sp":
+                continue
+            ph_elem = sp.find("p:nvSpPr/p:nvPr/p:ph", NS)
+            if ph_elem is None:
+                continue
+            lst_style = sp.find("p:txBody/a:lstStyle", NS)
+            if lst_style is None:
+                continue
+            ph_type = ph_elem.attrib.get("type")
+            ph_idx = ph_elem.attrib.get("idx")
+            for key in ((ph_type, ph_idx),
+                        (ph_type, None),
+                        (None, ph_idx)):
+                table.setdefault(key, []).append(lst_style)
+        _append_master_tx_styles(table, part_xml)
+    return table
+
+
+def _append_master_tx_styles(
+    table: dict[tuple[str | None, str | None], list[ET.Element]],
+    part_xml: ET.Element,
+) -> None:
+    for key, path in (
+        (_TX_STYLE_TITLE_KEY, "p:txStyles/p:titleStyle"),
+        (_TX_STYLE_BODY_KEY, "p:txStyles/p:bodyStyle"),
+        (_TX_STYLE_OTHER_KEY, "p:txStyles/p:otherStyle"),
+    ):
+        style = part_xml.find(path, NS)
+        if style is not None:
+            table.setdefault(key, []).append(style)
+
+
+def walk_sp_tree(
+    slide_xml: ET.Element,
+    *,
+    layout_xml: ET.Element | None = None,
+    master_xml: ET.Element | None = None,
+) -> list[ShapeNode]:
+    """Top-level entry: return shape nodes for a slide / layout / master XML.
+
+    When ``slide_xml`` is a regular slide, pass its ``layout_xml`` and
+    ``master_xml`` so placeholders can inherit geometry and text list styles
+    from the layout/master. Layout and master walks pass neither — their own
+    placeholders are the source of truth.
+    """
+    sp_tree = slide_xml.find("p:cSld/p:spTree", NS)
+    if sp_tree is None:
+        return []
+    placeholder_xfrms = _build_placeholder_xfrm_table(layout_xml, master_xml)
+    placeholder_lst_styles = _build_placeholder_lst_style_table(
+        layout_xml, master_xml,
+    )
+    return _walk_container(
+        sp_tree, parent_group_xfrm=None,
+        placeholder_xfrms=placeholder_xfrms or None,
+        placeholder_lst_styles=placeholder_lst_styles or None,
+    )
+
+
+def get_background(slide_xml: ET.Element) -> ET.Element | None:
+    """Return the <p:bg> element if the slide defines its own background."""
+    return slide_xml.find("p:cSld/p:bg", NS)

--- a/apps/inno-agent/scripts/pptx_to_svg/slide_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/slide_to_svg.py
@@ -1,0 +1,925 @@
+"""Per-slide composition: dispatches every ShapeNode through the right
+converter, accumulates <defs>, and produces one final SVG string.
+
+The output structure mirrors what svg_to_pptx expects so the deck can be
+round-tripped:
+    <svg viewBox="0 0 W H">
+        <defs>
+            <linearGradient id=.../>
+            <marker id=.../>
+            <filter id=.../>
+        </defs>
+        <!-- background -->
+        <rect ... />        (slide background, if any)
+        <g id="shape-1">...</g>
+        <g id="shape-2">...</g>
+        ...
+    </svg>
+
+Each top-level <g> wraps one shape and is treated by svg_to_pptx as an
+animation anchor.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from xml.etree import ElementTree as ET
+
+from .color_resolver import ColorPalette, find_color_elem, resolve_color
+from .custgeom_to_svg import convert_custom_geom
+from .effect_to_svg import convert_effects
+from .emu_units import NS, Xfrm, fmt_num
+from .fill_to_svg import resolve_fill
+from .ln_to_svg import resolve_stroke
+from .ooxml_loader import OoxmlPackage, PartRef, SlideRef
+from .pic_to_svg import convert_blip_fill, convert_picture
+from .prstgeom_to_svg import GeomResult, convert_prst_geom
+from .shape_walker import (
+    CONNECTOR, GRAPHIC, GROUP, PICTURE, SHAPE,
+    ShapeNode, get_background, walk_sp_tree,
+)
+from .tbl_to_svg import convert_tbl
+from .txbody_to_svg import (
+    TextResult,
+    convert_txbody,
+    convert_vertical_txbody,
+    is_vertical_txbody,
+    DEFAULT_FONT_SIZE_PX,
+)
+
+
+# ---------------------------------------------------------------------------
+# AssemblyContext
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AssemblyContext:
+    """Per-slide accumulator for unique IDs + media + defs."""
+
+    palette: ColorPalette | None
+    pkg: OoxmlPackage
+    slide_part: PartRef
+    theme_fonts: dict[str, str] = field(default_factory=dict)
+    media_subdir: str = "assets"
+    embed_images: bool = False
+    keep_hidden: bool = False
+    group_id_prefix: str = ""
+    render_graphic_previews: bool = True
+    asset_name_map: dict[str, str] = field(default_factory=dict)
+
+    # Sequence counters (single-element lists so handlers can mutate)
+    grad_seq: list[int] = field(default_factory=lambda: [0])
+    marker_seq: list[int] = field(default_factory=lambda: [0])
+    filter_seq: list[int] = field(default_factory=lambda: [0])
+    shape_seq: list[int] = field(default_factory=lambda: [0])
+    clip_seq: list[int] = field(default_factory=lambda: [0])
+
+    # Accumulated outputs
+    defs: list[str] = field(default_factory=list)
+    media: dict[str, bytes] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Public entry
+# ---------------------------------------------------------------------------
+
+def assemble_slide(
+    pkg: OoxmlPackage,
+    slide: SlideRef,
+    palette: ColorPalette | None,
+    *,
+    theme_fonts: dict[str, str] | None = None,
+    media_subdir: str = "assets",
+    embed_images: bool = False,
+    keep_hidden: bool = False,
+    inheritance_mode: str = "flat",
+    asset_name_map: dict[str, str] | None = None,
+) -> tuple[str, dict[str, bytes]]:
+    """Convert one slide to a complete SVG string + media files map.
+
+    inheritance_mode controls how master/layout shapes are rendered:
+        - "flat" (default): emit master + layout non-placeholder shapes inline
+          inside the slide SVG. This is the historical behavior, used for
+          round-trip fidelity with svg_to_pptx.
+        - "layered": skip inherited shapes entirely. The slide SVG contains
+          only its own shapes. Callers (e.g. /create-template's PPTX import)
+          render master/layout once each as separate SVGs and record the
+          inheritance graph in inheritance.json.
+    """
+    ctx = AssemblyContext(
+        palette=palette,
+        pkg=pkg,
+        slide_part=slide.part,
+        theme_fonts=theme_fonts or {},
+        media_subdir=media_subdir,
+        embed_images=embed_images,
+        keep_hidden=keep_hidden,
+        render_graphic_previews=(inheritance_mode == "flat"),
+        asset_name_map=asset_name_map or {},
+    )
+
+    canvas_w, canvas_h = pkg.slide_size_px
+
+    # Background (cSld/bg) — emit as the first body element.
+    body_parts: list[str] = []
+    bg_xml = (
+        _emit_background(slide, ctx, canvas_w, canvas_h)
+        if inheritance_mode == "flat"
+        else _emit_part_background(
+            SlideRef(index=slide.index, part=slide.part, layout=None, master=slide.master),
+            ctx, canvas_w, canvas_h,
+        )
+    )
+    if bg_xml:
+        body_parts.append(bg_xml)
+
+    if inheritance_mode == "flat":
+        # Inherited layout/master shapes render behind slide-local shapes. Skip
+        # placeholders; they define editable regions, not visible background.
+        body_parts.extend(_emit_inherited_shapes(slide, ctx))
+    elif inheritance_mode != "layered":
+        raise ValueError(
+            f"inheritance_mode must be 'flat' or 'layered', got {inheritance_mode!r}"
+        )
+
+    # Walk shapes — placeholders without their own xfrm inherit geometry from
+    # layout, then master.
+    nodes = walk_sp_tree(
+        slide.part.xml,
+        layout_xml=slide.layout.xml if slide.layout else None,
+        master_xml=slide.master.xml if slide.master else None,
+    )
+    for node in nodes:
+        chunk = _convert_node(node, ctx, top_level=True)
+        if chunk:
+            body_parts.append(chunk)
+
+    # Compose final SVG
+    defs_xml = "".join(ctx.defs) if ctx.defs else ""
+    defs_block = f"<defs>{defs_xml}</defs>" if defs_xml else ""
+
+    svg = (
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" '
+        f'width="{fmt_num(canvas_w)}" height="{fmt_num(canvas_h)}" '
+        f'viewBox="0 0 {fmt_num(canvas_w)} {fmt_num(canvas_h)}">'
+        f"{defs_block}"
+        + "\n".join(body_parts)
+        + "</svg>"
+    )
+    return svg, ctx.media
+
+
+def assemble_part_solo(
+    pkg: OoxmlPackage,
+    part: PartRef,
+    palette: ColorPalette | None,
+    *,
+    role: str,
+    parent_master: PartRef | None = None,
+    theme_fonts: dict[str, str] | None = None,
+    media_subdir: str = "assets",
+    embed_images: bool = False,
+    keep_hidden: bool = False,
+    asset_name_map: dict[str, str] | None = None,
+) -> tuple[str, dict[str, bytes]]:
+    """Render a single slideMaster or slideLayout part as a standalone SVG.
+
+    Used by the layered export path. Skips placeholders the same way
+    `_emit_inherited_shapes` does, so the output represents the part's
+    decorative / structural shapes only — what the part *contributes* to its
+    descendants. The first ancestor's background (if any) is emitted as the
+    first body element so the output reads like a real slide.
+
+    Args:
+        role: 'master' or 'layout'. Used as the group_id_prefix to keep ids
+            unique when the workspace inlines multiple parts in a viewer.
+        parent_master: when ``role == "layout"``, pass the parent slide
+            master so theme-style background fills (``<p:bgRef idx=...>``)
+            can resolve via the theme attached to that master. For
+            ``role == "master"`` the master is its own parent and this
+            argument is ignored.
+    """
+    if role not in {"master", "layout"}:
+        raise ValueError(f"role must be 'master' or 'layout', got {role!r}")
+
+    ctx = AssemblyContext(
+        palette=palette,
+        pkg=pkg,
+        slide_part=part,
+        theme_fonts=theme_fonts or {},
+        media_subdir=media_subdir,
+        embed_images=embed_images,
+        keep_hidden=keep_hidden,
+        group_id_prefix=f"{role}-",
+        render_graphic_previews=False,
+        asset_name_map=asset_name_map or {},
+    )
+
+    canvas_w, canvas_h = pkg.slide_size_px
+
+    body_parts: list[str] = []
+
+    # Layered semantics: each part's standalone SVG must contain only that
+    # part's own contribution. The master gets its own bg, the layout gets
+    # its own bg only if it overrides the master's, and consumers re-stack
+    # the layers when they need a flat view. We therefore inspect <p:bg> on
+    # this part alone — never inherited from above. Theme-style fills
+    # (<p:bgRef idx=...>) still need the parent master's <a:fmtScheme> to
+    # resolve, hence the SlideRef.master plumbing below.
+    if role == "master":
+        master_for_theme: PartRef | None = part
+    else:
+        master_for_theme = parent_master
+    fake_slide = SlideRef(
+        index=0,
+        part=part,
+        layout=None,
+        master=master_for_theme,
+    )
+    bg_xml = _emit_part_background(fake_slide, ctx, canvas_w, canvas_h)
+    if bg_xml:
+        body_parts.append(bg_xml)
+
+    # Walk shapes. Placeholders are visualized as lightweight layout guides in
+    # layered master/layout SVGs so template slots remain machine-visible.
+    for node in walk_sp_tree(part.xml):
+        if _is_placeholder_node(node):
+            chunk = _convert_placeholder_guide(node, ctx, top_level=True)
+        else:
+            chunk = _convert_node(node, ctx, top_level=True)
+        if chunk:
+            body_parts.append(chunk)
+
+    defs_xml = "".join(ctx.defs) if ctx.defs else ""
+    defs_block = f"<defs>{defs_xml}</defs>" if defs_xml else ""
+
+    svg = (
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" '
+        f'width="{fmt_num(canvas_w)}" height="{fmt_num(canvas_h)}" '
+        f'viewBox="0 0 {fmt_num(canvas_w)} {fmt_num(canvas_h)}">'
+        f"{defs_block}"
+        + "\n".join(body_parts)
+        + "</svg>"
+    )
+    return svg, ctx.media
+
+
+# ---------------------------------------------------------------------------
+# Per-node dispatch
+# ---------------------------------------------------------------------------
+
+def _convert_node(node: ShapeNode, ctx: AssemblyContext, *, top_level: bool) -> str:
+    if node.hidden and not ctx.keep_hidden:
+        return ""
+    if node.kind == SHAPE:
+        return _convert_shape(node, ctx, top_level=top_level)
+    if node.kind == PICTURE:
+        return _convert_picture(node, ctx, top_level=top_level)
+    if node.kind == CONNECTOR:
+        return _convert_connector(node, ctx, top_level=top_level)
+    if node.kind == GROUP:
+        return _convert_group(node, ctx, top_level=top_level)
+    if node.kind == GRAPHIC:
+        return _convert_graphic_fallback(node, ctx, top_level=top_level)
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Shape (<p:sp>)
+# ---------------------------------------------------------------------------
+
+def _convert_shape(node: ShapeNode, ctx: AssemblyContext, *, top_level: bool) -> str:
+    sp_pr = node.xml.find("p:spPr", NS)
+
+    # Check for blipFill (image-filled shape, e.g. Canva exports where images
+    # are expressed as <p:sp> + <a:blipFill> rather than <p:pic>).
+    geom = _resolve_geometry(node, sp_pr)
+
+    blip_fill_elem = sp_pr.find("a:blipFill", NS) if sp_pr is not None else None
+    blip_image = ""
+    if blip_fill_elem is not None:
+        blip_result = convert_blip_fill(
+            blip_fill_elem, node.xfrm, ctx.slide_part, ctx.pkg,
+            media_subdir=ctx.media_subdir,
+            embed_inline=ctx.embed_images,
+            asset_name_map=ctx.asset_name_map,
+        )
+        if blip_result.svg:
+            blip_image = _clip_blip_image(blip_result.svg, geom, ctx)
+            ctx.media.update(blip_result.media)
+
+    # Geometry (fill is "none" when blipFill is present, so only stroke draws)
+    geom_xml = _build_geometry_xml(node, sp_pr, ctx, geom=geom)
+
+    # Text body (a:txBody)
+    tx_body = node.xml.find("p:txBody", NS)
+    is_vertical = is_vertical_txbody(tx_body, node.xfrm)
+    text_default_fill = _resolve_text_style_default(node, ctx)
+    if tx_body is not None and is_vertical:
+        text_result = convert_vertical_txbody(
+            tx_body, node.xfrm, ctx.palette,
+            theme_fonts=ctx.theme_fonts,
+            default_fill=text_default_fill,
+            default_font_size_px=DEFAULT_FONT_SIZE_PX,
+            fallback_lst_styles=node.inherited_lst_styles,
+            id_prefix=f"{ctx.group_id_prefix}txt",
+            id_seq=ctx.grad_seq,
+        )
+    else:
+        text_result = convert_txbody(
+            tx_body, node.xfrm, ctx.palette,
+            theme_fonts=ctx.theme_fonts,
+            default_fill=text_default_fill,
+            default_font_size_px=DEFAULT_FONT_SIZE_PX,
+            fallback_lst_styles=node.inherited_lst_styles,
+            id_prefix=f"{ctx.group_id_prefix}txt",
+            id_seq=ctx.grad_seq,
+        ) if tx_body is not None else TextResult()
+    if text_result.defs:
+        ctx.defs.extend(text_result.defs)
+
+    if is_vertical:
+        # Vertical text: geometry + image in one group, text in separate group
+        geom_inner = (blip_image + "\n" + geom_xml) if blip_image else geom_xml
+        shape_xml = _wrap_shape_group(geom_inner, node, ctx, top_level=top_level)
+        if not text_result.svg:
+            return shape_xml
+        text_group = (
+            f'<g id="{ctx.group_id_prefix}shape-{node.spid or ctx.shape_seq[0]}-text"'
+            f' data-name="{_xml_escape(node.name)} text">\n'
+            f"{text_result.svg}\n</g>"
+        )
+        return f"{shape_xml}\n{text_group}"
+
+    # Normal: image (behind) + geometry (stroke) + text (top)
+    inner_parts = []
+    if blip_image:
+        inner_parts.append(blip_image)
+    if geom_xml:
+        inner_parts.append(geom_xml)
+    if text_result.svg:
+        inner_parts.append(text_result.svg)
+    inner = "\n".join(inner_parts) if inner_parts else ""
+    return _wrap_shape_group(inner, node, ctx, top_level=top_level)
+
+
+def _resolve_geometry(node: ShapeNode, sp_pr: ET.Element | None) -> GeomResult | None:
+    """Resolve a DrawingML shape geometry into an absolute SVG geometry model."""
+    prst_geom = sp_pr.find("a:prstGeom", NS) if sp_pr is not None else None
+    cust_geom = sp_pr.find("a:custGeom", NS) if sp_pr is not None else None
+
+    geom: GeomResult | None = None
+    if prst_geom is not None:
+        prst = prst_geom.attrib.get("prst", "rect")
+        geom = convert_prst_geom(prst, node.xfrm, prst_geom)
+        if geom is None:
+            # Unknown prst — fall back to rect bounding box
+            geom = convert_prst_geom("rect", node.xfrm, None)
+    elif cust_geom is not None:
+        d = convert_custom_geom(cust_geom, node.xfrm)
+        if d:
+            geom = GeomResult(tag="path", path_d=d)
+    else:
+        # No geometry hint at all — render bounding rect
+        geom = convert_prst_geom("rect", node.xfrm, None)
+
+    if geom is None:
+        return None
+    if geom.tag != "line" and (node.xfrm.w <= 0 or node.xfrm.h <= 0):
+        return None
+    return geom
+
+
+def _build_geometry_xml(node: ShapeNode, sp_pr: ET.Element | None,
+                        ctx: AssemblyContext,
+                        geom: GeomResult | None = None) -> str:
+    """Build the SVG geometry element with fill/stroke/effect attributes."""
+    if geom is None:
+        geom = _resolve_geometry(node, sp_pr)
+    if geom is None:
+        return ""
+
+    # Resolve style defaults early so markers can adopt the theme stroke color
+    # when <a:ln> doesn't carry an explicit solidFill.
+    style_defaults = _resolve_shape_style_defaults(node, ctx)
+
+    # Fill / stroke / effect
+    fill = resolve_fill(sp_pr, ctx.palette,
+                        id_prefix="g", id_seq=ctx.grad_seq)
+    stroke = resolve_stroke(
+        sp_pr, ctx.palette,
+        id_prefix="m", id_seq=ctx.marker_seq,
+        style_stroke_default=style_defaults.get("stroke"),
+    )
+    filter_id, effect_defs = convert_effects(sp_pr, ctx.palette,
+                                             id_prefix="fx",
+                                             id_seq=ctx.filter_seq)
+
+    ctx.defs.extend(fill.defs)
+    ctx.defs.extend(stroke.defs)
+    ctx.defs.extend(effect_defs)
+
+    attrs = {**fill.attrs, **stroke.attrs}
+    for key, value in style_defaults.items():
+        attrs.setdefault(key, value)
+    if filter_id is not None:
+        attrs["filter"] = f"url(#{filter_id})"
+
+    # Default fill / stroke when not specified by spPr (matches PowerPoint
+    # behavior: a:noFill on shape-level fill if there's a txBody, else any
+    # explicit fill present in spPr should already have been captured).
+    if "fill" not in attrs:
+        attrs["fill"] = "none"
+    if "stroke" not in attrs:
+        # Spec default for shapes is no stroke unless ln says otherwise.
+        # Skip emitting stroke="none" to keep markup tight.
+        pass
+
+    geom_attrs_xml = _attrs_to_xml({**geom.attrs, **attrs})
+    return _geom_to_svg(geom, geom_attrs_xml)
+
+
+def _resolve_shape_style_defaults(node: ShapeNode, ctx: AssemblyContext) -> dict[str, str]:
+    """Resolve minimal p:style defaults used when spPr omits explicit style.
+
+    Full theme style matrix reproduction is intentionally out of scope here;
+    this only prevents common theme-styled placeholders/shapes from becoming
+    transparent or unstroked when their visible color lives in p:style.
+    """
+    style = node.xml.find("p:style", NS)
+    if style is None:
+        return {}
+
+    defaults: dict[str, str] = {}
+
+    fill_ref = style.find("a:fillRef", NS)
+    fill_color = _resolve_ref_color(fill_ref, ctx)
+    if fill_color:
+        defaults["fill"] = fill_color
+
+    ln_ref = style.find("a:lnRef", NS)
+    line_color = _resolve_ref_color(ln_ref, ctx)
+    if line_color:
+        defaults["stroke"] = line_color
+        defaults.setdefault("stroke-width", "1")
+
+    return defaults
+
+
+def _resolve_text_style_default(node: ShapeNode, ctx: AssemblyContext) -> str:
+    """Resolve p:style fontRef color used by runs without explicit fill."""
+    style = node.xml.find("p:style", NS)
+    if style is None:
+        return "#000000"
+    font_ref = style.find("a:fontRef", NS)
+    font_color = _resolve_ref_color(font_ref, ctx)
+    return font_color or "#000000"
+
+
+def _resolve_ref_color(ref_elem: ET.Element | None, ctx: AssemblyContext) -> str | None:
+    color_elem = find_color_elem(ref_elem)
+    hex_, _alpha = resolve_color(color_elem, ctx.palette)
+    return hex_
+
+
+def _geom_to_svg(geom: GeomResult, attrs_xml: str = "") -> str:
+    """Serialize a resolved geometry with optional SVG attributes."""
+    if not attrs_xml:
+        attrs_xml = _attrs_to_xml(geom.attrs)
+    if geom.tag == "path":
+        return f'<path d="{geom.path_d}"{attrs_xml}/>'
+    if geom.tag in ("polygon", "polyline"):
+        return f'<{geom.tag} points="{geom.points}"{attrs_xml}/>'
+    return f"<{geom.tag}{attrs_xml}/>"
+
+
+def _clip_blip_image(image_xml: str, geom: GeomResult | None,
+                     ctx: AssemblyContext) -> str:
+    """Clip image fills to the owning shape geometry when it is not a plain rect."""
+    if geom is None or geom.tag == "line":
+        return image_xml
+    if geom.tag == "rect" and not geom.attrs.get("rx") and not geom.attrs.get("ry"):
+        return image_xml
+
+    ctx.clip_seq[0] += 1
+    clip_id = f"{ctx.group_id_prefix}clip{ctx.clip_seq[0]}"
+    clip_shape = _geom_to_svg(geom)
+    ctx.defs.append(
+        f'<clipPath id="{clip_id}" clipPathUnits="userSpaceOnUse">'
+        f'{clip_shape}</clipPath>'
+    )
+    return _inject_clip_path(image_xml, clip_id)
+
+
+def _inject_clip_path(image_xml: str, clip_id: str) -> str:
+    clip_attr = f' clip-path="url(#{clip_id})"'
+    if image_xml.startswith("<image"):
+        return image_xml.replace("<image", f"<image{clip_attr}", 1)
+    if image_xml.startswith("<svg"):
+        return image_xml.replace("<svg", f'<svg data-pptx-crop="1"{clip_attr}', 1)
+    return image_xml
+
+
+# ---------------------------------------------------------------------------
+# Picture (<p:pic>)
+# ---------------------------------------------------------------------------
+
+def _convert_picture(node: ShapeNode, ctx: AssemblyContext, *, top_level: bool) -> str:
+    result = convert_picture(
+        node.xml, node.xfrm, ctx.slide_part, ctx.pkg,
+        media_subdir=ctx.media_subdir,
+        embed_inline=ctx.embed_images,
+        asset_name_map=ctx.asset_name_map,
+    )
+    if not result.svg:
+        return ""
+    ctx.media.update(result.media)
+    return _wrap_shape_group(result.svg, node, ctx, top_level=top_level)
+
+
+# ---------------------------------------------------------------------------
+# Connector (<p:cxnSp>)
+# ---------------------------------------------------------------------------
+
+def _convert_connector(node: ShapeNode, ctx: AssemblyContext, *, top_level: bool) -> str:
+    sp_pr = node.xml.find("p:spPr", NS)
+    geom_xml = _build_geometry_xml(node, sp_pr, ctx)
+    return _wrap_shape_group(geom_xml, node, ctx, top_level=top_level)
+
+
+# ---------------------------------------------------------------------------
+# Group (<p:grpSp>)
+# ---------------------------------------------------------------------------
+
+def _convert_group(node: ShapeNode, ctx: AssemblyContext, *, top_level: bool) -> str:
+    """Render group contents flat (children already remapped to slide space)."""
+    inner_parts: list[str] = []
+    for child in node.children:
+        chunk = _convert_node(child, ctx, top_level=False)
+        if chunk:
+            inner_parts.append(chunk)
+    if not inner_parts:
+        return ""
+    inner = "\n".join(inner_parts)
+    return _wrap_shape_group(inner, node, ctx, top_level=top_level)
+
+
+# ---------------------------------------------------------------------------
+# Graphic frame fallback (<p:graphicFrame>)
+# ---------------------------------------------------------------------------
+
+def _convert_graphic_fallback(node: ShapeNode, ctx: AssemblyContext,
+                              *, top_level: bool) -> str:
+    """Render a <p:graphicFrame> by dispatching on its graphicData uri.
+
+    Currently:
+    - ``...drawingml/2006/table`` → real table renderer (`convert_tbl`)
+    - ``...presentationml/2006/ole`` → render the ``mc:Fallback`` preview
+      bitmap that PowerPoint bakes alongside every embedded OLE object.
+      Visually identical to what PowerPoint shows for an unedited embed.
+    - everything else (chart / SmartArt / diagram) → labelled bounding
+      rectangle so the slide composition is preserved even though the inner
+      content can't be drawn yet.
+    """
+    graphic_data = node.xml.find("a:graphic/a:graphicData", NS)
+    uri = graphic_data.attrib.get("uri", "graphicFrame") if graphic_data is not None else "graphicFrame"
+
+    if uri == "http://schemas.openxmlformats.org/drawingml/2006/table":
+        rendered = _render_graphic_table(node, ctx, graphic_data)
+        if rendered:
+            return _wrap_shape_group(rendered, node, ctx, top_level=top_level)
+
+    if uri == "http://schemas.openxmlformats.org/presentationml/2006/ole" and ctx.render_graphic_previews:
+        rendered = _render_graphic_preview(node, ctx)
+        if rendered:
+            labelled = rendered + "\n" + _graphic_preview_label(node, "ole preview")
+            return _wrap_shape_group(labelled, node, ctx, top_level=top_level)
+
+    if ctx.render_graphic_previews:
+        rendered = _render_graphic_preview(node, ctx)
+        if rendered:
+            labelled = rendered + "\n" + _graphic_preview_label(node, f"{uri.rsplit('/', 1)[-1]} preview")
+            return _wrap_shape_group(labelled, node, ctx, top_level=top_level)
+
+    label = uri.rsplit("/", 1)[-1]
+    placeholder = (
+        f'<rect x="{fmt_num(node.xfrm.x)}" y="{fmt_num(node.xfrm.y)}" '
+        f'width="{fmt_num(node.xfrm.w)}" height="{fmt_num(node.xfrm.h)}" '
+        f'fill="none" stroke="#999999" stroke-dasharray="4 4"/>'
+        f'<text x="{fmt_num(node.xfrm.x + node.xfrm.w / 2)}" '
+        f'y="{fmt_num(node.xfrm.y + node.xfrm.h / 2)}" '
+        f'text-anchor="middle" font-size="14" fill="#999999">'
+        f"[{_xml_escape(label)}]</text>"
+    )
+    return _wrap_shape_group(placeholder, node, ctx, top_level=top_level)
+
+
+def _graphic_preview_label(node: ShapeNode, label: str) -> str:
+    return (
+        f'<rect x="{fmt_num(node.xfrm.x)}" y="{fmt_num(node.xfrm.y)}" '
+        f'width="{fmt_num(node.xfrm.w)}" height="22" '
+        f'fill="#FFFFFF" fill-opacity="0.82" stroke="#999999" stroke-width="0.5"/>'
+        f'<text x="{fmt_num(node.xfrm.x + 6)}" y="{fmt_num(node.xfrm.y + 15)}" '
+        f'font-size="11" fill="#666666">[{_xml_escape(label)}]</text>'
+    )
+
+
+def _render_graphic_table(node: ShapeNode, ctx: AssemblyContext,
+                          graphic_data: ET.Element | None) -> str:
+    """Convert the <a:tbl> child of a graphicFrame to SVG, or return ''."""
+    if graphic_data is None:
+        return ""
+    tbl = graphic_data.find("a:tbl", NS)
+    if tbl is None:
+        return ""
+    result = convert_tbl(
+        tbl, node.xfrm, ctx.palette,
+        theme_fonts=ctx.theme_fonts,
+        id_prefix=f"tbl{ctx.shape_seq[0]}",
+        grad_seq=ctx.grad_seq,
+        marker_seq=ctx.marker_seq,
+    )
+    if result.defs:
+        ctx.defs.extend(result.defs)
+    return result.svg
+
+
+def _render_graphic_preview(node: ShapeNode, ctx: AssemblyContext) -> str:
+    """Render a graphicFrame's baked fallback preview bitmap when present.
+
+    PowerPoint stores a static raster preview for many embedded graphics
+    inside ``mc:AlternateContent``. The Fallback branch is normally a plain
+    ``p:pic`` (sometimes nested), so any conformant viewer that can't speak
+    the richer object paints the preview. We do the same for flat preview SVGs.
+
+    Falls back to '' when the deck has no Fallback pic (very old or
+    third-party authoring tools sometimes omit it). Caller then emits the
+    dashed placeholder.
+    """
+    ac = node.xml.find("a:graphic/a:graphicData/mc:AlternateContent", NS)
+    if ac is None:
+        return ""
+    pic = ac.find("mc:Fallback//p:pic", NS)
+    if pic is None:
+        # Some authoring tools put the preview directly in mc:Choice.
+        pic = ac.find("mc:Choice//p:pic", NS)
+        if pic is None:
+            return ""
+
+    # The inner pic carries its own absolute xfrm in this deck (and in every
+    # well-formed PPTX I've seen — PowerPoint copies the graphicFrame xfrm
+    # there during save). If it's missing, fall back to the graphicFrame's
+    # xfrm so the preview at least lands somewhere visible.
+    inner_xfrm = node.xfrm
+    pic_xfrm_elem = pic.find("p:spPr/a:xfrm", NS)
+    if pic_xfrm_elem is not None:
+        from .emu_units import parse_xfrm
+        parsed = parse_xfrm(pic_xfrm_elem)
+        if parsed.w > 0 and parsed.h > 0:
+            inner_xfrm = parsed
+
+    result = convert_picture(
+        pic, inner_xfrm, ctx.slide_part, ctx.pkg,
+        media_subdir=ctx.media_subdir,
+        embed_inline=ctx.embed_images,
+        asset_name_map=ctx.asset_name_map,
+    )
+    if not result.svg:
+        return ""
+    ctx.media.update(result.media)
+    return result.svg
+
+
+# ---------------------------------------------------------------------------
+# Background
+# ---------------------------------------------------------------------------
+
+def _emit_background(slide: SlideRef, ctx: AssemblyContext,
+                     w: float, h: float) -> str:
+    """Inspect <p:bg> on slide / layout / master in inheritance order."""
+    for part in (slide.part, slide.layout, slide.master):
+        if part is None:
+            continue
+        bg = get_background(part.xml)
+        if bg is None:
+            continue
+        bg_pr = bg.find("p:bgPr", NS)
+        bg_ref = bg.find("p:bgRef", NS)
+        placeholder_hex = None
+
+        if bg_pr is None and bg_ref is not None:
+            bg_pr = _theme_background_fill(slide, ctx, bg_ref)
+            color_elem = find_color_elem(bg_ref)
+            placeholder_hex, _ = resolve_color(color_elem, ctx.palette)
+        if bg_pr is None:
+            continue
+
+        bg_image = _emit_background_image(bg_pr, part, ctx, w, h)
+        if bg_image:
+            return bg_image
+
+        fill = resolve_fill(
+            bg_pr, ctx.palette,
+            id_prefix="bg", id_seq=ctx.grad_seq,
+            placeholder_hex=placeholder_hex,
+        )
+        ctx.defs.extend(fill.defs)
+        if not fill.attrs:
+            return ""
+        # Convert dict to attributes
+        attrs_xml = _attrs_to_xml(fill.attrs)
+        return (f'<rect x="0" y="0" width="{fmt_num(w)}" height="{fmt_num(h)}"'
+                f"{attrs_xml}/>")
+    return ""
+
+
+def _emit_part_background(slide: SlideRef, ctx: AssemblyContext,
+                          w: float, h: float) -> str:
+    """Render the background declared on the part itself only.
+
+    Distinct from `_emit_background`, which walks the slide → layout →
+    master inheritance chain. Used by the layered solo renderer so each
+    standalone master / layout SVG carries only its own ``<p:bg>`` — the
+    inheritance is rebuilt by consumers re-stacking the layers, and we'd
+    rather output nothing than have master decoration leak into a layout
+    file.
+    """
+    bg = get_background(slide.part.xml)
+    if bg is None:
+        return ""
+    bg_pr = bg.find("p:bgPr", NS)
+    bg_ref = bg.find("p:bgRef", NS)
+    placeholder_hex = None
+
+    if bg_pr is None and bg_ref is not None:
+        bg_pr = _theme_background_fill(slide, ctx, bg_ref)
+        color_elem = find_color_elem(bg_ref)
+        placeholder_hex, _ = resolve_color(color_elem, ctx.palette)
+    if bg_pr is None:
+        return ""
+
+    bg_image = _emit_background_image(bg_pr, slide.part, ctx, w, h)
+    if bg_image:
+        return bg_image
+
+    fill = resolve_fill(
+        bg_pr, ctx.palette,
+        id_prefix="bg", id_seq=ctx.grad_seq,
+        placeholder_hex=placeholder_hex,
+    )
+    ctx.defs.extend(fill.defs)
+    if not fill.attrs:
+        return ""
+    attrs_xml = _attrs_to_xml(fill.attrs)
+    return (f'<rect x="0" y="0" width="{fmt_num(w)}" height="{fmt_num(h)}"'
+            f"{attrs_xml}/>")
+
+
+def _emit_background_image(
+    bg_pr: ET.Element,
+    source_part: PartRef,
+    ctx: AssemblyContext,
+    w: float,
+    h: float,
+) -> str:
+    """Render a slide/layout/master background image fill as a full-canvas image."""
+    blip_fill = bg_pr.find("a:blipFill", NS)
+    if blip_fill is None:
+        return ""
+
+    result = convert_blip_fill(
+        blip_fill,
+        Xfrm(0.0, 0.0, w, h),
+        source_part,
+        ctx.pkg,
+        media_subdir=ctx.media_subdir,
+        embed_inline=ctx.embed_images,
+        asset_name_map=ctx.asset_name_map,
+    )
+    if result.media:
+        ctx.media.update(result.media)
+    return result.svg
+
+
+def _theme_background_fill(
+    slide: SlideRef,
+    ctx: AssemblyContext,
+    bg_ref: ET.Element,
+) -> ET.Element | None:
+    """Resolve p:bgRef idx into the theme background fill style list."""
+    idx_raw = bg_ref.attrib.get("idx")
+    if not idx_raw:
+        return None
+    try:
+        idx = int(idx_raw)
+    except ValueError:
+        return None
+    # ECMA style matrix background fill references are 1001-based.
+    bg_fill_index = idx - 1001
+    if bg_fill_index < 0:
+        return None
+
+    theme = ctx.pkg.resolve_theme(slide.master)
+    if theme is None:
+        return None
+    fill_list = theme.xml.find(".//a:fmtScheme/a:bgFillStyleLst", NS)
+    if fill_list is None:
+        return None
+    fills = [child for child in list(fill_list) if isinstance(child.tag, str)]
+    if bg_fill_index >= len(fills):
+        return None
+    return fills[bg_fill_index]
+
+
+def _emit_inherited_shapes(slide: SlideRef, ctx: AssemblyContext) -> list[str]:
+    parts: list[str] = []
+    for prefix, part in (("master-", slide.master), ("layout-", slide.layout)):
+        if part is None:
+            continue
+        original_part = ctx.slide_part
+        original_prefix = ctx.group_id_prefix
+        ctx.slide_part = part
+        ctx.group_id_prefix = prefix
+        try:
+            for node in walk_sp_tree(part.xml):
+                if _is_placeholder_node(node):
+                    continue
+                chunk = _convert_node(node, ctx, top_level=True)
+                if chunk:
+                    parts.append(chunk)
+        finally:
+            ctx.slide_part = original_part
+            ctx.group_id_prefix = original_prefix
+    return parts
+
+
+def _is_placeholder_node(node: ShapeNode) -> bool:
+    if node.placeholder is not None:
+        return True
+    if node.kind == GROUP:
+        return all(_is_placeholder_node(child) for child in node.children)
+    return False
+
+
+def _convert_placeholder_guide(node: ShapeNode, ctx: AssemblyContext,
+                               *, top_level: bool) -> str:
+    """Emit a lightweight visible guide for template placeholder slots."""
+    ph = node.placeholder
+    label_parts = ["ph"]
+    if ph is not None:
+        if ph.type:
+            label_parts.append(ph.type)
+        if ph.idx:
+            label_parts.append(f"idx={ph.idx}")
+    label = " ".join(label_parts)
+    guide = (
+        f'<rect x="{fmt_num(node.xfrm.x)}" y="{fmt_num(node.xfrm.y)}" '
+        f'width="{fmt_num(node.xfrm.w)}" height="{fmt_num(node.xfrm.h)}" '
+        f'fill="#F8FAFC" fill-opacity="0.18" stroke="#94A3B8" '
+        f'stroke-dasharray="6 4" stroke-width="1"/>'
+        f'<text x="{fmt_num(node.xfrm.x + 8)}" y="{fmt_num(node.xfrm.y + 18)}" '
+        f'font-size="12" fill="#64748B">{_xml_escape(label)}</text>'
+    )
+    return _wrap_shape_group(guide, node, ctx, top_level=top_level)
+
+
+# ---------------------------------------------------------------------------
+# Wrap / utilities
+# ---------------------------------------------------------------------------
+
+def _wrap_shape_group(inner: str, node: ShapeNode, ctx: AssemblyContext,
+                      *, top_level: bool) -> str:
+    """Wrap a shape's body in a <g> that carries the transform (rotation /
+    flip) and an id for animation anchoring."""
+    if not inner.strip():
+        return ""
+
+    transform = node.xfrm.to_svg_transform()
+    ctx.shape_seq[0] += 1
+    seq = ctx.shape_seq[0]
+    sid = node.spid or str(seq)
+    g_id = f"{ctx.group_id_prefix}shape-{sid}"
+
+    attrs: list[str] = [f'id="{g_id}"']
+    if node.name:
+        attrs.append(f'data-name="{_xml_escape(node.name)}"')
+    if node.placeholder is not None and node.placeholder.type:
+        attrs.append(f'data-ph-type="{_xml_escape(node.placeholder.type)}"')
+    if transform:
+        attrs.append(f'transform="{transform}"')
+    return f"<g {' '.join(attrs)}>\n{inner}\n</g>"
+
+
+def _attrs_to_xml(attrs: dict[str, str]) -> str:
+    if not attrs:
+        return ""
+    return "".join(f' {k}="{v}"' for k, v in attrs.items())
+
+
+def _xml_escape(text: str) -> str:
+    return (text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace('"', "&quot;"))

--- a/apps/inno-agent/scripts/pptx_to_svg/tbl_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/tbl_to_svg.py
@@ -1,0 +1,401 @@
+"""Convert a DrawingML <a:tbl> into SVG.
+
+Tables in PowerPoint are stored under <p:graphicFrame> with
+graphicData uri="...drawingml/2006/table" wrapping a single <a:tbl>:
+
+    <p:graphicFrame>
+      <p:xfrm>...</p:xfrm>
+      <a:graphic><a:graphicData uri="...table">
+        <a:tbl>
+          <a:tblPr/>
+          <a:tblGrid>
+            <a:gridCol w="..."/>...
+          </a:tblGrid>
+          <a:tr h="...">
+            <a:tc [gridSpan=N] [rowSpan=N] [hMerge=1] [vMerge=1]>
+              <a:txBody>...</a:txBody>
+              <a:tcPr>
+                <a:lnL/><a:lnR/><a:lnT/><a:lnB/>
+                <a:solidFill/>... or <a:gradFill/> ...
+              </a:tcPr>
+            </a:tc>
+          </a:tr>
+        </a:tbl>
+      </a:graphicData></a:graphic>
+    </p:graphicFrame>
+
+The graphicFrame's <p:xfrm> gives the table's slide-space position and total
+size; <a:tblGrid> + <a:tr> heights distribute that size across columns/rows.
+
+Cell painting order:
+1. background fill (rect at cell box)
+2. text body (re-uses convert_txbody)
+3. cell borders (lnT / lnR / lnB / lnL — stroked as separate <line>s so
+   neighbouring cells with different border styles render correctly)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from xml.etree import ElementTree as ET
+
+from .color_resolver import ColorPalette
+from .emu_units import NS, Xfrm, emu_to_px, fmt_num
+from .fill_to_svg import resolve_fill
+from .ln_to_svg import resolve_stroke
+from .txbody_to_svg import convert_txbody
+
+
+@dataclass
+class TableResult:
+    """Composite render output: SVG body + accumulated <defs>."""
+
+    svg: str = ""
+    defs: list[str] = None
+
+    def __post_init__(self) -> None:
+        if self.defs is None:
+            self.defs = []
+
+
+# ---------------------------------------------------------------------------
+# Public entry
+# ---------------------------------------------------------------------------
+
+def convert_tbl(
+    tbl: ET.Element,
+    xfrm: Xfrm,
+    palette: ColorPalette | None,
+    *,
+    theme_fonts: dict[str, str] | None = None,
+    id_prefix: str = "tbl",
+    grad_seq: list[int] | None = None,
+    marker_seq: list[int] | None = None,
+) -> TableResult:
+    """Render an <a:tbl> at the given absolute xfrm into SVG markup."""
+    grad_seq = grad_seq if grad_seq is not None else [0]
+    marker_seq = marker_seq if marker_seq is not None else [0]
+
+    col_widths_px = _column_widths_px(tbl)
+    if not col_widths_px:
+        return TableResult()
+    rows = tbl.findall("a:tr", NS)
+    if not rows:
+        return TableResult()
+    row_heights_px = [_row_height_px(r) for r in rows]
+
+    # PowerPoint's tblGrid widths and tr heights together describe the
+    # *intrinsic* table size. The graphicFrame xfrm width/height may differ;
+    # if it does, scale rows/columns proportionally so the table fills the
+    # frame the way PowerPoint renders it.
+    intrinsic_w = sum(col_widths_px) or xfrm.w
+    intrinsic_h = sum(row_heights_px) or xfrm.h
+    sx = (xfrm.w / intrinsic_w) if intrinsic_w else 1.0
+    sy = (xfrm.h / intrinsic_h) if intrinsic_h else 1.0
+    col_widths = [w * sx for w in col_widths_px]
+    row_heights = [h * sy for h in row_heights_px]
+
+    col_lefts = _cumulative_starts(xfrm.x, col_widths)
+    row_tops = _cumulative_starts(xfrm.y, row_heights)
+
+    # First pass: resolve merge state so spanned cells get the union geometry
+    # and dropped cells don't render anything. PowerPoint expresses merges via
+    # gridSpan/rowSpan on the anchor cell + hMerge/vMerge on the dropped cells.
+    cells = _build_cell_grid(rows, len(col_widths))
+
+    body_parts: list[str] = []
+    defs: list[str] = []
+
+    # Pass A: cell backgrounds.
+    for r, row_cells in enumerate(cells):
+        for c, cell in enumerate(row_cells):
+            if cell is None or cell.is_dropped:
+                continue
+            rect_x = col_lefts[c]
+            rect_y = row_tops[r]
+            rect_w = sum(col_widths[c:c + cell.col_span])
+            rect_h = sum(row_heights[r:r + cell.row_span])
+            tcPr = cell.element.find("a:tcPr", NS)
+            fill = resolve_fill(
+                tcPr, palette,
+                id_prefix=f"{id_prefix}fill",
+                id_seq=grad_seq,
+            )
+            defs.extend(fill.defs)
+            attrs = fill.attrs or {"fill": "none"}
+            attr_str = "".join(f' {k}="{v}"' for k, v in attrs.items())
+            body_parts.append(
+                f'<rect x="{fmt_num(rect_x)}" y="{fmt_num(rect_y)}" '
+                f'width="{fmt_num(rect_w)}" height="{fmt_num(rect_h)}"'
+                f'{attr_str}/>'
+            )
+
+    # Pass B: cell text. Cell xfrm uses default tcPr insets if none specified.
+    for r, row_cells in enumerate(cells):
+        for c, cell in enumerate(row_cells):
+            if cell is None or cell.is_dropped:
+                continue
+            tx_body = cell.element.find("a:txBody", NS)
+            if tx_body is None:
+                continue
+            tcPr = cell.element.find("a:tcPr", NS)
+            cell_x = col_lefts[c]
+            cell_y = row_tops[r]
+            cell_w = sum(col_widths[c:c + cell.col_span])
+            cell_h = sum(row_heights[r:r + cell.row_span])
+            cell_xfrm = Xfrm(x=cell_x, y=cell_y, w=cell_w, h=cell_h)
+            text_result = _convert_cell_text(
+                tx_body, tcPr, cell_xfrm, palette, theme_fonts,
+                id_prefix=f"{id_prefix}txt",
+                id_seq=grad_seq,
+            )
+            defs.extend(text_result.defs)
+            if text_result.svg:
+                body_parts.append(text_result.svg)
+
+    # Pass C: cell borders. Drawn last so they appear on top of fills/text.
+    for r, row_cells in enumerate(cells):
+        for c, cell in enumerate(row_cells):
+            if cell is None or cell.is_dropped:
+                continue
+            cell_x = col_lefts[c]
+            cell_y = row_tops[r]
+            cell_w = sum(col_widths[c:c + cell.col_span])
+            cell_h = sum(row_heights[r:r + cell.row_span])
+            tcPr = cell.element.find("a:tcPr", NS)
+            for tag, x1, y1, x2, y2 in (
+                ("a:lnT", cell_x, cell_y, cell_x + cell_w, cell_y),
+                ("a:lnR", cell_x + cell_w, cell_y, cell_x + cell_w, cell_y + cell_h),
+                ("a:lnB", cell_x, cell_y + cell_h, cell_x + cell_w, cell_y + cell_h),
+                ("a:lnL", cell_x, cell_y, cell_x, cell_y + cell_h),
+            ):
+                line_xml = _border_line(
+                    tcPr, tag, x1, y1, x2, y2, palette,
+                    id_prefix=f"{id_prefix}stk", id_seq=marker_seq, defs=defs,
+                )
+                if line_xml:
+                    body_parts.append(line_xml)
+
+    return TableResult(svg="\n".join(body_parts), defs=defs)
+
+
+# ---------------------------------------------------------------------------
+# Geometry helpers
+# ---------------------------------------------------------------------------
+
+def _column_widths_px(tbl: ET.Element) -> list[float]:
+    grid = tbl.find("a:tblGrid", NS)
+    if grid is None:
+        return []
+    widths: list[float] = []
+    for col in grid.findall("a:gridCol", NS):
+        w_emu = col.attrib.get("w")
+        if w_emu is None:
+            continue
+        try:
+            widths.append(emu_to_px(int(w_emu)))
+        except ValueError:
+            widths.append(0.0)
+    return widths
+
+
+def _row_height_px(row: ET.Element) -> float:
+    h_emu = row.attrib.get("h")
+    if h_emu is None:
+        return 0.0
+    try:
+        return emu_to_px(int(h_emu))
+    except ValueError:
+        return 0.0
+
+
+def _cumulative_starts(origin: float, sizes: list[float]) -> list[float]:
+    out = [origin]
+    acc = origin
+    for size in sizes[:-1]:
+        acc += size
+        out.append(acc)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Cell grid
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _CellSlot:
+    """Per-grid-position resolution of <a:tc> attributes."""
+
+    element: ET.Element
+    col_span: int = 1
+    row_span: int = 1
+    is_dropped: bool = False  # True for h/vMerge slaves: don't paint anything
+
+
+def _build_cell_grid(rows: list[ET.Element], col_count: int) -> list[list[_CellSlot | None]]:
+    """Map each (row, col) to the <a:tc> that owns it.
+
+    Anchor cells (the top-left of a merge) carry col_span/row_span; merged
+    slaves are marked is_dropped so the renderer skips them. Cells not part
+    of any merge get span 1×1.
+    """
+    grid: list[list[_CellSlot | None]] = [[None] * col_count for _ in rows]
+
+    for r, row in enumerate(rows):
+        c = 0
+        for tc in row.findall("a:tc", NS):
+            # Skip already-occupied slots from a row above's rowSpan anchor.
+            while c < col_count and grid[r][c] is not None:
+                c += 1
+            if c >= col_count:
+                break
+
+            grid_span = _safe_int(tc.attrib.get("gridSpan"), 1)
+            row_span = _safe_int(tc.attrib.get("rowSpan"), 1)
+            h_merge = tc.attrib.get("hMerge") == "1"
+            v_merge = tc.attrib.get("vMerge") == "1"
+
+            if h_merge or v_merge:
+                # This cell is a merge slave; leave the slot tied to the anchor
+                # if one was already placed there, else mark as dropped placeholder.
+                if grid[r][c] is None:
+                    grid[r][c] = _CellSlot(element=tc, is_dropped=True)
+                c += 1
+                continue
+
+            slot = _CellSlot(
+                element=tc,
+                col_span=max(grid_span, 1),
+                row_span=max(row_span, 1),
+            )
+            for dr in range(slot.row_span):
+                for dc in range(slot.col_span):
+                    rr = r + dr
+                    cc = c + dc
+                    if rr >= len(rows) or cc >= col_count:
+                        continue
+                    if dr == 0 and dc == 0:
+                        grid[rr][cc] = slot
+                    else:
+                        grid[rr][cc] = _CellSlot(
+                            element=tc, is_dropped=True,
+                        )
+            c += slot.col_span
+
+    return grid
+
+
+def _safe_int(value: str | None, default: int) -> int:
+    if value is None:
+        return default
+    try:
+        return int(value)
+    except ValueError:
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Cell text & borders
+# ---------------------------------------------------------------------------
+
+def _convert_cell_text(
+    tx_body: ET.Element,
+    tcPr: ET.Element | None,
+    cell_xfrm: Xfrm,
+    palette: ColorPalette | None,
+    theme_fonts: dict[str, str] | None,
+    *,
+    id_prefix: str,
+    id_seq: list[int] | None,
+):
+    """Render cell text. PowerPoint's <a:tcPr> can override txBody insets via
+    its own marL/marR/marT/marB attrs; convert_txbody reads from <a:bodyPr>,
+    so we materialise a synthetic bodyPr by mutating the txBody in place when
+    tcPr has its own insets. (We undo the mutation afterwards to keep the
+    slide tree pristine for any subsequent passes.)"""
+    body_pr = tx_body.find("a:bodyPr", NS)
+    overrides = _tcPr_inset_overrides(tcPr)
+    saved: dict[str, str | None] = {}
+    if overrides and body_pr is not None:
+        for key, val in overrides.items():
+            saved[key] = body_pr.attrib.get(key)
+            body_pr.set(key, val)
+    try:
+        return convert_txbody(
+            tx_body, cell_xfrm, palette, theme_fonts=theme_fonts,
+            id_prefix=id_prefix,
+            id_seq=id_seq,
+        )
+    finally:
+        if overrides and body_pr is not None:
+            for key, prior in saved.items():
+                if prior is None:
+                    body_pr.attrib.pop(key, None)
+                else:
+                    body_pr.set(key, prior)
+
+
+def _tcPr_inset_overrides(tcPr: ET.Element | None) -> dict[str, str]:
+    if tcPr is None:
+        return {}
+    out: dict[str, str] = {}
+    for src, dst in (("marL", "lIns"), ("marR", "rIns"),
+                     ("marT", "tIns"), ("marB", "bIns")):
+        if src in tcPr.attrib:
+            out[dst] = tcPr.attrib[src]
+    return out
+
+
+def _border_line(
+    tcPr: ET.Element | None,
+    tag: str,
+    x1: float, y1: float, x2: float, y2: float,
+    palette: ColorPalette | None,
+    *,
+    id_prefix: str,
+    id_seq: list[int],
+    defs: list[str],
+) -> str:
+    """Emit a single border <line> for a given cell side, or empty string when
+    that side is explicitly noFill / not specified."""
+    if tcPr is None:
+        return ""
+    ln = tcPr.find(tag, NS)
+    if ln is None:
+        return ""
+    # Skip explicit no-line.
+    if ln.find("a:noFill", NS) is not None:
+        return ""
+
+    stroke = resolve_stroke(
+        # resolve_stroke expects a parent that contains <a:ln>; wrap so it
+        # finds our tag's own children as the line spec.
+        _make_ln_wrapper(ln),
+        palette,
+        id_prefix=id_prefix,
+        id_seq=id_seq,
+    )
+    defs.extend(stroke.defs)
+    attrs = stroke.attrs
+    if not attrs.get("stroke"):
+        return ""
+    attr_str = "".join(f' {k}="{v}"' for k, v in attrs.items())
+    return (
+        f'<line x1="{fmt_num(x1)}" y1="{fmt_num(y1)}" '
+        f'x2="{fmt_num(x2)}" y2="{fmt_num(y2)}"{attr_str}/>'
+    )
+
+
+def _make_ln_wrapper(ln: ET.Element) -> ET.Element:
+    """resolve_stroke walks for ``parent.find('a:ln')``; tcPr borders ARE the
+    <a:ln> already, so wrap them in a synthetic parent that points back at
+    the original element under the expected tag.
+    """
+    wrapper = ET.Element(f"{{{NS['a']}}}wrapper")
+    proxy = ET.SubElement(wrapper, f"{{{NS['a']}}}ln")
+    # Carry attributes (e.g. w="...") and children (solidFill, prstDash, ...).
+    for k, v in ln.attrib.items():
+        proxy.set(k, v)
+    for child in list(ln):
+        proxy.append(child)
+    return wrapper

--- a/apps/inno-agent/scripts/pptx_to_svg/txbody_to_svg.py
+++ b/apps/inno-agent/scripts/pptx_to_svg/txbody_to_svg.py
@@ -1,0 +1,1152 @@
+"""DrawingML <p:txBody> -> SVG <text> conversion.
+
+Reverse of svg_to_pptx/drawingml_elements.convert_text.
+
+Strategy (v1):
+- Each <a:p> paragraph emits one <text> element (one line of baseline).
+  Multiple <a:r> runs in one paragraph become <tspan>s sharing the text
+  element's x.
+- Vertical layout: y of first paragraph is determined by anchor (t/ctr/b)
+  and tIns/bIns. Subsequent paragraphs stack downward with line height
+  derived from the largest font in the paragraph * 1.2 (default leading).
+- Horizontal layout: text-anchor follows pPr@algn. x is computed from the
+  text frame plus lIns/rIns and the alignment.
+- No automatic word wrap (PPT's wrap is layout-time; v1 trusts the existing
+  text frame width and emits text as-is). a:br produces an explicit linebreak.
+- Bullet points (a:buChar / a:buAutoNum) are rendered as literal prefixes
+  so the visual lands without relying on PowerPoint list semantics.
+
+Color / font / size attributes propagate from a:rPr; missing attributes fall
+back to paragraph/list defaults, endParaRPr, or spec-default values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from xml.etree import ElementTree as ET
+
+from .color_resolver import ColorPalette, find_color_elem, resolve_color
+from .emu_units import (
+    NS, Xfrm, fmt_num, emu_to_px, hundredths_pt_to_px,
+)
+from .fill_to_svg import resolve_fill
+
+
+# ---------------------------------------------------------------------------
+# Defaults (matches DrawingML spec)
+# ---------------------------------------------------------------------------
+
+# Default body insets when bodyPr omits them: 0.1 inch left/right, 0.05 top/bot.
+DEFAULT_INSETS_EMU = {"l": 91440, "t": 45720, "r": 91440, "b": 45720}
+
+# Default font size = 1800 (= 18 pt = 24 px). Spec is actually 1800 (18pt).
+DEFAULT_FONT_SIZE_PX = 24.0
+DEFAULT_LINE_HEIGHT_RATIO = 1.2  # leading multiplier
+DEFAULT_FILL_HEX = "#000000"
+
+
+@dataclass
+class TextRun:
+    """A single run with resolved style + text."""
+
+    text: str
+    font_size_px: float
+    font_family: str  # full font-family stack (latin, ea fallback joined)
+    fill: str
+    fill_opacity: float = 1.0
+    defs: list[str] = field(default_factory=list)
+    bold: bool = False
+    italic: bool = False
+    underline: bool = False
+    strikethrough: bool = False
+    letter_spacing_px: float = 0.0
+    is_break: bool = False  # marks an a:br within a paragraph
+
+
+@dataclass
+class TextParagraph:
+    """One <a:p>: a list of runs sharing alignment + level."""
+
+    runs: list[TextRun] = field(default_factory=list)
+    align: str = "l"  # l / ctr / r / just / dist
+    level: int = 0
+    indent_px: float = 0.0
+    margin_left_px: float = 0.0
+    line_height_ratio: float = DEFAULT_LINE_HEIGHT_RATIO
+    space_before_px: float = 0.0
+    space_after_px: float = 0.0
+    bullet_prefix: str = ""  # rendered prefix like '• ' or '1. '
+
+
+@dataclass
+class TextResult:
+    """Resolved text body ready for SVG emission.
+
+    `svg` is one or more <text> elements, already absolutely positioned
+    inside the slide coordinate system. `defs` holds text gradient fills.
+    """
+
+    svg: str = ""
+    defs: list[str] = field(default_factory=list)
+
+
+VERTICAL_TEXT_MODES = {"eaVert", "vert", "wordArtVert", "wordArtVertRtl"}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def convert_txbody(
+    tx_body: ET.Element | None,
+    xfrm: Xfrm,
+    palette: ColorPalette | None,
+    *,
+    theme_fonts: dict[str, str] | None = None,
+    default_fill: str = DEFAULT_FILL_HEX,
+    default_font_size_px: float = DEFAULT_FONT_SIZE_PX,
+    fallback_lst_styles: tuple[ET.Element, ...] = (),
+    id_prefix: str = "txt",
+    id_seq: list[int] | None = None,
+) -> TextResult:
+    """Convert <p:txBody> under the given shape geometry to SVG <text>(s)."""
+    if tx_body is None:
+        return TextResult()
+
+    body_pr = tx_body.find("a:bodyPr", NS)
+    paragraphs = _parse_paragraphs(
+        tx_body, palette, theme_fonts or {}, default_fill=default_fill,
+        default_font_size_px=default_font_size_px,
+        fallback_lst_styles=fallback_lst_styles,
+        id_prefix=id_prefix, id_seq=id_seq,
+    )
+    if not paragraphs or not _has_visible_text(paragraphs):
+        return TextResult()
+
+    # Insets + anchor + wrap
+    lins = _read_emu_attr(body_pr, "lIns", DEFAULT_INSETS_EMU["l"])
+    tins = _read_emu_attr(body_pr, "tIns", DEFAULT_INSETS_EMU["t"])
+    rins = _read_emu_attr(body_pr, "rIns", DEFAULT_INSETS_EMU["r"])
+    bins = _read_emu_attr(body_pr, "bIns", DEFAULT_INSETS_EMU["b"])
+    anchor = body_pr.attrib.get("anchor", "t") if body_pr is not None else "t"
+    wrap_mode = body_pr.attrib.get("wrap", "square") if body_pr is not None else "square"
+
+    inner_x = xfrm.x + lins
+    inner_y = xfrm.y + tins
+    inner_w = max(xfrm.w - lins - rins, 1.0)
+    inner_h = max(xfrm.h - tins - bins, 1.0)
+
+    # Pre-wrap each paragraph into concrete display lines.
+    wrap_width = inner_w if wrap_mode == "square" else float("inf")
+    para_lines: list[list[list[TextRun]]] = [
+        _wrap_paragraph_into_lines(p, wrap_width) for p in paragraphs
+    ]
+
+    # Pre-compute heights to support anchor=ctr / b
+    para_heights = [
+        _paragraph_height_from_lines(p, lines)
+        for p, lines in zip(paragraphs, para_lines)
+    ]
+    total_h = sum(para_heights)
+    if anchor == "ctr":
+        cursor_y = inner_y + max(0.0, (inner_h - total_h) / 2.0)
+    elif anchor == "b":
+        cursor_y = inner_y + max(0.0, inner_h - total_h)
+    else:
+        cursor_y = inner_y
+
+    bottom_y = inner_y + inner_h
+    text_blocks: list[str] = []
+    for para, lines, height in zip(paragraphs, para_lines, para_heights):
+        cursor_y += para.space_before_px
+        visible_lines = _clip_lines_to_bottom(para, lines, cursor_y, bottom_y)
+        if visible_lines:
+            text_blocks.append(
+                _emit_paragraph(para, visible_lines, inner_x, inner_w, cursor_y)
+            )
+        cursor_y += height + para.space_after_px
+        if cursor_y >= bottom_y:
+            break
+
+    return TextResult(svg="\n".join(text_blocks), defs=_collect_text_defs(paragraphs))
+
+
+def is_vertical_txbody(tx_body: ET.Element | None, xfrm: Xfrm | None = None) -> bool:
+    if tx_body is None:
+        return False
+    body_pr = tx_body.find("a:bodyPr", NS)
+    if body_pr is None:
+        return False
+    if body_pr.attrib.get("vert") in VERTICAL_TEXT_MODES:
+        return True
+    return _looks_like_auto_stacked_cjk(tx_body, body_pr, xfrm)
+
+
+def convert_vertical_txbody(
+    tx_body: ET.Element | None,
+    xfrm: Xfrm,
+    palette: ColorPalette | None,
+    *,
+    theme_fonts: dict[str, str] | None = None,
+    default_fill: str = DEFAULT_FILL_HEX,
+    default_font_size_px: float = DEFAULT_FONT_SIZE_PX,
+    fallback_lst_styles: tuple[ET.Element, ...] = (),
+    id_prefix: str = "txt",
+    id_seq: list[int] | None = None,
+) -> TextResult:
+    """Render East Asian vertical text as upright stacked glyphs.
+
+    PowerPoint often combines ``bodyPr@vert=eaVert`` with a rotated text box.
+    Rendering the text inside the rotated shape group makes Chinese glyphs lie
+    sideways. This helper computes the final rotated box and places glyphs
+    upright in slide coordinates.
+    """
+    if tx_body is None:
+        return TextResult()
+
+    paragraphs = _parse_paragraphs(
+        tx_body, palette, theme_fonts or {}, default_fill=default_fill,
+        default_font_size_px=default_font_size_px,
+        fallback_lst_styles=fallback_lst_styles,
+        id_prefix=id_prefix, id_seq=id_seq,
+    )
+    runs = [
+        run
+        for para in paragraphs
+        for run in para.runs
+        if not run.is_break and run.text
+    ]
+    if not runs:
+        return TextResult()
+
+    box_x, box_y, box_w, box_h = _rotated_bbox(xfrm)
+    center_x = box_x + box_w / 2.0
+
+    glyphs: list[tuple[str, TextRun]] = []
+    for run in runs:
+        for char in run.text:
+            if char in "\r\n":
+                continue
+            if char == " ":
+                continue
+            glyphs.append((char, run))
+
+    if not glyphs:
+        return TextResult()
+
+    advances = [glyph_run.font_size_px * 1.05 for _, glyph_run in glyphs]
+    total_h = sum(advances)
+    top_y = box_y + max(0.0, (box_h - total_h) / 2.0)
+
+    bottom_y = box_y + box_h
+    spans: list[str] = []
+    cursor_y = top_y
+    first_run: TextRun | None = None
+    first_baseline: float | None = None
+    previous_baseline: float | None = None
+    for (char, run), advance in zip(glyphs, advances):
+        if cursor_y + advance > bottom_y:
+            break
+        baseline_y = cursor_y + run.font_size_px * 0.85
+        tspan_attrs = _run_tspan_attrs(run)
+        if first_run is None:
+            first_run = run
+            first_baseline = baseline_y
+            spans.append(f"<tspan{tspan_attrs}>{_xml_escape(char)}</tspan>")
+        else:
+            dy = baseline_y - (previous_baseline or baseline_y)
+            spans.append(
+                f'<tspan x="{fmt_num(center_x)}" dy="{fmt_num(dy)}"'
+                f"{tspan_attrs}>{_xml_escape(char)}</tspan>"
+            )
+        previous_baseline = baseline_y
+        cursor_y += advance
+
+    if first_run is None or first_baseline is None:
+        return TextResult()
+
+    attrs = _text_base_attrs(first_run, center_x, first_baseline, "middle")
+    return TextResult(
+        svg=f"<text{attrs}>{''.join(spans)}</text>",
+        defs=_collect_text_defs(paragraphs),
+    )
+
+
+def _rotated_bbox(xfrm: Xfrm) -> tuple[float, float, float, float]:
+    rot = round(xfrm.rot) % 360
+    cx = xfrm.x + xfrm.w / 2.0
+    cy = xfrm.y + xfrm.h / 2.0
+    if rot in (90, 270):
+        return cx - xfrm.h / 2.0, cy - xfrm.w / 2.0, xfrm.h, xfrm.w
+    return xfrm.x, xfrm.y, xfrm.w, xfrm.h
+
+
+def _looks_like_auto_stacked_cjk(
+    tx_body: ET.Element,
+    body_pr: ET.Element,
+    xfrm: Xfrm | None,
+) -> bool:
+    """Detect PowerPoint's narrow-box CJK vertical layout without vert=eaVert."""
+    if xfrm is None or xfrm.w <= 0 or xfrm.h <= 0:
+        return False
+    if body_pr.attrib.get("wrap", "square") != "square":
+        return False
+    if xfrm.w > 64 or xfrm.h < xfrm.w * 2.4:
+        return False
+
+    text = _plain_text(tx_body)
+    chars = [ch for ch in text if not ch.isspace()]
+    if len(chars) < 3 or len(chars) > 16:
+        return False
+    cjk_count = sum(1 for ch in chars if _is_cjk(ch))
+    if cjk_count / len(chars) < 0.8:
+        return False
+
+    lins = _read_emu_attr(body_pr, "lIns", DEFAULT_INSETS_EMU["l"])
+    rins = _read_emu_attr(body_pr, "rIns", DEFAULT_INSETS_EMU["r"])
+    inner_w = max(xfrm.w - lins - rins, 1.0)
+    return inner_w <= DEFAULT_FONT_SIZE_PX
+
+
+def _plain_text(tx_body: ET.Element) -> str:
+    """Return concatenated literal text for layout heuristics."""
+    parts: list[str] = []
+    for text_elem in tx_body.findall(".//a:t", NS):
+        if text_elem.text:
+            parts.append(text_elem.text)
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _read_emu_attr(elem: ET.Element | None, attr: str, default_emu: int) -> float:
+    """Read an EMU integer attribute and return px."""
+    if elem is None:
+        return emu_to_px(default_emu)
+    val = elem.attrib.get(attr)
+    if val is None:
+        return emu_to_px(default_emu)
+    try:
+        return emu_to_px(int(val))
+    except ValueError:
+        return emu_to_px(default_emu)
+
+
+def _parse_paragraphs(
+    tx_body: ET.Element,
+    palette: ColorPalette | None,
+    theme_fonts: dict[str, str],
+    *,
+    default_fill: str = DEFAULT_FILL_HEX,
+    default_font_size_px: float = DEFAULT_FONT_SIZE_PX,
+    fallback_lst_styles: tuple[ET.Element, ...] = (),
+    id_prefix: str = "txt",
+    id_seq: list[int] | None = None,
+) -> list[TextParagraph]:
+    """Walk <a:p> children producing TextParagraph objects."""
+    paragraphs: list[TextParagraph] = []
+    autonum_state: dict[int, int] = {}
+    lst_style = tx_body.find("a:lstStyle", NS)
+    lst_styles = (
+        (lst_style,) + fallback_lst_styles
+        if lst_style is not None else fallback_lst_styles
+    )
+
+    for p_elem in tx_body.findall("a:p", NS):
+        para = _parse_paragraph(
+            p_elem, palette, theme_fonts, autonum_state,
+            lst_styles=lst_styles,
+            default_fill=default_fill,
+            default_font_size_px=default_font_size_px,
+            id_prefix=id_prefix, id_seq=id_seq,
+        )
+        paragraphs.append(para)
+
+    return paragraphs
+
+
+def _parse_paragraph(
+    p_elem: ET.Element,
+    palette: ColorPalette | None,
+    theme_fonts: dict[str, str],
+    autonum_state: dict[int, int],
+    *,
+    lst_styles: tuple[ET.Element, ...] = (),
+    default_fill: str = DEFAULT_FILL_HEX,
+    default_font_size_px: float = DEFAULT_FONT_SIZE_PX,
+    id_prefix: str = "txt",
+    id_seq: list[int] | None = None,
+) -> TextParagraph:
+    para = TextParagraph()
+
+    p_pr = p_elem.find("a:pPr", NS)
+    if p_pr is not None:
+        try:
+            para.level = int(p_pr.attrib.get("lvl", "0"))
+        except ValueError:
+            para.level = 0
+
+    para_style_chain = (p_pr,) + _lst_style_level_prs(lst_styles, para.level)
+    para.align = _attr_chain(para_style_chain, "algn") or "l"
+    para.margin_left_px = _emu_px_attr_chain(para_style_chain, "marL", 0.0)
+    para.indent_px = _emu_px_attr_chain(para_style_chain, "indent", 0.0)
+    para.line_height_ratio = _line_height_ratio(para_style_chain)
+    para.space_before_px = _spacing_points_px(para_style_chain, "a:spcBef/a:spcPts")
+    para.space_after_px = _spacing_points_px(para_style_chain, "a:spcAft/a:spcPts")
+    para.bullet_prefix = _resolve_bullet_prefix(
+        para_style_chain, para.level, autonum_state,
+    )
+
+    # Default endParaRPr style (applies if a run has no rPr)
+    end_rpr = p_elem.find("a:endParaRPr", NS)
+    # defRPr from pPr and txBody/lstStyle, both optional.
+    def_rpr = p_pr.find("a:defRPr", NS) if p_pr is not None else None
+    list_def_rpr = _child_chain(para_style_chain[1:], "a:defRPr")
+
+    for child in list(p_elem):
+        if not isinstance(child.tag, str):
+            continue
+        local = child.tag.split("}", 1)[-1]
+        if local == "r":
+            rpr = child.find("a:rPr", NS)
+            text_elem = child.find("a:t", NS)
+            text = text_elem.text or "" if text_elem is not None else ""
+            run = _build_run(
+                text, rpr, end_rpr, palette, theme_fonts,
+                def_rpr=def_rpr,
+                list_def_rpr=list_def_rpr,
+                default_fill=default_fill,
+                default_font_size_px=default_font_size_px,
+                id_prefix=id_prefix, id_seq=id_seq,
+            )
+            para.runs.append(run)
+        elif local == "br":
+            para.runs.append(TextRun(
+                text="",
+                font_size_px=default_font_size_px,
+                font_family="sans-serif", fill=default_fill,
+                is_break=True,
+            ))
+        elif local == "fld":
+            # Field (datetime / slidenum). Use the literal a:t fallback.
+            rpr = child.find("a:rPr", NS)
+            text_elem = child.find("a:t", NS)
+            text = text_elem.text or "" if text_elem is not None else ""
+            if text:
+                run = _build_run(
+                    text, rpr, end_rpr, palette, theme_fonts,
+                    def_rpr=def_rpr,
+                    list_def_rpr=list_def_rpr,
+                    default_fill=default_fill,
+                    default_font_size_px=default_font_size_px,
+                    id_prefix=id_prefix, id_seq=id_seq,
+                )
+                para.runs.append(run)
+
+    return para
+
+
+def _build_run(
+    text: str,
+    rpr: ET.Element | None,
+    end_rpr: ET.Element | None,
+    palette: ColorPalette | None,
+    theme_fonts: dict[str, str],
+    *,
+    def_rpr: ET.Element | None = None,
+    list_def_rpr: ET.Element | None = None,
+    default_fill: str = DEFAULT_FILL_HEX,
+    default_font_size_px: float = DEFAULT_FONT_SIZE_PX,
+    id_prefix: str = "txt",
+    id_seq: list[int] | None = None,
+) -> TextRun:
+    """Resolve a single <a:r> run from its rPr and fallback run properties."""
+    style_chain = (rpr, def_rpr, list_def_rpr, end_rpr)
+    # font-size: rPr > pPr/defRPr > lstStyle/lvlNpPr/defRPr > endParaRPr > default
+    sz = _attr_chain(style_chain, "sz")
+    font_size_px = hundredths_pt_to_px(sz, default_font_size_px)
+    # Bold / italic
+    bold = _attr_chain(style_chain, "b") == "1"
+    italic = _attr_chain(style_chain, "i") == "1"
+    # Underline / strike
+    u_val = _attr_chain(style_chain, "u")
+    underline = u_val not in (None, "", "none")
+    strike_val = _attr_chain(style_chain, "strike")
+    strikethrough = strike_val in ("sngStrike", "dblStrike")
+
+    # Letter spacing (rPr@spc, in 1/100 pt)
+    spc = _attr_chain(style_chain, "spc")
+    letter_spacing_px = 0.0
+    if spc is not None:
+        try:
+            letter_spacing_px = float(spc) / 100.0 * 4.0 / 3.0  # pt -> px
+        except ValueError:
+            pass
+
+    # Color
+    fill = default_fill
+    fill_opacity = 1.0
+    defs: list[str] = []
+    color_source = None
+    for src in style_chain:
+        if src is None:
+            continue
+        grad = src.find("a:gradFill", NS)
+        if grad is not None:
+            grad_fill = resolve_fill(
+                grad, palette,
+                id_prefix=id_prefix,
+                id_seq=id_seq,
+            )
+            if grad_fill.attrs.get("fill"):
+                fill = grad_fill.attrs["fill"]
+                fill_opacity = 1.0
+                defs.extend(grad_fill.defs)
+                color_source = None
+                break
+        solid = src.find("a:solidFill", NS)
+        if solid is not None:
+            color_source = solid
+            break
+    if color_source is not None:
+        color_elem = find_color_elem(color_source)
+        hex_, alpha = resolve_color(color_elem, palette)
+        if hex_:
+            fill = hex_
+            fill_opacity = alpha
+
+    # Font typeface
+    latin_face = _typeface_chain(style_chain, "latin")
+    ea_face = _typeface_chain(style_chain, "ea")
+    cs_face = _typeface_chain(style_chain, "cs")
+
+    # Resolve theme refs (e.g. typeface="+mn-lt" / "+mj-ea")
+    latin_face = _resolve_theme_typeface(latin_face, theme_fonts)
+    ea_face = _resolve_theme_typeface(ea_face, theme_fonts)
+    cs_face = _resolve_theme_typeface(cs_face, theme_fonts)
+
+    font_family = _build_font_stack(latin_face, ea_face, cs_face)
+
+    return TextRun(
+        text=text,
+        font_size_px=font_size_px,
+        font_family=font_family,
+        fill=fill,
+        fill_opacity=fill_opacity,
+        defs=defs,
+        bold=bold,
+        italic=italic,
+        underline=underline,
+        strikethrough=strikethrough,
+        letter_spacing_px=letter_spacing_px,
+    )
+
+
+def _lst_style_level_prs(
+    lst_styles: tuple[ET.Element, ...],
+    level: int,
+) -> tuple[ET.Element, ...]:
+    """Return txBody/lstStyle paragraph properties for a paragraph level."""
+    level_idx = min(max(level, 0), 8) + 1
+    level_prs: list[ET.Element] = []
+    for lst_style in lst_styles:
+        lvl_pr = lst_style.find(f"a:lvl{level_idx}pPr", NS)
+        if lvl_pr is not None:
+            level_prs.append(lvl_pr)
+    return tuple(level_prs)
+
+
+def _child_chain(
+    sources: tuple[ET.Element | None, ...],
+    path: str,
+) -> ET.Element | None:
+    for src in sources:
+        if src is None:
+            continue
+        child = src.find(path, NS)
+        if child is not None:
+            return child
+    return None
+
+
+def _emu_px_attr_chain(
+    sources: tuple[ET.Element | None, ...],
+    attr: str,
+    default: float,
+) -> float:
+    value = _attr_chain(sources, attr)
+    if value is None:
+        return default
+    try:
+        return emu_to_px(int(value))
+    except ValueError:
+        return default
+
+
+def _line_height_ratio(sources: tuple[ET.Element | None, ...]) -> float:
+    ln_spc = _child_chain(sources, "a:lnSpc")
+    if ln_spc is None:
+        return DEFAULT_LINE_HEIGHT_RATIO
+    spc_pct = ln_spc.find("a:spcPct", NS)
+    if spc_pct is None:
+        return DEFAULT_LINE_HEIGHT_RATIO
+    try:
+        return float(spc_pct.attrib.get("val", "100000")) / 100000.0
+    except ValueError:
+        return DEFAULT_LINE_HEIGHT_RATIO
+
+
+def _spacing_points_px(
+    sources: tuple[ET.Element | None, ...],
+    path: str,
+) -> float:
+    spacing = _child_chain(sources, path)
+    if spacing is None:
+        return 0.0
+    try:
+        return hundredths_pt_to_px(int(spacing.attrib.get("val", "0")))
+    except ValueError:
+        return 0.0
+
+
+def _attr_chain(sources: tuple[ET.Element | None, ...], attr: str) -> str | None:
+    """Return the first non-empty value of `attr` from any source element."""
+    for src in sources:
+        if src is None:
+            continue
+        v = src.attrib.get(attr)
+        if v is not None:
+            return v
+    return None
+
+
+def _typeface(rpr: ET.Element | None, child_tag: str) -> str | None:
+    if rpr is None:
+        return None
+    elem = rpr.find(f"a:{child_tag}", NS)
+    if elem is None:
+        return None
+    val = elem.attrib.get("typeface")
+    return val or None
+
+
+def _typeface_chain(
+    sources: tuple[ET.Element | None, ...],
+    child_tag: str,
+) -> str | None:
+    for src in sources:
+        face = _typeface(src, child_tag)
+        if face:
+            return face
+    return None
+
+
+def _resolve_theme_typeface(face: str | None, theme_fonts: dict[str, str]) -> str | None:
+    """Theme references look like '+mj-lt' (major latin) / '+mn-ea' (minor EA)."""
+    if not face or not face.startswith("+"):
+        return face
+    code = face[1:]
+    if code == "mj-lt":
+        return theme_fonts.get("majorLatin") or face
+    if code == "mn-lt":
+        return theme_fonts.get("minorLatin") or face
+    if code == "mj-ea":
+        return theme_fonts.get("majorEastAsia") or theme_fonts.get("majorLatin") or face
+    if code == "mn-ea":
+        return theme_fonts.get("minorEastAsia") or theme_fonts.get("minorLatin") or face
+    return face
+
+
+def _build_font_stack(latin: str | None, ea: str | None, cs: str | None) -> str:
+    """Build a CSS font-family stack: original PPT names first, then fallbacks."""
+    parts: list[str] = []
+    seen: set[str] = set()
+    for face in (latin, ea, cs):
+        if face and face not in seen:
+            parts.append(_quote_font(face))
+            seen.add(face)
+    # Generic fallback so the browser can render even if PPT fonts are absent.
+    parts.append("sans-serif")
+    return ", ".join(parts)
+
+
+def _quote_font(name: str) -> str:
+    """Quote a font name if it contains spaces or non-ASCII chars.
+
+    Uses XML entity-escaped double quotes (&quot;) so the resulting CSS string
+    survives being embedded inside an SVG attribute that itself uses double
+    quotes. CSS parsers accept the unescaped form after attribute parsing.
+    """
+    if any(c.isspace() or ord(c) > 127 for c in name):
+        return f"&quot;{name}&quot;"
+    return name
+
+
+def _resolve_bullet_prefix(
+    sources: tuple[ET.Element | None, ...],
+    level: int,
+    autonum_state: dict[int, int],
+) -> str:
+    """Render bullet glyphs / numbering as a literal text prefix."""
+    bu_none = _child_chain(sources, "a:buNone")
+    if bu_none is not None:
+        autonum_state.pop(level, None)
+        return ""
+    bu_char = _child_chain(sources, "a:buChar")
+    if bu_char is not None:
+        ch = bu_char.attrib.get("char", "•")
+        return f"{ch} "
+    bu_auto = _child_chain(sources, "a:buAutoNum")
+    if bu_auto is not None:
+        start_at = bu_auto.attrib.get("startAt")
+        if start_at is not None:
+            try:
+                autonum_state[level] = int(start_at)
+            except ValueError:
+                autonum_state[level] = 1
+        else:
+            autonum_state[level] = autonum_state.get(level, 0) + 1
+        return _format_auto_number(
+            autonum_state[level],
+            bu_auto.attrib.get("type", "arabicPeriod"),
+        )
+    return ""
+
+
+def _format_auto_number(value: int, kind: str) -> str:
+    lower = kind.lower()
+    if "alphalc" in lower:
+        token = _alpha_number(value, uppercase=False)
+    elif "alphauc" in lower:
+        token = _alpha_number(value, uppercase=True)
+    elif "romanlc" in lower:
+        token = _roman_number(value).lower()
+    elif "romanuc" in lower:
+        token = _roman_number(value).upper()
+    else:
+        token = str(value)
+
+    if "parenboth" in lower:
+        return f"({token}) "
+    if "parenr" in lower:
+        return f"{token}) "
+    if "period" in lower:
+        return f"{token}. "
+    return f"{token} "
+
+
+def _alpha_number(value: int, *, uppercase: bool) -> str:
+    value = max(1, value)
+    chars: list[str] = []
+    while value:
+        value -= 1
+        chars.append(chr(ord("A") + (value % 26)))
+        value //= 26
+    text = "".join(reversed(chars))
+    return text if uppercase else text.lower()
+
+
+def _roman_number(value: int) -> str:
+    value = max(1, min(value, 3999))
+    parts: list[str] = []
+    for n, token in (
+        (1000, "M"), (900, "CM"), (500, "D"), (400, "CD"),
+        (100, "C"), (90, "XC"), (50, "L"), (40, "XL"),
+        (10, "X"), (9, "IX"), (5, "V"), (4, "IV"), (1, "I"),
+    ):
+        while value >= n:
+            parts.append(token)
+            value -= n
+    return "".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Layout / emission
+# ---------------------------------------------------------------------------
+
+def _has_visible_text(paragraphs: list[TextParagraph]) -> bool:
+    for p in paragraphs:
+        for r in p.runs:
+            if r.text.strip():
+                return True
+    return False
+
+
+def _collect_text_defs(paragraphs: list[TextParagraph]) -> list[str]:
+    """Return unique text fill defs referenced by parsed runs."""
+    defs: list[str] = []
+    seen: set[str] = set()
+    for para in paragraphs:
+        for run in para.runs:
+            for item in run.defs:
+                if item not in seen:
+                    defs.append(item)
+                    seen.add(item)
+    return defs
+
+
+# ---------------------------------------------------------------------------
+# Word-wrap / text measurement
+# ---------------------------------------------------------------------------
+
+def _is_cjk(ch: str) -> bool:
+    """Check if a character is CJK (Chinese/Japanese/Korean) or full-width."""
+    cp = ord(ch)
+    return (0x4E00 <= cp <= 0x9FFF or 0x3400 <= cp <= 0x4DBF or
+            0x2E80 <= cp <= 0x2EFF or 0x3000 <= cp <= 0x303F or
+            0xFF00 <= cp <= 0xFFEF or 0xF900 <= cp <= 0xFAFF or
+            0x20000 <= cp <= 0x2A6DF)
+
+
+def _char_width(ch: str, font_size: float, bold: bool) -> float:
+    """Estimate a single character's rendered width in pixels.
+
+    Mirrors svg_to_pptx/drawingml_utils.estimate_text_width so wrapping breaks
+    align with the same heuristic used to estimate text-box sizes elsewhere.
+    """
+    if _is_cjk(ch):
+        w = font_size  # CJK is approximately 1em per glyph
+    elif ch == ' ':
+        w = font_size * 0.3
+    elif ch in 'mMwWOQ%':
+        w = font_size * 0.75
+    elif ch in 'iIlj!|':
+        w = font_size * 0.3
+    elif ch.isdigit():
+        # digits are tabular (uniform ~0.55em) in most UI fonts, including
+        # '1' — classing it with 'il|' under-sizes the width and makes
+        # renderers that ignore wrap="none" (LibreOffice) wrap the line
+        w = font_size * 0.55
+    else:
+        w = font_size * 0.55
+    # Bold Latin generally expands a little. CJK glyphs keep their em advance
+    # in common PPT fonts; applying the bold multiplier causes short Chinese
+    # titles such as "少年强国说" to wrap even though PowerPoint keeps them on
+    # one line.
+    if bold and not _is_cjk(ch):
+        w *= 1.05
+    return w
+
+
+def _estimate_run_width(text: str, run: TextRun) -> float:
+    glyph_width = sum(_char_width(c, run.font_size_px, run.bold) for c in text)
+    tracking_width = run.letter_spacing_px * max(len(text) - 1, 0)
+    return (glyph_width + tracking_width) * 1.05
+
+
+def _advance_width(ch: str, index_in_segment: int, run: TextRun) -> float:
+    """Return the width added by one character inside a measured line segment."""
+    tracking = run.letter_spacing_px if index_in_segment > 0 else 0.0
+    return _char_width(ch, run.font_size_px, run.bold) + tracking
+
+
+def _find_break_point(
+    text: str, start: int, max_width: float, run: TextRun,
+) -> tuple[int, float]:
+    """Find the longest prefix of text[start:] that fits in max_width.
+
+    Returns (end_index, used_width). Prefers breaking after whitespace, after
+    CJK characters, or after hyphens. If even the first character doesn't fit,
+    returns (start, 0.0) — the caller should flush the current line first.
+    """
+    cur_w = 0.0
+    last_break = start
+    last_break_w = 0.0
+
+    for i in range(start, len(text)):
+        ch = text[i]
+        ch_w = _advance_width(ch, i - start, run)
+        if cur_w + ch_w > max_width:
+            if last_break > start:
+                return last_break, last_break_w
+            return start, 0.0
+        cur_w += ch_w
+        # Update last_break point
+        if ch.isspace() or _is_cjk(ch) or ch in "-—、，。！？：；":
+            last_break = i + 1
+            last_break_w = cur_w
+    # Whole rest fits
+    return len(text), cur_w
+
+
+def _wrap_paragraph_into_lines(
+    para: TextParagraph,
+    max_width: float,
+) -> list[list[TextRun]]:
+    """Split a paragraph's runs into display lines respecting `max_width`.
+
+    Each line is a list of (possibly truncated) TextRuns. Explicit a:br runs
+    force a new line. When max_width is +inf the original runs are returned
+    unchanged (one logical line per a:br segment).
+
+    Bullet prefix is prepended to the first non-empty run if present.
+    """
+    lines: list[list[TextRun]] = [[]]
+    cur_w = 0.0
+
+    if _should_keep_single_line(para, max_width):
+        return [[_copy_run(run, text=run.text) for run in para.runs if not run.is_break and run.text]]
+
+    if para.bullet_prefix and para.runs:
+        first_run = next((r for r in para.runs if not r.is_break), None)
+        if first_run is not None:
+            bullet_run = _copy_run(first_run, text=para.bullet_prefix)
+            lines[-1].append(bullet_run)
+            cur_w = _estimate_run_width(para.bullet_prefix, bullet_run)
+
+    for run in para.runs:
+        if run.is_break:
+            lines.append([])
+            cur_w = 0.0
+            continue
+        if not run.text:
+            continue
+        text = run.text
+        i = 0
+        while i < len(text):
+            avail = max_width - cur_w
+            if avail <= 0 and lines[-1]:
+                # Line is full; start a new one
+                lines.append([])
+                cur_w = 0.0
+                avail = max_width
+
+            end, used = _find_break_point(text, i, avail, run)
+            if end == i:
+                # Nothing fits even from a fresh line — force one char to avoid
+                # an infinite loop.
+                if lines[-1]:
+                    lines.append([])
+                    cur_w = 0.0
+                    continue
+                end = i + 1
+                used = _advance_width(text[i], 0, run)
+
+            chunk = text[i:end]
+            lines[-1].append(_copy_run(run, text=chunk))
+            cur_w += used
+            i = end
+
+            if i < len(text):
+                # More to render — wrap to next line
+                lines.append([])
+                cur_w = 0.0
+
+    return lines
+
+
+def _should_keep_single_line(para: TextParagraph, max_width: float) -> bool:
+    if max_width == float("inf") or para.bullet_prefix:
+        return False
+    if any(run.is_break for run in para.runs):
+        return False
+
+    text_runs = [run for run in para.runs if run.text]
+    if not text_runs:
+        return False
+    text = "".join(run.text for run in text_runs)
+    non_space_count = sum(1 for ch in text if not ch.isspace())
+
+    # Short labels/titles are usually intentionally single-line in PPT. Let
+    # them overflow slightly rather than inventing a line break from imperfect
+    # font metrics or alignment spaces.
+    if non_space_count <= 18:
+        return True
+
+    estimated = sum(_estimate_run_width(run.text, run) for run in text_runs)
+    return estimated <= max_width * 1.12
+
+
+def _copy_run(run: TextRun, *, text: str) -> TextRun:
+    return TextRun(
+        text=text,
+        font_size_px=run.font_size_px,
+        font_family=run.font_family,
+        fill=run.fill,
+        fill_opacity=run.fill_opacity,
+        defs=list(run.defs),
+        bold=run.bold,
+        italic=run.italic,
+        underline=run.underline,
+        strikethrough=run.strikethrough,
+        letter_spacing_px=run.letter_spacing_px,
+    )
+
+
+def _paragraph_height_from_lines(p: TextParagraph,
+                                 lines: list[list[TextRun]]) -> float:
+    """Total px height after wrapping. Each line uses its own max font size."""
+    if not lines:
+        return DEFAULT_FONT_SIZE_PX * p.line_height_ratio
+    height = 0.0
+    for line in lines:
+        height += _line_height(p, line)
+    return height
+
+
+def _line_height(p: TextParagraph, line: list[TextRun]) -> float:
+    max_font = max((r.font_size_px for r in line), default=DEFAULT_FONT_SIZE_PX)
+    return max_font * p.line_height_ratio
+
+
+def _clip_lines_to_bottom(
+    para: TextParagraph,
+    lines: list[list[TextRun]],
+    top_y: float,
+    bottom_y: float,
+) -> list[list[TextRun]]:
+    """Return the leading display lines whose line boxes fit in the text frame."""
+    visible: list[list[TextRun]] = []
+    cursor_y = top_y
+    for line in lines:
+        line_h = _line_height(para, line)
+        # PowerPoint lets the first line that starts within the box render even
+        # when it slightly exceeds the bottom — only suppress lines whose top
+        # is already at/below the bottom edge.
+        if cursor_y >= bottom_y:
+            break
+        visible.append(line)
+        cursor_y += line_h
+    return visible
+
+
+def _paragraph_height(p: TextParagraph) -> float:
+    """Legacy helper kept for callers that don't pre-wrap (currently unused)."""
+    lines = 1
+    max_font = 0.0
+    for r in p.runs:
+        if r.is_break:
+            lines += 1
+            continue
+        max_font = max(max_font, r.font_size_px)
+    if max_font == 0.0:
+        max_font = DEFAULT_FONT_SIZE_PX
+    return lines * max_font * p.line_height_ratio
+
+
+def _emit_paragraph(
+    para: TextParagraph,
+    lines: list[list[TextRun]],
+    inner_x: float, inner_w: float,
+    top_y: float,
+) -> str:
+    """Render a paragraph (already split into lines) as one <text> element.
+
+    Each pre-wrapped display line becomes a sequence of <tspan>s: the first
+    tspan on a line carries the explicit x and dy (line-height advance);
+    subsequent tspans on the same line inherit x.
+    """
+    align = para.align
+    if align == "ctr":
+        anchor_x = inner_x + inner_w / 2.0
+        text_anchor = "middle"
+    elif align == "r":
+        anchor_x = inner_x + inner_w
+        text_anchor = "end"
+    else:  # 'l' / 'just' / 'dist' / unknown
+        anchor_x = inner_x + para.indent_px + para.margin_left_px
+        text_anchor = "start"
+
+    if not lines or all(not line for line in lines):
+        return ""
+
+    # First non-empty line drives the text-level baseline + default style
+    first_line_idx = next((i for i, ln in enumerate(lines) if ln), 0)
+    first_line = lines[first_line_idx]
+    first_run = first_line[0] if first_line else None
+    first_font = first_run.font_size_px if first_run else DEFAULT_FONT_SIZE_PX
+    first_baseline = top_y + 0.85 * first_font
+
+    spans: list[str] = []
+    for line_idx, line in enumerate(lines):
+        if not line:
+            # Blank line (e.g. consecutive a:br): still advance baseline
+            spans.append(
+                f'<tspan x="{fmt_num(anchor_x)}" '
+                f'dy="{fmt_num(first_font * para.line_height_ratio)}"></tspan>'
+            )
+            continue
+        line_font = max(r.font_size_px for r in line)
+        for run_idx, run in enumerate(line):
+            attrs = _run_tspan_attrs(run)
+            if run_idx == 0 and line_idx > 0:
+                # Start-of-line tspan: position via x + dy
+                spans.append(
+                    f'<tspan x="{fmt_num(anchor_x)}" '
+                    f'dy="{fmt_num(line_font * para.line_height_ratio)}"'
+                    f'{attrs}>{_xml_escape(run.text)}</tspan>'
+                )
+            else:
+                spans.append(
+                    f"<tspan{attrs}>{_xml_escape(run.text)}</tspan>"
+                )
+
+    base_attrs = _text_base_attrs(first_run, anchor_x, first_baseline, text_anchor)
+    return f"<text{base_attrs}>{''.join(spans)}</text>"
+
+
+def _text_base_attrs(run: TextRun | None, x: float, y: float,
+                     text_anchor: str) -> str:
+    parts = [
+        f'x="{fmt_num(x)}"',
+        f'y="{fmt_num(y)}"',
+        f'text-anchor="{text_anchor}"',
+        'xml:space="preserve"',
+    ]
+    if run is None:
+        return " " + " ".join(parts)
+    parts.append(f'font-family="{run.font_family}"')
+    parts.append(f'font-size="{fmt_num(run.font_size_px)}"')
+    parts.append(f'fill="{run.fill}"')
+    if run.fill_opacity < 1.0:
+        parts.append(f'fill-opacity="{fmt_num(run.fill_opacity, 4)}"')
+    if run.bold:
+        parts.append('font-weight="bold"')
+    if run.italic:
+        parts.append('font-style="italic"')
+    if run.underline and run.strikethrough:
+        parts.append('text-decoration="underline line-through"')
+    elif run.underline:
+        parts.append('text-decoration="underline"')
+    elif run.strikethrough:
+        parts.append('text-decoration="line-through"')
+    if run.letter_spacing_px:
+        parts.append(f'letter-spacing="{fmt_num(run.letter_spacing_px)}"')
+    return " " + " ".join(parts)
+
+
+def _run_tspan_attrs(run: TextRun) -> str:
+    """Per-run overrides on a <tspan>. Only emit attributes that differ from
+    the run that drove the parent <text> (we keep things simple: emit only
+    overrides that can plausibly change run-to-run, never re-emit common
+    defaults). For v1 we just always emit fill / font-size / weight to be
+    safe — tspan inherits when omitted, so callers can simplify later.
+    """
+    parts = [
+        f'fill="{run.fill}"',
+        f'font-size="{fmt_num(run.font_size_px)}"',
+    ]
+    if run.fill_opacity < 1.0:
+        parts.append(f'fill-opacity="{fmt_num(run.fill_opacity, 4)}"')
+    if run.bold:
+        parts.append('font-weight="bold"')
+    if run.italic:
+        parts.append('font-style="italic"')
+    if run.underline and run.strikethrough:
+        parts.append('text-decoration="underline line-through"')
+    elif run.underline:
+        parts.append('text-decoration="underline"')
+    elif run.strikethrough:
+        parts.append('text-decoration="line-through"')
+    if run.letter_spacing_px:
+        parts.append(f'letter-spacing="{fmt_num(run.letter_spacing_px)}"')
+    return " " + " ".join(parts)
+
+
+def _xml_escape(text: str) -> str:
+    return (text.replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace('"', "&quot;"))

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -3,7 +3,8 @@
 import "source-map-support/register.js";
 
 import { createServer, type IncomingMessage as HttpReq, type ServerResponse } from "node:http";
-import { spawnSync } from "node:child_process";
+import { spawnSync, execFile } from "node:child_process";
+import { promisify } from "node:util";
 import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
@@ -1322,6 +1323,114 @@ const TEXT_NOEXT_NAMES = new Set(["makefile", "dockerfile", "gemfile", "rakefile
 
 /** Office document extensions previewable via LiteParse text extraction. */
 const OFFICE_PREVIEW_EXTENSIONS = new Set([".docx", ".xlsx", ".pptx"]);
+
+/** Map an office extension to a preview format the frontend dispatches on. */
+function officeFormat(filePath: string): "docx" | "xlsx" | "pptx" | undefined {
+	const ext = extname(filePath).toLowerCase();
+	if (ext === ".docx") return "docx";
+	if (ext === ".xlsx") return "xlsx";
+	if (ext === ".pptx") return "pptx";
+	return undefined;
+}
+
+// --- PPTX → SVG conversion (pure-Python converter, no LibreOffice) ---
+const PPTX_TIMEOUT_MS = 60_000;
+const MAX_PPTX_SLIDES = 200;
+const MAX_PPTX_BYTES = 50 * 1024 * 1024;
+const execFileAsync = promisify(execFile);
+let cachedPythonExe: string | null | undefined;
+
+/** Absolute path to the vendored pptx_to_svg CLI (dev = repo, prod = bundled). */
+function pptxScriptPath(): string {
+	// In a packaged Electron app, codeDir points inside app.asar but the script
+	// is unpacked (asarUnpack) to app.asar.unpacked — Python can't read asar.
+	const base = paths.codeDir.replace(/app\.asar([\\/])/, "app.asar.unpacked$1");
+	return join(base, "scripts", "pptx_to_svg.py");
+}
+
+/** Resolve a usable Python executable, caching the result. */
+function resolvePythonExecutable(): string | null {
+	if (cachedPythonExe !== undefined) return cachedPythonExe;
+	const candidates: string[] = [];
+	const override = process.env.INNO_PYTHON?.trim();
+	if (override) candidates.push(override);
+	// On Windows the launcher is usually `python`; elsewhere prefer `python3`.
+	if (process.platform === "win32") candidates.push("python", "python3");
+	else candidates.push("python3", "python");
+	for (const candidate of candidates) {
+		try {
+			const probe = spawnSync(candidate, ["--version"], { stdio: "ignore", windowsHide: true });
+			if (!probe.error && probe.status === 0) {
+				cachedPythonExe = candidate;
+				return candidate;
+			}
+		} catch {
+			// try next candidate
+		}
+	}
+	cachedPythonExe = null;
+	return null;
+}
+
+interface PptxSvgSlide {
+	index: number;
+	svg: string;
+}
+
+interface PptxConvertResult {
+	slides: PptxSvgSlide[];
+	canvasPx?: [number, number];
+}
+
+/**
+ * Convert a .pptx to per-slide SVG strings via the vendored Python converter.
+ * Runs asynchronously (never blocks the HTTP loop) and always cleans up its
+ * temp directory. Throws on failure so the caller can return a 422 fallback.
+ */
+async function convertPptxToSvg(filePath: string): Promise<PptxConvertResult> {
+	const python = resolvePythonExecutable();
+	if (!python) {
+		throw new Error("Python is not available; set INNO_PYTHON or install python3");
+	}
+	const script = pptxScriptPath();
+	if (!existsSync(script)) {
+		throw new Error(`pptx converter not found at ${script}`);
+	}
+	const outDir = join(tmpdir(), `inno-pptx-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+	ensureDir(outDir);
+	try {
+		const { stdout } = await execFileAsync(
+			python,
+			[script, filePath, "--embed-images", "--inheritance-mode", "flat", "-o", outDir],
+			{ timeout: PPTX_TIMEOUT_MS, maxBuffer: 8 * 1024 * 1024, windowsHide: true },
+		);
+		const svgDir = join(outDir, "svg");
+		if (!existsSync(svgDir)) {
+			throw new Error("converter produced no output");
+		}
+		const files = readdirSync(svgDir)
+			.filter((f) => /^slide_\d+\.svg$/i.test(f))
+			.sort((a, b) => {
+				const na = Number(a.match(/\d+/)?.[0] ?? 0);
+				const nb = Number(b.match(/\d+/)?.[0] ?? 0);
+				return na - nb;
+			});
+		const slides: PptxSvgSlide[] = [];
+		for (const file of files.slice(0, MAX_PPTX_SLIDES)) {
+			const index = Number(file.match(/\d+/)?.[0] ?? slides.length + 1);
+			slides.push({ index, svg: readFileSync(join(svgDir, file), "utf-8") });
+		}
+		if (slides.length === 0) {
+			throw new Error("converter produced no slides");
+		}
+		let canvasPx: [number, number] | undefined;
+		const match = /Canvas:\s*([\d.]+)\s*x\s*([\d.]+)\s*px/i.exec(stdout);
+		if (match) canvasPx = [Number(match[1]), Number(match[2])];
+		return { slides, canvasPx };
+	} finally {
+		rmSync(outDir, { recursive: true, force: true });
+	}
+}
 
 /** Whether a file looks like a dotfile config (almost always text). */
 function isDotfileText(filePath: string): boolean {
@@ -2862,18 +2971,23 @@ const server = createServer(async (req, res) => {
 			if (!forceText && (kind === "binary" || kind === "pdf" || kind === "image" || kind === "office")) {
 				const relPath = workspaceRelativePath(root, filePath);
 				const rawUrl = `/api/workspace/raw?workspaceId=${encodeURIComponent(wsId)}&path=${encodeURIComponent(relPath)}`;
+				const format = kind === "office" ? officeFormat(filePath) : undefined;
+				// pptx is rendered as SVG via the Python converter; docx/xlsx are
+				// rendered client-side from the raw bytes, so they need no previewUrl.
+				let previewUrl: string | undefined;
+				if (format === "pptx") {
+					previewUrl = `/api/workspace/pptx-preview?workspaceId=${encodeURIComponent(wsId)}&path=${encodeURIComponent(relPath)}`;
+				}
 				json(res, 200, {
 					path: relPath,
 					name: basename(filePath),
 					kind,
+					format,
 					mimeType: contentType,
 					size: stat.size,
 					updatedAt: stat.mtime.toISOString(),
 					url: rawUrl,
-					// Office docs carry a separate URL that returns extracted text JSON.
-					previewUrl: kind === "office"
-						? `/api/workspace/office-preview?workspaceId=${encodeURIComponent(wsId)}&path=${encodeURIComponent(relPath)}`
-						: undefined,
+					previewUrl,
 				});
 				return;
 			}
@@ -2978,6 +3092,38 @@ const server = createServer(async (req, res) => {
 			} catch (err) {
 				logger.warn({ err }, "failed to parse office document");
 				json(res, 422, { error: err instanceof Error ? err.message : "Failed to parse document" });
+			}
+			return;
+		}
+
+		// Render a .pptx as per-slide SVG via the vendored Python converter.
+		if (method === "GET" && url.startsWith("/api/workspace/pptx-preview?")) {
+			const params = new URL(url, "http://localhost").searchParams;
+			const requestedPath = params.get("path") ?? "";
+			const wsId = workspaceIdFromQuery(url);
+			const filePath = safeWorkspacePath(wsId, requestedPath);
+			if (!filePath || !existsSync(filePath) || !statSync(filePath).isFile()) {
+				json(res, 404, { error: "Workspace file not found" });
+				return;
+			}
+			if (statSync(filePath).size > MAX_PPTX_BYTES) {
+				json(res, 413, { error: "Presentation is too large to preview" });
+				return;
+			}
+			try {
+				const result = await convertPptxToSvg(filePath);
+				json(res, 200, {
+					name: basename(filePath),
+					slideCount: result.slides.length,
+					slides: result.slides,
+					canvasPx: result.canvasPx,
+				});
+			} catch (err) {
+				logger.warn({ err }, "failed to convert pptx to svg");
+				json(res, 422, {
+					error: err instanceof Error ? err.message : "Failed to render presentation",
+					code: "PPTX_CONVERT_FAILED",
+				});
 			}
 			return;
 		}

--- a/apps/inno-agent/web/package.json
+++ b/apps/inno-agent/web/package.json
@@ -34,6 +34,7 @@
 		"cytoscape": "^3.30.4",
 		"cytoscape-cola": "^2.5.1",
 		"cytoscape-cose-bilkent": "^4.1.0",
+		"docx-preview": "^0.3.7",
 		"highlight.js": "^11.11.1",
 		"i18next": "^26.2.0",
 		"lit": "^3.3.1",
@@ -44,7 +45,8 @@
 		"react": "19.2.5",
 		"react-arborist": "^3.7.0",
 		"react-dom": "19.2.5",
-		"react-i18next": "^17.0.3"
+		"react-i18next": "^17.0.3",
+		"xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 	},
 	"devDependencies": {
 		"@types/cytoscape": "^3.21.9",

--- a/apps/inno-agent/web/src/api/workspace.ts
+++ b/apps/inno-agent/web/src/api/workspace.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from "./client.js";
-import type { WorkspaceFileDetail, WorkspaceTree, WorkspaceTreeNode } from "../types/workspace.js";
+import type { PptxPreviewResult, WorkspaceFileDetail, WorkspaceTree, WorkspaceTreeNode } from "../types/workspace.js";
 
 function qs(workspaceId?: string): string {
 	return workspaceId ? `?workspaceId=${encodeURIComponent(workspaceId)}` : "";
@@ -85,6 +85,13 @@ export function workspaceFolderZipUrl(path: string, workspaceId?: string): strin
 	if (workspaceId) params.set("workspaceId", workspaceId);
 	const qs = params.toString();
 	return `/api/workspace/download-folder${qs ? `?${qs}` : ""}`;
+}
+
+/** Fetch a pptx rendered to per-slide SVG. */
+export async function getPptxPreview(path: string, workspaceId?: string): Promise<PptxPreviewResult> {
+	const params = new URLSearchParams({ path });
+	if (workspaceId) params.set("workspaceId", workspaceId);
+	return apiFetch<PptxPreviewResult>(`/api/workspace/pptx-preview?${params.toString()}`);
 }
 
 // ---- HTML resource inlining for srcdoc previews ----

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -270,6 +270,31 @@ inno-workspace-panel textarea {
 	background-clip: padding-box;
 }
 
+/* Office previews: make injected SVG / docx pages fit the preview width. */
+/* pptx: the converter emits <svg width="960" height="540">; override so it
+   scales to the slide card instead of overflowing at its intrinsic size. */
+.pptx-slide svg {
+	display: block;
+	width: 100%;
+	height: 100%;
+}
+
+/* docx: docx-preview lays out fixed-width A4 pages. Let the wrapper shrink to
+   the panel and scale each page down proportionally on narrow previews. */
+.docx-host .docx-wrapper {
+	width: 100%;
+	max-width: 100%;
+	padding: 0;
+	background: transparent;
+}
+
+.docx-host .docx-wrapper > section.docx {
+	width: 100% !important;
+	max-width: 100%;
+	margin: 0 auto 1rem;
+	box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+}
+
 .inno-icon-button {
 	display: inline-flex;
 	align-items: center;

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -138,7 +138,16 @@
 		"officeNote": "Text extracted for preview · formatting may differ",
 		"officeUnavailable": "Preview unavailable",
 		"pageCount": "{{count}} pages",
-		"page": "Page"
+		"page": "Page",
+		"pptxLoading": "Rendering slides...",
+		"pptxCount": "{{count}} slides",
+		"pptxSlide": "Slide {{n}}",
+		"pptxFailed": "Failed to render presentation",
+		"docxLoading": "Rendering document...",
+		"docxFailed": "Failed to render document",
+		"xlsxLoading": "Rendering spreadsheet...",
+		"xlsxFailed": "Failed to render spreadsheet",
+		"xlsxLargeSheetWarning": "Large sheet — showing first {{n}} rows"
 	},
 	"profile": {
 		"title": "Learner Profile",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -138,7 +138,16 @@
 		"officeNote": "已提取文本用于预览 · 排版可能与原文不同",
 		"officeUnavailable": "无法预览",
 		"pageCount": "{{count}} 页",
-		"page": "第"
+		"page": "第",
+		"pptxLoading": "正在渲染幻灯片…",
+		"pptxCount": "共 {{count}} 页",
+		"pptxSlide": "第 {{n}} 页",
+		"pptxFailed": "演示文稿渲染失败",
+		"docxLoading": "正在渲染文档…",
+		"docxFailed": "文档渲染失败",
+		"xlsxLoading": "正在渲染表格…",
+		"xlsxFailed": "表格渲染失败",
+		"xlsxLargeSheetWarning": "表格较大 — 仅显示前 {{n}} 行"
 	},
 	"profile": {
 		"title": "学习者画像",

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type DragEvent } from "react";
+import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type DragEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Tree, type NodeRendererProps, type TreeApi, type CreateHandler, type RenameHandler, type DeleteHandler, type MoveHandler } from "react-arborist";
 import MDEditor from "@uiw/react-md-editor";
@@ -17,7 +17,7 @@ import { cpp } from "@codemirror/lang-cpp";
 import { rust } from "@codemirror/lang-rust";
 import { go } from "@codemirror/lang-go";
 import type { Extension } from "@codemirror/state";
-import { RefreshCw, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Sparkles, Download, FileCode2 } from "lucide-react";
+import { RefreshCw, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Sparkles, Download, FileCode2, Presentation, FileSpreadsheet } from "lucide-react";
 import { workspaceStore } from "../stores/workspace-store.js";
 import { workspaceFileUrl, workspaceFolderZipUrl, triggerDownload } from "../api/workspace.js";
 import { workspacesStore } from "../stores/workspaces-store.js";
@@ -26,13 +26,19 @@ import { settingsStore } from "../stores/settings-store.js";
 import { getSessionWorkspace } from "../api/workspaces.js";
 import { TerminalDrawer } from "./terminal/TerminalDrawer.js";
 import { RunButton } from "./terminal/RunButton.js";
-import type { WorkspaceFileDetail, WorkspaceFileKind } from "../types/workspace.js";
+import type { WorkspaceFileDetail, WorkspaceFileKind, WorkspaceOfficeFormat } from "../types/workspace.js";
 import { type ArboristNode, toArboristNodes } from "../types/workspace.js";
 import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 import { useStoreSnapshot } from "./hooks.js";
 import "@earendil-works/pi-web-ui";
 import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
+
+// Heavy office renderers are lazy-loaded so docx-preview / xlsx stay off the
+// critical path and only download when an office file is actually opened.
+const PptxPreview = lazy(() => import("./office/PptxPreview.js"));
+const DocxPreview = lazy(() => import("./office/DocxPreview.js"));
+const XlsxPreview = lazy(() => import("./office/XlsxPreview.js"));
 
 /* ---------- helpers ---------- */
 
@@ -48,7 +54,19 @@ function nodeIcon(name: string, isDir: boolean, isOpen: boolean) {
 	if (lower.endsWith(".md")) return <FileText size={14} />;
 	if (lower.endsWith(".pdf")) return <FileType size={14} />;
 	if (lower.endsWith(".html") || lower.endsWith(".htm")) return <Globe size={14} />;
+	if (lower.endsWith(".pptx")) return <Presentation size={14} />;
+	if (lower.endsWith(".xlsx")) return <FileSpreadsheet size={14} />;
+	if (lower.endsWith(".docx")) return <FileText size={14} />;
 	return <File size={14} />;
+}
+
+/** Derive the office format from a filename when the backend didn't supply it. */
+function officeFormatFromName(name: string): WorkspaceOfficeFormat | undefined {
+	const lower = name.toLowerCase();
+	if (lower.endsWith(".pptx")) return "pptx";
+	if (lower.endsWith(".docx")) return "docx";
+	if (lower.endsWith(".xlsx")) return "xlsx";
+	return undefined;
 }
 
 /** Whether a file kind supports text editing */
@@ -300,6 +318,15 @@ function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: bo
 		);
 	}
 	if (file.kind === "office") {
+		const fmt = file.format ?? officeFormatFromName(file.name);
+		const fallback = (
+			<div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">
+				{t("preview.loadingFile")}
+			</div>
+		);
+		if (fmt === "pptx") return <Suspense fallback={fallback}><PptxPreview file={file} /></Suspense>;
+		if (fmt === "docx") return <Suspense fallback={fallback}><DocxPreview file={file} /></Suspense>;
+		if (fmt === "xlsx") return <Suspense fallback={fallback}><XlsxPreview file={file} /></Suspense>;
 		return <OfficePreview file={file} />;
 	}
 	if (file.kind === "binary") {

--- a/apps/inno-agent/web/src/react/office/DocxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/DocxPreview.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Download } from "lucide-react";
+import { renderAsync } from "docx-preview";
+import type { WorkspaceFileDetail } from "../../types/workspace.js";
+import { triggerDownload } from "../../api/workspace.js";
+
+/**
+ * Render a .docx into an HTML container with formatting preserved, via
+ * docx-preview (client-side, no LibreOffice). Options mirror pi-web-ui's
+ * DocxArtifact for parity.
+ */
+export default function DocxPreview({ file }: { file: WorkspaceFileDetail }) {
+	const { t } = useTranslation();
+	const containerRef = useRef<HTMLDivElement>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState("");
+
+	useEffect(() => {
+		if (!file.url) {
+			setError(t("preview.docxFailed", "Failed to render document"));
+			setLoading(false);
+			return;
+		}
+		let cancelled = false;
+		setLoading(true);
+		setError("");
+		const container = containerRef.current;
+		if (container) container.innerHTML = "";
+		(async () => {
+			try {
+				const res = await fetch(file.url as string);
+				if (!res.ok) throw new Error(res.statusText);
+				const buf = await res.arrayBuffer();
+				if (cancelled || !containerRef.current) return;
+				await renderAsync(buf, containerRef.current, undefined, {
+					className: "docx",
+					inWrapper: true,
+					ignoreWidth: true,
+					ignoreHeight: false,
+					ignoreFonts: false,
+					breakPages: true,
+					ignoreLastRenderedPageBreak: true,
+					experimental: false,
+					trimXmlDeclaration: true,
+					useBase64URL: false,
+					renderHeaders: true,
+					renderFooters: true,
+					renderFootnotes: true,
+					renderEndnotes: true,
+				});
+			} catch (e) {
+				if (!cancelled) setError(e instanceof Error ? e.message : t("preview.docxFailed", "Failed to render document"));
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		})();
+		return () => { cancelled = true; };
+	}, [file.url, t]);
+
+	const downloadOriginal = () => {
+		if (file.url) triggerDownload(`${file.url}${file.url.includes("?") ? "&" : "?"}download=1`);
+	};
+
+	return (
+		<div className="workspace-scroll h-full overflow-auto bg-[var(--inno-surface-muted)]">
+			{loading ? (
+				<div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">
+					{t("preview.docxLoading", "Rendering document...")}
+				</div>
+			) : null}
+			{error ? (
+				<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[var(--inno-text-muted)]">
+					<div className="font-medium text-[var(--inno-text)]">{file.name}</div>
+					<div className="text-xs text-red-500">{error}</div>
+					<button
+						className="flex items-center gap-1 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)]"
+						onClick={downloadOriginal}
+					>
+						<Download size={12} />
+						{t("files.download", "Download")}
+					</button>
+				</div>
+			) : null}
+			<div ref={containerRef} className={`docx-host px-4 py-4 ${loading || error ? "hidden" : ""}`} />
+		</div>
+	);
+}

--- a/apps/inno-agent/web/src/react/office/PptxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/PptxPreview.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Download, Loader2 } from "lucide-react";
+import type { PptxPreviewResult, PptxSlide, WorkspaceFileDetail } from "../../types/workspace.js";
+import { triggerDownload } from "../../api/workspace.js";
+
+/**
+ * Render a .pptx as a vertical stack of slide SVGs, produced by the backend
+ * Python converter (no LibreOffice). SVGs are shape-only with base64-embedded
+ * images, so they inject safely into a plain container.
+ */
+export default function PptxPreview({ file }: { file: WorkspaceFileDetail }) {
+	const { t } = useTranslation();
+	const [slides, setSlides] = useState<PptxSlide[]>([]);
+	const [aspect, setAspect] = useState<number>(16 / 9);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState("");
+
+	useEffect(() => {
+		if (!file.previewUrl) {
+			setError(t("preview.pptxFailed", "Failed to render presentation"));
+			setLoading(false);
+			return;
+		}
+		let cancelled = false;
+		setLoading(true);
+		setError("");
+		setSlides([]);
+		fetch(file.previewUrl)
+			.then(async (res) => {
+				if (!res.ok) {
+					const body = await res.json().catch(() => ({}));
+					throw new Error((body as { error?: string }).error || res.statusText);
+				}
+				return res.json() as Promise<PptxPreviewResult>;
+			})
+			.then((res) => {
+				if (cancelled) return;
+				setSlides(res.slides);
+				if (res.canvasPx && res.canvasPx[1] > 0) setAspect(res.canvasPx[0] / res.canvasPx[1]);
+			})
+			.catch((e) => { if (!cancelled) setError(e instanceof Error ? e.message : t("preview.pptxFailed", "Failed to render presentation")); })
+			.finally(() => { if (!cancelled) setLoading(false); });
+		return () => { cancelled = true; };
+	}, [file.previewUrl, t]);
+
+	const downloadOriginal = () => {
+		if (file.url) triggerDownload(`${file.url}${file.url.includes("?") ? "&" : "?"}download=1`);
+	};
+
+	if (loading) {
+		return (
+			<div className="flex h-full items-center justify-center gap-2 text-sm text-[var(--inno-text-muted)]">
+				<Loader2 size={16} className="animate-spin" />
+				{t("preview.pptxLoading", "Rendering slides...")}
+			</div>
+		);
+	}
+	if (error) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[var(--inno-text-muted)]">
+				<div className="font-medium text-[var(--inno-text)]">{file.name}</div>
+				<div className="text-xs text-red-500">{error}</div>
+				<button className="flex items-center gap-1 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)]" onClick={downloadOriginal}>
+					<Download size={12} />
+					{t("files.download", "Download")}
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="workspace-scroll h-full overflow-auto bg-[var(--inno-surface-muted)] p-4">
+			<div className="mb-3 flex items-center justify-between gap-2">
+				<div className="text-xs text-[var(--inno-text-muted)]">
+					{t("preview.pptxCount", "{{count}} slides", { count: slides.length })}
+				</div>
+				<button className="flex shrink-0 items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]" onClick={downloadOriginal}>
+					<Download size={12} />
+					{t("files.download", "Download")}
+				</button>
+			</div>
+			<div className="mx-auto flex max-w-4xl flex-col gap-4">
+				{slides.map((slide) => (
+					<div key={slide.index} className="overflow-hidden rounded-lg border border-[var(--inno-border)] bg-white shadow-sm">
+						<div className="flex items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1">
+							<span className="text-[10px] font-medium uppercase tracking-wide text-[var(--inno-text-subtle)]">
+								{t("preview.pptxSlide", "Slide {{n}}", { n: slide.index })}
+							</span>
+						</div>
+						<div
+							className="pptx-slide w-full"
+							style={{ aspectRatio: String(aspect) }}
+							dangerouslySetInnerHTML={{ __html: slide.svg }}
+						/>
+					</div>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/inno-agent/web/src/react/office/XlsxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/XlsxPreview.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Download } from "lucide-react";
+import * as XLSX from "xlsx";
+import type { WorkspaceFileDetail } from "../../types/workspace.js";
+import { triggerDownload } from "../../api/workspace.js";
+
+/** Cap rendered rows per sheet to avoid blowing up the DOM on huge sheets. */
+const MAX_ROWS = 2000;
+
+/**
+ * Render a .xlsx workbook as HTML tables (client-side via SheetJS, no
+ * LibreOffice). Multiple sheets get a tab strip. Mirrors pi-web-ui's
+ * ExcelArtifact styling.
+ */
+export default function XlsxPreview({ file }: { file: WorkspaceFileDetail }) {
+	const { t } = useTranslation();
+	const [workbook, setWorkbook] = useState<XLSX.WorkBook | null>(null);
+	const [active, setActive] = useState(0);
+	const [truncated, setTruncated] = useState(false);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState("");
+	const tableRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (!file.url) {
+			setError(t("preview.xlsxFailed", "Failed to render spreadsheet"));
+			setLoading(false);
+			return;
+		}
+		let cancelled = false;
+		setLoading(true);
+		setError("");
+		setWorkbook(null);
+		setActive(0);
+		(async () => {
+			try {
+				const res = await fetch(file.url as string);
+				if (!res.ok) throw new Error(res.statusText);
+				const buf = await res.arrayBuffer();
+				if (cancelled) return;
+				const wb = XLSX.read(buf, { type: "array" });
+				if (!cancelled) setWorkbook(wb);
+			} catch (e) {
+				if (!cancelled) setError(e instanceof Error ? e.message : t("preview.xlsxFailed", "Failed to render spreadsheet"));
+			} finally {
+				if (!cancelled) setLoading(false);
+			}
+		})();
+		return () => { cancelled = true; };
+	}, [file.url, t]);
+
+	const sheetNames = workbook?.SheetNames ?? [];
+	const activeName = sheetNames[active];
+
+	const tableHtml = useMemo(() => {
+		if (!workbook || !activeName) return "";
+		const sheet = workbook.Sheets[activeName];
+		if (!sheet) return "";
+		// Trim the sheet range to MAX_ROWS so sheet_to_html can't explode.
+		let wasTruncated = false;
+		const ref = sheet["!ref"];
+		let target = sheet;
+		if (ref) {
+			const range = XLSX.utils.decode_range(ref);
+			if (range.e.r - range.s.r + 1 > MAX_ROWS) {
+				range.e.r = range.s.r + MAX_ROWS - 1;
+				target = { ...sheet, "!ref": XLSX.utils.encode_range(range) };
+				wasTruncated = true;
+			}
+		}
+		setTruncated(wasTruncated);
+		return XLSX.utils.sheet_to_html(target, { id: `sheet-${activeName}` });
+	}, [workbook, activeName]);
+
+	useEffect(() => {
+		const host = tableRef.current;
+		if (!host) return;
+		host.innerHTML = tableHtml;
+		const table = host.querySelector("table");
+		if (!table) return;
+		table.className = "border-collapse text-[var(--inno-text)]";
+		table.querySelectorAll("td, th").forEach((cell) => {
+			(cell as HTMLElement).className = "border border-[var(--inno-border)] px-3 py-1.5 text-xs text-left whitespace-nowrap";
+		});
+		const headerCells = table.querySelectorAll("thead th, tr:first-child td");
+		headerCells.forEach((th) => {
+			(th as HTMLElement).className = "border border-[var(--inno-border)] px-3 py-1.5 text-xs font-semibold bg-[var(--inno-surface-muted)] text-[var(--inno-text)] sticky top-0";
+		});
+	}, [tableHtml]);
+
+	const downloadOriginal = () => {
+		if (file.url) triggerDownload(`${file.url}${file.url.includes("?") ? "&" : "?"}download=1`);
+	};
+
+	if (loading) {
+		return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.xlsxLoading", "Rendering spreadsheet...")}</div>;
+	}
+	if (error) {
+		return (
+			<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[var(--inno-text-muted)]">
+				<div className="font-medium text-[var(--inno-text)]">{file.name}</div>
+				<div className="text-xs text-red-500">{error}</div>
+				<button className="flex items-center gap-1 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)]" onClick={downloadOriginal}>
+					<Download size={12} />
+					{t("files.download", "Download")}
+				</button>
+			</div>
+		);
+	}
+
+	return (
+		<div className="flex h-full flex-col bg-[var(--inno-surface)]">
+			{sheetNames.length > 1 ? (
+				<div className="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1">
+					{sheetNames.map((name, i) => (
+						<button
+							key={name}
+							onClick={() => setActive(i)}
+							className={`shrink-0 rounded px-2.5 py-1 text-xs ${i === active ? "bg-[var(--inno-surface)] font-medium text-[var(--inno-text)]" : "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)]"}`}
+						>
+							{name}
+						</button>
+					))}
+				</div>
+			) : null}
+			{truncated ? (
+				<div className="shrink-0 bg-amber-500/10 px-3 py-1 text-[11px] text-amber-600">
+					{t("preview.xlsxLargeSheetWarning", "Large sheet — showing first {{n}} rows", { n: MAX_ROWS })}
+				</div>
+			) : null}
+			<div className="workspace-scroll flex-1 overflow-auto p-3">
+				<div ref={tableRef} />
+			</div>
+		</div>
+	);
+}

--- a/apps/inno-agent/web/src/types/workspace.ts
+++ b/apps/inno-agent/web/src/types/workspace.ts
@@ -15,17 +15,36 @@ export interface WorkspaceTree extends WorkspaceTreeNode {
 
 export type WorkspaceFileKind = "markdown" | "html" | "pdf" | "image" | "office" | "text" | "binary";
 
+/** Specific office format, used to pick the right client-side renderer. */
+export type WorkspaceOfficeFormat = "docx" | "xlsx" | "pptx";
+
 export interface WorkspaceFileDetail {
 	path: string;
 	name: string;
 	kind: WorkspaceFileKind;
+	/** For office docs: which format, so the frontend picks the right renderer. */
+	format?: WorkspaceOfficeFormat;
 	mimeType: string;
 	size: number;
 	updatedAt: string;
 	content?: string;
 	url?: string;
-	/** For office docs: URL returning extracted-text JSON. */
+	/** For pptx: URL returning per-slide SVG JSON. */
 	previewUrl?: string;
+}
+
+/** One slide of a pptx rendered to SVG. */
+export interface PptxSlide {
+	index: number;
+	svg: string;
+}
+
+/** Response shape of GET /api/workspace/pptx-preview. */
+export interface PptxPreviewResult {
+	name: string;
+	slideCount: number;
+	slides: PptxSlide[];
+	canvasPx?: [number, number];
 }
 
 /** Node shape expected by react-arborist */

--- a/apps/inno-agent/web/vite.config.ts
+++ b/apps/inno-agent/web/vite.config.ts
@@ -151,6 +151,8 @@ export default defineConfig({
 					"markdown-editor": ["@uiw/react-md-editor"],
 					cytoscape: ["cytoscape", "cytoscape-cola", "cytoscape-cose-bilkent"],
 					katex: ["katex"],
+					"docx-preview": ["docx-preview"],
+					xlsx: ["xlsx"],
 				},
 			},
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -200,6 +200,7 @@
 				"cytoscape": "^3.30.4",
 				"cytoscape-cola": "^2.5.1",
 				"cytoscape-cose-bilkent": "^4.1.0",
+				"docx-preview": "^0.3.7",
 				"highlight.js": "^11.11.1",
 				"i18next": "^26.2.0",
 				"lit": "^3.3.1",
@@ -210,7 +211,8 @@
 				"react": "19.2.5",
 				"react-arborist": "^3.7.0",
 				"react-dom": "19.2.5",
-				"react-i18next": "^17.0.3"
+				"react-i18next": "^17.0.3",
+				"xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 			},
 			"devDependencies": {
 				"@types/cytoscape": "^3.21.9",

--- a/package.json
+++ b/package.json
@@ -37,13 +37,15 @@
 			"apps/inno-agent/dist/**/*",
 			"apps/inno-agent/web/dist/**/*",
 			"apps/inno-agent/presets/**/*",
+			"apps/inno-agent/scripts/**/*",
 			"node_modules/**/*",
 			"!node_modules/.cache/**/*"
 		],
 		"asarUnpack": [
 			"**/node_modules/node-pty/**/*",
 			"**/node_modules/@homebridge/**/*",
-			"apps/inno-agent/presets/**/*"
+			"apps/inno-agent/presets/**/*",
+			"apps/inno-agent/scripts/**/*"
 		],
 		"mac": {
 			"icon": "build/icon.icns",
@@ -110,6 +112,6 @@
 		"gaxios": {
 			"rimraf": "6.1.2"
 		},
-		"xlsx": "0.18.5"
+		"xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
 	}
 }


### PR DESCRIPTION
## Summary
- **pptx** → per-slide SVG via a vendored pure-Python `pptx_to_svg` converter (stdlib-only, no LibreOffice), run through a new `/api/workspace/pptx-preview` route using async `execFile`
- **docx** → `docx-preview` client-side rendering (formatting preserved)
- **xlsx** → SheetJS client-side parsing into HTML tables
- `@llamaindex/liteparse` kept for L2 wiki ingestion; `office-preview` route stays as a fallback
- Heavy renderers are lazy-loaded and code-split; converter bundled for Docker (runtime python3) and Electron (asarUnpack)
- Fixes a stale `xlsx` override that conflicted with pi-web-ui's 0.20.3 tarball
- Responsive CSS so pptx/docx previews fit the panel width

## Test plan
- [x] `npm run build` (backend tsc + web tsc/vite) passes
- [x] `npm ls docx-preview xlsx` resolves cleanly, no `invalid`
- [x] Live: `/api/workspace/pptx-preview` returns per-slide SVG + canvasPx; temp dir cleaned up after each request
- [x] `/api/workspace/file` returns `format` + pptx-only `previewUrl`; docx/xlsx serve raw for client render
- [x] Separate `docx-preview` / `xlsx` chunks in the build output
- [ ] Manual: open .pptx/.docx/.xlsx in the workspace panel and confirm rendering + width fit
- [ ] Fallback: with no Python available, pptx route returns 422 and UI shows download button