### PR TITLE
fix(skills): 修复技能库简介丢失 + 对齐本地 hub server 解析

### DIFF
--- a/apps/inno-agent/src/content-source/types.ts
+++ b/apps/inno-agent/src/content-source/types.ts
@@ -57,3 +57,26 @@ export const CATEGORY_MARKER: Record<ContentCategory, string> = {
 export function isSafeItemName(name: string): boolean {
 	return !!name && !name.includes("/") && !name.includes("\\") && !name.includes("..");
 }
+
+/**
+ * Map over items with a bounded number of in-flight async tasks, preserving
+ * order. Reading one marker file (SKILL.md / preset.json) per item over
+ * raw.githubusercontent.com throttles bursts (429); capping concurrency stops
+ * a large catalog from tripping the limit and silently dropping items.
+ */
+export async function mapWithConcurrency<T, R>(
+	items: T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	const results = new Array<R>(items.length);
+	let next = 0;
+	const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+		while (next < items.length) {
+			const index = next++;
+			results[index] = await fn(items[index], index);
+		}
+	});
+	await Promise.all(workers);
+	return results;
+}

--- a/apps/inno-agent/src/presets/preset-store.ts
+++ b/apps/inno-agent/src/presets/preset-store.ts
@@ -3,6 +3,7 @@ import { join, relative } from "node:path";
 import type { RuntimePaths } from "../runtime.js";
 import type { WorkspaceMeta, WorkspaceRegistry } from "../workspace/workspace-registry.js";
 import type { RemoteContentSource } from "../content-source/index.js";
