### PR TITLE
fix(presets): 修复简单模式预置列表拉取不全(raw 429 限流)

### DIFF
--- a/apps/inno-agent/src/content-source/github-source.ts
+++ b/apps/inno-agent/src/content-source/github-source.ts
@@ -35,7 +35,9 @@ const TREE_CACHE_TTL_MS = 5 * 60 * 1000;
  *     for a few minutes, instead of a per-directory `contents` walk that
  *     quickly exhausts the unauthenticated 60/hour budget.
  *   - File bytes come from raw.githubusercontent.com (a CDN that does NOT count
- *     against the API rate limit).
+ *     against the API rate limit, but has its own per-IP anonymous throttle —
+ *     so raw fetches are authenticated + retried with backoff, see rawHeaders /
+ *     fetchWithRetry).
  */
 export class GitHubContentSource implements RemoteContentSource {
 	private treeCache: { entries: GitTreeEntry[]; fetchedAt: number } | null = null;
@@ -79,6 +81,48 @@ export class GitHubContentSource implements RemoteContentSource {
 		return `https://raw.githubusercontent.com/${this.hub.owner}/${this.hub.repo}/${this.hub.ref}/${encoded}`;
 	}
 
+	/**
+	 * Headers for raw.githubusercontent.com. Unlike {@link headers}, this omits
+	 * the JSON `Accept` (raw returns file bytes) but MUST still carry the token:
+	 * anonymous raw requests share a per-IP budget that a burst of preset.json
+	 * reads exhausts, returning 429. Authenticating ties them to the account's
+	 * far larger limit.
+	 */
+	private rawHeaders(): Record<string, string> {
+		const headers: Record<string, string> = { "User-Agent": "inno-agent" };
+		const token = this.hub.token?.trim() || process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+		if (token) headers.Authorization = `Bearer ${token}`;
+		return headers;
+	}
+
+	/**
+	 * Fetch with bounded exponential backoff on transient throttling (429) and
+	 * server errors (5xx). Honors `Retry-After` when present. Returns the final
+	 * Response (which may still be non-ok) so callers decide how to treat it.
+	 */
+	private async fetchWithRetry(url: string, headers: Record<string, string>, attempts = 4): Promise<Response> {
+		let lastErr: unknown;
+		for (let attempt = 0; attempt < attempts; attempt++) {
+			try {
+				const res = await fetch(url, { headers });
+				if (res.status !== 429 && res.status < 500) return res;
+				if (attempt === attempts - 1) return res;
+				const retryAfter = Number(res.headers.get("retry-after"));
+				const delayMs = Number.isFinite(retryAfter) && retryAfter > 0
+					? retryAfter * 1000
+					: Math.min(2000, 250 * 2 ** attempt);
+				logger.warn({ url, status: res.status, attempt, delayMs }, "content-source: retrying throttled raw fetch");
+				await new Promise((resolve) => setTimeout(resolve, delayMs));
+			} catch (err) {
+				lastErr = err;
+				if (attempt === attempts - 1) throw err;
+				await new Promise((resolve) => setTimeout(resolve, Math.min(2000, 250 * 2 ** attempt)));
+			}
+		}
+		// Unreachable: the loop either returns or throws on the last attempt.
+		throw lastErr ?? new Error(`fetch failed for ${url}`);
+	}
+
 	private async getTree(forceRefresh = false): Promise<GitTreeEntry[]> {
 		const now = Date.now();
 		if (!forceRefresh && this.treeCache && now - this.treeCache.fetchedAt < TREE_CACHE_TTL_MS) {
@@ -117,8 +161,11 @@ export class GitHubContentSource implements RemoteContentSource {
 		if (!isSafeItemName(name)) throw new Error(`Invalid item name: ${name}`);
 		const repoPath = `${this.prefixFor(category)}${name}/${relPath}`;
 		try {
-			const res = await fetch(this.rawUrl(repoPath), { headers: { "User-Agent": "inno-agent" } });
-			if (!res.ok) return null;
+			const res = await this.fetchWithRetry(this.rawUrl(repoPath), this.rawHeaders());
+			if (!res.ok) {
+				logger.warn({ repoPath, status: res.status }, "content-source: raw file fetch not ok");
+				return null;
+			}
 			return await res.text();
 		} catch (err) {
 			logger.warn({ err, repoPath }, "content-source: failed to read item text file");
@@ -139,7 +186,7 @@ export class GitHubContentSource implements RemoteContentSource {
 			const rel = blob.path.slice(dirPrefix.length);
 			if (!rel || rel.includes("..")) continue;
 			const localPath = join(targetDir, rel);
-			const res = await fetch(this.rawUrl(blob.path), { headers: { "User-Agent": "inno-agent" } });
+			const res = await this.fetchWithRetry(this.rawUrl(blob.path), this.rawHeaders());
 			if (!res.ok) throw new Error(`Failed to download ${blob.path} (${res.status})`);
 			const buf = Buffer.from(await res.arrayBuffer());
 			ensureDir(dirname(localPath));

--- a/apps/inno-agent/src/presets/preset-store.ts
+++ b/apps/inno-agent/src/presets/preset-store.ts
@@ -115,29 +115,48 @@ export function listPresets(paths: RuntimePaths): PresetMeta[] {
  */
 export async function listRemotePresets(source: RemoteContentSource, forceRefresh = false): Promise<PresetMeta[]> {
 	const items = await source.listItems("presets", { forceRefresh });
-	const metas = await Promise.all(
-		items.map(async (item): Promise<PresetMeta | null> => {
-			// Bundle service ships metadata inline in index.json.
-			const m = item.meta;
-			if (m && typeof m.name === "string" && m.name.trim()) {
-				return {
-					id: item.name,
-					name: m.name.trim(),
-					description: typeof m.description === "string" ? m.description.trim() : "",
-					icon: typeof m.icon === "string" && m.icon.trim() ? m.icon.trim() : undefined,
-					category: typeof m.category === "string" && m.category.trim() ? m.category.trim() : undefined,
-				};
-			}
-			// GitHub: read the preset.json file.
-			const text = await source.readItemTextFile("presets", item.name, "preset.json");
-			if (!text) {
-				logger.warn({ id: item.name }, "remote preset missing preset.json; skipping");
-				return null;
-			}
-			return parsePresetMeta(text, item.name);
-		}),
-	);
+	// GitHub reads one preset.json per item over raw.githubusercontent.com, which
+	// throttles bursts (429). Cap concurrency so a large catalog doesn't trip the
+	// limit and silently drop presets from the list.
+	const metas = await mapWithConcurrency(items, 5, async (item): Promise<PresetMeta | null> => {
+		// Bundle service ships metadata inline in index.json.
+		const m = item.meta;
+		if (m && typeof m.name === "string" && m.name.trim()) {
+			return {
+				id: item.name,
+				name: m.name.trim(),
+				description: typeof m.description === "string" ? m.description.trim() : "",
+				icon: typeof m.icon === "string" && m.icon.trim() ? m.icon.trim() : undefined,
+				category: typeof m.category === "string" && m.category.trim() ? m.category.trim() : undefined,
+			};
+		}
+		// GitHub: read the preset.json file.
+		const text = await source.readItemTextFile("presets", item.name, "preset.json");
+		if (!text) {
+			logger.warn({ id: item.name }, "remote preset missing preset.json; skipping");
+			return null;
+		}
+		return parsePresetMeta(text, item.name);
+	});
 	return metas.filter((m): m is PresetMeta => m !== null).sort((a, b) => a.name.localeCompare(b.name));
+}
+
+/** Map over items with a bounded number of in-flight async tasks, preserving order. */
+async function mapWithConcurrency<T, R>(
+	items: T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	const results = new Array<R>(items.length);
+	let next = 0;
+	const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+		while (next < items.length) {
+			const index = next++;
+			results[index] = await fn(items[index], index);
+		}
+	});
+	await Promise.all(workers);
+	return results;
 }
 
 /**


### PR DESCRIPTION
## 问题

简单模式(Simple Mode)欢迎页的预置 agent 列表拉取不全,只显示部分预置,且每次刷新数量不固定。

## 根因

预置列表走 `/api/preset-library` → `listRemotePresets()`,GitHub 内容源分两步:

1. 列目录:调 `api.github.com` git tree,**带 token**,能正常拿到全部 18 个目录;
2. 读元数据:对每个目录用 `Promise.all` **并发**调 `readItemTextFile()` 读 `preset.json`,走 `raw.githubusercontent.com`。

第 2 步三个问题叠加:
- **没带 token**:`readItemTextFile` 写死了 `{ "User-Agent": "inno-agent" }`,没复用带鉴权的 `headers()`,走的是匿名限额;
- **并发爆发**:18 个 raw 请求一次性打出去,触发 `raw.githubusercontent.com` 的 429 Too Many Requests;
- **静默丢弃**:429 → `if (!res.ok) return null` → 被 `.filter()` 掉,只有一条 warn,无重试、不报错。

server 端逻辑是 `remote.length > 0` 就直接返回,所以残缺列表也不会触发 bundled fallback。

## 改动

`apps/inno-agent/src/content-source/github-source.ts`
- 新增 `rawHeaders()`:raw 请求也带上 token(运行时从配置/环境变量读取,非硬编码);
- 新增 `fetchWithRetry()`:对 429/5xx 做有上限的指数退避重试,尊重 `Retry-After`;
- `readItemTextFile` / `downloadItem` 的 raw 请求改走上述两者;非 ok 补日志。

`apps/inno-agent/src/presets/preset-store.ts`
- `listRemotePresets` 用 `mapWithConcurrency(..., 5, ...)` 替换 `Promise.all`,限并发到 5。

## 验证

用真实 token 对线上 hub 跑完整 `listRemotePresets`(同一之前持续 429 的 IP):

- 修复前:**2 / 18**(其余被 429 丢弃)
- 修复后:**18 / 18**

`tsc --noEmit` 与 `tsc` build 均通过。
