### PR TITLE
fix: 优化 skill prompt 格式并增强 frontmatter 解析健壮性

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -108,7 +108,7 @@ function buildWorkspaceContextSections(workspaceDir: string): string[] {
 			if (skills.length > 0) {
 				const block = formatSkillsForPrompt(skills);
 				if (block.trim()) {
-					sections.push(`# 本工作区私有技能${block}`);
+					sections.push(`# 本工作区私有技能\n${block}`);
 				}
 			}
 		} catch (err) {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -791,6 +791,7 @@ function parseSkillFrontmatter(content: string): Record<string, string | boolean
 		const kv = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
 		if (!kv) continue;
 		const raw = kv[2].trim();
+		if (kv[1] in fm) continue; // 保留第一个值（标准YAML行为）
 		fm[kv[1]] = raw === "true" ? true : raw === "false" ? false : raw.replace(/^["']|["']$/g, "");
 	}
 	return fm;


### PR DESCRIPTION
修改内容

本 PR 对 skill 系统进行了两处轻量优化：

修复 skill prompt 拼接导致的 Markdown 结构问题
增强 frontmatter 解析的健壮性，避免重复 key 静默覆盖

修改说明
1. Prompt 格式修复
修复 skill 区块标题与内容未正确分隔的问题：
sections.push(# 本工作区私有技能${block})
sections.push(# 本工作区私有技能\n${block})

2. Frontmatter 解析增强
避免重复 key 被静默覆盖：
fm[kv[1]] = value
if (kv[1] in fm) continue

影响
提升 skill prompt 结构清晰度
避免 metadata 静默覆盖问题
无破坏性变更（兼容现有系统）

备注
本次修改属于轻量级健壮性优化，不涉及架构调整。