### PR TITLE
feat: export a session to Markdown for review

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1574,6 +1574,100 @@ interface SessionSummary {
 
 type SessionTopicMetadata = Record<string, { topic: string; updatedAt: string; generated?: boolean }>;
 
+/**
+ * Serialize a parsed session (summary + merged messages) into a review-friendly
+ * Markdown document. User turns become `## 🧑 用户`, assistant turns become
+ * `## 🤖 助手`; thinking traces and tool calls are folded into `<details>` so
+ * the linear reading flow stays clean while the full trace remains available.
+ *
+ * Images are inlined as data URLs so the exported file is self-contained.
+ */
+function sessionToMarkdown(
+	summary: SessionSummary,
+	messages: SessionMessageSummary[],
+): string {
+	const lines: string[] = [];
+	const title = summary.name?.trim() || "未命名对话";
+	lines.push(`# ${title}`, "");
+	const createdAt = safeFormatDate(summary.createdAt);
+	const updatedAt = safeFormatDate(summary.updatedAt);
+	const channels = summary.channels.length > 0 ? summary.channels.join("、") : "—";
+	lines.push(
+		`> 共 ${messages.length} 条消息 · 渠道：${channels}`,
+		`> 创建：${createdAt} · 更新：${updatedAt}`,
+		`> 导出：${new Date().toISOString()}`,
+		"",
+		"---",
+		"",
+	);
+	for (const msg of messages) {
+		const time = safeFormatDate(new Date(msg.timestamp).toISOString());
+		if (msg.role === "user") {
+			lines.push(`## 🧑 用户`, "");
+			lines.push(`*${time}*`, "");
+		} else {
+			lines.push(`## 🤖 助手`, "");
+			lines.push(`*${time}*`, "");
+		}
+		if (msg.content.trim()) {
+			lines.push(msg.content.trim(), "");
+		}
+		if (msg.images && msg.images.length > 0) {
+			for (const img of msg.images) {
+				if (img.previewUrl) {
+					lines.push(`![image](${img.previewUrl})`, "");
+				}
+			}
+		}
+		if (msg.thinking && msg.thinking.trim()) {
+			lines.push(
+				"<details><summary>💭 思考过程</summary>",
+				"",
+				msg.thinking.trim(),
+				"",
+				"</details>",
+				"",
+			);
+		}
+		if (msg.tools && msg.tools.length > 0) {
+			for (const tool of msg.tools) {
+				const tag = tool.isError ? "❌" : "🔧";
+				lines.push(
+					`<details><summary>${tag} 工具调用：${tool.toolName}</summary>`,
+					"",
+					"**参数：**",
+					"",
+					"```json",
+					safeStringify(tool.args),
+					"```",
+					"",
+				);
+				if (tool.result !== undefined) {
+					lines.push("**结果：**", "", "```json", safeStringify(tool.result), "```", "");
+				}
+				lines.push("</details>", "");
+			}
+		}
+	}
+	return lines.join("\n");
+}
+
+/** Format an ISO date string for display; returns "—" on invalid input. */
+function safeFormatDate(iso: string): string {
+	const t = Date.parse(iso);
+	if (Number.isNaN(t)) return "—";
+	return new Date(t).toISOString().replace("T", " ").replace(/\.\d+Z$/, "Z");
+}
+
+/** Pretty JSON.stringify with a fallback for non-serializable values. */
+function safeStringify(value: unknown): string {
+	try {
+		return JSON.stringify(value, null, 2) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
 function sessionTopicMetadataPath(): string {
 	return join(dataDir, "sessions", "meta.json");
 }
@@ -2492,6 +2586,33 @@ const server = createServer(async (req, res) => {
 						.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
 				: [];
 			json(res, 200, sessions);
+			return;
+		}
+
+		const exportSessionMatch = matchRoute("GET", method, url, "/api/sessions/:id/export.md");
+		if (exportSessionMatch) {
+			const sessionPath = sessionFileFromId(join(dataDir, "sessions"), decodeURIComponent(exportSessionMatch.id));
+			if (!sessionPath || !existsSync(sessionPath)) {
+				json(res, 404, { error: "Session not found" });
+				return;
+			}
+			const parsed = parseSessionFile(sessionPath);
+			if (!parsed) {
+				json(res, 422, { error: "Unable to parse session" });
+				return;
+			}
+			const summary = withRecordedTopic(
+				withRecordedChannels(parsed.summary, readSessionChannelMetadata()),
+				readSessionTopicMetadata(),
+			);
+			const md = sessionToMarkdown(summary, parsed.messages);
+			const baseName = (summary.name?.trim() || summary.id.replace(/\.jsonl$/, "")).replace(/[\\/:*?"<>|]/g, "_").slice(0, 80);
+			res.writeHead(200, {
+				"Content-Type": "text/markdown; charset=utf-8",
+				"Content-Disposition": contentDispositionAttachment(`${baseName}.md`),
+				"Cache-Control": "no-store",
+			});
+			res.end(md);
 			return;
 		}
 

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -42,6 +42,9 @@
 		"questionPending": "Please answer the question above before continuing",
 		"questionPendingJump": "View question"
 	},
+	"sessions": {
+		"export": "Export as Markdown"
+	},
 	"notebook": {
 		"title": "Notebook",
 		"subtitle": "{{nodes}} nodes · {{edges}} edges",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -42,6 +42,9 @@
 		"questionPending": "请完成上方问卷后再继续对话",
 		"questionPendingJump": "查看问卷"
 	},
+	"sessions": {
+		"export": "导出为 Markdown"
+	},
 	"notebook": {
 		"title": "笔记本",
 		"subtitle": "{{nodes}} 个节点 · {{edges}} 条连接",

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "motion/react";
 import {
 	PanelLeftOpen,
@@ -10,6 +11,7 @@ import {
 	Trash2,
 	Archive,
 	ArchiveRestore,
+	Download,
 	ChevronRight,
 	Search,
 	X,
@@ -22,6 +24,7 @@ import { workspacesStore } from "../stores/workspaces-store.js";
 import { workspaceStore } from "../stores/workspace-store.js";
 import { settingsStore } from "../stores/settings-store.js";
 import type { WorkspaceMeta } from "../api/workspaces.js";
+import { triggerDownload } from "../api/workspace.js";
 import type { SessionChannel, SessionMeta } from "../api/sessions.js";
 import { useStoreSnapshot } from "./hooks.js";
 
@@ -253,6 +256,7 @@ function SessionCard({
 	onGenerate,
 	onArchive,
 	onDelete,
+	onExport,
 }: {
 	session: SessionMeta;
 	active: boolean;
@@ -268,7 +272,9 @@ function SessionCard({
 	onGenerate: () => void;
 	onArchive: () => void;
 	onDelete: () => void;
+	onExport: () => void;
 }) {
+	const { t } = useTranslation();
 	return (
 		<div
 			className={`group/card relative mb-1 w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
@@ -350,6 +356,13 @@ function SessionCard({
 						onClick={(e) => { e.stopPropagation(); onStartEdit(); }}
 					>
 						<Pencil size={12} />
+					</button>
+					<button
+						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+						title={t("sessions.export", "导出为 Markdown")}
+						onClick={(e) => { e.stopPropagation(); onExport(); }}
+					>
+						<Download size={12} />
 					</button>
 					<button
 						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
@@ -563,6 +576,13 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 		} else {
 			void sessionsStore.archiveSession(session.id);
 		}
+	}, []);
+
+	const handleExport = useCallback((session: SessionMeta) => {
+		// Hits the backend export endpoint, which streams a `text/markdown`
+		// attachment built from the session's merged messages. The browser
+		// follows the Content-Disposition header to name the file.
+		triggerDownload(`/api/sessions/${encodeURIComponent(session.id)}/export.md`);
 	}, []);
 
 	const handleDelete = useCallback((session: SessionMeta) => {
@@ -925,6 +945,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 													onGenerate={() => generateName(session)}
 													onArchive={() => handleArchive(session)}
 													onDelete={() => handleDelete(session)}
+													onExport={() => handleExport(session)}
 												/>
 											))}
 										</motion.div>


### PR DESCRIPTION
  ## 功能

  在会话侧边栏的每个 session 卡片上新增「导出」按钮(下载图标,hover 时显示,位于 Rename 和 Archive 之间),一键把整个对话导出为Markdown 文件,方便学习者离线保存、复习、分享。

  ## 导出格式

  - 标题 + 元信息(消息数、渠道、创建/更新/导出时间)
  - 用户/助手消息交替,带 `## 🧑 用户` / `## 🤖 助手` 标题和时间戳
  - 助手的 thinking 和 tool call 折叠进 `<details>`,保持阅读流畅同时保留完整 trace
  - 内嵌图片保留为 data URL(自包含文件)

  ## 实现

  - **后端**:新增 `GET /api/sessions/:id/export.md`,复用现有 `parseSessionFile` 把 JSONL 合并成干净消息列表,序列化为
  Markdown,以 `text/markdown` + RFC 5987 `Content-Disposition`(支持中文文件名)返回。复用现有
  `sessionFileFromId`(防路径穿越)和 `contentDispositionAttachment` 帮手。
  - **前端**:在 `SessionSidebar.tsx` 的 session 卡片动作组加 Download 按钮,调 `triggerDownload` 命中后端接口(复用
  `api/workspace.ts` 现成帮手)。
  - **i18n**:新增 `sessions.export` key(zh-CN / en)。

  ## 不改动的部分

  不修改 session 存储结构、不引入新依赖、不触碰 PI SDK。纯增量路由 + 一个按钮。

  ## 验证

  - [x] 后端 / 前端 TypeScript 类型检查通过
  - [x] 前端 Vite 构建通过
  - [x] 正常 session 导出:HTTP 200,中文文件名 `日常问候与简单交流.md` 正确
  - [x] 导出内容完整(标题/元信息/消息交替/Markdown 正文/工具调用折叠)
  - [x] 不存在的 session → HTTP 404
  - [x] 路径穿越攻击 `../../config.json` → HTTP 404(basename 校验)