+import { mapWithConcurrency } from "../content-source/types.js";
 import { logger } from "../logger.js";
 
 /**
@@ -139,24 +140,6 @@ export async function listRemotePresets(source: RemoteContentSource, forceRefres
 		return parsePresetMeta(text, item.name);
 	});
 	return metas.filter((m): m is PresetMeta => m !== null).sort((a, b) => a.name.localeCompare(b.name));
-}
-
-/** Map over items with a bounded number of in-flight async tasks, preserving order. */
-async function mapWithConcurrency<T, R>(
-	items: T[],
-	limit: number,
-	fn: (item: T, index: number) => Promise<R>,
-): Promise<R[]> {
-	const results = new Array<R>(items.length);
-	let next = 0;
-	const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
-		while (next < items.length) {
-			const index = next++;
-			results[index] = await fn(items[index], index);
-		}
-	});
-	await Promise.all(workers);
-	return results;
 }
 
 /**

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -53,6 +53,7 @@ import { questionBridge, type QuestionBridgeResult } from "./agent/question-brid
 import { DEFAULT_WORKSPACE_ID, TEMP_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
 import { listPresets, listRemotePresets, ensurePresetCached, instantiatePreset } from "./presets/preset-store.js";
 import { createContentSource, type RemoteContentSource } from "./content-source/index.js";
+import { mapWithConcurrency } from "./content-source/types.js";
 import { RunRecordStore } from "./terminal/run-record-store.js";
 import { TerminalSessionManager } from "./terminal/terminal-session-manager.js";
 import type { ClientTerminalEvent, ServerTerminalEvent } from "./terminal/terminal-types.js";
@@ -1078,27 +1079,28 @@ async function listSkillLibrary(forceRefresh = false): Promise<SkillLibraryItem[
 			: [],
 	);
 
-	const result = await Promise.all(
-		items.map(async (item): Promise<SkillLibraryItem> => {
-			// Prefer inline meta (bundle service); otherwise read SKILL.md frontmatter.
-			let description = typeof item.meta?.description === "string" ? item.meta.description : "";
-			let category = typeof item.meta?.category === "string" ? item.meta.category.trim() : "";
-			if (!description || !category) {
-				const md = await source.readItemTextFile("skills", item.name, "SKILL.md");
-				if (md) {
-					const fields = extractFrontmatterFields(md);
-					if (!description) description = fields.description;
-					if (!category) category = fields.category;
-				}
+	// One SKILL.md read per item over raw.githubusercontent.com; cap concurrency
+	// so a large library doesn't burst past the raw CDN throttle (429) and lose
+	// descriptions. Matches the preset library's approach.
+	const result = await mapWithConcurrency(items, 5, async (item): Promise<SkillLibraryItem> => {
+		// Prefer inline meta (bundle service); otherwise read SKILL.md frontmatter.
+		let description = typeof item.meta?.description === "string" ? item.meta.description : "";
+		let category = typeof item.meta?.category === "string" ? item.meta.category.trim() : "";
+		if (!description || !category) {
+			const md = await source.readItemTextFile("skills", item.name, "SKILL.md");
+			if (md) {
+				const fields = extractFrontmatterFields(md);
+				if (!description) description = fields.description;
+				if (!category) category = fields.category;
 			}
-			return {
-				name: item.name,
-				description,
-				category: category || undefined,
-				installed: localNames.has(slugifySkillName(item.name)),
-			};
-		}),
-	);
+		}
+		return {
+			name: item.name,
+			description,
+			category: category || undefined,
+			installed: localNames.has(slugifySkillName(item.name)),
+		};
+	});
 	return result.sort((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/scripts/content-hub-server/server.mjs
+++ b/scripts/content-hub-server/server.mjs
@@ -59,23 +59,40 @@ function isUsableItemDir(name) {
 	return ITEM_NAME_RE.test(name) && name !== "." && name !== ".." && !name.startsWith("_") && !name.startsWith(".") && name !== "__MACOSX";
 }
 
-/** Read a skill's description from SKILL.md frontmatter (best-effort, single-line + block scalar). */
-function readSkillDescription(skillDir) {
+/** Read description + category from SKILL.md frontmatter in one pass. */
+function readSkillMeta(skillDir) {
 	const md = join(skillDir, "SKILL.md");
-	if (!existsSync(md)) return "";
-	const text = readFileSync(md, "utf-8").replace(/\r\n/g, "\n");
+	if (!existsSync(md)) return { description: "", category: "" };
+	const text = readFileSync(md, "utf-8").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 	const fm = text.match(/^---\n([\s\S]*?)\n---/);
-	if (!fm) return "";
+	if (!fm) return { description: "", category: "" };
 	const lines = fm[1].split("\n");
+	return {
+		description: extractFrontmatterField(lines, "description"),
+		category: extractFrontmatterField(lines, "category"),
+	};
+}
+
+/**
+ * Extract a single YAML frontmatter field by key. Supports inline values
+ * (optionally quoted) and block scalars (>, |, >-, |- etc.). Mirrors the
+ * backend's extractFrontmatterFields logic in server.ts exactly.
+ */
+function extractFrontmatterField(lines, key) {
+	const re = new RegExp(`^${key}:\\s*(.*)$`);
 	for (let i = 0; i < lines.length; i++) {
-		const m = lines[i].match(/^description:\s*(.*)$/);
+		const m = lines[i].match(re);
 		if (!m) continue;
 		const inline = m[1].trim();
+		// Block scalar (>- , |, > , |- ...) → gather indented continuation lines.
 		if (/^[>|][+-]?\s*$/.test(inline)) {
 			const block = [];
 			for (let j = i + 1; j < lines.length; j++) {
-				if (/^\s+\S/.test(lines[j]) || lines[j].trim() === "") block.push(lines[j].trim());
-				else break;
+				if (/^\s+\S/.test(lines[j]) || lines[j].trim() === "") {
+					block.push(lines[j].trim());
+				} else {
+					break;
+				}
 			}
 			return block.join(" ").replace(/\s+/g, " ").trim();
 		}
@@ -95,9 +112,8 @@ function buildIndex() {
 			if (!entry.isDirectory() || !isUsableItemDir(entry.name)) continue;
 			const dir = join(skillsRoot, entry.name);
 			if (!existsSync(join(dir, CATEGORY.skills.marker))) continue;
-			// id = directory name (used for routing/download); skills have no
-			// display name distinct from the directory, so name mirrors id.
-			index.skills.push({ id: entry.name, name: entry.name, description: readSkillDescription(dir) });
+			const meta = readSkillMeta(dir);
+			index.skills.push({ id: entry.name, name: entry.name, description: meta.description, category: meta.category || undefined });
 		}
 	}
 


### PR DESCRIPTION
本 PR 包含两个相关修复，围绕「技能库元数据一致性」。

---

## 1. 技能库简介丢失（raw CDN 429 限流）

### 问题
普通模式下打开「技能库」，部分 skill 的简介（description）丢失，显示空白。空描述的 skill 呈**散乱分布**（不是连续一段），每次刷新失败的 skill 还不固定。

### 根因
`listSkillLibrary()`（server.ts）对每个 skill 用 `Promise.all` **一次性全并发**（43 个）调 `readItemTextFile()` 读 `SKILL.md`，走 `raw.githubusercontent.com`。突发并发触发 raw CDN 的 per-IP 429 限流，失败的请求返回空描述。

这与 #66 修复的 preset 列表拉取不全是**同一根因**。#66 已修好共享的 `readItemTextFile`（raw 请求带 token + 429 退避重试），但**只给 preset 侧加了并发上限**，`listSkillLibrary` 仍是全并发，缺少这层保护。

### 改动
- `content-source/types.ts`：把 #66 私有放在 `preset-store.ts` 的 `mapWithConcurrency` **提取为共享 export**。
- `presets/preset-store.ts`：改为 import 共享的 `mapWithConcurrency`，删除本地副本（无行为变化）。
- `server.ts`：`listSkillLibrary` 的 `Promise.all` 换成 `mapWithConcurrency(items, 5, fn)`，与 preset 库并发上限一致。

---

## 2. 对齐本地 content-hub-server 的 frontmatter 解析

### 问题
自托管的 `scripts/content-hub-server/server.mjs` 构建 `index.json` 时，解析逻辑与后端略有偏差：
- 只 normalize 了 `\r\n`（漏了孤立的 `\r`）；
- **完全不提取 `category` 字段** —— 用 bundle 部署时 skill 的分类会丢（GitHub 源通过 `extractFrontmatterFields` 会同时提 description + category）。

### 改动
- 把 `readSkillDescription` 重构为 `readSkillMeta`（一次读取，同时出 description + category）；
- 抽出 `extractFrontmatterField` helper，逻辑与后端 `extractFrontmatterFields` **完全一致**（inline + 引号 + 块标量 `>`/`|`/`>-`/`|-`）；
- 补上孤立 `\r` 的 normalize；
- skills 索引输出 `category` 字段。

---

## 验证

**技能库/预置库**（同一之前持续 429 的 IP + 真实 token）：
- skill-library：**43 / 43** 全部带简介，0 空描述
- preset-library：**18 / 18**

**本地 hub server**（content-example + 临时 fixture）：
- inline description：正常
- 块标量 `>-` 多行描述：正确折叠成一行
- `category` 字段：正确提取并输出

反复 force-refresh 稳定，日志无 rate-limit 警告。`node -c` 语法检查 + `tsc` build 均通过。