### PR TITLE
style(ui): design token sweep & right panel line simplification

### DIFF
--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -28,6 +28,25 @@
 	--inno-ring: 0 0 0 3px rgba(52, 54, 58, 0.14);
 	--inno-selection-bg: rgba(52, 54, 58, 0.12);
 	--inno-grid-color: rgba(31, 35, 40, 0.025);
+
+	/* Transition tokens — custom cubic-bezier per Emil's design engineering.
+	   `ease`/`ease-in` feel sluggish; these give punchy, responsive motion. */
+	--inno-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+	--inno-ease-in-out: cubic-bezier(0.77, 0, 0.175, 1);
+	--inno-dur-fast: 120ms;
+	--inno-dur-ui: 160ms;
+	--inno-dur-modal: 220ms;
+
+	/* Semantic state colors — derive from the palette above via color-mix so
+	   they adapt to every theme automatically. No per-theme overrides needed. */
+	--inno-danger-bg: color-mix(in srgb, var(--inno-danger) 10%, transparent);
+	--inno-danger-border: color-mix(in srgb, var(--inno-danger) 22%, transparent);
+	--inno-success-bg: color-mix(in srgb, var(--inno-success) 10%, transparent);
+	--inno-success-border: color-mix(in srgb, var(--inno-success) 22%, transparent);
+	--inno-warning-bg: color-mix(in srgb, var(--inno-warning) 12%, transparent);
+	--inno-warning-border: color-mix(in srgb, var(--inno-warning) 22%, transparent);
+	--inno-focus-border: var(--inno-accent);
+
 	color: var(--inno-text);
 	background: var(--inno-background);
 	font-synthesis-weight: none;

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -201,7 +201,7 @@ inno-session-sidebar {
 	height: 100%;
 	min-height: 0;
 	overflow: hidden;
-	border-right: 1px solid #d5dae2;
+	border-right: 1px solid var(--inno-border);
 	background: var(--inno-sidebar-bg);
 	font-size: 12px;
 	line-height: 1.35;
@@ -257,7 +257,7 @@ inno-workspace-panel textarea {
 
 .chat-scroll {
 	scrollbar-width: thin;
-	scrollbar-color: rgba(148, 163, 184, 0.28) transparent;
+	scrollbar-color: var(--inno-scrollbar-thumb) transparent;
 }
 
 .chat-scroll::-webkit-scrollbar,
@@ -278,14 +278,14 @@ inno-workspace-panel textarea {
 .sidebar-scroll::-webkit-scrollbar-thumb {
 	border: 2px solid transparent;
 	border-radius: 999px;
-	background: rgba(148, 163, 184, 0.26);
+	background: var(--inno-scrollbar-thumb);
 	background-clip: padding-box;
 }
 
 .chat-scroll:hover::-webkit-scrollbar-thumb,
 .workspace-scroll:hover::-webkit-scrollbar-thumb,
 .sidebar-scroll:hover::-webkit-scrollbar-thumb {
-	background: rgba(100, 116, 139, 0.42);
+	background: var(--inno-scrollbar-thumb-hover);
 	background-clip: padding-box;
 }
 
@@ -318,21 +318,21 @@ inno-workspace-panel textarea {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	border: 1px solid #cbd5e1;
-	background: #ffffff;
-	color: #64748b;
-	transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+	border: 1px solid var(--inno-border);
+	background: var(--inno-surface);
+	color: var(--inno-text-muted);
+	transition: background-color var(--inno-dur-ui) var(--inno-ease-out), border-color var(--inno-dur-ui) var(--inno-ease-out), color var(--inno-dur-ui) var(--inno-ease-out), box-shadow var(--inno-dur-ui) var(--inno-ease-out), transform var(--inno-dur-fast) var(--inno-ease-out);
 }
 
 .inno-icon-button:hover:not(:disabled) {
-	border-color: rgba(148, 163, 184, 0.85);
-	background: #ffffff;
-	color: #0f172a;
-	box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+	border-color: var(--inno-border-strong);
+	background: var(--inno-surface);
+	color: var(--inno-text);
+	box-shadow: var(--inno-shadow-soft);
 }
 
 .inno-icon-button:active:not(:disabled) {
-	transform: translateY(1px);
+	transform: scale(0.97);
 }
 
 .inno-primary-button,
@@ -340,8 +340,8 @@ inno-workspace-panel textarea {
 	border-color: transparent;
 	background: var(--inno-accent);
 	color: #ffffff;
-	box-shadow: 0 1px 2px rgba(15, 23, 42, 0.08);
-	transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease, box-shadow 150ms ease, transform 150ms ease;
+	box-shadow: var(--inno-shadow-soft);
+	transition: background-color var(--inno-dur-ui) var(--inno-ease-out), border-color var(--inno-dur-ui) var(--inno-ease-out), color var(--inno-dur-ui) var(--inno-ease-out), box-shadow var(--inno-dur-ui) var(--inno-ease-out), transform var(--inno-dur-fast) var(--inno-ease-out);
 }
 
 .inno-primary-button:hover:not(:disabled),
@@ -353,7 +353,7 @@ inno-workspace-panel textarea {
 
 .inno-primary-button:active:not(:disabled),
 .inno-primary-icon-button:active:not(:disabled) {
-	transform: translateY(1px);
+	transform: scale(0.97);
 }
 
 .inno-primary-button:disabled,
@@ -372,7 +372,7 @@ inno-workspace-panel textarea {
 .inno-message {
 	min-width: 0;
 	max-width: 100%;
-	box-shadow: 0 1px 1px rgba(15, 23, 42, 0.03);
+	box-shadow: var(--inno-shadow-soft);
 }
 
 .inno-message details,
@@ -399,14 +399,20 @@ inno-workspace-panel textarea {
 }
 
 .inno-composer {
-	border: 1px solid #cbd5e1;
-	background: #ffffff;
-	box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+	border: 1px solid var(--inno-border);
+	background: var(--inno-surface);
+	box-shadow: var(--inno-shadow-soft);
+	transition: border-color var(--inno-dur-ui) var(--inno-ease-out), box-shadow var(--inno-dur-ui) var(--inno-ease-out);
+}
+
+.inno-composer:focus-within {
+	border-color: var(--inno-focus-border);
+	box-shadow: var(--inno-ring);
 }
 
 .inno-workspace-card {
-	border: 1px solid #e2e8f0;
-	background: #ffffff;
+	border: 1px solid var(--inno-border);
+	background: var(--inno-surface);
 	box-shadow: none;
 }
 
@@ -558,13 +564,13 @@ inno-workspace-panel textarea {
 	bottom: 12px;
 	width: 1px;
 	background: transparent;
-	transition: background-color 120ms ease, box-shadow 120ms ease;
+	transition: background-color var(--inno-dur-fast) var(--inno-ease-out), box-shadow var(--inno-dur-fast) var(--inno-ease-out);
 }
 
 .workspace-resize-handle:hover::after,
 .workspace-resizing .workspace-resize-handle::after {
-	background: rgba(37, 99, 235, 0.45);
-	box-shadow: 0 0 0 2px rgba(37, 99, 235, 0.08);
+	background: var(--inno-accent);
+	box-shadow: var(--inno-ring);
 }
 
 .workspace-resizing {
@@ -599,12 +605,6 @@ inno-workspace-panel textarea {
 	background-image: none;
 }
 
-:root[data-theme="innospark"] .inno-sidebar-scope,
-:root[data-theme="innospark"] inno-session-sidebar {
-	border-color: rgba(85, 90, 255, 0.08);
-	background: var(--inno-sidebar-bg);
-}
-
 :root[data-theme="innospark"] .inno-sidebar-scope header,
 :root[data-theme="innospark"] .inno-sidebar-scope [class*="border-b"] {
 	border-color: rgba(85, 90, 255, 0.1);
@@ -612,7 +612,7 @@ inno-workspace-panel textarea {
 
 :root[data-theme="innospark"] .inno-sidebar-scope [role="button"],
 :root[data-theme="innospark"] .inno-sidebar-scope button {
-	transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+	transition: background-color var(--inno-dur-ui) var(--inno-ease-out), border-color var(--inno-dur-ui) var(--inno-ease-out), color var(--inno-dur-ui) var(--inno-ease-out), box-shadow var(--inno-dur-ui) var(--inno-ease-out), transform var(--inno-dur-fast) var(--inno-ease-out);
 }
 
 :root[data-theme="innospark"] .inno-sidebar-scope [role="button"]:hover,
@@ -623,7 +623,7 @@ inno-workspace-panel textarea {
 
 :root[data-theme="innospark"] .inno-sidebar-scope [role="button"]:active,
 :root[data-theme="innospark"] .inno-sidebar-scope button:active:not(:disabled) {
-	transform: translateY(1px);
+	transform: scale(0.97);
 }
 
 :root[data-theme="innospark"] .inno-panel-title,
@@ -645,9 +645,9 @@ inno-workspace-panel textarea {
 :root[data-theme="innospark"] .inno-composer {
 	border: 2px solid rgba(85, 90, 255, 0.25);
 	border-radius: 22px;
-	background: #ffffff;
+	background: var(--inno-surface);
 	box-shadow: 0 2px 4px rgba(85, 90, 255, 0.08), 0 10px 28px rgba(85, 90, 255, 0.1);
-	transition: border-color 160ms ease, box-shadow 160ms ease, transform 160ms ease;
+	transition: border-color var(--inno-dur-ui) var(--inno-ease-out), box-shadow var(--inno-dur-ui) var(--inno-ease-out);
 }
 
 :root[data-theme="innospark"] .inno-composer:focus-within {
@@ -662,19 +662,6 @@ inno-workspace-panel textarea {
 :root[data-theme="innospark"] .inno-icon-button,
 :root[data-theme="innospark"] .inno-composer button {
 	border-radius: 999px;
-}
-
-:root[data-theme="innospark"] .inno-icon-button {
-	border-color: rgba(85, 90, 255, 0.14);
-	background: #ffffff;
-	color: var(--inno-text-muted);
-	box-shadow: 0 1px 2px rgba(85, 90, 255, 0.06);
-}
-
-:root[data-theme="innospark"] .inno-icon-button:hover:not(:disabled) {
-	border-color: rgba(85, 90, 255, 0.28);
-	color: var(--inno-text);
-	box-shadow: 0 2px 8px rgba(85, 90, 255, 0.1);
 }
 
 :root[data-theme="innospark"] .inno-composer button[title="Send"],
@@ -710,26 +697,6 @@ inno-workspace-panel textarea {
 	background: rgba(255, 255, 255, 0.7);
 }
 
-:root[data-theme="innospark"] .workspace-panel,
-:root[data-theme="innospark"] inno-workspace-panel {
-	border-color: rgba(85, 90, 255, 0.12);
-	background: var(--inno-workspace-bg);
-}
-
-:root[data-theme="innospark"] .inno-workspace-card,
-:root[data-theme="innospark"] .inno-workspace-scope .rounded-lg:not(.inno-primary-button):not(.inno-primary-icon-button),
-:root[data-theme="innospark"] .inno-workspace-scope .rounded:not(.inno-primary-button):not(.inno-primary-icon-button) {
-	border-color: rgba(85, 90, 255, 0.12);
-	background-color: rgba(255, 255, 255, 0.86);
-}
-
-:root[data-theme="innospark"] .workspace-resize-handle:hover::after,
-:root[data-theme="innospark"].workspace-resizing .workspace-resize-handle::after,
-:root[data-theme="innospark"] .workspace-resizing .workspace-resize-handle::after {
-	background: rgba(85, 90, 255, 0.5);
-	box-shadow: 0 0 0 2px rgba(85, 90, 255, 0.1);
-}
-
 @media (max-width: 960px) {
 	.app-layout--workspace-half {
 		--workspace-w: clamp(280px, 42vw, var(--inno-workspace-width));
@@ -745,7 +712,7 @@ inno-workspace-panel textarea {
 /* Sidebar scrollbar */
 .sidebar-scroll {
 	scrollbar-width: thin;
-	scrollbar-color: rgba(148, 163, 184, 0.25) transparent;
+	scrollbar-color: var(--inno-scrollbar-thumb) transparent;
 }
 
 /*
@@ -767,4 +734,32 @@ inno-workspace-panel textarea {
 	line-height: inherit !important;
 	letter-spacing: inherit !important;
 	tab-size: inherit !important;
+}
+
+/* Reduced motion — collapse non-essential animation for users who prefer it.
+   Keeps opacity/color transitions for comprehension; kills movement. */
+@media (prefers-reduced-motion: reduce) {
+	*, *::before, *::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
+}
+
+/* Flip-card 3D — shared by ChatCenter (switch-workspace) and SessionSidebar.
+   Replaces duplicated inline style={{ transformStyle, backfaceVisibility }}. */
+.flip-card-scene {
+	perspective: 600px;
+}
+.flip-card {
+	transform-style: preserve-3d;
+	position: relative;
+}
+.flip-card-face {
+	backface-visibility: hidden;
+}
+.flip-card-back {
+	backface-visibility: hidden;
+	transform: rotateY(180deg);
 }

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -881,7 +881,7 @@ export function ChatCenter() {
 						{simpleMode ? null : preselectedWs ? (
 							<div className="mt-3 flex flex-wrap items-center gap-2">
 								<span className="text-xs text-[var(--inno-text-subtle)]">工作区</span>
-								<span className="rounded-full bg-[var(--inno-accent-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]">
+								<span className="rounded-full bg-[var(--inno-accent-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--inno-accent)]">
 									{preselectedWs.name}
 								</span>
 								<span className="text-[10px] text-[var(--inno-text-subtle)]">新对话将创建于此工作区</span>

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -31,8 +31,8 @@ const PASTE_COLLAPSE_CHARS = 2000;
 const CHANNEL_BADGE_CLASS: Record<string, string> = {
 	cli: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]",
 	web: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]",
-	feishu: "bg-emerald-50 text-emerald-500",
-	scheduler: "bg-amber-50 text-amber-500",
+	feishu: "bg-[var(--inno-success-bg)] text-[var(--inno-success)]",
+	scheduler: "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)]",
 	qq: "bg-cyan-50 text-cyan-500",
 	wechat: "bg-lime-50 text-lime-500",
 };
@@ -92,13 +92,13 @@ function ImageLightbox({ src, onClose }: { src: string; onClose: () => void }) {
 function ErrorBlock({ error }: { error: string }) {
 	const isLong = error.length > 80 || error.includes("\n");
 	return (
-		<details className="rounded-md border border-red-200 bg-red-50 px-2.5 py-1.5 text-xs text-red-700" open={!isLong}>
+		<details className="rounded-md border border-[var(--inno-danger-border)] bg-[var(--inno-danger-bg)] px-2.5 py-1.5 text-xs text-[var(--inno-danger)]" open={!isLong}>
 			<summary className="flex cursor-pointer select-none items-center gap-1.5 font-medium">
 				<AlertTriangle size={13} className="shrink-0" />
 				Request failed
-				{isLong ? <span className="text-red-400">· click to expand</span> : null}
+				{isLong ? <span className="text-[var(--inno-danger)]">· click to expand</span> : null}
 			</summary>
-			<pre className="mt-1.5 max-h-48 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-red-600">{error}</pre>
+			<pre className="mt-1.5 max-h-48 overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-[var(--inno-danger)]">{error}</pre>
 		</details>
 	);
 }
@@ -160,7 +160,7 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 							<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
 								{message.tools.map((tool) => (
 									<details key={tool.toolCallId} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1">
-										<summary className={tool.isError ? "cursor-pointer break-words text-red-600 [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>
+										<summary className={tool.isError ? "cursor-pointer break-words text-[var(--inno-danger)] [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>
 											{tool.toolName}
 										</summary>
 										<pre className="mt-1 max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] [overflow-wrap:anywhere]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
@@ -217,7 +217,7 @@ function ModeChip({ selected, onClick, disabled, children }: { selected: boolean
 			disabled={disabled}
 			className={`rounded-full border px-1.5 py-px text-[10px] leading-tight transition-colors disabled:cursor-not-allowed disabled:opacity-40 ${
 				selected
-					? "border-blue-300 bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
+					? "border-[var(--inno-accent)] bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
 					: "border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
 			}`}
 		>
@@ -306,7 +306,7 @@ function PresetPicker({
 										disabled={openingPresetId !== null}
 										onClick={() => onOpen(preset.id)}
 										title={preset.description}
-										className="group flex flex-col items-start rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2.5 text-left transition-colors hover:border-blue-300 hover:bg-blue-50/40 disabled:opacity-50"
+										className="group flex flex-col items-start rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2.5 text-left transition-colors hover:border-[var(--inno-accent)] hover:bg-[var(--inno-surface-muted)] disabled:opacity-50"
 									>
 										<span className="text-sm font-medium text-[var(--inno-text)] group-hover:text-[var(--inno-accent)]">
 											{preset.name}
@@ -781,7 +781,7 @@ export function ChatCenter() {
 			/>
 			{chat.isSending ? (
 				<button
-					className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-red-600 text-white transition-colors hover:bg-red-700"
+					className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--inno-danger)] text-white transition-opacity hover:opacity-90 active:scale-[0.97]"
 					title="Stop generation"
 					onClick={handleStop}
 				>
@@ -825,7 +825,7 @@ export function ChatCenter() {
 								disabled={togglingMode}
 								title={simpleMode ? "当前:简单模式 · 点击切换到普通模式" : "当前:普通模式 · 点击切换到简单模式"}
 								aria-label={simpleMode ? "切换到普通模式" : "切换到简单模式"}
-								className="mb-3 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:cursor-wait"
+								className="mb-3 rounded-xl outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
 								style={{ perspective: "600px" }}
 							>
 								<motion.div
@@ -836,14 +836,14 @@ export function ChatCenter() {
 								>
 									{/* Front — Normal mode */}
 									<span
-										className="absolute inset-0 flex items-center justify-center rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] text-base font-semibold text-[var(--inno-accent)] shadow-sm transition-colors hover:border-blue-300"
+										className="absolute inset-0 flex items-center justify-center rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] text-base font-semibold text-[var(--inno-accent)] shadow-sm transition-colors hover:border-[var(--inno-accent)]"
 										style={{ backfaceVisibility: "hidden" }}
 									>
 										IA
 									</span>
 									{/* Back — Simple mode */}
 									<span
-										className="absolute inset-0 flex items-center justify-center rounded-xl border border-blue-400 bg-[var(--inno-accent)] text-base font-semibold text-white shadow-sm"
+										className="absolute inset-0 flex items-center justify-center rounded-xl border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-base font-semibold text-white shadow-sm"
 										style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
 									>
 										IA
@@ -858,9 +858,9 @@ export function ChatCenter() {
 								type="button"
 								onClick={toggleMode}
 								disabled={togglingMode}
-								className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1 text-[11px] text-[var(--inno-text-muted)] transition-colors hover:border-blue-300 hover:text-[var(--inno-accent)] disabled:cursor-wait disabled:opacity-60"
+								className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1 text-[11px] text-[var(--inno-text-muted)] transition-colors hover:border-[var(--inno-accent)] hover:text-[var(--inno-accent)] disabled:cursor-wait disabled:opacity-60"
 							>
-								<span className={`h-1.5 w-1.5 rounded-full ${simpleMode ? "bg-blue-500" : "bg-slate-300"}`} />
+								<span className={`h-1.5 w-1.5 rounded-full ${simpleMode ? "bg-[var(--inno-accent)]" : "bg-[var(--inno-border-strong)]"}`} />
 								{simpleMode ? "简单模式 · 切换到普通模式" : "普通模式 · 切换到简单模式"}
 							</button>
 						</div>
@@ -884,7 +884,7 @@ export function ChatCenter() {
 						{simpleMode ? null : preselectedWs ? (
 							<div className="mt-3 flex flex-wrap items-center gap-2">
 								<span className="text-xs text-[var(--inno-text-subtle)]">工作区</span>
-								<span className="rounded-full bg-[var(--inno-accent-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--inno-accent)] ring-1 ring-blue-100">
+								<span className="rounded-full bg-[var(--inno-accent-soft)] px-2.5 py-0.5 text-[11px] font-medium text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]">
 									{preselectedWs.name}
 								</span>
 								<span className="text-[10px] text-[var(--inno-text-subtle)]">新对话将创建于此工作区</span>
@@ -903,14 +903,14 @@ export function ChatCenter() {
 										placeholder="工作区名称,例如:pandas demo"
 										value={wsName}
 										onChange={(e) => setWsName(e.target.value)}
-										className="ml-1 w-[200px] rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
+										className="ml-1 w-[200px] rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-px text-[10px] leading-tight outline-none focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 									/>
 								) : null}
 								{wsMode === "existing" ? (
 									<select
 										value={wsExistingId}
 										onChange={(e) => setWsExistingId(e.target.value)}
-										className="ml-1 max-w-[220px] rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-px text-[10px] leading-tight outline-none focus:border-blue-400 focus:ring-1 focus:ring-blue-100"
+										className="ml-1 max-w-[220px] rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-px text-[10px] leading-tight outline-none focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 									>
 										<option value="">选择一个工作区…</option>
 										{selectableWorkspaces.map((w) => (
@@ -921,7 +921,7 @@ export function ChatCenter() {
 							</div>
 						)}
 
-						{wsError ? <p className="mt-2 text-xs text-red-600">{wsError}</p> : null}
+						{wsError ? <p className="mt-2 text-xs text-[var(--inno-danger)]">{wsError}</p> : null}
 					</div>
 				</div>
 			</section>
@@ -938,7 +938,7 @@ export function ChatCenter() {
 				<div className="mx-auto flex min-w-0 max-w-3xl flex-col gap-3">
 					{chat.isLoadingHistory && chat.messages.length === 0 ? (
 						<div className="flex h-full flex-col items-center justify-center pt-20 text-[var(--inno-text-muted)]">
-							<span className="mb-3 inline-block h-5 w-5 animate-spin rounded-full border-2 border-slate-400 border-t-transparent" />
+							<span className="mb-3 inline-block h-5 w-5 animate-spin rounded-full border-2 border-[var(--inno-border-strong)] border-t-transparent" />
 							<p className="text-sm">Loading session…</p>
 						</div>
 					) : null}
@@ -958,7 +958,7 @@ export function ChatCenter() {
 							animate={{ opacity: 1, y: 0 }}
 							transition={{ duration: 0.2, ease: "easeOut" }}
 						>
-							<div className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-blue-100 bg-[var(--inno-accent-soft)] px-3 py-2 text-[13px]">
+							<div className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-accent-soft)] px-3 py-2 text-[13px]">
 								{chat.activeTools.map((tool) => (
 									<div key={tool.toolCallId} className="flex min-w-0 items-center gap-2 text-[var(--inno-text-muted)]">
 										<span className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
@@ -995,7 +995,7 @@ export function ChatCenter() {
 								<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
 									{chat.completedTools.map((tool) => (
 										<details key={tool.toolCallId} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1">
-											<summary className={tool.isError ? "cursor-pointer break-words text-red-600 [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>{tool.toolName}</summary>
+											<summary className={tool.isError ? "cursor-pointer break-words text-[var(--inno-danger)] [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>{tool.toolName}</summary>
 											<pre className="mt-1 max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] [overflow-wrap:anywhere]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
 										</details>
 									))}

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -3,6 +3,7 @@ import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
 import { Paperclip, X, SendHorizonal, Square, RotateCcw, Image, AlertTriangle, Search } from "lucide-react";
+import { Spinner } from "./ui/Spinner.js";
 import type { ChatMessage } from "../types/chat.js";
 import type { InlineImage } from "../api/chat.js";
 import { chatStore } from "../stores/chat-store.js";
@@ -94,7 +95,7 @@ function ErrorBlock({ error }: { error: string }) {
 	return (
 		<details className="rounded-md border border-[var(--inno-danger-border)] bg-[var(--inno-danger-bg)] px-2.5 py-1.5 text-xs text-[var(--inno-danger)]" open={!isLong}>
 			<summary className="flex cursor-pointer select-none items-center gap-1.5 font-medium">
-				<AlertTriangle size={13} className="shrink-0" />
+				<AlertTriangle size={14} className="shrink-0" />
 				Request failed
 				{isLong ? <span className="text-[var(--inno-danger)]">· click to expand</span> : null}
 			</summary>
@@ -264,7 +265,7 @@ function PresetPicker({
 
 			{showSearch ? (
 				<div className="mb-2 flex items-center gap-2 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1.5">
-					<Search size={13} className="shrink-0 text-[var(--inno-text-subtle)]" />
+					<Search size={14} className="shrink-0 text-[var(--inno-text-subtle)]" />
 					<input
 						type="text"
 						value={query}
@@ -732,7 +733,7 @@ export function ChatCenter() {
 							title="Remove image"
 							onClick={() => removeInlineImage(index)}
 						>
-							<X size={10} />
+							<X size={12} />
 						</button>
 					</span>
 				))}
@@ -763,10 +764,10 @@ export function ChatCenter() {
 			<input ref={fileInputRef} id="file-input" type="file" className="hidden" multiple onChange={handleFiles} />
 			<input ref={imageInputRef} id="image-input" type="file" className="hidden" multiple accept="image/*" onChange={handleImageFiles} />
 			<button className="inno-icon-button flex h-9 w-9 shrink-0 rounded-md disabled:opacity-50" title={activeWorkspaceId ? "Upload files to workspace" : "请先选择已有工作区或开始对话后再上传文件"} disabled={chat.isSending || isUploading || !activeWorkspaceId} onClick={() => fileInputRef.current?.click()}>
-				{isUploading ? <span className="h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" /> : <Paperclip size={18} />}
+				{isUploading ? <Spinner size={16} /> : <Paperclip size={16} />}
 			</button>
 			<button className="inno-icon-button flex h-9 w-9 shrink-0 rounded-md disabled:opacity-50" title="Attach image" disabled={chat.isSending} onClick={() => imageInputRef.current?.click()}>
-				<Image size={18} />
+				<Image size={16} />
 			</button>
 			<textarea
 				ref={inputRef}
@@ -805,7 +806,7 @@ export function ChatCenter() {
 						disabled={isUploading}
 						onClick={handleSend}
 					>
-						<SendHorizonal size={18} />
+						<SendHorizonal size={16} />
 					</button>
 				</>
 			)}
@@ -825,26 +826,22 @@ export function ChatCenter() {
 								disabled={togglingMode}
 								title={simpleMode ? "当前:简单模式 · 点击切换到普通模式" : "当前:普通模式 · 点击切换到简单模式"}
 								aria-label={simpleMode ? "切换到普通模式" : "切换到简单模式"}
-								className="mb-3 rounded-xl outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
-								style={{ perspective: "600px" }}
+								className="flip-card-scene mb-3 rounded-xl outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
 							>
 								<motion.div
 									animate={{ rotateY: simpleMode ? 180 : 0 }}
 									transition={{ type: "spring", stiffness: 320, damping: 22 }}
-									style={{ transformStyle: "preserve-3d", position: "relative" }}
-									className="flex h-12 w-12 items-center justify-center"
+									className="flip-card flex h-12 w-12 items-center justify-center"
 								>
 									{/* Front — Normal mode */}
 									<span
-										className="absolute inset-0 flex items-center justify-center rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] text-base font-semibold text-[var(--inno-accent)] shadow-sm transition-colors hover:border-[var(--inno-accent)]"
-										style={{ backfaceVisibility: "hidden" }}
+										className="flip-card-face absolute inset-0 flex items-center justify-center rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] text-base font-semibold text-[var(--inno-accent)] shadow-sm transition-colors hover:border-[var(--inno-accent)]"
 									>
 										IA
 									</span>
 									{/* Back — Simple mode */}
 									<span
-										className="absolute inset-0 flex items-center justify-center rounded-xl border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-base font-semibold text-white shadow-sm"
-										style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
+										className="flip-card-back absolute inset-0 flex items-center justify-center rounded-xl border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-base font-semibold text-white shadow-sm"
 									>
 										IA
 									</span>
@@ -938,7 +935,7 @@ export function ChatCenter() {
 				<div className="mx-auto flex min-w-0 max-w-3xl flex-col gap-3">
 					{chat.isLoadingHistory && chat.messages.length === 0 ? (
 						<div className="flex h-full flex-col items-center justify-center pt-20 text-[var(--inno-text-muted)]">
-							<span className="mb-3 inline-block h-5 w-5 animate-spin rounded-full border-2 border-[var(--inno-border-strong)] border-t-transparent" />
+							<Spinner size={20} className="mb-3 text-[var(--inno-border-strong)]" />
 							<p className="text-sm">Loading session…</p>
 						</div>
 					) : null}
@@ -961,7 +958,7 @@ export function ChatCenter() {
 							<div className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-accent-soft)] px-3 py-2 text-[13px]">
 								{chat.activeTools.map((tool) => (
 									<div key={tool.toolCallId} className="flex min-w-0 items-center gap-2 text-[var(--inno-text-muted)]">
-										<span className="inline-block h-3 w-3 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent" />
+										<Spinner size={12} className="shrink-0" />
 										<span className="min-w-0 break-words font-mono text-xs [overflow-wrap:anywhere]">{tool.toolName}</span>
 									</div>
 								))}

--- a/apps/inno-agent/web/src/react/JobsPanel.tsx
+++ b/apps/inno-agent/web/src/react/JobsPanel.tsx
@@ -5,6 +5,7 @@ import { Plus, Play, Pencil, ToggleLeft, ToggleRight, Trash2 } from "lucide-reac
 import { jobsStore } from "../stores/jobs-store.js";
 import type { CreateJobInput, ScheduledJob, TaskType } from "../types/jobs.js";
 import { useStoreSnapshot } from "./hooks.js";
+import { checkboxCls } from "./ui/checkbox.js";
 import { ScheduleEditor } from "./jobs/ScheduleEditor.js";
 import {
 	DEFAULT_SCHEDULE,
@@ -201,7 +202,7 @@ export function JobsPanel() {
 												<span className="rounded bg-[var(--inno-surface-muted)] px-1.5 py-0.5 text-[var(--inno-text-muted)]">
 													{t(`jobs.taskTypes.${job.taskType}`)}
 												</span>
-												<span className={job.enabled ? "text-green-600" : "text-red-500"}>
+												<span className={job.enabled ? "text-[var(--inno-success)]" : "text-[var(--inno-danger)]"}>
 													{job.enabled ? t("common.enabled") : t("common.disabled")}
 												</span>
 											</div>
@@ -223,7 +224,7 @@ export function JobsPanel() {
 											{isRunning ? t("jobs.actions.running") : t("jobs.actions.run")}
 										</button>
 										<button
-											className="flex items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]"
+											className="flex items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 											title={t("jobs.actions.edit")}
 											onClick={() => openEditForm(job)}
 										>
@@ -231,7 +232,7 @@ export function JobsPanel() {
 											{t("jobs.actions.edit")}
 										</button>
 										<button
-											className="flex items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]"
+											className="flex items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 											title={job.enabled ? t("jobs.actions.disable") : t("jobs.actions.enable")}
 											onClick={() => void jobsStore.update(job.id, { enabled: !job.enabled })}
 										>
@@ -239,7 +240,7 @@ export function JobsPanel() {
 											{job.enabled ? t("jobs.actions.disable") : t("jobs.actions.enable")}
 										</button>
 										<button
-											className="flex items-center gap-1 rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+											className="flex items-center gap-1 rounded px-2 py-1 text-xs text-[var(--inno-danger)] hover:bg-[var(--inno-danger-bg)]"
 											title={t("jobs.actions.delete")}
 											onClick={() => void jobsStore.remove(job.id)}
 										>
@@ -283,7 +284,7 @@ export function JobsPanel() {
 							<label className="block text-sm">
 								<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.name")}</span>
 								<input
-									className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+									className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 									placeholder={t("jobs.form.namePlaceholder") ?? ""}
 									value={form.name}
 									onChange={(event) => setForm({ ...form, name: event.target.value })}
@@ -305,7 +306,7 @@ export function JobsPanel() {
 							<label className="block text-sm">
 								<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.taskType")}</span>
 								<select
-									className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+									className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 									value={form.taskType}
 									onChange={(event) => setForm({ ...form, taskType: event.target.value as TaskType })}
 								>
@@ -320,7 +321,7 @@ export function JobsPanel() {
 							<label className="block text-sm">
 								<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.prompt")}</span>
 								<textarea
-									className="h-24 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+									className="h-24 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 									placeholder={t("jobs.form.promptPlaceholder") ?? ""}
 									value={form.prompt}
 									onChange={(event) => setForm({ ...form, prompt: event.target.value })}
@@ -330,6 +331,7 @@ export function JobsPanel() {
 							<label className="flex items-center gap-2 text-sm text-[var(--inno-text)]">
 								<input
 									type="checkbox"
+									className={checkboxCls}
 									checked={form.enabled}
 									onChange={(event) => setForm({ ...form, enabled: event.target.checked })}
 								/>
@@ -337,9 +339,9 @@ export function JobsPanel() {
 							</label>
 						</div>
 						<div className="mt-4 flex justify-end gap-2">
-							{formError ? <div className="mr-auto text-xs text-red-600">{formError}</div> : null}
+							{formError ? <div className="mr-auto text-xs text-[var(--inno-danger)]">{formError}</div> : null}
 							<button
-								className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)] disabled:opacity-50"
+								className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-50"
 								disabled={isSaving}
 								onClick={() => setShowForm(false)}
 							>

--- a/apps/inno-agent/web/src/react/JobsPanel.tsx
+++ b/apps/inno-agent/web/src/react/JobsPanel.tsx
@@ -194,7 +194,7 @@ export function JobsPanel() {
 							const isRunning = state.runningJobId === job.id;
 							const human = humanizeCron(job.cron, humanI18n);
 							return (
-								<div key={job.id} className={`rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-3 ${job.enabled ? "" : "opacity-60"}`}>
+								<div key={job.id} className={`rounded-lg bg-[var(--inno-surface)] p-3 ${job.enabled ? "" : "opacity-60"}`}>
 									<div className="flex items-start justify-between gap-2">
 										<div className="min-w-0 flex-1">
 											<div className="truncate text-sm font-medium text-[var(--inno-text)]">{job.name}</div>

--- a/apps/inno-agent/web/src/react/JobsPanel.tsx
+++ b/apps/inno-agent/web/src/react/JobsPanel.tsx
@@ -6,6 +6,7 @@ import { jobsStore } from "../stores/jobs-store.js";
 import type { CreateJobInput, ScheduledJob, TaskType } from "../types/jobs.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { checkboxCls } from "./ui/checkbox.js";
+import { Spinner } from "./ui/Spinner.js";
 import { ScheduleEditor } from "./jobs/ScheduleEditor.js";
 import {
 	DEFAULT_SCHEDULE,
@@ -181,7 +182,7 @@ export function JobsPanel() {
 				<div className="min-h-0 flex-1 overflow-y-auto p-3">
 					{state.isLoading ? (
 						<div className="flex items-center justify-center py-8 text-[var(--inno-text-muted)]">
-							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+							<Spinner size={16} className="mr-2" />
 							{t("common.loading")}
 						</div>
 					) : null}

--- a/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
+++ b/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
@@ -112,7 +112,7 @@ function SummarySection() {
 				<Stat label={t("profile.summary.openMisconceptions")} value={openMisc} />
 			</div>
 			<textarea
-				className="h-32 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+				className="h-32 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 				placeholder={t("profile.summary.placeholder") ?? ""}
 				value={buffer}
 				onChange={(e) => {
@@ -123,7 +123,7 @@ function SummarySection() {
 			{dirty ? (
 				<div className="mt-2 flex justify-end gap-2">
 					<button
-						className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]"
+						className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 						onClick={() => {
 							setBuffer(profile?.profile_summary ?? "");
 							setDirty(false);
@@ -214,7 +214,7 @@ function GoalsSection() {
 					</button>
 				}
 			>
-				{error ? <div className="mb-2 rounded bg-red-50 p-2 text-xs text-red-700">{error}</div> : null}
+				{error ? <div className="mb-2 rounded bg-[var(--inno-danger-bg)] p-2 text-xs text-[var(--inno-danger)]">{error}</div> : null}
 				{goals.length === 0 ? (
 					<p className="text-sm text-[var(--inno-text-muted)]">{t("profile.goals.empty")}</p>
 				) : (
@@ -273,7 +273,7 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 					<label className="block text-sm">
 						<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.goals.title")}</span>
 						<input
-							className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+							className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 							placeholder={t("profile.goals.namePlaceholder") ?? ""}
 							value={draft.title}
 							autoFocus
@@ -322,7 +322,7 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 					<label className="block text-sm">
 						<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.goals.successCriteria")}</span>
 						<textarea
-							className="h-20 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+							className="h-20 w-full resize-none rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 							placeholder={t("profile.goals.successCriteriaPlaceholder") ?? ""}
 							value={draft.success_criteria.join("\n")}
 							onChange={(e) =>
@@ -335,9 +335,9 @@ function GoalFormDialog({ onClose, onSubmit }: { onClose: () => void; onSubmit: 
 					</label>
 				</div>
 				<div className="mt-4 flex justify-end gap-2">
-					{error ? <div className="mr-auto text-xs text-red-600">{error}</div> : null}
+					{error ? <div className="mr-auto text-xs text-[var(--inno-danger)]">{error}</div> : null}
 					<button
-						className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)] disabled:opacity-50"
+						className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-50"
 						disabled={saving}
 						onClick={onClose}
 					>
@@ -415,20 +415,20 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 						) : null}
 					</div>
 					<div className="flex shrink-0 gap-1.5">
-						<button className="rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={() => setEditing(true)}>
+						<button className="rounded bg-[var(--inno-surface-muted)] px-2 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => setEditing(true)}>
 							{t("common.edit")}
 						</button>
-						<button className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50" onClick={() => void doDelete()}>
+						<button className="rounded px-2 py-1 text-xs text-[var(--inno-danger)] hover:bg-[var(--inno-danger-bg)]" onClick={() => void doDelete()}>
 							{t("common.delete")}
 						</button>
 					</div>
 				</div>
-				{error ? <div className="mt-2 rounded bg-red-50 p-2 text-xs text-red-700">{error}</div> : null}
+				{error ? <div className="mt-2 rounded bg-[var(--inno-danger-bg)] p-2 text-xs text-[var(--inno-danger)]">{error}</div> : null}
 			</div>
 		);
 	}
 	return (
-		<div className="rounded-lg border border-[var(--inno-accent-soft)] bg-blue-50/40 p-3">
+		<div className="rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-surface-muted)] p-3">
 			<div className="grid gap-2">
 				<input
 					className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm"
@@ -493,7 +493,7 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 						{saving ? t("common.saving") : t("common.save")}
 					</button>
 				</div>
-				{error ? <div className="mt-1 rounded bg-red-50 p-2 text-xs text-red-700">{error}</div> : null}
+				{error ? <div className="mt-1 rounded bg-[var(--inno-danger-bg)] p-2 text-xs text-[var(--inno-danger)]">{error}</div> : null}
 			</div>
 		</div>
 	);
@@ -502,17 +502,17 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 function statusToneFor(status: string): string {
 	switch (status) {
 		case "active":
-			return "bg-green-50 text-green-700 ring-1 ring-green-100";
+			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]";
 		case "paused":
 			return "bg-yellow-50 text-yellow-700 ring-1 ring-yellow-100";
 		case "completed":
-			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]";
 		case "archived":
 			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 		case "repairing":
 			return "bg-orange-50 text-orange-700 ring-1 ring-orange-100";
 		case "resolved":
-			return "bg-green-50 text-green-700 ring-1 ring-green-100";
+			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]";
 		case "stale":
 			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 		default:
@@ -589,8 +589,8 @@ function KnowledgeRow({ state }: { state: KnowledgeState }) {
 				</div>
 				<div className="truncate text-xs text-[var(--inno-text-muted)]">{state.domain || "-"}</div>
 				<div>
-					<div className="h-1.5 w-full rounded-full bg-slate-200">
-						<div className="h-1.5 rounded-full bg-blue-500" style={{ width: `${pct}%` }} />
+					<div className="h-1.5 w-full rounded-full bg-[var(--inno-surface-muted)]">
+						<div className="h-1.5 rounded-full bg-[var(--inno-accent)]" style={{ width: `${pct}%` }} />
 					</div>
 					<div className="mt-0.5 text-[10px] text-[var(--inno-text-muted)]">{pct}%</div>
 				</div>
@@ -821,7 +821,7 @@ function ChipInput({ label, values, onChange, placeholder }: { label: string; va
 			<div className="mb-1 text-xs font-medium text-[var(--inno-text)]">{label}</div>
 			<div className="flex flex-wrap gap-1">
 				{values.map((v) => (
-					<span key={v} className="inline-flex items-center gap-1 rounded-full bg-[var(--inno-accent-soft)] px-2 py-0.5 text-xs text-[var(--inno-accent)] ring-1 ring-blue-100">
+					<span key={v} className="inline-flex items-center gap-1 rounded-full bg-[var(--inno-accent-soft)] px-2 py-0.5 text-xs text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]">
 						{v}
 						<button className="text-[var(--inno-accent)] hover:text-[var(--inno-accent)]" onClick={() => onChange(values.filter((x) => x !== v))}>
 							×
@@ -829,7 +829,7 @@ function ChipInput({ label, values, onChange, placeholder }: { label: string; va
 					</span>
 				))}
 				<input
-					className="min-w-[120px] flex-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 text-xs focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+					className="min-w-[120px] flex-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 text-xs focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 					placeholder={placeholder}
 					value={input}
 					onChange={(e) => setInput(e.target.value)}
@@ -883,7 +883,7 @@ export function LearnerProfilePanel() {
 					</div>
 				) : null}
 
-				{state.error ? <div className="rounded bg-red-50 p-2 text-sm text-red-700">{state.error}</div> : null}
+				{state.error ? <div className="rounded bg-[var(--inno-danger-bg)] p-2 text-sm text-[var(--inno-danger)]">{state.error}</div> : null}
 
 				{state.profile ? (
 					<>

--- a/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
+++ b/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
@@ -392,7 +392,7 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 
 	if (!editing) {
 		return (
-			<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-3">
+			<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 				<div className="flex items-start justify-between gap-2">
 					<div className="min-w-0">
 						<div className="text-sm font-medium text-[var(--inno-text)]">{goal.title}</div>
@@ -423,7 +423,7 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 		);
 	}
 	return (
-		<div className="rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-surface-muted)] p-3">
+		<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 			<div className="grid gap-2">
 				<input
 					className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm"
@@ -497,17 +497,17 @@ function GoalCard({ goal }: { goal: LearningGoal }) {
 function statusToneFor(status: string): string {
 	switch (status) {
 		case "active":
-			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]";
+			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)]";
 		case "paused":
-			return "bg-yellow-50 text-yellow-700 ring-1 ring-yellow-100";
+			return "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)]";
 		case "completed":
-			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]";
 		case "archived":
 			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 		case "repairing":
-			return "bg-orange-50 text-orange-700 ring-1 ring-orange-100";
+			return "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)]";
 		case "resolved":
-			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]";
+			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)]";
 		case "stale":
 			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 		default:
@@ -573,7 +573,7 @@ function KnowledgeRow({ state }: { state: KnowledgeState }) {
 	}
 
 	return (
-		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
+		<div className="rounded-lg bg-[var(--inno-surface)]">
 			<button
 				className="grid w-full grid-cols-[1fr_120px_100px_90px] items-center gap-3 px-3 py-2 text-left text-sm hover:bg-[var(--inno-surface-muted)]"
 				onClick={() => setExpanded(!expanded)}
@@ -690,7 +690,7 @@ function MisconceptionRow({ item }: { item: Misconception }) {
 	}
 
 	return (
-		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-3">
+		<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 			<div className="mb-2 text-sm text-[var(--inno-text)]">{item.description}</div>
 			<div className="mb-2 text-xs text-[var(--inno-text-muted)]">{item.concept_id} · {formatDate(item.last_seen_at)}</div>
 			<div className="grid grid-cols-2 gap-2">
@@ -816,7 +816,7 @@ function ChipInput({ label, values, onChange, placeholder }: { label: string; va
 			<div className="mb-1 text-xs font-medium text-[var(--inno-text)]">{label}</div>
 			<div className="flex flex-wrap gap-1">
 				{values.map((v) => (
-					<span key={v} className="inline-flex items-center gap-1 rounded-full bg-[var(--inno-accent-soft)] px-2 py-0.5 text-xs text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]">
+					<span key={v} className="inline-flex items-center gap-1 rounded-full bg-[var(--inno-accent-soft)] px-2 py-0.5 text-xs text-[var(--inno-accent)]">
 						{v}
 						<button className="text-[var(--inno-accent)] hover:text-[var(--inno-accent)]" onClick={() => onChange(values.filter((x) => x !== v))}>
 							×
@@ -856,7 +856,7 @@ export function LearnerProfilePanel() {
 	return (
 		<div className="h-full overflow-y-auto p-3">
 			<div className="flex flex-col gap-3">
-				<div className="flex items-center justify-between rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-4 py-3">
+				<div className="flex items-center justify-between rounded-lg bg-[var(--inno-surface)] px-4 py-3">
 					<div>
 						<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("profile.title")}</h3>
 						<p className="text-xs text-[var(--inno-text-muted)]">{t("profile.subtitle")}</p>
@@ -866,7 +866,7 @@ export function LearnerProfilePanel() {
 							</p>
 						) : null}
 					</div>
-					<button className="rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void learnerStore.load()}>
+					<button className="rounded-md px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void learnerStore.load()}>
 						{t("profile.refresh")}
 					</button>
 				</div>

--- a/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
+++ b/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "motion/react";
+import { ChevronRight } from "lucide-react";
+import { Spinner } from "./ui/Spinner.js";
 import { learnerStore } from "../stores/learner-store.js";
 import type {
 	GoalStatus,
@@ -52,14 +54,7 @@ function Section({
 					onClick={() => setCollapsed(!collapsed)}
 					aria-expanded={!collapsed}
 				>
-					<svg
-						className={`h-4 w-4 shrink-0 text-[var(--inno-text-subtle)] transition-transform duration-150 ${collapsed ? "" : "rotate-90"}`}
-						viewBox="0 0 16 16"
-						fill="none"
-						aria-hidden
-					>
-						<path d="M6 4l4 4-4 4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
-					</svg>
+					<ChevronRight size={16} className={`shrink-0 text-[var(--inno-text-subtle)] transition-transform duration-150 ${collapsed ? "" : "rotate-90"}`} />
 					<h4 className="truncate text-base font-semibold text-[var(--inno-text)]">{title}</h4>
 					{typeof count === "number" ? (
 						<span className="rounded-full bg-[var(--inno-surface-muted)] px-2 py-0.5 text-xs font-medium text-[var(--inno-text-muted)]">{count}</span>
@@ -878,7 +873,7 @@ export function LearnerProfilePanel() {
 
 				{state.isLoading ? (
 					<div className="flex items-center justify-center py-8 text-[var(--inno-text-muted)]">
-						<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+						<Spinner size={16} className="mr-2" />
 						{t("common.loading")}
 					</div>
 				) : null}

--- a/apps/inno-agent/web/src/react/Notebook.tsx
+++ b/apps/inno-agent/web/src/react/Notebook.tsx
@@ -12,13 +12,13 @@ const FILTER_TYPES: (WikiPageType | "all")[] = ["all", "source-summary", "entity
 function typeColor(type?: WikiPageType): string {
 	switch (type) {
 		case "source-summary":
-			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]";
 		case "entity":
-			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]";
+			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)]";
 		case "concept":
-			return "bg-orange-50 text-orange-700 ring-1 ring-orange-100";
+			return "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)]";
 		case "analysis":
-			return "bg-purple-50 text-purple-700 ring-1 ring-purple-100";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]";
 		default:
 			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 	}
@@ -70,7 +70,7 @@ export function Notebook() {
 							key={type}
 							className={`rounded-full px-2 py-0.5 text-xs transition-colors ${
 								state.filterType === type
-									? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]"
+									? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
 									: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 							}`}
 							onClick={() => notebookStore.setFilterType(type)}

--- a/apps/inno-agent/web/src/react/Notebook.tsx
+++ b/apps/inno-agent/web/src/react/Notebook.tsx
@@ -12,9 +12,9 @@ const FILTER_TYPES: (WikiPageType | "all")[] = ["all", "source-summary", "entity
 function typeColor(type?: WikiPageType): string {
 	switch (type) {
 		case "source-summary":
-			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]";
 		case "entity":
-			return "bg-green-50 text-green-700 ring-1 ring-green-100";
+			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]";
 		case "concept":
 			return "bg-orange-50 text-orange-700 ring-1 ring-orange-100";
 		case "analysis":
@@ -58,7 +58,7 @@ export function Notebook() {
 				<div className="border-b border-[var(--inno-border)] p-2">
 					<input
 						type="text"
-						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 						placeholder={t("notebook.search") ?? ""}
 						value={state.searchQuery}
 						onChange={(event) => notebookStore.setSearchQuery(event.target.value)}
@@ -70,8 +70,8 @@ export function Notebook() {
 							key={type}
 							className={`rounded-full px-2 py-0.5 text-xs transition-colors ${
 								state.filterType === type
-									? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100"
-									: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]"
+									? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]"
+									: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 							}`}
 							onClick={() => notebookStore.setFilterType(type)}
 						>
@@ -104,7 +104,7 @@ export function Notebook() {
 									</div>
 								</button>
 								<button
-									className={`absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-muted)] hover:bg-red-50 hover:text-red-600 disabled:opacity-50 ${state.isDeletingPage ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
+									className={`absolute right-1.5 top-1.5 flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-muted)] hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)] disabled:opacity-50 ${state.isDeletingPage ? "opacity-100" : "opacity-0 group-hover:opacity-100"}`}
 									title={t("notebook.delete.button")}
 									disabled={state.isDeletingPage}
 									onClick={(e) => {

--- a/apps/inno-agent/web/src/react/Notebook.tsx
+++ b/apps/inno-agent/web/src/react/Notebook.tsx
@@ -112,7 +112,7 @@ export function Notebook() {
 										void handleDelete(page.path, title);
 									}}
 								>
-									<Trash2 size={13} />
+									<Trash2 size={14} />
 								</button>
 							</div>
 						);
@@ -128,7 +128,7 @@ export function Notebook() {
 							onClick={() => setSidebarOpen((v) => !v)}
 							title={sidebarOpen ? t("common.collapseSidebar", "Collapse sidebar") : t("common.expandSidebar", "Expand sidebar")}
 						>
-							{sidebarOpen ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
+							{sidebarOpen ? <PanelLeftClose size={16} /> : <PanelLeftOpen size={16} />}
 						</button>
 						<div className="inline-flex rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-0.5 text-xs">
 							<button
@@ -136,7 +136,7 @@ export function Notebook() {
 								onClick={() => notebookStore.setView("graph")}
 								title={t("notebook.view.graph")}
 							>
-								<Network size={13} />
+								<Network size={14} />
 								<span className="hidden @[680px]:inline">{t("notebook.view.graph")}</span>
 							</button>
 							<button
@@ -144,7 +144,7 @@ export function Notebook() {
 								onClick={() => notebookStore.setView("page")}
 								title={t("notebook.view.page")}
 							>
-								<FileText size={13} />
+								<FileText size={14} />
 								<span className="hidden @[680px]:inline">{t("notebook.view.page")}</span>
 							</button>
 						</div>

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -22,7 +22,7 @@ function OptionRow({
 		<button
 			className={`flex w-full items-start gap-2.5 rounded-md border px-3 py-2 text-left text-[13px] transition-colors ${
 				selected
-					? "border-blue-400 bg-[var(--inno-accent-soft)] text-[var(--inno-text)]"
+					? "border-[var(--inno-accent)] bg-[var(--inno-accent-soft)] text-[var(--inno-text)]"
 					: "border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text)] hover:border-[var(--inno-border-strong)] hover:bg-[var(--inno-surface-muted)]"
 			}`}
 			onClick={onSelect}
@@ -30,7 +30,7 @@ function OptionRow({
 		>
 			<span className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border border-[var(--inno-border-strong)]">
 				{selected ? (
-					<span className={`block ${multi ? "h-2 w-2 rounded-sm bg-blue-500" : "h-2 w-2 rounded-full bg-blue-500"}`} />
+					<span className={`block ${multi ? "h-2 w-2 rounded-sm bg-[var(--inno-accent)]" : "h-2 w-2 rounded-full bg-[var(--inno-accent)]"}`} />
 				) : null}
 			</span>
 			<span className="min-w-0 flex-1">
@@ -120,7 +120,7 @@ function QuestionTab({
 						<div className="flex items-center gap-1.5 pt-1">
 							<input
 								type="text"
-								className="min-w-0 flex-1 rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-[13px] focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+								className="min-w-0 flex-1 rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-[13px] focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 								placeholder="Type something..."
 								value={customText}
 								onChange={(e) => setCustomText(e.target.value)}
@@ -212,8 +212,8 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 								className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
 									activeTab === i
 										? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
-										: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] hover:bg-slate-200"
-								}${answers.has(i) ? " ring-1 ring-green-300" : ""}`}
+										: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
+								}${answers.has(i) ? " ring-1 ring-[var(--inno-success-border)]" : ""}`}
 								onClick={() => setActiveTab(i)}
 							>
 								{q.header}

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -213,7 +213,7 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 									activeTab === i
 										? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
 										: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
-								}${answers.has(i) ? " ring-1 ring-[var(--inno-success-border)]" : ""}`}
+								}`}
 								onClick={() => setActiveTab(i)}
 							>
 								{q.header}

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -62,13 +62,13 @@ function channelLabel(channel: SessionChannel): string {
 
 function channelClass(channel: SessionChannel): string {
 	const classes: Record<string, string> = {
-		cli: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-200/60",
-		web: "bg-[var(--inno-surface-muted)] text-[var(--inno-text)] ring-1 ring-slate-200/80",
-		feishu: "bg-emerald-50 text-emerald-600 ring-1 ring-emerald-200/60",
-		scheduler: "bg-amber-50 text-amber-600 ring-1 ring-amber-200/60",
+		cli: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]",
+		web: "bg-[var(--inno-surface-muted)] text-[var(--inno-text)] ring-1 ring-[var(--inno-border)]",
+		feishu: "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]",
+		scheduler: "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)] ring-1 ring-[var(--inno-warning-border)]/60",
 		qq: "bg-cyan-50 text-cyan-600 ring-1 ring-cyan-200/60",
 		wechat: "bg-lime-50 text-lime-600 ring-1 ring-lime-200/60",
-		unknown: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)] ring-1 ring-slate-200/60",
+		unknown: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)] ring-1 ring-[var(--inno-border)]",
 	};
 	return classes[channel] ?? classes.unknown;
 }
@@ -80,13 +80,13 @@ function channelClass(channel: SessionChannel): string {
  */
 function channelInteractionClass(channel: SessionChannel): string {
 	const classes: Record<string, string> = {
-		cli: "bg-transparent text-[var(--inno-accent)] ring-1 ring-blue-300/70",
-		web: "bg-transparent text-[var(--inno-text-muted)] ring-1 ring-slate-300/70",
-		feishu: "bg-transparent text-emerald-500 ring-1 ring-emerald-300/70",
-		scheduler: "bg-transparent text-amber-500 ring-1 ring-amber-300/70",
+		cli: "bg-transparent text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]",
+		web: "bg-transparent text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border-strong)]",
+		feishu: "bg-transparent text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]",
+		scheduler: "bg-transparent text-[var(--inno-warning)] ring-1 ring-[var(--inno-warning-border)]",
 		qq: "bg-transparent text-cyan-500 ring-1 ring-cyan-300/70",
 		wechat: "bg-transparent text-lime-500 ring-1 ring-lime-300/70",
-		unknown: "bg-transparent text-[var(--inno-text-subtle)] ring-1 ring-slate-200/70",
+		unknown: "bg-transparent text-[var(--inno-text-subtle)] ring-1 ring-[var(--inno-border)]",
 	};
 	return classes[channel] ?? classes.unknown;
 }
@@ -106,13 +106,13 @@ function orderedSessionChannels(session: SessionMeta): Array<{ channel: SessionC
 }
 
 function channelFilterClass(channel: SessionChannel | null, active: boolean): string {
-	if (!active) return "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-slate-200 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] hover:ring-slate-300";
+	if (!active) return "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] hover:ring-[var(--inno-border-strong)]";
 	if (!channel) return "inno-primary-button ring-1 ring-[var(--inno-accent)]";
 	const map: Record<string, string> = {
-		cli: "bg-[var(--inno-accent)] text-white ring-1 ring-blue-600 hover:bg-[var(--inno-accent)] hover:text-white",
+		cli: "bg-[var(--inno-accent)] text-white ring-1 ring-[var(--inno-accent)] hover:bg-[var(--inno-accent)] hover:text-white",
 		web: "inno-primary-button ring-1 ring-[var(--inno-accent)]",
-		feishu: "bg-emerald-600 text-white ring-1 ring-emerald-600 hover:bg-emerald-600 hover:text-white",
-		scheduler: "bg-amber-600 text-white ring-1 ring-amber-600 hover:bg-amber-600 hover:text-white",
+		feishu: "bg-[var(--inno-success)] text-white ring-1 ring-[var(--inno-success)] hover:bg-[var(--inno-success)] hover:text-white",
+		scheduler: "bg-[var(--inno-warning)] text-white ring-1 ring-[var(--inno-warning)] hover:bg-[var(--inno-warning)] hover:text-white",
 		qq: "bg-cyan-600 text-white ring-1 ring-cyan-600 hover:bg-cyan-600 hover:text-white",
 		wechat: "bg-lime-600 text-white ring-1 ring-lime-600 hover:bg-lime-600 hover:text-white",
 	};
@@ -182,7 +182,7 @@ function GroupHeader({
 				<FolderKanban size={12} className="shrink-0 text-[var(--inno-text-subtle)]" />
 				{editing ? (
 					<input
-						className="min-w-0 flex-1 rounded border border-blue-300 bg-[var(--inno-surface)] px-1 py-0.5 text-[11px] normal-case text-[var(--inno-text)] outline-none focus:ring-1 focus:ring-blue-200"
+						className="min-w-0 flex-1 rounded border border-[var(--inno-accent)] bg-[var(--inno-surface)] px-1 py-0.5 text-[11px] normal-case text-[var(--inno-text)] outline-none focus-visible:shadow-[var(--inno-ring)]"
 						value={editingName}
 						autoFocus
 						onClick={(e) => { e.stopPropagation(); }}
@@ -219,7 +219,7 @@ function GroupHeader({
 								<Pencil size={11} />
 							</button>
 							<button
-								className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-red-50 hover:text-red-600"
+								className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)]"
 								title="删除工作区"
 								onClick={(e) => { e.stopPropagation(); onDelete(); }}
 							>
@@ -229,7 +229,7 @@ function GroupHeader({
 					) : null}
 				</div>
 			) : null}
-			<span className="inno-sidebar-meta rounded-full bg-slate-200 px-1.5 py-0 font-medium text-[var(--inno-text-muted)] tabular-nums">
+			<span className="inno-sidebar-meta rounded-full bg-[var(--inno-surface-muted)] px-1.5 py-0 font-medium text-[var(--inno-text-muted)] tabular-nums">
 				{group.sessions.length}
 			</span>
 		</div>
@@ -290,7 +290,7 @@ function SessionCard({
 			<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
 				{editing ? (
 					<input
-						className="inno-sidebar-title min-w-0 flex-1 rounded border border-blue-300 bg-[var(--inno-surface)] px-1.5 py-0.5 outline-none focus:ring-2 focus:ring-blue-200"
+						className="inno-sidebar-title min-w-0 flex-1 rounded border border-[var(--inno-accent)] bg-[var(--inno-surface)] px-1.5 py-0.5 outline-none focus-visible:shadow-[var(--inno-ring)]"
 						value={editingName}
 						autoFocus
 						onClick={(e) => e.stopPropagation()}
@@ -330,7 +330,7 @@ function SessionCard({
 				</div>
 				<div className="flex items-center gap-0.5 opacity-0 group-hover/card:opacity-100 transition-opacity duration-150">
 					{opening ? (
-						<span className="h-3 w-3 animate-spin rounded-full border-2 border-slate-400 border-t-transparent" />
+						<span className="h-3 w-3 animate-spin rounded-full border-2 border-[var(--inno-border-strong)] border-t-transparent" />
 					) : null}
 					<button
 						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-40"
@@ -359,7 +359,7 @@ function SessionCard({
 						{session.archived ? <ArchiveRestore size={12} /> : <Archive size={12} />}
 					</button>
 					<button
-						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-red-50 hover:text-red-600"
+						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)]"
 						title="Delete"
 						onClick={(e) => { e.stopPropagation(); onDelete(); }}
 					>
@@ -621,9 +621,9 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 
 	if (simpleMode) {
 		return (
-			<aside className="inno-sidebar-scope flex h-full min-h-0 flex-col overflow-hidden border-r border-slate-200/80 bg-[var(--inno-sidebar-bg)]">
+			<aside className="inno-sidebar-scope flex h-full min-h-0 flex-col overflow-hidden border-r border-[var(--inno-border)] bg-[var(--inno-sidebar-bg)]">
 				{/* Header: brand + collapse */}
-				<div className="flex items-center justify-between gap-2 border-b border-slate-200/70 px-3 py-2.5">
+				<div className="flex items-center justify-between gap-2 border-b border-[var(--inno-border)] px-3 py-2.5">
 					<div className="flex min-w-0 items-center gap-2">
 						<button
 							type="button"
@@ -631,7 +631,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 							disabled={togglingMode}
 							title={simpleMode ? "当前:简单模式 · 点击切换到普通模式" : "当前:普通模式 · 点击切换到简单模式"}
 							aria-label={simpleMode ? "切换到普通模式" : "切换到简单模式"}
-							className="shrink-0 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:cursor-wait"
+							className="shrink-0 rounded-lg outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
 							style={{ perspective: "500px" }}
 						>
 							<motion.div
@@ -647,7 +647,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 									IA
 								</span>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-blue-400 bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
+									className="absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
 									style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
 								>
 									IA
@@ -700,7 +700,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 									<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
 										<div className="inno-sidebar-title min-w-0 truncate font-medium text-[var(--inno-text)]">{session.name}</div>
 										<button
-											className="rounded p-0.5 text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-red-50 hover:text-red-600 group-hover/srow:opacity-100"
+											className="rounded p-0.5 text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)] group-hover/srow:opacity-100"
 											title="删除对话"
 											onClick={(e) => { e.stopPropagation(); handleDelete(session); }}
 										>
@@ -713,7 +713,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 									<div className="mt-1 flex items-center gap-1.5">
 										{ws ? (
 											<span
-												className="inline-flex max-w-[140px] items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-1.5 py-px text-[9px] font-medium leading-none text-[var(--inno-text-muted)] ring-1 ring-slate-200/70"
+												className="inline-flex max-w-[140px] items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-1.5 py-px text-[9px] font-medium leading-none text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)]"
 												title={`工作区:${ws.name}`}
 											>
 												<FolderKanban size={9} className="shrink-0" />
@@ -729,7 +729,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 				</div>
 
 				{/* Footer: new chat (mode switch lives on the IA logo above) */}
-				<div className="border-t border-slate-200/70 p-2">
+				<div className="border-t border-[var(--inno-border)] p-2">
 					<button
 						className="inno-sidebar-text inno-new-chat-button flex w-full items-center justify-center gap-2 rounded-lg inno-primary-button px-3 py-1.5 font-medium text-white shadow-sm transition-colors"
 						onClick={newChat}
@@ -744,9 +744,9 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 	/* ── Expanded sidebar ── */
 
 	return (
-		<aside className="inno-sidebar-scope flex h-full min-h-0 flex-col overflow-hidden border-r border-slate-200/80 bg-[var(--inno-sidebar-bg)]">
+		<aside className="inno-sidebar-scope flex h-full min-h-0 flex-col overflow-hidden border-r border-[var(--inno-border)] bg-[var(--inno-sidebar-bg)]">
 			{/* Header */}
-			<div className="border-b border-slate-200/70 px-3 py-2.5">
+			<div className="border-b border-[var(--inno-border)] px-3 py-2.5">
 				<div className="flex items-center justify-between gap-2">
 					<div className="flex items-center gap-2 min-w-0">
 						<button
@@ -755,7 +755,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 							disabled={togglingMode}
 							title={simpleMode ? "当前:简单模式 · 点击切换到普通模式" : "当前:普通模式 · 点击切换到简单模式"}
 							aria-label={simpleMode ? "切换到普通模式" : "切换到简单模式"}
-							className="shrink-0 rounded-lg outline-none focus-visible:ring-2 focus-visible:ring-blue-400 disabled:cursor-wait"
+							className="shrink-0 rounded-lg outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
 							style={{ perspective: "500px" }}
 						>
 							<motion.div
@@ -771,7 +771,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 									IA
 								</span>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-blue-400 bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
+									className="absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
 									style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
 								>
 									IA
@@ -804,7 +804,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 			</div>
 
 			{/* Search + Filter bar */}
-			<div className="space-y-1.5 border-b border-slate-200/60 px-2 py-1.5">
+			<div className="space-y-1.5 border-b border-[var(--inno-border)] px-2 py-1.5">
 				{/* Search */}
 				<div className="relative">
 					{showSearch ? (
@@ -812,7 +812,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 							<div className="relative flex-1">
 								<Search size={12} className="absolute left-2 top-1/2 -translate-y-1/2 text-[var(--inno-text-subtle)]" />
 								<input
-									className="inno-sidebar-text w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] py-1 pl-7 pr-7 outline-none placeholder:text-[var(--inno-text-subtle)] focus:border-blue-300 focus:ring-1 focus:ring-blue-200"
+									className="inno-sidebar-text w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] py-1 pl-7 pr-7 outline-none placeholder:text-[var(--inno-text-subtle)] focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 									placeholder="搜索对话..."
 									value={state.searchQuery}
 									autoFocus
@@ -937,7 +937,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 			</div>
 
 			{/* Footer */}
-			<div className="border-t border-slate-200/70 p-2">
+			<div className="border-t border-[var(--inno-border)] p-2">
 				<button
 					className="inno-sidebar-text inno-new-chat-button flex w-full items-center justify-center gap-2 rounded-lg inno-primary-button px-3 py-1.5 font-medium text-white shadow-sm transition-colors"
 					onClick={newChat}

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -63,13 +63,13 @@ function channelLabel(channel: SessionChannel): string {
 
 function channelClass(channel: SessionChannel): string {
 	const classes: Record<string, string> = {
-		cli: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]",
-		web: "bg-[var(--inno-surface-muted)] text-[var(--inno-text)] ring-1 ring-[var(--inno-border)]",
-		feishu: "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]",
+		cli: "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]",
+		web: "bg-[var(--inno-surface-muted)] text-[var(--inno-text)]",
+		feishu: "bg-[var(--inno-success-bg)] text-[var(--inno-success)]",
 		scheduler: "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)] ring-1 ring-[var(--inno-warning-border)]/60",
 		qq: "bg-cyan-50 text-cyan-600 ring-1 ring-cyan-200/60",
 		wechat: "bg-lime-50 text-lime-600 ring-1 ring-lime-200/60",
-		unknown: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)] ring-1 ring-[var(--inno-border)]",
+		unknown: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]",
 	};
 	return classes[channel] ?? classes.unknown;
 }
@@ -81,13 +81,13 @@ function channelClass(channel: SessionChannel): string {
  */
 function channelInteractionClass(channel: SessionChannel): string {
 	const classes: Record<string, string> = {
-		cli: "bg-transparent text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]",
+		cli: "bg-transparent text-[var(--inno-accent)]",
 		web: "bg-transparent text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border-strong)]",
-		feishu: "bg-transparent text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]",
+		feishu: "bg-transparent text-[var(--inno-success)]",
 		scheduler: "bg-transparent text-[var(--inno-warning)] ring-1 ring-[var(--inno-warning-border)]",
 		qq: "bg-transparent text-cyan-500 ring-1 ring-cyan-300/70",
 		wechat: "bg-transparent text-lime-500 ring-1 ring-lime-300/70",
-		unknown: "bg-transparent text-[var(--inno-text-subtle)] ring-1 ring-[var(--inno-border)]",
+		unknown: "bg-transparent text-[var(--inno-text-subtle)]",
 	};
 	return classes[channel] ?? classes.unknown;
 }
@@ -107,7 +107,7 @@ function orderedSessionChannels(session: SessionMeta): Array<{ channel: SessionC
 }
 
 function channelFilterClass(channel: SessionChannel | null, active: boolean): string {
-	if (!active) return "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] hover:ring-[var(--inno-border-strong)]";
+	if (!active) return "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] hover:ring-[var(--inno-border-strong)]";
 	if (!channel) return "inno-primary-button ring-1 ring-[var(--inno-accent)]";
 	const map: Record<string, string> = {
 		cli: "bg-[var(--inno-accent)] text-white ring-1 ring-[var(--inno-accent)] hover:bg-[var(--inno-accent)] hover:text-white",
@@ -710,7 +710,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 									<div className="mt-1 flex items-center gap-1.5">
 										{ws ? (
 											<span
-												className="inline-flex max-w-[140px] items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-1.5 py-px text-[9px] font-medium leading-none text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)]"
+												className="inline-flex max-w-[140px] items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-1.5 py-px text-[9px] font-medium leading-none text-[var(--inno-text-muted)]"
 												title={`工作区:${ws.name}`}
 											>
 												<FolderKanban size={12} className="shrink-0" />

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -24,6 +24,7 @@ import { settingsStore } from "../stores/settings-store.js";
 import type { WorkspaceMeta } from "../api/workspaces.js";
 import type { SessionChannel, SessionMeta } from "../api/sessions.js";
 import { useStoreSnapshot } from "./hooks.js";
+import { Spinner } from "./ui/Spinner.js";
 
 interface SessionSidebarProps {
 	collapsed: boolean;
@@ -216,14 +217,14 @@ function GroupHeader({
 								title="重命名工作区"
 								onClick={(e) => { e.stopPropagation(); onStartEdit(); }}
 							>
-								<Pencil size={11} />
+								<Pencil size={12} />
 							</button>
 							<button
 								className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)]"
 								title="删除工作区"
 								onClick={(e) => { e.stopPropagation(); onDelete(); }}
 							>
-								<Trash2 size={11} />
+								<Trash2 size={12} />
 							</button>
 						</>
 					) : null}
@@ -330,7 +331,7 @@ function SessionCard({
 				</div>
 				<div className="flex items-center gap-0.5 opacity-0 group-hover/card:opacity-100 transition-opacity duration-150">
 					{opening ? (
-						<span className="h-3 w-3 animate-spin rounded-full border-2 border-[var(--inno-border-strong)] border-t-transparent" />
+						<Spinner size={12} className="text-[var(--inno-border-strong)]" />
 					) : null}
 					<button
 						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-40"
@@ -339,7 +340,7 @@ function SessionCard({
 						onClick={(e) => { e.stopPropagation(); onGenerate(); }}
 					>
 						{generatingId === session.id ? (
-							<span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
+							<Spinner size={12} />
 						) : (
 							<Sparkles size={12} />
 						)}
@@ -631,24 +632,20 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 							disabled={togglingMode}
 							title={simpleMode ? "当前:简单模式 · 点击切换到普通模式" : "当前:普通模式 · 点击切换到简单模式"}
 							aria-label={simpleMode ? "切换到普通模式" : "切换到简单模式"}
-							className="shrink-0 rounded-lg outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
-							style={{ perspective: "500px" }}
+							className="flip-card-scene shrink-0 rounded-lg outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
 						>
 							<motion.div
 								animate={{ rotateY: simpleMode ? 180 : 0 }}
 								transition={{ type: "spring", stiffness: 320, damping: 22 }}
-								style={{ transformStyle: "preserve-3d", position: "relative" }}
-								className="h-7 w-7"
+								className="flip-card h-7 w-7"
 							>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] text-[10px] font-semibold text-[var(--inno-text)] shadow-sm"
-									style={{ backfaceVisibility: "hidden" }}
+									className="flip-card-face absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] text-[10px] font-semibold text-[var(--inno-text)] shadow-sm"
 								>
 									IA
 								</span>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
-									style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
+									className="flip-card-back absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
 								>
 									IA
 								</span>
@@ -672,7 +669,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 					<div className="px-2 pb-1 text-[11px] font-medium uppercase tracking-wide text-[var(--inno-text-subtle)]">最近</div>
 					{state.isLoading ? (
 						<div className="flex items-center justify-center py-8">
-							<span className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--inno-border-strong)] border-t-transparent" />
+							<Spinner size={16} className="text-[var(--inno-border-strong)]" />
 						</div>
 					) : recentSessions.length === 0 ? (
 						<div className="inno-sidebar-text px-2 py-8 text-center text-[var(--inno-text-subtle)]">暂无对话</div>
@@ -716,7 +713,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 												className="inline-flex max-w-[140px] items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-1.5 py-px text-[9px] font-medium leading-none text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)]"
 												title={`工作区:${ws.name}`}
 											>
-												<FolderKanban size={9} className="shrink-0" />
+												<FolderKanban size={12} className="shrink-0" />
 												<span className="truncate">{ws.name}</span>
 											</span>
 										) : null}
@@ -755,24 +752,20 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 							disabled={togglingMode}
 							title={simpleMode ? "当前:简单模式 · 点击切换到普通模式" : "当前:普通模式 · 点击切换到简单模式"}
 							aria-label={simpleMode ? "切换到普通模式" : "切换到简单模式"}
-							className="shrink-0 rounded-lg outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
-							style={{ perspective: "500px" }}
+							className="flip-card-scene shrink-0 rounded-lg outline-none focus-visible:shadow-[var(--inno-ring)] disabled:cursor-wait"
 						>
 							<motion.div
 								animate={{ rotateY: simpleMode ? 180 : 0 }}
 								transition={{ type: "spring", stiffness: 320, damping: 22 }}
-								style={{ transformStyle: "preserve-3d", position: "relative" }}
-								className="h-7 w-7"
+								className="flip-card h-7 w-7"
 							>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] text-[10px] font-semibold text-[var(--inno-text)] shadow-sm"
-									style={{ backfaceVisibility: "hidden" }}
+									className="flip-card-face absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] text-[10px] font-semibold text-[var(--inno-text)] shadow-sm"
 								>
 									IA
 								</span>
 								<span
-									className="absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
-									style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
+									className="flip-card-back absolute inset-0 flex items-center justify-center rounded-lg border border-[var(--inno-accent)] bg-[var(--inno-accent)] text-[10px] font-semibold text-white shadow-sm"
 								>
 									IA
 								</span>
@@ -790,7 +783,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 							title="Refresh"
 							onClick={() => void sessionsStore.load()}
 						>
-							<RefreshCw size={13} />
+							<RefreshCw size={14} />
 						</button>
 						<button
 							className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text-muted)]"
@@ -831,7 +824,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 								className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text-muted)]"
 								onClick={() => { setShowSearch(false); sessionsStore.setSearchQuery(""); }}
 							>
-								<X size={13} />
+								<X size={14} />
 							</button>
 						</div>
 					) : (
@@ -873,7 +866,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 			<div className="flex-1 min-h-0 overflow-y-auto px-1.5 pb-2 sidebar-scroll">
 				{state.isLoading ? (
 					<div className="flex items-center justify-center py-8">
-						<span className="h-4 w-4 animate-spin rounded-full border-2 border-[var(--inno-border-strong)] border-t-transparent" />
+						<Spinner size={16} className="text-[var(--inno-border-strong)]" />
 					</div>
 				) : groups.length === 0 ? (
 					<div className="inno-sidebar-text px-2 py-8 text-center text-[var(--inno-text-subtle)]">

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -10,6 +10,9 @@ import type { InnoModelInfo, InnoProviderModel as ProviderModel, InnoSettings, C
 import type { WikiStats } from "../types/wiki.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { setLocale } from "../i18n/index.js";
+import { Switch } from "./ui/Switch.js";
+import { inputCls } from "./ui/input.js";
+import { checkboxCls } from "./ui/checkbox.js";
 
 const apiOptions = ["openai-completions", "openai-responses", "anthropic-messages"];
 
@@ -160,9 +163,9 @@ function ModelEditForm({ model, settings, onClose }: {
 				</div>
 			</div>
 			<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
-				<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
-				<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
-				<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.preserveApiKey} onChange={(e) => setForm({ ...form, preserveApiKey: e.target.checked })} /> {t("settings.form.preserveApiKey")}</label>
+				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
+				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
+				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.preserveApiKey} onChange={(e) => setForm({ ...form, preserveApiKey: e.target.checked })} /> {t("settings.form.preserveApiKey")}</label>
 			</div>
 			{formError ? <div className="mt-2 rounded bg-red-50 px-2 py-1 text-xs text-red-700">{formError}</div> : null}
 			<div className="mt-2 flex gap-2">
@@ -306,8 +309,8 @@ function NewProviderForm() {
 						</div>
 					</div>
 					<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
-						<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
-						<label className="flex items-center gap-1.5"><input type="checkbox" className="h-3.5 w-3.5" checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
+						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
+						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
 					</div>
 					{formError ? <div className="mt-2 rounded bg-red-50 px-2 py-1 text-xs text-red-700">{formError}</div> : null}
 					{saveMessage ? <div className="mt-2 rounded bg-green-50 px-2 py-1 text-xs text-green-700">{saveMessage}</div> : null}
@@ -510,7 +513,6 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 		}
 	}
 
-	const inputCls = "w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs";
 	const labelCls = "mb-0.5 block text-[10px] text-[var(--inno-text-muted)]";
 	const checkCls = "flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]";
 
@@ -540,7 +542,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								<div className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.channels.feishu.desc")}</div>
 							</div>
 							<label className={checkCls}>
-								<input type="checkbox" className="h-3.5 w-3.5" checked={feishuEnabled} onChange={(e) => setFeishuEnabled(e.target.checked)} />
+								<input type="checkbox" className={checkboxCls} checked={feishuEnabled} onChange={(e) => setFeishuEnabled(e.target.checked)} />
 								{t("settings.channels.enabled")}
 							</label>
 						</div>
@@ -576,7 +578,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 									className="w-full rounded border border-[var(--inno-border)] bg-[var(--inno-bg-alt)] px-3 py-2 text-xs text-[var(--inno-text)] hover:bg-[var(--inno-bg-hover)] flex items-center justify-center gap-2"
 									onClick={startFeishuQrRegister}
 								>
-									<QrCodeIcon className="h-3.5 w-3.5" />
+									<QrCodeIcon className={checkboxCls} />
 									{t("settings.feishu.qrRegister")}
 								</button>
 							)}
@@ -597,7 +599,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								</div>
 								<div className="col-span-2 flex items-center gap-3">
 									<label className={checkCls}>
-										<input type="checkbox" className="h-3.5 w-3.5" checked={feishuPersonalOnly} onChange={(e) => setFeishuPersonalOnly(e.target.checked)} />
+										<input type="checkbox" className={checkboxCls} checked={feishuPersonalOnly} onChange={(e) => setFeishuPersonalOnly(e.target.checked)} />
 										{t("settings.channels.personalOnly")}
 									</label>
 								</div>
@@ -617,7 +619,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								<div className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.channels.qq.desc")}</div>
 							</div>
 							<label className={checkCls}>
-								<input type="checkbox" className="h-3.5 w-3.5" checked={qqEnabled} onChange={(e) => setQqEnabled(e.target.checked)} />
+								<input type="checkbox" className={checkboxCls} checked={qqEnabled} onChange={(e) => setQqEnabled(e.target.checked)} />
 								{t("settings.channels.enabled")}
 							</label>
 						</div>
@@ -629,7 +631,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								</div>
 								<div className="col-span-2 flex items-center gap-3">
 									<label className={checkCls}>
-										<input type="checkbox" className="h-3.5 w-3.5" checked={qqPersonalOnly} onChange={(e) => setQqPersonalOnly(e.target.checked)} />
+										<input type="checkbox" className={checkboxCls} checked={qqPersonalOnly} onChange={(e) => setQqPersonalOnly(e.target.checked)} />
 										{t("settings.channels.personalOnly")}
 									</label>
 								</div>
@@ -649,7 +651,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								<div className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.channels.wechat.desc")}</div>
 							</div>
 							<label className={checkCls}>
-								<input type="checkbox" className="h-3.5 w-3.5" checked={wechatEnabled} onChange={(e) => setWechatEnabled(e.target.checked)} />
+								<input type="checkbox" className={checkboxCls} checked={wechatEnabled} onChange={(e) => setWechatEnabled(e.target.checked)} />
 								{t("settings.channels.enabled")}
 							</label>
 						</div>
@@ -709,7 +711,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								</div>
 								<div className="flex items-center gap-3">
 									<label className={checkCls}>
-										<input type="checkbox" className="h-3.5 w-3.5" checked={wechatPersonalOnly} onChange={(e) => setWechatPersonalOnly(e.target.checked)} />
+										<input type="checkbox" className={checkboxCls} checked={wechatPersonalOnly} onChange={(e) => setWechatPersonalOnly(e.target.checked)} />
 										{t("settings.channels.personalOnly")}
 									</label>
 								</div>
@@ -804,7 +806,6 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 		}
 	}
 
-	const inputCls = "h-8 min-w-0 w-full rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:border-blue-400 focus:outline-none";
 	const sourceLabel = type === "github"
 		? `GitHub · ${owner || "?"}/${repo || "?"}`
 		: `${t("settings.contentHub.bundle", "自托管服务")} · ${baseUrl || "?"}`;
@@ -942,8 +943,6 @@ function OcrSettings({ settings }: { settings: InnoSettings }) {
 		}
 	}
 
-	const inputCls = "h-8 min-w-0 w-full rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:border-blue-400 focus:outline-none";
-
 	return (
 		<div className="min-w-0 rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
 			<button className="inno-settings-card-toggle flex w-full min-w-0 items-start gap-2 text-left" onClick={() => setOpen((v) => !v)}>
@@ -1039,15 +1038,7 @@ function MemoryToggleRow({
 				<h4 className="text-sm font-medium text-[var(--inno-text)]">{title}</h4>
 				<p className="mt-1 text-xs text-[var(--inno-text-muted)]">{desc}</p>
 			</div>
-			<button
-				role="switch"
-				aria-checked={shown}
-				disabled={saving || locked}
-				onClick={() => onToggle(!enabled)}
-				className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${shown ? "bg-[var(--inno-accent)]" : "bg-slate-300"}`}
-			>
-				<span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-[var(--inno-surface)] transition-transform ${shown ? "translate-x-[18px]" : "translate-x-1"}`} />
-			</button>
+			<Switch checked={shown} onChange={onToggle} disabled={saving || locked} />
 		</div>
 	);
 }
@@ -1145,15 +1136,7 @@ function SimpleModeSettings({ settings }: { settings: InnoSettings }) {
 						{enabled ? t("settings.simpleMode.onDesc") : t("settings.simpleMode.offDesc")}
 					</p>
 				</div>
-				<button
-					role="switch"
-					aria-checked={enabled}
-					disabled={saving}
-					onClick={() => void handleToggle(!enabled)}
-					className={`relative mt-0.5 inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${enabled ? "bg-[var(--inno-accent)]" : "bg-slate-300"}`}
-				>
-					<span className={`inline-block h-3.5 w-3.5 transform rounded-full bg-[var(--inno-surface)] transition-transform ${enabled ? "translate-x-[18px]" : "translate-x-1"}`} />
-				</button>
+				<Switch checked={enabled} onChange={(v) => void handleToggle(v)} disabled={saving} />
 			</div>
 		</div>
 	);

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -121,7 +121,7 @@ function ModelEditForm({ model, settings, onClose }: {
 	const maskedKey = provider?.apiKey ? "••••••••" : "";
 
 	return (
-		<div className="rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-surface-muted)] p-3">
+		<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 			<div className="mb-2 flex items-center justify-between">
 				<span className="text-xs font-medium text-[var(--inno-text)]">{t("settings.editModel", "Edit Model")}</span>
 				<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={onClose}><X size={14} /></button>
@@ -517,7 +517,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 	const checkCls = "flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]";
 
 	return (
-		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
+		<div className="rounded-lg bg-[var(--inno-surface)]">
 			<button
 				className="flex w-full items-center justify-between px-4 py-3 text-left"
 				onClick={() => { setExpanded((v) => !v); setFormError(null); setSaveMsg(null); }}
@@ -535,7 +535,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 			{expanded && (
 				<div className="border-t border-[var(--inno-border)] px-4 pb-4 pt-3 grid gap-4">
 					{/* Feishu */}
-					<div className="rounded-lg border border-[var(--inno-border)] p-3">
+					<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 						<div className="mb-2 flex items-center justify-between">
 							<div>
 								<div className="text-xs font-medium text-[var(--inno-text)]">{t("settings.channels.feishu.title")}</div>
@@ -550,7 +550,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 						{/* Feishu QR Registration */}
 						<div className="mb-3">
 							{feishuQrState === "waitingScan" && feishuQrUrl ? (
-								<div className="flex flex-col items-center gap-2 rounded-lg border border-[var(--inno-border)] bg-[var(--inno-bg-alt)] p-4">
+								<div className="flex flex-col items-center gap-2 rounded-lg bg-[var(--inno-bg-alt)] p-4">
 									<div className="text-xs font-medium text-[var(--inno-text)]">{t("settings.feishu.qrTitle")}</div>
 									<QRCodeSVG value={feishuQrUrl} size={192} />
 									<div className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.feishu.qrSubtitle")}</div>
@@ -612,7 +612,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 					</div>
 
 					{/* QQ */}
-					<div className="rounded-lg border border-[var(--inno-border)] p-3">
+					<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 						<div className="mb-2 flex items-center justify-between">
 							<div>
 								<div className="text-xs font-medium text-[var(--inno-text)]">{t("settings.channels.qq.title")}</div>
@@ -644,7 +644,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 					</div>
 
 					{/* WeChat (iLink native) */}
-					<div className="rounded-lg border border-[var(--inno-border)] p-3">
+					<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 						<div className="mb-2 flex items-center justify-between">
 							<div>
 								<div className="text-xs font-medium text-[var(--inno-text)]">{t("settings.channels.wechat.title")}</div>
@@ -725,7 +725,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 
 					{/* Bridge Token (used by QQ sidecar) */}
 					{qqEnabled && (
-						<div className="rounded-lg border border-[var(--inno-border)] p-3">
+						<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 							<div className="text-xs font-medium text-[var(--inno-text)] mb-1">{t("settings.channels.bridgeToken")}</div>
 							<div className="text-[10px] text-[var(--inno-text-subtle)] mb-2">{t("settings.channels.bridgeTokenHint")}</div>
 							<input
@@ -811,7 +811,7 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 		: `${t("settings.contentHub.bundle", "自托管服务")} · ${baseUrl || "?"}`;
 
 	return (
-		<div className="min-w-0 rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+		<div className="min-w-0 rounded-lg bg-[var(--inno-surface)] p-4">
 			<button className="inno-settings-card-toggle flex w-full min-w-0 items-start gap-2 text-left" onClick={() => setOpen((v) => !v)}>
 				<Database size={16} className="mt-0.5 shrink-0 text-[var(--inno-text)]" />
 				<div className="min-w-0 flex-1">
@@ -944,7 +944,7 @@ function OcrSettings({ settings }: { settings: InnoSettings }) {
 	}
 
 	return (
-		<div className="min-w-0 rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+		<div className="min-w-0 rounded-lg bg-[var(--inno-surface)] p-4">
 			<button className="inno-settings-card-toggle flex w-full min-w-0 items-start gap-2 text-left" onClick={() => setOpen((v) => !v)}>
 				<KeyRound size={16} className="mt-0.5 shrink-0 text-[var(--inno-text)]" />
 				<div className="min-w-0 flex-1">
@@ -1081,7 +1081,7 @@ function MemorySettings({ settings }: { settings: InnoSettings }) {
 	];
 
 	return (
-		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+		<div className="rounded-lg bg-[var(--inno-surface)] p-4">
 			<h4 className="mb-3 text-sm font-medium text-[var(--inno-text)]">{t("settings.memorySection")}</h4>
 			{locked ? <p className="mb-3 text-xs text-[var(--inno-warning)]">{t("settings.simpleMode.memoryLocked")}</p> : null}
 			<div className="grid gap-4">
@@ -1128,7 +1128,7 @@ function SimpleModeSettings({ settings }: { settings: InnoSettings }) {
 	}
 
 	return (
-		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+		<div className="rounded-lg bg-[var(--inno-surface)] p-4">
 			<div className="flex items-start justify-between gap-3">
 				<div className="min-w-0">
 					<h4 className="text-sm font-medium text-[var(--inno-text)]">{t("settings.simpleMode.title")}</h4>
@@ -1170,7 +1170,7 @@ export function SettingsPanel() {
 		<div className="h-full overflow-y-auto p-3">
 			<div className="grid gap-3">
 				{/* Status cards */}
-				<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+				<div className="rounded-lg bg-[var(--inno-surface)] p-4">
 					<div className="mb-3 flex items-center justify-between">
 						<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("settings.title")}</h3>
 						<div className="flex items-center gap-2">
@@ -1214,7 +1214,7 @@ export function SettingsPanel() {
 				</div>
 
 				{/* Models */}
-				<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
+				<div className="rounded-lg bg-[var(--inno-surface)] p-4">
 					<h4 className="mb-3 text-sm font-medium text-[var(--inno-text)]">{t("settings.models")}</h4>
 					<div className="grid gap-2">
 						{models.map((model) => {

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -121,10 +121,10 @@ function ModelEditForm({ model, settings, onClose }: {
 	const maskedKey = provider?.apiKey ? "••••••••" : "";
 
 	return (
-		<div className="rounded-lg border border-[var(--inno-accent-soft)] bg-blue-50/50 p-3">
+		<div className="rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-surface-muted)] p-3">
 			<div className="mb-2 flex items-center justify-between">
 				<span className="text-xs font-medium text-[var(--inno-text)]">{t("settings.editModel", "Edit Model")}</span>
-				<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={onClose}><X size={14} /></button>
+				<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={onClose}><X size={14} /></button>
 			</div>
 			<div className="grid grid-cols-2 gap-2">
 				<div>
@@ -167,7 +167,7 @@ function ModelEditForm({ model, settings, onClose }: {
 				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
 				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.preserveApiKey} onChange={(e) => setForm({ ...form, preserveApiKey: e.target.checked })} /> {t("settings.form.preserveApiKey")}</label>
 			</div>
-			{formError ? <div className="mt-2 rounded bg-red-50 px-2 py-1 text-xs text-red-700">{formError}</div> : null}
+			{formError ? <div className="mt-2 rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-xs text-[var(--inno-danger)]">{formError}</div> : null}
 			<div className="mt-2 flex gap-2">
 				<button className="rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
 					{saving ? t("settings.savingProvider") : t("settings.saveProvider")}
@@ -201,7 +201,7 @@ function ThemeSettings() {
 							className={`h-5 w-5 rounded-full border-2 transition-all ${
 								active
 									? "border-[var(--inno-accent)] ring-2 ring-[var(--inno-accent)]/30 scale-110"
-									: "border-[var(--inno-border-strong)] hover:border-slate-400"
+									: "border-[var(--inno-border-strong)] hover:border-[var(--inno-border-strong)]"
 							}`}
 							style={{ backgroundColor: THEME_PREVIEW_COLORS[id] }}
 						/>
@@ -312,8 +312,8 @@ function NewProviderForm() {
 						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
 						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
 					</div>
-					{formError ? <div className="mt-2 rounded bg-red-50 px-2 py-1 text-xs text-red-700">{formError}</div> : null}
-					{saveMessage ? <div className="mt-2 rounded bg-green-50 px-2 py-1 text-xs text-green-700">{saveMessage}</div> : null}
+					{formError ? <div className="mt-2 rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-xs text-[var(--inno-danger)]">{formError}</div> : null}
+					{saveMessage ? <div className="mt-2 rounded bg-[var(--inno-success-bg)] px-2 py-1 text-xs text-[var(--inno-success)]">{saveMessage}</div> : null}
 					<button className="mt-3 rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
 						{saving ? t("settings.savingProvider") : t("settings.saveProvider")}
 					</button>
@@ -527,9 +527,9 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 					<span className="text-sm font-medium text-[var(--inno-text)]">{t("settings.channels.title")}</span>
 				</div>
 				<div className="flex items-center gap-2 text-xs text-[var(--inno-text-subtle)]">
-					{feishuEnabled && <span className="rounded bg-green-50 px-1.5 py-0.5 text-green-700">{t("settings.channels.feishu.title")}</span>}
+					{feishuEnabled && <span className="rounded bg-[var(--inno-success-bg)] px-1.5 py-0.5 text-[var(--inno-success)]">{t("settings.channels.feishu.title")}</span>}
 					{qqEnabled && <span className="rounded bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-[var(--inno-accent)]">{t("settings.channels.qq.title")}</span>}
-					{wechatEnabled && <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-emerald-700">{t("settings.channels.wechat.title")}</span>}
+					{wechatEnabled && <span className="rounded bg-[var(--inno-success-bg)] px-1.5 py-0.5 text-[var(--inno-success)]">{t("settings.channels.wechat.title")}</span>}
 				</div>
 			</button>
 			{expanded && (
@@ -557,18 +557,18 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 									<div className="text-[10px] text-[var(--inno-accent)]">{t("settings.feishu.qrWaiting")}</div>
 								</div>
 							) : feishuQrState === "confirmed" ? (
-								<div className="flex items-center gap-2 rounded-lg border border-green-200 bg-green-50 p-3">
-									<CheckCircle className="h-4 w-4 text-green-600" />
-									<span className="text-xs text-green-700">{t("settings.feishu.qrConfirmed")}</span>
+								<div className="flex items-center gap-2 rounded-lg border border-[var(--inno-success-border)] bg-[var(--inno-success-bg)] p-3">
+									<CheckCircle className="h-4 w-4 text-[var(--inno-success)]" />
+									<span className="text-xs text-[var(--inno-success)]">{t("settings.feishu.qrConfirmed")}</span>
 								</div>
 							) : feishuQrState === "expired" ? (
-								<div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3">
-									<span className="text-xs text-amber-700">{t("settings.feishu.qrExpired")}</span>
+								<div className="flex items-center gap-2 rounded-lg border border-[var(--inno-warning-border)] bg-[var(--inno-warning-bg)] p-3">
+									<span className="text-xs text-[var(--inno-warning)]">{t("settings.feishu.qrExpired")}</span>
 									<button className="ml-auto rounded bg-[var(--inno-accent)] px-2 py-0.5 text-[10px] text-white" onClick={startFeishuQrRegister}>{t("settings.feishu.qrRegenerate")}</button>
 								</div>
 							) : feishuQrState === "denied" ? (
-								<div className="flex items-center gap-2 rounded-lg border border-red-200 bg-red-50 p-3">
-									<span className="text-xs text-red-700">{t("settings.feishu.qrDenied")}</span>
+								<div className="flex items-center gap-2 rounded-lg border border-[var(--inno-danger-border)] bg-[var(--inno-danger-bg)] p-3">
+									<span className="text-xs text-[var(--inno-danger)]">{t("settings.feishu.qrDenied")}</span>
 									<button className="ml-auto rounded bg-[var(--inno-accent)] px-2 py-0.5 text-[10px] text-white" onClick={startFeishuQrRegister}>{t("settings.feishu.qrRegenerate")}</button>
 								</div>
 							) : feishuQrState === "scanning" ? (
@@ -578,12 +578,12 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 									className="w-full rounded border border-[var(--inno-border)] bg-[var(--inno-bg-alt)] px-3 py-2 text-xs text-[var(--inno-text)] hover:bg-[var(--inno-bg-hover)] flex items-center justify-center gap-2"
 									onClick={startFeishuQrRegister}
 								>
-									<QrCodeIcon className={checkboxCls} />
+									<QrCodeIcon size={14} />
 									{t("settings.feishu.qrRegister")}
 								</button>
 							)}
 							{feishuQrError && (
-								<div className="mt-1 rounded bg-red-50 px-2 py-1 text-[10px] text-red-600">{feishuQrError}</div>
+								<div className="mt-1 rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-[10px] text-[var(--inno-danger)]">{feishuQrError}</div>
 							)}
 						</div>
 
@@ -661,8 +661,8 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 								<div className="flex items-center gap-2 rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2.5 py-2">
 									{wxConnected ? (
 										<>
-											<Wifi size={14} className="text-green-600" />
-											<span className="text-xs font-medium text-green-700">{t("settings.channels.wechat.connected")}</span>
+											<Wifi size={14} className="text-[var(--inno-success)]" />
+											<span className="text-xs font-medium text-[var(--inno-success)]">{t("settings.channels.wechat.connected")}</span>
 											{wxBotId && <span className="text-[10px] text-[var(--inno-text-subtle)] ml-1">{t("settings.channels.wechat.botId")}: {wxBotId}</span>}
 										</>
 									) : (
@@ -679,13 +679,13 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 										<QRCodeSVG value={qrUrl} size={192} level="M" />
 									)}
 									{qrStatus === "confirmed" && (
-										<div className="flex items-center gap-1.5 text-xs text-green-600">
+										<div className="flex items-center gap-1.5 text-xs text-[var(--inno-success)]">
 											<CheckCircle size={14} />
 											{t("settings.channels.wechat.confirmed")}
 										</div>
 									)}
 									{qrStatus === "expired" && (
-										<div className="text-xs text-amber-600">{t("settings.channels.wechat.expired")}</div>
+										<div className="text-xs text-[var(--inno-warning)]">{t("settings.channels.wechat.expired")}</div>
 									)}
 									{qrStatus === "scanning" && (
 										<div className="text-xs text-[var(--inno-text-subtle)]">{t("settings.channels.wechat.scanning")}</div>
@@ -706,7 +706,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 										</button>
 									)}
 									{qrError && (
-										<div className="rounded bg-red-50 px-2 py-1 text-xs text-red-700">{qrError}</div>
+										<div className="rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-xs text-[var(--inno-danger)]">{qrError}</div>
 									)}
 								</div>
 								<div className="flex items-center gap-3">
@@ -739,8 +739,8 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 						</div>
 					)}
 
-					{formError && <div className="rounded bg-red-50 px-2 py-1 text-xs text-red-700">{formError}</div>}
-					{saveMsg && <div className="rounded bg-green-50 px-2 py-1 text-xs text-green-700">{saveMsg}</div>}
+					{formError && <div className="rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-xs text-[var(--inno-danger)]">{formError}</div>}
+					{saveMsg && <div className="rounded bg-[var(--inno-success-bg)] px-2 py-1 text-xs text-[var(--inno-success)]">{saveMsg}</div>}
 					<button
 						className="rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50 justify-self-start"
 						disabled={saving}
@@ -830,13 +830,13 @@ function ContentHubSettings({ settings }: { settings: InnoSettings }) {
 					<div className="flex flex-wrap items-center gap-1.5">
 						<button
 							onClick={() => setType("github")}
-							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "github" ? "border-blue-400 bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]" : "border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"}`}
+							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "github" ? "border-[var(--inno-accent)] bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]" : "border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"}`}
 						>
 							GitHub
 						</button>
 						<button
 							onClick={() => setType("bundle")}
-							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "bundle" ? "border-blue-400 bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]" : "border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"}`}
+							className={`flex h-7 items-center rounded-md border px-2.5 text-xs ${type === "bundle" ? "border-[var(--inno-accent)] bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]" : "border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"}`}
 						>
 							{t("settings.contentHub.bundle", "自托管服务")}
 						</button>
@@ -1083,7 +1083,7 @@ function MemorySettings({ settings }: { settings: InnoSettings }) {
 	return (
 		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] p-4">
 			<h4 className="mb-3 text-sm font-medium text-[var(--inno-text)]">{t("settings.memorySection")}</h4>
-			{locked ? <p className="mb-3 text-xs text-amber-600">{t("settings.simpleMode.memoryLocked")}</p> : null}
+			{locked ? <p className="mb-3 text-xs text-[var(--inno-warning)]">{t("settings.simpleMode.memoryLocked")}</p> : null}
 			<div className="grid gap-4">
 				{layers.map(({ key, ns }) => {
 					const enabled = state[key];
@@ -1192,11 +1192,11 @@ export function SettingsPanel() {
 						</div>
 					</div>
 					{state.isLoading ? <div className="text-sm text-[var(--inno-text-muted)]">{t("settings.loading")}</div> : null}
-					{state.error ? <div className="rounded bg-red-50 p-2 text-sm text-red-700">{state.error}</div> : null}
+					{state.error ? <div className="rounded bg-[var(--inno-danger-bg)] p-2 text-sm text-[var(--inno-danger)]">{state.error}</div> : null}
 					<div className="grid grid-cols-3 gap-3 text-sm">
 						<div className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
 							<div className="text-xs text-[var(--inno-text-muted)]">{t("settings.stats.server")}</div>
-							<div className={healthOk ? "font-medium text-green-700" : "font-medium text-red-600"}>
+							<div className={healthOk ? "font-medium text-[var(--inno-success)]" : "font-medium text-[var(--inno-danger)]"}>
 								{healthOk ? t("settings.stats.healthy") : t("settings.stats.offline")}
 							</div>
 						</div>
@@ -1248,7 +1248,7 @@ export function SettingsPanel() {
 											<Pencil size={13} />
 										</button>
 										<button
-											className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-red-50 hover:text-red-600 group-hover:opacity-100"
+											className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)] group-hover:opacity-100"
 											title={t("common.delete", "Delete")}
 											onClick={() => {
 												if (window.confirm(t("settings.confirmDelete", { id: `${model.provider}/${model.id}` }) ?? "")) {

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -701,7 +701,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 											className="flex items-center gap-1.5 rounded-md inno-primary-button px-3 py-1.5 text-xs text-white"
 											onClick={() => void startQrLogin()}
 										>
-											<QrCodeIcon size={13} />
+											<QrCodeIcon size={14} />
 											{wxConnected ? t("settings.channels.wechat.relogin") : t("settings.channels.wechat.scanLogin")}
 										</button>
 									)}
@@ -1245,7 +1245,7 @@ export function SettingsPanel() {
 											title={t("common.edit", "Edit")}
 											onClick={() => setEditingModel(key)}
 										>
-											<Pencil size={13} />
+											<Pencil size={14} />
 										</button>
 										<button
 											className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)] group-hover:opacity-100"
@@ -1256,7 +1256,7 @@ export function SettingsPanel() {
 												}
 											}}
 										>
-											<Trash2 size={13} />
+											<Trash2 size={14} />
 										</button>
 										{!current && (
 											<button

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -152,7 +152,7 @@ function SkillFileNode({ node, style, dragHandle }: NodeRendererProps<ArboristNo
 			style={style}
 			className={`group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer select-none ${
 				selected
-					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100"
+					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]"
 					: "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 			}`}
 			onClick={(e) => {
@@ -300,7 +300,7 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 					<div className="min-w-0 flex-1">
 						<div className="flex items-center gap-2">
 							<span className="truncate text-sm font-medium text-[var(--inno-text)]">{skill.name}</span>
-							<span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${skill.enabled ? "bg-green-50 text-green-700 ring-1 ring-green-100" : "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]"}`}>
+							<span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${skill.enabled ? "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]" : "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]"}`}>
 								{skill.enabled ? t("common.enabled", "Enabled") : t("common.disabled", "Disabled")}
 							</span>
 						</div>
@@ -314,10 +314,10 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 						{t("common.enable", "Enable")}
 					</label>
 					<div className="flex-1" />
-					<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-slate-200 hover:text-[var(--inno-text)]" title={t("preview.refresh", "Refresh")} onClick={() => void skillsStore.refreshTree()}>
+					<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("preview.refresh", "Refresh")} onClick={() => void skillsStore.refreshTree()}>
 						<RefreshCw size={12} />
 					</button>
-					<button className="flex h-6 w-6 items-center justify-center rounded text-red-400 hover:bg-red-50 hover:text-red-600" title={t("common.delete", "Delete")} onClick={() => { void skillsStore.remove(skill.name); onBack(); }}>
+					<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-danger)] hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)]" title={t("common.delete", "Delete")} onClick={() => { void skillsStore.remove(skill.name); onBack(); }}>
 						<Trash2 size={12} />
 					</button>
 				</div>
@@ -363,7 +363,7 @@ function SkillRow({ skill, onClick }: { skill: SkillInfo; onClick: () => void })
 			className="flex w-full items-center gap-3 border-b border-[var(--inno-border)] px-3 py-2.5 text-left transition-colors hover:bg-[var(--inno-surface-muted)]"
 			onClick={onClick}
 		>
-			<span className={`h-2 w-2 shrink-0 rounded-full ${skill.enabled ? "bg-green-500" : "bg-slate-300"}`} />
+			<span className={`h-2 w-2 shrink-0 rounded-full ${skill.enabled ? "bg-[var(--inno-success)]" : "bg-[var(--inno-border-strong)]"}`} />
 			<div className="min-w-0 flex-1">
 				<div className="truncate text-sm font-medium text-[var(--inno-text)]">{skill.name}</div>
 				{skill.description && <div className="truncate text-xs text-[var(--inno-text-muted)]">{skill.description}</div>}
@@ -393,7 +393,7 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 	const totalMatched = useMemo(() => groups.reduce((sum, [, items]) => sum + items.length, 0), [groups]);
 
 	return (
-		<div className="absolute inset-0 z-30 flex items-center justify-center bg-slate-900/40 p-4" onClick={onClose}>
+		<div className="absolute inset-0 z-30 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
 			<div
 				className="flex max-h-full w-full max-w-2xl flex-col overflow-hidden rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] shadow-xl"
 				onClick={(e) => e.stopPropagation()}
@@ -445,7 +445,7 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 					) : null}
 				</div>
 
-				{state.error ? <div className="border-b border-[var(--inno-border)] bg-red-50 px-4 py-2 text-xs text-red-700">{state.error}</div> : null}
+				{state.error ? <div className="border-b border-[var(--inno-border)] bg-[var(--inno-danger-bg)] px-4 py-2 text-xs text-[var(--inno-danger)]">{state.error}</div> : null}
 
 				{/* Body */}
 				<div className="min-h-0 flex-1 overflow-y-auto">
@@ -477,7 +477,7 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 												{item.description && <div className="mt-0.5 line-clamp-3 text-xs leading-relaxed text-[var(--inno-text-muted)]">{item.description}</div>}
 											</div>
 											{item.installed ? (
-												<span className="flex shrink-0 items-center gap-1 rounded-md bg-green-50 px-2.5 py-1 text-xs font-medium text-green-700 ring-1 ring-green-100">
+												<span className="flex shrink-0 items-center gap-1 rounded-md bg-[var(--inno-success-bg)] px-2.5 py-1 text-xs font-medium text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]">
 													<Check size={12} /> {t("skills.installed")}
 												</span>
 											) : (
@@ -594,7 +594,7 @@ export function SkillsPanel() {
 					</div>
 				) : null}
 
-				{state.error ? <div className="border-b border-[var(--inno-border)] bg-red-50 px-3 py-2 text-xs text-red-700">{state.error}</div> : null}
+				{state.error ? <div className="border-b border-[var(--inno-border)] bg-[var(--inno-danger-bg)] px-3 py-2 text-xs text-[var(--inno-danger)]">{state.error}</div> : null}
 
 				{/* Skills list */}
 				<div className="min-h-0 flex-1 overflow-y-auto">

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -117,7 +117,7 @@ function FilePreview({ file, skillName, isLoading }: { file: WorkspaceFileDetail
 				<div className="text-lg font-medium text-[var(--inno-text)]">{file.name}</div>
 				<div>{t("preview.binaryFile", "Binary file")} · {formatSize(file.size)}</div>
 				<button
-					className="mt-2 flex items-center gap-1.5 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
+					className="mt-2 flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
 					onClick={() => skillsStore.openAsText()}
 				>
 					<FileCode2 size={14} />
@@ -153,7 +153,7 @@ function SkillFileNode({ node, style, dragHandle }: NodeRendererProps<ArboristNo
 			style={style}
 			className={`group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer select-none ${
 				selected
-					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]"
+					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
 					: "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 			}`}
 			onClick={(e) => {
@@ -208,7 +208,7 @@ function SkillFilePane({ skillName, onToggleSidebar, sidebarOpen }: { skillName:
 						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md inno-primary-button px-2.5 text-xs text-white disabled:opacity-50" onClick={() => void skillsStore.saveFile()}>
 							<Save size={12} /> {t("common.save", "Save")}
 						</button>
-						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] disabled:opacity-50" onClick={() => skillsStore.cancelEditing()}>
+						<button disabled={state.isSaving} className="flex h-7 items-center gap-1 rounded-md px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] disabled:opacity-50" onClick={() => skillsStore.cancelEditing()}>
 							<X size={12} /> {t("common.cancel", "Cancel")}
 						</button>
 					</div>
@@ -243,7 +243,7 @@ function SkillFilePane({ skillName, onToggleSidebar, sidebarOpen }: { skillName:
 					</div>
 				</div>
 				{canEdit && (
-					<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => skillsStore.startEditing()}>
+					<button className="flex h-7 items-center gap-1 rounded-md px-2.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => skillsStore.startEditing()}>
 						<Pencil size={12} /> {t("common.edit", "Edit")}
 					</button>
 				)}
@@ -301,7 +301,7 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 					<div className="min-w-0 flex-1">
 						<div className="flex items-center gap-2">
 							<span className="truncate text-sm font-medium text-[var(--inno-text)]">{skill.name}</span>
-							<span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${skill.enabled ? "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]" : "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]"}`}>
+							<span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium ${skill.enabled ? "bg-[var(--inno-success-bg)] text-[var(--inno-success)]" : "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]"}`}>
 								{skill.enabled ? t("common.enabled", "Enabled") : t("common.disabled", "Disabled")}
 							</span>
 						</div>
@@ -472,13 +472,13 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 								{items.map((item) => {
 									const isImporting = state.importing.has(item.name);
 									return (
-										<div key={item.name} className="flex items-start gap-3 border-b border-[var(--inno-border)] px-4 py-3">
+										<div key={item.name} className="flex items-start gap-3 px-4 py-3">
 											<div className="min-w-0 flex-1">
 												<div className="truncate text-sm font-medium text-[var(--inno-text)]">{item.name}</div>
 												{item.description && <div className="mt-0.5 line-clamp-3 text-xs leading-relaxed text-[var(--inno-text-muted)]">{item.description}</div>}
 											</div>
 											{item.installed ? (
-												<span className="flex shrink-0 items-center gap-1 rounded-md bg-[var(--inno-success-bg)] px-2.5 py-1 text-xs font-medium text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]">
+												<span className="flex shrink-0 items-center gap-1 rounded-md bg-[var(--inno-success-bg)] px-2.5 py-1 text-xs font-medium text-[var(--inno-success)]">
 													<Check size={12} /> {t("skills.installed")}
 												</span>
 											) : (
@@ -558,11 +558,11 @@ export function SkillsPanel() {
 					<h3 className="min-w-0 truncate text-sm font-medium text-[var(--inno-text)]">{t("skills.title")}</h3>
 					<div className="flex shrink-0 items-center gap-1.5">
 						<input ref={uploadRef} type="file" className="hidden" accept=".zip,application/zip,.md,text/markdown,text/plain" onChange={handleUpload} />
-						<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("skills.library")} onClick={() => skillsStore.openLibrary()}>
+						<button className="flex h-7 items-center gap-1 rounded-md px-2 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("skills.library")} onClick={() => skillsStore.openLibrary()}>
 							<Library size={14} />
 							<span className="hidden @[26rem]/skillspanel:inline">{t("skills.library")}</span>
 						</button>
-						<button className="flex h-7 w-7 items-center justify-center rounded-md border border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("preview.refresh", "Refresh")} onClick={() => void skillsStore.reload()}>
+						<button className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("preview.refresh", "Refresh")} onClick={() => void skillsStore.reload()}>
 							<RefreshCw size={14} />
 						</button>
 						<button className="flex h-7 items-center gap-1 rounded-md inno-primary-button px-2 text-xs text-white disabled:opacity-50" disabled={state.isUploading} title={state.isUploading ? t("skills.uploading") : t("skills.upload")} onClick={() => uploadRef.current?.click()}>

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -26,6 +26,7 @@ import { type ArboristNode, toArboristNodes } from "../types/workspace.js";
 import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 import { groupByCategory, matchesQuery } from "../utils/category-grouping.js";
 import { useStoreSnapshot } from "./hooks.js";
+import { checkboxCls } from "./ui/checkbox.js";
 import "@earendil-works/pi-web-ui";
 import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
@@ -309,7 +310,7 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 				{/* Toolbar */}
 				<div className="flex items-center gap-1 border-b border-[var(--inno-border)] px-2 py-1.5">
 					<label className="flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
-						<input type="checkbox" className="h-3.5 w-3.5" checked={skill.enabled} onChange={(e) => void skillsStore.setEnabled(skill.name, e.target.checked)} />
+						<input type="checkbox" className={checkboxCls} checked={skill.enabled} onChange={(e) => void skillsStore.setEnabled(skill.name, e.target.checked)} />
 						{t("common.enable", "Enable")}
 					</label>
 					<div className="flex-1" />

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -27,6 +27,7 @@ import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 import { groupByCategory, matchesQuery } from "../utils/category-grouping.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { checkboxCls } from "./ui/checkbox.js";
+import { Spinner } from "./ui/Spinner.js";
 import "@earendil-works/pi-web-ui";
 import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
@@ -119,7 +120,7 @@ function FilePreview({ file, skillName, isLoading }: { file: WorkspaceFileDetail
 					className="mt-2 flex items-center gap-1.5 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
 					onClick={() => skillsStore.openAsText()}
 				>
-					<FileCode2 size={13} />
+					<FileCode2 size={14} />
 					{t("preview.openAsText", "Open as Text")}
 				</button>
 			</div>
@@ -196,7 +197,7 @@ function SkillFilePane({ skillName, onToggleSidebar, sidebarOpen }: { skillName:
 				<div className="flex h-10 items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3">
 					<div className="flex min-w-0 flex-1 items-center gap-2">
 						<button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={onToggleSidebar}>
-							{sidebarOpen ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
+							{sidebarOpen ? <PanelLeftClose size={16} /> : <PanelLeftOpen size={16} />}
 						</button>
 						<div className="min-w-0">
 							<div className="truncate text-sm font-medium">{state.file.name}</div>
@@ -232,7 +233,7 @@ function SkillFilePane({ skillName, onToggleSidebar, sidebarOpen }: { skillName:
 			<div className="flex h-10 items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3">
 				<div className="flex min-w-0 flex-1 items-center gap-2">
 					<button className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={onToggleSidebar}>
-						{sidebarOpen ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
+						{sidebarOpen ? <PanelLeftClose size={16} /> : <PanelLeftOpen size={16} />}
 					</button>
 					<div className="min-w-0">
 						<div className="truncate text-sm font-medium">{state.file?.name ?? t("preview.noFile", "No file selected")}</div>
@@ -326,7 +327,7 @@ function SkillDetail({ skill, onBack }: { skill: SkillInfo; onBack: () => void }
 				<div ref={treeContainerRef} className="min-h-0 flex-1 overflow-hidden">
 					{state.isLoadingTree && !arboristData.length ? (
 						<div className="flex items-center justify-center py-8 text-[var(--inno-text-muted)]">
-							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+							<Spinner size={16} className="mr-2" />
 						</div>
 					) : !arboristData.length ? (
 						<div className="p-3 text-xs text-[var(--inno-text-muted)]">{t("preview.empty", "Empty")}</div>
@@ -451,7 +452,7 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 				<div className="min-h-0 flex-1 overflow-y-auto">
 					{state.isLoading ? (
 						<div className="flex items-center justify-center py-12 text-[var(--inno-text-muted)]">
-							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+							<Spinner size={16} className="mr-2" />
 							{t("common.loading")}
 						</div>
 					) : state.library.length === 0 ? (
@@ -558,14 +559,14 @@ export function SkillsPanel() {
 					<div className="flex shrink-0 items-center gap-1.5">
 						<input ref={uploadRef} type="file" className="hidden" accept=".zip,application/zip,.md,text/markdown,text/plain" onChange={handleUpload} />
 						<button className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("skills.library")} onClick={() => skillsStore.openLibrary()}>
-							<Library size={13} />
+							<Library size={14} />
 							<span className="hidden @[26rem]/skillspanel:inline">{t("skills.library")}</span>
 						</button>
 						<button className="flex h-7 w-7 items-center justify-center rounded-md border border-[var(--inno-border)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" title={t("preview.refresh", "Refresh")} onClick={() => void skillsStore.reload()}>
-							<RefreshCw size={13} />
+							<RefreshCw size={14} />
 						</button>
 						<button className="flex h-7 items-center gap-1 rounded-md inno-primary-button px-2 text-xs text-white disabled:opacity-50" disabled={state.isUploading} title={state.isUploading ? t("skills.uploading") : t("skills.upload")} onClick={() => uploadRef.current?.click()}>
-							<Upload size={13} />
+							<Upload size={14} />
 							<span className="hidden @[26rem]/skillspanel:inline">{state.isUploading ? t("skills.uploading") : t("skills.upload")}</span>
 						</button>
 					</div>
@@ -574,7 +575,7 @@ export function SkillsPanel() {
 				{/* Search (visible when there's anything to search through) */}
 				{state.skills.length > 0 ? (
 					<div className="flex items-center gap-2 border-b border-[var(--inno-border)] px-3 py-2">
-						<Search size={13} className="shrink-0 text-[var(--inno-text-subtle)]" />
+						<Search size={14} className="shrink-0 text-[var(--inno-text-subtle)]" />
 						<input
 							type="text"
 							value={query}
@@ -600,7 +601,7 @@ export function SkillsPanel() {
 				<div className="min-h-0 flex-1 overflow-y-auto">
 					{state.isLoading ? (
 						<div className="flex items-center justify-center py-8 text-[var(--inno-text-muted)]">
-							<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+							<Spinner size={16} className="mr-2" />
 							{t("common.loading")}
 						</div>
 					) : state.skills.length === 0 ? (

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -510,7 +510,7 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 			style={style}
 			className={`group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer select-none ${
 				selected
-					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]"
+					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]"
 					: "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 			}`}
 			onClick={(e) => {

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -181,7 +181,7 @@ function CsvPreview({ name, content }: { name: string; content: string }) {
 				</thead>
 				<tbody>
 					{body.map((r, ri) => (
-						<tr key={ri} className="odd:bg-[var(--inno-surface)] even:bg-slate-50/60">
+						<tr key={ri} className="odd:bg-[var(--inno-surface)] even:bg-[var(--inno-surface-muted)]">
 							{header.map((_, ci) => (
 								<td key={ci} className="border border-[var(--inno-border)] px-2 py-1 align-top text-[var(--inno-text-muted)]">
 									{r[ci] ?? ""}
@@ -243,7 +243,7 @@ function OfficePreview({ file }: { file: WorkspaceFileDetail }) {
 		return (
 			<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[var(--inno-text-muted)]">
 				<div className="font-medium text-[var(--inno-text)]">{file.name}</div>
-				<div className="text-xs text-red-500">{error}</div>
+				<div className="text-xs text-[var(--inno-danger)]">{error}</div>
 				<button className="flex items-center gap-1 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]" onClick={downloadOriginal}>
 					<Download size={12} />
 					{t("files.download", "Download")}
@@ -490,7 +490,7 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 				</div>
 			</div>
 			<div className="workspace-scroll min-h-0 flex-1 overflow-auto">
-				{state.error ? <div className="p-4 text-sm text-red-500">{state.error}</div> : null}
+				{state.error ? <div className="p-4 text-sm text-[var(--inno-danger)]">{state.error}</div> : null}
 				{!state.error && state.file ? <Preview file={state.file} isLoading={state.isLoadingFile} /> : null}
 				{!state.error && !state.file ? <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.noPreview", "Nothing to preview")}</div> : null}
 			</div>
@@ -510,8 +510,8 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 			style={style}
 			className={`group flex items-center gap-1.5 rounded-md px-2 py-1 text-xs cursor-pointer select-none ${
 				selected
-					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100"
-					: "text-[var(--inno-text-muted)] hover:bg-slate-100/85 hover:text-[var(--inno-text)]"
+					? "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]"
+					: "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
 			}`}
 			onClick={(e) => {
 				e.stopPropagation();
@@ -535,7 +535,7 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 			{node.isEditing ? (
 				<input
 					autoFocus
-					className="min-w-0 flex-1 rounded border border-blue-300 bg-[var(--inno-surface)] px-1 py-0.5 text-xs outline-none focus:ring-1 focus:ring-blue-200"
+					className="min-w-0 flex-1 rounded border border-[var(--inno-accent)] bg-[var(--inno-surface)] px-1 py-0.5 text-xs outline-none focus-visible:shadow-[var(--inno-ring)]"
 					defaultValue={node.data.name}
 					onFocus={(e) => {
 						const val = e.currentTarget.value;
@@ -625,7 +625,7 @@ function DeleteConfirm({ paths, onConfirm, onCancel }: { paths: string[]; onConf
 					<button className="rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text)] hover:bg-[var(--inno-surface-muted)]" onClick={onCancel}>
 						{t("common.cancel", "Cancel")}
 					</button>
-					<button className="rounded-md bg-red-500 px-3 py-1.5 text-xs text-white hover:bg-red-600" onClick={onConfirm}>
+					<button className="rounded-md bg-[var(--inno-danger)] px-3 py-1.5 text-xs text-white hover:bg-[var(--inno-danger)]" onClick={onConfirm}>
 						{t("common.delete", "Delete")}
 					</button>
 				</div>
@@ -834,7 +834,7 @@ export function WorkspaceBrowser() {
 		<div ref={rootRef} className={`grid h-full min-h-0 gap-3 bg-transparent p-3 transition-[grid-template-columns] duration-200 ${showContent ? (sidebarOpen ? "grid-cols-[260px_minmax(0,1fr)]" : "grid-cols-[0px_minmax(0,1fr)]") : "grid-cols-[minmax(0,1fr)]"}`}>
 			{/* --- Tree pane --- */}
 			<aside
-				className={`inno-workspace-card relative flex min-h-0 flex-col overflow-hidden rounded-lg transition-opacity duration-200 ${isDragOver ? "border-blue-400 bg-[var(--inno-accent-soft)]" : ""} ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
+				className={`inno-workspace-card relative flex min-h-0 flex-col overflow-hidden rounded-lg transition-opacity duration-200 ${isDragOver ? "border-[var(--inno-accent)] bg-[var(--inno-accent-soft)]" : ""} ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
 				onDragOver={handleDragOver}
 				onDragLeave={handleDragLeave}
 				onDrop={handleDrop}
@@ -846,10 +846,10 @@ export function WorkspaceBrowser() {
 							{activeWorkspaceName || "工作区"}
 						</span>
 					</div>
-					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] transition-colors hover:bg-violet-100 hover:text-violet-600 disabled:opacity-40" title={t("files.uploadSkill", "上传技能包 (.zip/.md) 到 .skills")} onClick={() => skillUploadRef.current?.click()}>
+					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-accent)] disabled:opacity-40" title={t("files.uploadSkill", "上传技能包 (.zip/.md) 到 .skills")} onClick={() => skillUploadRef.current?.click()}>
 						<Sparkles size={13} />
 					</button>
-					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] transition-colors hover:bg-slate-200 hover:text-[var(--inno-text)] disabled:opacity-40" title={t("preview.refresh", "Refresh")} onClick={() => void workspaceStore.loadTree()}>
+					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-40" title={t("preview.refresh", "Refresh")} onClick={() => void workspaceStore.loadTree()}>
 						<RefreshCw size={13} />
 					</button>
 					<input ref={skillUploadRef} type="file" multiple accept=".zip,application/zip,.md,text/markdown" className="hidden" onChange={handleSkillUploadChange} />

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -338,7 +338,7 @@ function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: bo
 					className="mt-2 flex items-center gap-1.5 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]"
 					onClick={() => workspaceStore.openAsText()}
 				>
-					<FileCode2 size={13} />
+					<FileCode2 size={14} />
 					{t("preview.openAsText", "Open as Text")}
 				</button>
 			</div>
@@ -467,7 +467,7 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 						onClick={onToggleSidebar}
 						title={sidebarOpen ? t("common.collapseSidebar", "Collapse sidebar") : t("common.expandSidebar", "Expand sidebar")}
 					>
-						{sidebarOpen ? <PanelLeftClose size={15} /> : <PanelLeftOpen size={15} />}
+						{sidebarOpen ? <PanelLeftClose size={16} /> : <PanelLeftOpen size={16} />}
 					</button>
 					<div className="min-w-0">
 						<div className="truncate text-sm font-medium">{state.file?.name ?? t("preview.noFile", "No file selected")}</div>
@@ -847,10 +847,10 @@ export function WorkspaceBrowser() {
 						</span>
 					</div>
 					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-accent)] disabled:opacity-40" title={t("files.uploadSkill", "上传技能包 (.zip/.md) 到 .skills")} onClick={() => skillUploadRef.current?.click()}>
-						<Sparkles size={13} />
+						<Sparkles size={14} />
 					</button>
 					<button disabled={busy} className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-40" title={t("preview.refresh", "Refresh")} onClick={() => void workspaceStore.loadTree()}>
-						<RefreshCw size={13} />
+						<RefreshCw size={14} />
 					</button>
 					<input ref={skillUploadRef} type="file" multiple accept=".zip,application/zip,.md,text/markdown" className="hidden" onChange={handleSkillUploadChange} />
 				</div>

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -126,7 +126,7 @@ export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChan
 						return (
 							<button
 								key={tab}
-								className={`inno-workspace-tab flex h-7 shrink-0 items-center gap-1 whitespace-nowrap rounded-md transition-colors ${compact ? "w-7 justify-center px-0" : "px-2"} ${isActive ? "bg-[var(--inno-surface)] font-medium text-[var(--inno-accent)] shadow-sm ring-1 ring-[var(--inno-border)]" : "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
+								className={`inno-workspace-tab flex h-7 shrink-0 items-center gap-1 whitespace-nowrap rounded-md transition-colors ${compact ? "w-7 justify-center px-0" : "px-2"} ${isActive ? "bg-[var(--inno-surface)] font-medium text-[var(--inno-accent)] shadow-sm" : "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
 								title={compact ? label : undefined}
 								aria-label={compact ? label : undefined}
 								onClick={() => onTabChange(tab)}

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -126,7 +126,7 @@ export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChan
 						return (
 							<button
 								key={tab}
-								className={`inno-workspace-tab flex h-7 shrink-0 items-center gap-1 whitespace-nowrap rounded-md transition-colors ${compact ? "w-7 justify-center px-0" : "px-2"} ${isActive ? "bg-[var(--inno-surface)] font-medium text-[var(--inno-accent)] shadow-sm ring-1 ring-slate-200" : "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
+								className={`inno-workspace-tab flex h-7 shrink-0 items-center gap-1 whitespace-nowrap rounded-md transition-colors ${compact ? "w-7 justify-center px-0" : "px-2"} ${isActive ? "bg-[var(--inno-surface)] font-medium text-[var(--inno-accent)] shadow-sm ring-1 ring-[var(--inno-border)]" : "text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
 								title={compact ? label : undefined}
 								aria-label={compact ? label : undefined}
 								onClick={() => onTabChange(tab)}

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -24,12 +24,12 @@ interface WorkspacePanelProps {
 const TAB_ORDER: RightPanelTab[] = ["preview", "notebook", "profile", "jobs", "skills", "settings"];
 
 const TAB_ICONS: Record<RightPanelTab, React.ReactNode> = {
-	notebook: <BookOpen size={13} />,
-	preview: <FolderKanban size={13} />,
-	profile: <UserRound size={13} />,
-	jobs: <BriefcaseBusiness size={13} />,
-	skills: <Sparkles size={13} />,
-	settings: <Settings size={13} />,
+	notebook: <BookOpen size={14} />,
+	preview: <FolderKanban size={14} />,
+	profile: <UserRound size={14} />,
+	jobs: <BriefcaseBusiness size={14} />,
+	skills: <Sparkles size={14} />,
+	settings: <Settings size={14} />,
 };
 
 function WorkspaceContent({ activeTab }: { activeTab: RightPanelTab }) {

--- a/apps/inno-agent/web/src/react/jobs/ScheduleEditor.tsx
+++ b/apps/inno-agent/web/src/react/jobs/ScheduleEditor.tsx
@@ -29,7 +29,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 				<label className="block text-sm">
 					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.frequency")}</span>
 					<select
-						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 						value={value.frequency}
 						onChange={(e) => patch({ frequency: e.target.value as Frequency })}
 					>
@@ -45,7 +45,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 						<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.time")}</span>
 						<input
 							type="time"
-							className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+							className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 							value={timeStr}
 							onChange={(e) => {
 								const [h, m] = e.target.value.split(":").map(Number);
@@ -66,7 +66,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 								<button
 									type="button"
 									key={d}
-									className={`rounded-full px-3 py-1 text-xs transition-colors ${ active ? "inno-primary-button" : "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-slate-200 hover:bg-[var(--inno-surface-muted)]" }`}
+									className={`rounded-full px-3 py-1 text-xs transition-colors ${ active ? "inno-primary-button" : "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)] hover:bg-[var(--inno-surface-muted)]" }`}
 									onClick={() => {
 										const next = active
 											? value.weekdays.filter((x) => x !== d)
@@ -86,7 +86,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 				<label className="block text-sm">
 					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.dayOfMonth")}</span>
 					<select
-						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 						value={String(value.day)}
 						onChange={(e) => patch({ day: Number(e.target.value) })}
 					>
@@ -105,7 +105,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.onceDate")}</span>
 					<input
 						type="date"
-						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 						value={value.date}
 						onChange={(e) => patch({ date: e.target.value })}
 					/>
@@ -116,7 +116,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 				<label className="block text-sm">
 					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("jobs.form.customCron")}</span>
 					<input
-						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 font-mono text-sm focus:border-blue-300 focus:outline-none focus:ring-2 focus:ring-blue-100"
+						className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 font-mono text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
 						placeholder={t("jobs.form.cronPlaceholder") ?? ""}
 						value={value.cron}
 						onChange={(e) => patch({ cron: e.target.value })}
@@ -125,7 +125,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 				</label>
 			) : null}
 
-			{error ? <div className="text-xs text-red-600">{error}</div> : null}
+			{error ? <div className="text-xs text-[var(--inno-danger)]">{error}</div> : null}
 		</div>
 	);
 }

--- a/apps/inno-agent/web/src/react/jobs/ScheduleEditor.tsx
+++ b/apps/inno-agent/web/src/react/jobs/ScheduleEditor.tsx
@@ -66,7 +66,7 @@ export function ScheduleEditor({ value, onChange, error }: ScheduleEditorProps) 
 								<button
 									type="button"
 									key={d}
-									className={`rounded-full px-3 py-1 text-xs transition-colors ${ active ? "inno-primary-button" : "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)] hover:bg-[var(--inno-surface-muted)]" }`}
+									className={`rounded-full px-3 py-1 text-xs transition-colors ${ active ? "inno-primary-button" : "bg-[var(--inno-surface)] text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]" }`}
 									onClick={() => {
 										const next = active
 											? value.weekdays.filter((x) => x !== d)

--- a/apps/inno-agent/web/src/react/notebook/GraphView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/GraphView.tsx
@@ -343,7 +343,7 @@ export function GraphView() {
 					<RefreshCw size={13} />
 					<span className="hidden @[680px]:inline">{t("notebook.graph.refresh")}</span>
 				</button>
-				<div className="mx-1 h-4 w-px bg-slate-200" />
+				<div className="mx-1 h-4 w-px bg-[var(--inno-surface-muted)]" />
 				<span className="text-[var(--inno-text-subtle)]">{t("notebook.graph.show")}</span>
 				{ALL_CATEGORIES.map((cat) => {
 					const active = visibleCategories.has(cat);

--- a/apps/inno-agent/web/src/react/notebook/GraphView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/GraphView.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Scan, Shuffle, RefreshCw } from "lucide-react";
+import { Spinner } from "../ui/Spinner.js";
 import cytoscape, { type Core, type ElementDefinition } from "cytoscape";
 // @ts-expect-error - cytoscape-cola has no public types
 import cola from "cytoscape-cola";
@@ -332,15 +333,15 @@ export function GraphView() {
 		<div className="relative flex h-full min-h-0 flex-col">
 			<div className="@container flex items-center gap-2 border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
 				<button className="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={fit} title={t("notebook.graph.fit")}>
-					<Scan size={13} />
+					<Scan size={14} />
 					<span className="hidden @[680px]:inline">{t("notebook.graph.fit")}</span>
 				</button>
 				<button className="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={reLayout} title={t("notebook.graph.relayout")}>
-					<Shuffle size={13} />
+					<Shuffle size={14} />
 					<span className="hidden @[680px]:inline">{t("notebook.graph.relayout")}</span>
 				</button>
 				<button className="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void notebookStore.loadGraph()} title={t("notebook.graph.refresh")}>
-					<RefreshCw size={13} />
+					<RefreshCw size={14} />
 					<span className="hidden @[680px]:inline">{t("notebook.graph.refresh")}</span>
 				</button>
 				<div className="mx-1 h-4 w-px bg-[var(--inno-surface-muted)]" />
@@ -399,7 +400,7 @@ export function GraphView() {
 			</div>
 			{state.isLoading ? (
 				<div className="absolute inset-0 flex items-center justify-center bg-white/40 text-sm text-[var(--inno-text-muted)]">
-					<span className="mr-2 inline-block h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" />
+					<Spinner size={16} className="mr-2" />
 					{t("common.loading")}
 				</div>
 			) : null}

--- a/apps/inno-agent/web/src/react/notebook/PageView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/PageView.tsx
@@ -12,9 +12,9 @@ import "@uiw/react-markdown-preview/markdown.css";
 function typeColor(type?: WikiPageType): string {
 	switch (type) {
 		case "source-summary":
-			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-blue-100";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]";
 		case "entity":
-			return "bg-green-50 text-green-700 ring-1 ring-green-100";
+			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]";
 		case "concept":
 			return "bg-orange-50 text-orange-700 ring-1 ring-orange-100";
 		case "analysis":
@@ -28,13 +28,13 @@ function FrontmatterHeader({ frontmatter }: { frontmatter: WikiPageFrontmatter }
 	const { t } = useTranslation();
 	const statusColors: Record<string, string> = {
 		draft: "bg-yellow-50 text-yellow-700 ring-1 ring-yellow-100",
-		reviewed: "bg-green-50 text-green-700 ring-1 ring-green-100",
-		outdated: "bg-red-50 text-red-700 ring-1 ring-red-100",
+		reviewed: "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]",
+		outdated: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)] ring-1 ring-[var(--inno-danger-border)]",
 	};
 	const confidenceColors: Record<string, string> = {
-		low: "bg-red-50 text-red-700 ring-1 ring-red-100",
+		low: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)] ring-1 ring-[var(--inno-danger-border)]",
 		medium: "bg-yellow-50 text-yellow-700 ring-1 ring-yellow-100",
-		high: "bg-green-50 text-green-700 ring-1 ring-green-100",
+		high: "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]",
 	};
 
 	return (
@@ -44,13 +44,13 @@ function FrontmatterHeader({ frontmatter }: { frontmatter: WikiPageFrontmatter }
 				<span className={`rounded px-1.5 py-0.5 ${typeColor(frontmatter.type)}`}>{t(`notebook.types.${frontmatter.type}`)}</span>
 				<span className={`rounded px-1.5 py-0.5 ${statusColors[frontmatter.status] ?? ""}`}>{t(`notebook.status.${frontmatter.status}`)}</span>
 				<span className={`rounded px-1.5 py-0.5 ${confidenceColors[frontmatter.confidence] ?? ""}`}>{t(`notebook.confidence.${frontmatter.confidence}`)}</span>
-				{frontmatter.contested ? <span className="rounded bg-red-50 px-1.5 py-0.5 text-red-700 ring-1 ring-red-100">{t("notebook.contested")}</span> : null}
+				{frontmatter.contested ? <span className="rounded bg-[var(--inno-danger-bg)] px-1.5 py-0.5 text-[var(--inno-danger)] ring-1 ring-[var(--inno-danger-border)]">{t("notebook.contested")}</span> : null}
 				<span className="text-[var(--inno-text-muted)]">{frontmatter.updated}</span>
 			</div>
 			{frontmatter.tags.length > 0 ? (
 				<div className="mt-2 flex flex-wrap gap-1">
 					{frontmatter.tags.map((tag) => (
-						<span key={tag} className="rounded-full bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-xs text-[var(--inno-accent)] ring-1 ring-blue-100">
+						<span key={tag} className="rounded-full bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-xs text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]">
 							#{tag}
 						</span>
 					))}
@@ -99,7 +99,7 @@ export function PageView() {
 					<button className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white" onClick={() => void notebookStore.savePage()}>
 						{t("common.save")}
 					</button>
-					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={() => notebookStore.cancelEditing()}>
+					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => notebookStore.cancelEditing()}>
 						{t("common.cancel")}
 					</button>
 				</div>
@@ -117,7 +117,7 @@ export function PageView() {
 				<button className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white" onClick={() => notebookStore.startEditing()}>
 					{t("common.edit")}
 				</button>
-				<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-slate-200 hover:text-[var(--inno-text)]" onClick={() => notebookStore.setView("graph")}>
+				<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => notebookStore.setView("graph")}>
 					{t("notebook.page.backToGraph")}
 				</button>
 			</div>

--- a/apps/inno-agent/web/src/react/notebook/PageView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/PageView.tsx
@@ -13,13 +13,13 @@ import "@uiw/react-markdown-preview/markdown.css";
 function typeColor(type?: WikiPageType): string {
 	switch (type) {
 		case "source-summary":
-			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]";
 		case "entity":
-			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]";
+			return "bg-[var(--inno-success-bg)] text-[var(--inno-success)]";
 		case "concept":
-			return "bg-orange-50 text-orange-700 ring-1 ring-orange-100";
+			return "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)]";
 		case "analysis":
-			return "bg-purple-50 text-purple-700 ring-1 ring-purple-100";
+			return "bg-[var(--inno-accent-soft)] text-[var(--inno-accent)]";
 		default:
 			return "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]";
 	}
@@ -28,14 +28,14 @@ function typeColor(type?: WikiPageType): string {
 function FrontmatterHeader({ frontmatter }: { frontmatter: WikiPageFrontmatter }) {
 	const { t } = useTranslation();
 	const statusColors: Record<string, string> = {
-		draft: "bg-yellow-50 text-yellow-700 ring-1 ring-yellow-100",
-		reviewed: "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]",
-		outdated: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)] ring-1 ring-[var(--inno-danger-border)]",
+		draft: "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)]",
+		reviewed: "bg-[var(--inno-success-bg)] text-[var(--inno-success)]",
+		outdated: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)]",
 	};
 	const confidenceColors: Record<string, string> = {
-		low: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)] ring-1 ring-[var(--inno-danger-border)]",
-		medium: "bg-yellow-50 text-yellow-700 ring-1 ring-yellow-100",
-		high: "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]",
+		low: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)]",
+		medium: "bg-[var(--inno-warning-bg)] text-[var(--inno-warning)]",
+		high: "bg-[var(--inno-success-bg)] text-[var(--inno-success)]",
 	};
 
 	return (
@@ -45,13 +45,13 @@ function FrontmatterHeader({ frontmatter }: { frontmatter: WikiPageFrontmatter }
 				<span className={`rounded px-1.5 py-0.5 ${typeColor(frontmatter.type)}`}>{t(`notebook.types.${frontmatter.type}`)}</span>
 				<span className={`rounded px-1.5 py-0.5 ${statusColors[frontmatter.status] ?? ""}`}>{t(`notebook.status.${frontmatter.status}`)}</span>
 				<span className={`rounded px-1.5 py-0.5 ${confidenceColors[frontmatter.confidence] ?? ""}`}>{t(`notebook.confidence.${frontmatter.confidence}`)}</span>
-				{frontmatter.contested ? <span className="rounded bg-[var(--inno-danger-bg)] px-1.5 py-0.5 text-[var(--inno-danger)] ring-1 ring-[var(--inno-danger-border)]">{t("notebook.contested")}</span> : null}
+				{frontmatter.contested ? <span className="rounded bg-[var(--inno-danger-bg)] px-1.5 py-0.5 text-[var(--inno-danger)]">{t("notebook.contested")}</span> : null}
 				<span className="text-[var(--inno-text-muted)]">{frontmatter.updated}</span>
 			</div>
 			{frontmatter.tags.length > 0 ? (
 				<div className="mt-2 flex flex-wrap gap-1">
 					{frontmatter.tags.map((tag) => (
-						<span key={tag} className="rounded-full bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-xs text-[var(--inno-accent)] ring-1 ring-[var(--inno-accent-soft)]">
+						<span key={tag} className="rounded-full bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-xs text-[var(--inno-accent)]">
 							#{tag}
 						</span>
 					))}

--- a/apps/inno-agent/web/src/react/notebook/PageView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/PageView.tsx
@@ -6,6 +6,7 @@ import { parseFrontmatter } from "../../utils/frontmatter.js";
 import { normalizeMarkdownMath } from "../../utils/markdown-math.js";
 import { useStoreSnapshot } from "../hooks.js";
 import "@earendil-works/pi-web-ui";
+import { Spinner } from "../ui/Spinner.js";
 import "@uiw/react-md-editor/markdown-editor.css";
 import "@uiw/react-markdown-preview/markdown.css";
 
@@ -73,7 +74,7 @@ export function PageView() {
 	if (state.isLoading) {
 		return (
 			<div className="flex h-full items-center justify-center text-[var(--inno-text-muted)]">
-				<span className="inline-block h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
+				<Spinner size={20} />
 			</div>
 		);
 	}

--- a/apps/inno-agent/web/src/react/office/DocxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/DocxPreview.tsx
@@ -72,7 +72,7 @@ export default function DocxPreview({ file }: { file: WorkspaceFileDetail }) {
 			{error ? (
 				<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[var(--inno-text-muted)]">
 					<div className="font-medium text-[var(--inno-text)]">{file.name}</div>
-					<div className="text-xs text-red-500">{error}</div>
+					<div className="text-xs text-[var(--inno-danger)]">{error}</div>
 					<button
 						className="flex items-center gap-1 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)]"
 						onClick={downloadOriginal}

--- a/apps/inno-agent/web/src/react/office/PptxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/PptxPreview.tsx
@@ -60,7 +60,7 @@ export default function PptxPreview({ file }: { file: WorkspaceFileDetail }) {
 		return (
 			<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[var(--inno-text-muted)]">
 				<div className="font-medium text-[var(--inno-text)]">{file.name}</div>
-				<div className="text-xs text-red-500">{error}</div>
+				<div className="text-xs text-[var(--inno-danger)]">{error}</div>
 				<button className="flex items-center gap-1 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)]" onClick={downloadOriginal}>
 					<Download size={12} />
 					{t("files.download", "Download")}

--- a/apps/inno-agent/web/src/react/office/PptxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/PptxPreview.tsx
@@ -1,8 +1,9 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Download, Loader2 } from "lucide-react";
+import { Download } from "lucide-react";
 import type { PptxPreviewResult, PptxSlide, WorkspaceFileDetail } from "../../types/workspace.js";
 import { triggerDownload } from "../../api/workspace.js";
+import { Spinner } from "../ui/Spinner.js";
 
 /**
  * Render a .pptx as a vertical stack of slide SVGs, produced by the backend
@@ -51,7 +52,7 @@ export default function PptxPreview({ file }: { file: WorkspaceFileDetail }) {
 	if (loading) {
 		return (
 			<div className="flex h-full items-center justify-center gap-2 text-sm text-[var(--inno-text-muted)]">
-				<Loader2 size={16} className="animate-spin" />
+				<Spinner size={16} />
 				{t("preview.pptxLoading", "Rendering slides...")}
 			</div>
 		);

--- a/apps/inno-agent/web/src/react/office/XlsxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/XlsxPreview.tsx
@@ -100,7 +100,7 @@ export default function XlsxPreview({ file }: { file: WorkspaceFileDetail }) {
 		return (
 			<div className="flex h-full flex-col items-center justify-center gap-3 p-6 text-center text-sm text-[var(--inno-text-muted)]">
 				<div className="font-medium text-[var(--inno-text)]">{file.name}</div>
-				<div className="text-xs text-red-500">{error}</div>
+				<div className="text-xs text-[var(--inno-danger)]">{error}</div>
 				<button className="flex items-center gap-1 rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface)]" onClick={downloadOriginal}>
 					<Download size={12} />
 					{t("files.download", "Download")}
@@ -125,7 +125,7 @@ export default function XlsxPreview({ file }: { file: WorkspaceFileDetail }) {
 				</div>
 			) : null}
 			{truncated ? (
-				<div className="shrink-0 bg-amber-500/10 px-3 py-1 text-[11px] text-amber-600">
+				<div className="shrink-0 bg-[var(--inno-warning-bg)] px-3 py-1 text-[11px] text-[var(--inno-warning)]">
 					{t("preview.xlsxLargeSheetWarning", "Large sheet — showing first {{n}} rows", { n: MAX_ROWS })}
 				</div>
 			) : null}

--- a/apps/inno-agent/web/src/react/terminal/RunButton.tsx
+++ b/apps/inno-agent/web/src/react/terminal/RunButton.tsx
@@ -32,7 +32,7 @@ export function RunButton({ filePath, className }: RunButtonProps) {
 			onClick={handleClick}
 			className={
 				className ??
-				"flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 text-xs font-medium text-[var(--inno-text)] transition-colors hover:border-emerald-200 hover:bg-emerald-50 hover:text-emerald-700"
+				"flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 text-xs font-medium text-[var(--inno-text)] transition-colors hover:border-[var(--inno-success-border)] hover:bg-[var(--inno-success-bg)] hover:text-[var(--inno-success)]"
 			}
 			title={`Run: ${command}`}
 		>

--- a/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
+++ b/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
@@ -10,9 +10,9 @@ interface RunsPanelProps {
 }
 
 function statusBadge(code: number | null | undefined): { text: string; cls: string } {
-	if (code === null || code === undefined) return { text: "未完成", cls: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] ring-1 ring-slate-200" };
-	if (code === 0) return { text: "✓ 0", cls: "bg-emerald-50 text-emerald-700 ring-1 ring-emerald-100" };
-	return { text: `✗ ${code}`, cls: "bg-red-50 text-red-700 ring-1 ring-red-100" };
+	if (code === null || code === undefined) return { text: "未完成", cls: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)]" };
+	if (code === 0) return { text: "✓ 0", cls: "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]" };
+	return { text: `✗ ${code}`, cls: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)] ring-1 ring-[var(--inno-danger-border)]" };
 }
 
 function formatDuration(start: string, end?: string): string {
@@ -112,7 +112,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 							<button
 								key={r.id}
 								onClick={() => setSelectedId(r.id)}
-								className={`flex w-full items-start gap-2 border-b border-[var(--inno-border)] px-2 py-1.5 text-left text-[11px] transition-colors ${selected ? "bg-[var(--inno-surface)] ring-1 ring-inset ring-slate-200" : "hover:bg-[var(--inno-surface)]"}`}
+								className={`flex w-full items-start gap-2 border-b border-[var(--inno-border)] px-2 py-1.5 text-left text-[11px] transition-colors ${selected ? "bg-[var(--inno-surface)] ring-1 ring-inset ring-[var(--inno-border)]" : "hover:bg-[var(--inno-surface)]"}`}
 							>
 								<span className={`shrink-0 rounded px-1 py-0.5 font-mono ${badge.cls}`}>{badge.text}</span>
 								<div className="min-w-0 flex-1">
@@ -147,7 +147,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 								</button>
 								{archiveMsg ? <span className="text-[10px] text-[var(--inno-text-muted)]">{archiveMsg}</span> : null}
 							</div>
-							<pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words bg-[#0f172a] p-3 font-mono text-[11px] leading-snug text-slate-100">
+							<pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap break-words bg-[#0f172a] p-3 font-mono text-[11px] leading-snug text-[var(--inno-text-muted)]">
 								{detail.outputTail || "(无输出)"}
 							</pre>
 						</>
@@ -156,7 +156,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 					)}
 				</div>
 			</div>
-			{error ? <div className="border-t border-red-200 bg-red-50 p-2 text-[11px] text-red-700">{error}</div> : null}
+			{error ? <div className="border-t border-[var(--inno-danger-border)] bg-[var(--inno-danger-bg)] p-2 text-[11px] text-[var(--inno-danger)]">{error}</div> : null}
 		</div>
 	);
 }

--- a/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
+++ b/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
@@ -10,9 +10,9 @@ interface RunsPanelProps {
 }
 
 function statusBadge(code: number | null | undefined): { text: string; cls: string } {
-	if (code === null || code === undefined) return { text: "未完成", cls: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border)]" };
-	if (code === 0) return { text: "✓ 0", cls: "bg-[var(--inno-success-bg)] text-[var(--inno-success)] ring-1 ring-[var(--inno-success-border)]" };
-	return { text: `✗ ${code}`, cls: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)] ring-1 ring-[var(--inno-danger-border)]" };
+	if (code === null || code === undefined) return { text: "未完成", cls: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]" };
+	if (code === 0) return { text: "✓ 0", cls: "bg-[var(--inno-success-bg)] text-[var(--inno-success)]" };
+	return { text: `✗ ${code}`, cls: "bg-[var(--inno-danger-bg)] text-[var(--inno-danger)]" };
 }
 
 function formatDuration(start: string, end?: string): string {
@@ -99,7 +99,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 				</button>
 			</div>
 
-			<div className="grid min-h-0 flex-1 grid-cols-[220px_minmax(0,1fr)] divide-x divide-slate-200">
+			<div className="grid min-h-0 flex-1 grid-cols-[220px_minmax(0,1fr)] divide-x divide-[var(--inno-border)]">
 				{/* List */}
 				<div className="min-h-0 overflow-y-auto bg-[var(--inno-workspace-bg)]">
 					{runs.length === 0 && !loading ? (
@@ -112,7 +112,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 							<button
 								key={r.id}
 								onClick={() => setSelectedId(r.id)}
-								className={`flex w-full items-start gap-2 border-b border-[var(--inno-border)] px-2 py-1.5 text-left text-[11px] transition-colors ${selected ? "bg-[var(--inno-surface)] ring-1 ring-inset ring-[var(--inno-border)]" : "hover:bg-[var(--inno-surface)]"}`}
+								className={`flex w-full items-start gap-2 px-2 py-1.5 text-left text-[11px] transition-colors ${selected ? "bg-[var(--inno-surface)] ring-1 ring-inset ring-[var(--inno-border)]" : "hover:bg-[var(--inno-surface)]"}`}
 							>
 								<span className={`shrink-0 rounded px-1 py-0.5 font-mono ${badge.cls}`}>{badge.text}</span>
 								<div className="min-w-0 flex-1">

--- a/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
+++ b/apps/inno-agent/web/src/react/terminal/RunsPanel.tsx
@@ -119,7 +119,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 									<div className="truncate font-mono text-[var(--inno-text)]" title={r.command}>{r.command}</div>
 									<div className="truncate text-[10px] text-[var(--inno-text-subtle)]">{formatTime(r.startedAt)} · {formatDuration(r.startedAt, r.endedAt)}{r.sourceFile ? ` · ${r.sourceFile}` : ""}</div>
 								</div>
-								<ChevronRight size={10} className="mt-0.5 shrink-0 text-[var(--inno-text-subtle)]" />
+								<ChevronRight size={12} className="mt-0.5 shrink-0 text-[var(--inno-text-subtle)]" />
 							</button>
 						);
 					})}
@@ -142,7 +142,7 @@ export function RunsPanel({ sessionId, onClose }: RunsPanelProps) {
 									disabled={archiveBusy}
 									className="flex h-6 items-center gap-1 rounded-md inno-primary-button px-2 text-[11px] font-medium text-white transition-colors disabled:opacity-50"
 								>
-									<Archive size={11} />
+									<Archive size={12} />
 									{archiveBusy ? "归档中…" : "归档为笔记"}
 								</button>
 								{archiveMsg ? <span className="text-[10px] text-[var(--inno-text-muted)]">{archiveMsg}</span> : null}

--- a/apps/inno-agent/web/src/react/terminal/TerminalDrawer.tsx
+++ b/apps/inno-agent/web/src/react/terminal/TerminalDrawer.tsx
@@ -86,7 +86,7 @@ export function TerminalDrawer() {
 						<>
 							<button
 								onClick={toggleHistory}
-								className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${showHistory ? "bg-[var(--inno-surface)] text-[var(--inno-text)] ring-1 ring-[var(--inno-border)]" : "text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
+								className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${showHistory ? "bg-[var(--inno-surface)] text-[var(--inno-text)]" : "text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
 								title="历史"
 							>
 								<History size={12} />

--- a/apps/inno-agent/web/src/react/terminal/TerminalDrawer.tsx
+++ b/apps/inno-agent/web/src/react/terminal/TerminalDrawer.tsx
@@ -17,12 +17,12 @@ const STATUS_LABEL: Record<TerminalStatus, string> = {
 };
 
 const STATUS_DOT: Record<TerminalStatus, string> = {
-	idle: "bg-slate-300",
-	connecting: "bg-amber-400 animate-pulse",
-	connected: "bg-emerald-500",
-	running: "bg-blue-500 animate-pulse",
-	disconnected: "bg-slate-300",
-	error: "bg-red-500",
+	idle: "bg-[var(--inno-border-strong)]",
+	connecting: "bg-[var(--inno-warning)] animate-pulse",
+	connected: "bg-[var(--inno-success)]",
+	running: "bg-[var(--inno-accent)] animate-pulse",
+	disconnected: "bg-[var(--inno-border-strong)]",
+	error: "bg-[var(--inno-danger)]",
 };
 
 /**
@@ -80,13 +80,13 @@ export function TerminalDrawer() {
 					aria-label={STATUS_LABEL[term.status]}
 				/>
 				{term.cwd ? <span className="truncate text-[11px] text-[var(--inno-text-subtle)]" title={term.cwd}>{term.cwd}</span> : null}
-				{term.error ? <span className="text-[11px] text-red-600">{term.error}</span> : null}
+				{term.error ? <span className="text-[11px] text-[var(--inno-danger)]">{term.error}</span> : null}
 				<div className="ml-auto flex items-center gap-1">
 					{term.isOpen && sess.currentSessionId ? (
 						<>
 							<button
 								onClick={toggleHistory}
-								className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${showHistory ? "bg-[var(--inno-surface)] text-[var(--inno-text)] ring-1 ring-slate-200" : "text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
+								className={`flex h-6 w-6 items-center justify-center rounded-md transition-colors ${showHistory ? "bg-[var(--inno-surface)] text-[var(--inno-text)] ring-1 ring-[var(--inno-border)]" : "text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"}`}
 								title="历史"
 							>
 								<History size={12} />

--- a/apps/inno-agent/web/src/react/ui/Spinner.tsx
+++ b/apps/inno-agent/web/src/react/ui/Spinner.tsx
@@ -1,0 +1,19 @@
+interface SpinnerProps {
+	size?: number;
+	className?: string;
+}
+
+/**
+ * Border-pattern spinner (the majority pattern across the codebase, 12:1 over
+ * Loader2). Color follows `currentColor` so it inherits text color. The
+ * `border-t-transparent` creates the spinning-gap effect.
+ */
+export function Spinner({ size = 14, className = "" }: SpinnerProps) {
+	return (
+		<span
+			aria-hidden="true"
+			className={`inline-block animate-spin rounded-full border-2 border-current border-t-transparent ${className}`}
+			style={{ width: size, height: size }}
+		/>
+	);
+}

--- a/apps/inno-agent/web/src/react/ui/Switch.tsx
+++ b/apps/inno-agent/web/src/react/ui/Switch.tsx
@@ -8,7 +8,7 @@ interface SwitchProps {
 
 /**
  * Controlled toggle switch. Routes through --inno-* theme vars so all 4 themes
- * render correctly (the old inline version hardcoded bg-slate-300 for OFF).
+ * render correctly (the old inline version used a hardcoded slate color for OFF).
  * Press feedback uses scale(0.97) + custom ease-out per Emil's principles.
  */
 export function Switch({ checked, onChange, disabled, "aria-label": ariaLabel, className = "" }: SwitchProps) {

--- a/apps/inno-agent/web/src/react/ui/Switch.tsx
+++ b/apps/inno-agent/web/src/react/ui/Switch.tsx
@@ -1,0 +1,34 @@
+interface SwitchProps {
+	checked: boolean;
+	onChange: (value: boolean) => void;
+	disabled?: boolean;
+	"aria-label"?: string;
+	className?: string;
+}
+
+/**
+ * Controlled toggle switch. Routes through --inno-* theme vars so all 4 themes
+ * render correctly (the old inline version hardcoded bg-slate-300 for OFF).
+ * Press feedback uses scale(0.97) + custom ease-out per Emil's principles.
+ */
+export function Switch({ checked, onChange, disabled, "aria-label": ariaLabel, className = "" }: SwitchProps) {
+	return (
+		<button
+			type="button"
+			role="switch"
+			aria-checked={checked}
+			aria-label={ariaLabel}
+			disabled={disabled}
+			onClick={() => onChange(!checked)}
+			className={`relative inline-flex h-5 w-9 flex-shrink-0 items-center rounded-full transition-colors disabled:cursor-not-allowed disabled:opacity-50 active:scale-[0.97] ${
+				checked ? "bg-[var(--inno-accent)]" : "bg-[var(--inno-border-strong)]"
+			} ${className}`}
+			style={{ transitionTimingFunction: "var(--inno-ease-out)", transitionDuration: "var(--inno-dur-ui)" }}
+		>
+			<span
+				className={`inline-block h-3.5 w-3.5 transform rounded-full bg-[var(--inno-surface)] transition-transform ${checked ? "translate-x-[18px]" : "translate-x-1"}`}
+				style={{ transitionTimingFunction: "var(--inno-ease-out)", transitionDuration: "var(--inno-dur-ui)" }}
+			/>
+		</button>
+	);
+}

--- a/apps/inno-agent/web/src/react/ui/checkbox.ts
+++ b/apps/inno-agent/web/src/react/ui/checkbox.ts
@@ -1,0 +1,7 @@
+/**
+ * Shared native checkbox className. Uses `accent-[var(--inno-accent)]` so the
+ * check mark follows the active theme's accent color instead of the browser
+ * default blue.
+ */
+export const checkboxCls =
+	"h-3.5 w-3.5 rounded-[3px] border border-[var(--inno-border-strong)] bg-[var(--inno-surface)] accent-[var(--inno-accent)] cursor-pointer";

--- a/apps/inno-agent/web/src/react/ui/input.ts
+++ b/apps/inno-agent/web/src/react/ui/input.ts
@@ -1,0 +1,12 @@
+/**
+ * Shared input className — routes border/bg/text/focus through --inno-* theme
+ * vars so inputs render correctly under all 4 themes. Focus ring uses
+ * --inno-ring (a box-shadow) via `shadow-` not `ring-`, and `focus-visible:`
+ * so it doesn't fire on mouse click.
+ */
+export const inputCls =
+	"h-8 w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] transition-colors focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]";
+
+/** Textarea variant — same base, grows vertically. */
+export const textareaCls =
+	"w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1.5 text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] transition-colors focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]";


### PR DESCRIPTION
## Summary

- **Phase 1–4**: Route all colors through `--inno-*` design tokens (app.css, hardcoded palette colors, spinner/switch/input/checkbox primitives, icon/chevron cleanups). All 4 themes (light/warm/ocean/innospark) render correctly.
- **Phase 5**: Simplify right-side panels by removing redundant borders — nested card borders inside bordered panels, per-row `border-b` separators (→ `divide-y`), `ring-1` on status badges, hardcoded `bg-yellow-50`/`bg-orange-50` → theme tokens. Large card backgrounds use `--inno-surface` (white) instead of `--inno-surface-muted` (gray) to avoid heavy color areas. Low-emphasis outline buttons converted to ghost buttons.

## Changes

| Area | Files | What |
|---|---|---|
| Design tokens | `app.css`, `themes.css` (frozen) | Route colors through `--inno-*` vars, fix InnoSpark overrides |
| Shared primitives | `ui/Switch.tsx`, `ui/Spinner.tsx`, `ui/input.ts`, `ui/checkbox.ts` | Reusable theme-aware components |
| Component sweep | 14 React components | Hardcoded colors → tokens, icon/chevron unification |
| Line simplification | SettingsPanel, LearnerProfilePanel, JobsPanel, SkillsPanel, RunsPanel, PageView, Notebook, etc. | Remove nested borders, redundant rings, ghost buttons |

## Test plan

- [ ] `npm --workspace inno-agent-web run build` passes
- [ ] Settings panel: inner cards use subtle spacing, not heavy gray fills or double borders
- [ ] Learner Profile panel: goals/knowledge/misconceptions cards blend cleanly, status badges have no ring
- [ ] Skills panel: library list rows use `divide-y`, buttons are ghost style
- [ ] Runs panel: `divide-slate-200` fixed to theme var, history rows use `divide-y`
- [ ] Switch through all 4 themes (light/warm/ocean/innospark) — no hardcoded colors leak
- [ ] No visual regression on borders that DO remain (outer panel shells, header separators, input borders)