### PR TITLE
fix(i18n): 补全 zh-CN / en 缺失的 17 个翻译 key

### DIFF
--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -40,7 +40,24 @@
 		"pasteCollapsed": "«Pasted {{count}} lines»",
 		"pasteCollapsedUndo": "Undo paste",
 		"questionPending": "Please answer the question above before continuing",
-		"questionPendingJump": "View question"
+		"questionPendingJump": "View question",
+		"clear": "Clear",
+		"collapseSidebar": "Collapse sidebar",
+		"expandSidebar": "Expand sidebar"
+	},
+	"files": {
+		"newFile": "New File",
+		"newFolder": "New Folder",
+		"newFileHere": "New File Here",
+		"newFolderHere": "New Folder Here",
+		"rename": "Rename",
+		"delete": "Delete",
+		"download": "Download",
+		"downloadFolder": "Download as ZIP",
+		"confirmDelete": "Delete?",
+		"editing": "Editing",
+		"dropToUpload": "Drop files to upload",
+		"uploadSkill": "Upload skill package (.zip/.md) to .skills"
 	},
 	"notebook": {
 		"title": "Notebook",
@@ -356,6 +373,7 @@
 			"wikiStat": "{{count}} pages · {{size}}"
 		},
 		"models": "Models",
+		"editModel": "Edit Model",
 		"current": "Current",
 		"use": "Use",
 		"providers": "Providers",
@@ -399,6 +417,7 @@
 			"clear": "Clear"
 		},
 		"form": {
+			"apiType": "API Type",
 			"providerId": "Provider id",
 			"baseUrl": "Base URL",
 			"apiKey": "API key",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -40,7 +40,24 @@
 		"pasteCollapsed": "«已粘贴 {{count}} 行»",
 		"pasteCollapsedUndo": "撤销粘贴",
 		"questionPending": "请完成上方问卷后再继续对话",
-		"questionPendingJump": "查看问卷"
+		"questionPendingJump": "查看问卷",
+		"clear": "清除",
+		"collapseSidebar": "收起侧栏",
+		"expandSidebar": "展开侧栏"
+	},
+	"files": {
+		"newFile": "新建文件",
+		"newFolder": "新建文件夹",
+		"newFileHere": "在此新建文件",
+		"newFolderHere": "在此新建文件夹",
+		"rename": "重命名",
+		"delete": "删除",
+		"download": "下载",
+		"downloadFolder": "下载为 ZIP",
+		"confirmDelete": "确认删除？",
+		"editing": "编辑中",
+		"dropToUpload": "拖放文件以上传",
+		"uploadSkill": "上传技能包 (.zip/.md) 到 .skills"
 	},
 	"notebook": {
 		"title": "笔记本",
@@ -356,6 +373,7 @@
 			"wikiStat": "{{count}} 篇 · {{size}}"
 		},
 		"models": "模型",
+		"editModel": "编辑模型",
 		"current": "当前",
 		"use": "使用",
 		"providers": "服务提供方",
@@ -399,6 +417,7 @@
 			"clear": "清除"
 		},
 		"form": {
+			"apiType": "API 类型",
 			"providerId": "提供方 ID",
 			"baseUrl": "Base URL",
 			"apiKey": "API Key",


### PR DESCRIPTION
  ## 问题描述

  `WorkspaceBrowser.tsx` / `SkillsPanel.tsx` / `SettingsPanel.tsx` / `Notebook.tsx` 中有 17 处 `t("key", "English
  fallback")` 调用引用的 key，在两个 locale 文件里**完全不存在**。i18next 找不到 key时回退到内联英文默认值，导致**中文界面下混入英文**（"New File"、"Rename"、"API Type" 等）。

  其中整个 `files` namespace（14 个 key）在 `zh-CN.json` 和 `en.json` 里**完全缺失**。

  ### 缺失的 17 个 key

  | Namespace | Key |
  |---|---|
  | common | clear, collapseSidebar, expandSidebar |
  | files | newFile, newFolder, newFileHere, newFolderHere, rename, delete, download, downloadFolder, confirmDelete,
  editing, dropToUpload, uploadSkill |
  | settings | editModel, form.apiType |

  ## 修复方案

  在 `zh-CN.json` 和 `en.json` 里补全这 17 个 key 的中英文翻译，对照代码里的英文 fallback 译成中文（例如 `files.newFile`
  "New File" → "新建文件"）。

  ## 验证

  - ✅ 两个 JSON 文件语法合法（`json.load` 通过）
  - ✅ 重新静态扫描：代码中使用但 `zh-CN.json` 未定义的 key 数量 = **0**（修复前 17）
  - ✅ 前端 TypeScript 类型检查通过（`tsc --noEmit`）
  - ✅ 前端 Vite 构建通过（`npm run web:build`）
  - ✅ 验证构建产物 `dist/assets/index-*.js` bundle 中已包含 "新建文件"、"下载为 ZIP"、"收起侧栏"、"清除" 等中文文案
