### PR TITLE
fix katex font link fallback

### DIFF
--- a/apps/inno-agent/web/vite.config.ts
+++ b/apps/inno-agent/web/vite.config.ts
@@ -1,6 +1,6 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
-import { existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { basename, extname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vite";
@@ -51,13 +51,17 @@ export default defineConfig({
 			buildStart() {
 				// pi-web-ui's built CSS references url(fonts/KaTeX_...) relative to its dist/.
 				// The actual fonts live in node_modules/katex/dist/fonts/.
-				// Create a symlink so Vite can resolve them.
+				// Link the font directory so Vite can resolve it; copy as a fallback
+				// when the host filesystem refuses symlink creation.
+				const source = resolve(monoRoot, "node_modules/katex/dist/fonts");
 				const target = resolve(monoRoot, "node_modules/@earendil-works/pi-web-ui/dist/fonts");
 				if (!existsSync(target)) {
-					symlinkSync(
-						resolve(monoRoot, "node_modules/katex/dist/fonts"),
-						target,
-					);
+					try {
+						symlinkSync(source, target, process.platform === "win32" ? "junction" : "dir");
+					} catch (err) {
+						if ((err as NodeJS.ErrnoException).code !== "EPERM") throw err;
+						cpSync(source, target, { recursive: true });
+					}
 				}
 			},
 		},


### PR DESCRIPTION
## Summary

Fixes the Vite KaTeX font linking step so frontend builds do not fail on hosts that reject directory symlink creation.

## Details

- Keeps the existing symlink behavior for normal Unix-like environments by using a directory symlink.
- Uses a Windows junction for directory links on Windows.
- Falls back to copying the KaTeX font directory only when symlink creation is denied with `EPERM`.

## Validation

- `npm run build`

## Notes

The local build originally failed on Windows with `EPERM` while creating `node_modules/@earendil-works/pi-web-ui/dist/fonts`. This change keeps non-Windows behavior intact while making Windows and restricted filesystems resilient.