### PR TITLE
fix(i18n): wire remaining hardcoded UI strings to i18n

### DIFF
--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -513,7 +513,15 @@
 		"errWsName": "Please enter a workspace name",
 		"errWsSelect": "Please select a workspace",
 		"errOpenPreset": "Failed to open preset",
-		"errCreateSession": "Failed to create session"
+		"errCreateSession": "Failed to create session",
+		"removeUpload": "Remove upload",
+		"removeImage": "Remove image",
+		"composerPlaceholder": "Type a message…"
+	},
+	"question": {
+		"typeSomething": "Type something…",
+		"chatAboutThis": "Chat about this",
+		"submit": "Submit"
 	},
 	"sidebar": {
 		"expand": "Expand",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -513,7 +513,15 @@
 		"errWsName": "请填写工作区名称",
 		"errWsSelect": "请选择一个工作区",
 		"errOpenPreset": "打开预设失败",
-		"errCreateSession": "创建会话失败"
+		"errCreateSession": "创建会话失败",
+		"removeUpload": "移除上传",
+		"removeImage": "移除图片",
+		"composerPlaceholder": "输入消息…"
+	},
+	"question": {
+		"typeSomething": "输入自定义答案…",
+		"chatAboutThis": "直接聊聊",
+		"submit": "提交"
 	},
 	"sidebar": {
 		"expand": "展开",

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -714,7 +714,7 @@ export function ChatCenter() {
 					<span key={`${file.path}-${index}`} className="inline-flex items-center gap-1 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1 text-xs shadow-sm">
 						<span className="max-w-[220px] truncate">{file.fileName}</span>
 						<span className="text-[var(--inno-text-muted)]">{file.path}</span>
-						<button className="text-[var(--inno-text-muted)] hover:text-[var(--inno-text)]" title="Remove upload" onClick={() => removeUpload(index)}>
+						<button className="text-[var(--inno-text-muted)] hover:text-[var(--inno-text)]" title={t("chat.removeUpload")} onClick={() => removeUpload(index)}>
 							<X size={14} />
 						</button>
 					</span>
@@ -731,7 +731,7 @@ export function ChatCenter() {
 						<img src={img.previewUrl} alt={img.name} className="h-12 w-12 rounded object-cover" />
 						<button
 							className="absolute -right-1.5 -top-1.5 flex h-4 w-4 items-center justify-center rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text-muted)] shadow-sm hover:bg-[var(--inno-accent-soft)] hover:text-[var(--inno-accent)]"
-							title="Remove image"
+							title={t("chat.removeImage")}
 							onClick={() => removeInlineImage(index)}
 						>
 							<X size={12} />
@@ -1056,7 +1056,7 @@ export function ChatCenter() {
 					{renderUploadChips()}
 					{renderInlineImagePreviews()}
 					{renderQuestionHint()}
-					{renderComposer("Type a message...")}
+					{renderComposer(t("chat.composerPlaceholder"))}
 				</div>
 			</div>
 		</section>

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { motion } from "motion/react";
 import type { PendingQuestion, QuestionAnswer, QuestionData, QuestionnaireResult } from "../types/chat.js";
 import { chatStore } from "../stores/chat-store.js";
@@ -58,6 +59,7 @@ function QuestionTab({
 	focusedOption: number;
 	setFocusedOption: (i: number) => void;
 }) {
+	const { t } = useTranslation();
 	const [customText, setCustomText] = useState("");
 	const isMulti = q.multiSelect === true;
 	const hasPreview = q.options.some((o) => o.preview);
@@ -121,7 +123,7 @@ function QuestionTab({
 							<input
 								type="text"
 								className="min-w-0 flex-1 rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-[13px] focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
-								placeholder="Type something..."
+								placeholder={t("question.typeSomething")}
 								value={customText}
 								onChange={(e) => setCustomText(e.target.value)}
 								onKeyDown={(e) => {
@@ -146,13 +148,14 @@ function QuestionTab({
 				className="text-xs text-[var(--inno-text-subtle)] underline hover:text-[var(--inno-text-muted)]"
 				onClick={onDismiss}
 			>
-				Chat about this
+				{t("question.chatAboutThis")}
 			</button>
 		</div>
 	);
 }
 
 export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
+	const { t } = useTranslation();
 	const { questionId, params } = pending;
 	const questions = params.questions;
 	const [activeTab, setActiveTab] = useState(0);
@@ -238,7 +241,7 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 						disabled={!allAnswered}
 						onClick={handleSubmit}
 					>
-						Submit
+						{t("question.submit")}
 					</button>
 				</div>
 			</div>

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -791,7 +791,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 						</button>
 						<button
 							className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text-muted)]"
-							title="Collapse"
+							title={t("sidebar.collapse")}
 							onClick={() => appStore.setSidebarCollapsed(true)}
 						>
 							<PanelLeftClose size={14} />

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -23,38 +23,6 @@ interface SessionsStoreEvents {
 	change: void;
 }
 
-export type DateGroup = "today" | "yesterday" | "thisWeek" | "earlier" | "archived";
-
-export interface SessionGroup {
-	key: DateGroup;
-	label: string;
-	sessions: SessionMeta[];
-}
-
-function dateGroupOf(updatedAt: string, archived?: boolean): DateGroup {
-	if (archived) return "archived";
-	const now = new Date();
-	const d = new Date(updatedAt);
-	const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-	const yesterdayStart = new Date(todayStart.getTime() - 86_400_000);
-	const weekStart = new Date(todayStart.getTime() - todayStart.getDay() * 86_400_000);
-
-	if (d >= todayStart) return "today";
-	if (d >= yesterdayStart) return "yesterday";
-	if (d >= weekStart) return "thisWeek";
-	return "earlier";
-}
-
-const GROUP_LABELS: Record<DateGroup, string> = {
-	today: "今天",
-	yesterday: "昨天",
-	thisWeek: "本周",
-	earlier: "更早",
-	archived: "已归档",
-};
-
-const GROUP_ORDER: DateGroup[] = ["today", "yesterday", "thisWeek", "earlier", "archived"];
-
 class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	sessions: SessionMeta[] = [];
 	currentSessionId: string | null = null;
@@ -106,22 +74,6 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 			);
 		}
 		return list;
-	}
-
-	get groupedSessions(): SessionGroup[] {
-		const groups = new Map<DateGroup, SessionMeta[]>();
-		for (const session of this.filteredSessions) {
-			const key = dateGroupOf(session.updatedAt, session.archived);
-			if (!groups.has(key)) groups.set(key, []);
-			groups.get(key)!.push(session);
-		}
-		return GROUP_ORDER
-			.filter((key) => groups.has(key))
-			.map((key) => ({
-				key,
-				label: GROUP_LABELS[key],
-				sessions: groups.get(key)!,
-			}));
 	}
 
 	get availableChannels(): SessionChannel[] {


### PR DESCRIPTION
## Summary
- Wire the last few hardcoded UI strings through i18n so they follow the language switch
- Remove dead code in sessions-store that carried hardcoded Chinese labels

## Changes
- **SessionSidebar**: collapse button `title` now uses `t("sidebar.collapse")`
- **ChatCenter**: remove-upload / remove-image button titles + normal-layout composer placeholder now use `t()`
- **QuestionDialog**: type-something placeholder, "Chat about this" and "Submit" buttons now use `t()` (added `useTranslation`)
- **i18n**: added `chat.removeUpload` / `chat.removeImage` / `chat.composerPlaceholder` and a new `question.*` namespace (`typeSomething` / `chatAboutThis` / `submit`) to both `en.json` and `zh-CN.json`
- **sessions-store**: removed the unused `groupedSessions` getter + `GROUP_LABELS` (hardcoded Chinese `今天/昨天/...`), `DateGroup`, `SessionGroup`, `dateGroupOf`, `GROUP_ORDER` — no component referenced them

## Test plan
- [x] `npm run build` passes (tsc + vite)
- [x] Verified both locales are present in the built bundle for the touched strings
- [ ] Toggle Settings → Language between 中文 / English and confirm the touched strings switch