### PR TITLE
feat: 文件工具参数流式预览与生成进度反馈

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -134,6 +134,8 @@ export function createInnoExtension(
 				baseUrl: providerConfig.baseUrl,
 				apiKey: providerConfig.apiKey || "local",
 				api: providerConfig.api ?? "openai-completions",
+				headers: providerConfig.headers,
+				authHeader: providerConfig.authHeader,
 				models: providerConfig.models.map((m) => ({
 					id: m.id,
 					name: m.name,

--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -195,6 +195,8 @@ export async function initSession(
 				baseUrl: providerConfig.baseUrl,
 				apiKey: providerConfig.apiKey || "local",
 				api: providerConfig.api ?? "openai-completions",
+				headers: providerConfig.headers,
+				authHeader: providerConfig.authHeader,
 				models: providerConfig.models.map(modelConfigToProviderModel),
 			});
 			_registeredProviderIds.add(providerId);
@@ -302,6 +304,8 @@ export async function refreshConfiguredProviders(config: InnoConfig): Promise<vo
 			baseUrl: providerConfig.baseUrl,
 			apiKey: providerConfig.apiKey || "local",
 			api: providerConfig.api ?? "openai-completions",
+			headers: providerConfig.headers,
+			authHeader: providerConfig.authHeader,
 			models: providerConfig.models.map(modelConfigToProviderModel),
 		});
 		_registeredProviderIds.add(providerId);

--- a/apps/inno-agent/src/agent/provider-sync.ts
+++ b/apps/inno-agent/src/agent/provider-sync.ts
@@ -25,6 +25,8 @@ interface PiModelsJson {
 		baseUrl?: string;
 		apiKey?: string;
 		api?: string;
+		headers?: Record<string, string>;
+		authHeader?: boolean;
 		models?: Array<{
 			id: string;
 			name?: string;
@@ -70,6 +72,8 @@ export function syncProvidersForSubagents(config: InnoConfig): void {
 			baseUrl: providerConfig.baseUrl,
 			apiKey: providerConfig.apiKey,
 			api: providerConfig.api,
+			headers: providerConfig.headers,
+			authHeader: providerConfig.authHeader,
 			models: providerConfig.models.map((m) => ({
 				id: m.id,
 				name: m.name,

--- a/apps/inno-agent/src/cli.ts
+++ b/apps/inno-agent/src/cli.ts
@@ -4,6 +4,7 @@ import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { installFetchLogger } from "./utils/fetch-logger.js";
 import { main, type ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { loadConfig } from "./config.js";
+import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
 import { createInnoExtension, type ConfigHolder } from "./agent/inno-extension.js";
 import { ensureDir } from "./storage/file-store.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
@@ -26,6 +27,7 @@ applyRuntimeEnvironment(paths);
 
 // Load config
 const config = loadConfig(paths.configPath);
+applyProviderProxyBypass(config);
 
 // Ensure data directories exist
 ensureDir(paths.learnerDataDir);

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -16,6 +16,9 @@ export interface InnoProviderConfig {
 	baseUrl: string;
 	apiKey: string;
 	api?: InnoProviderApi;
+	headers?: Record<string, string>;
+	authHeader?: boolean;
+	bypassProxy?: boolean;
 	models: InnoModelConfig[];
 }
 
@@ -191,15 +194,29 @@ export function normalizeModelConfig(model: Partial<InnoModelConfig> & { id: str
 	};
 }
 
+function normalizeProviderHeaders(headers: InnoProviderConfig["headers"] | undefined): Record<string, string> | undefined {
+	if (!headers || typeof headers !== "object" || Array.isArray(headers)) return undefined;
+	const normalized = Object.fromEntries(
+		Object.entries(headers)
+			.map(([key, value]) => [key.trim(), value] as const)
+			.filter(([key, value]) => key.length > 0 && typeof value === "string"),
+	);
+	return Object.keys(normalized).length > 0 ? normalized : undefined;
+}
+
 export function normalizeProviderConfig(provider: Partial<InnoProviderConfig>): InnoProviderConfig {
 	const baseUrl = provider.baseUrl?.trim() ?? "";
 	if (!baseUrl) throw new Error("Provider baseUrl is required");
 	const models = (provider.models ?? []).map((model) => normalizeModelConfig(model));
 	if (models.length === 0) throw new Error("Provider must include at least one model");
+	const headers = normalizeProviderHeaders(provider.headers);
 	return {
 		baseUrl,
 		apiKey: provider.apiKey ?? "",
 		api: provider.api?.trim() || "openai-completions",
+		...(headers ? { headers } : {}),
+		...(provider.authHeader === true ? { authHeader: true } : {}),
+		...(provider.bypassProxy === true ? { bypassProxy: true } : {}),
 		models,
 	};
 }

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -350,13 +350,16 @@ export function upsertProvider(
 	config: InnoConfig,
 	providerId: string,
 	provider: InnoProviderConfig,
-	options: { makeDefault?: boolean; preserveApiKey?: boolean } = {},
+	options: { makeDefault?: boolean; preserveApiKey?: boolean; preserveHeaders?: boolean } = {},
 ): InnoConfig {
 	const id = providerId.trim();
 	if (!id) throw new Error("Provider id is required");
 	const existing = config.providers[id];
 	const normalized = normalizeProviderConfig({
 		...provider,
+		headers: options.preserveHeaders && existing && provider.headers === undefined
+			? existing.headers
+			: provider.headers,
 		apiKey:
 			options.preserveApiKey && existing && (!provider.apiKey || provider.apiKey.startsWith("****"))
 				? existing.apiKey

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -11,6 +11,7 @@ import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { loadConfig, saveConfig, setDefaultModel, upsertProvider, deleteProvider, deleteModel, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig, type InnoModelConfig, type InnoProviderConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
+import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
 import { ensureDir, readJson, readText, writeJson, writeText } from "./storage/file-store.js";
 import {
 	createNewSession,
@@ -142,6 +143,9 @@ function piEventToSseEvent(event: any): unknown | null {
 			const ev = event.assistantMessageEvent;
 			if (ev.type === "text_delta") return { type: "text_delta", delta: ev.delta };
 			if (ev.type === "thinking_delta") return { type: "thinking_delta", delta: ev.delta };
+			if (ev.type === "toolcall_start" || ev.type === "toolcall_delta" || ev.type === "toolcall_end") {
+				return toolCallStreamEventFromAssistantEvent(ev);
+			}
 			if (ev.type === "error") return { type: "error", message: ev.error.errorMessage || `LLM API error (stopReason: ${ev.error.stopReason})` };
 			return null;
 		}
@@ -156,9 +160,55 @@ function piEventToSseEvent(event: any): unknown | null {
 			return { type: "tool_start", toolCallId: event.toolCallId, toolName: event.toolName, args: event.args };
 		case "tool_execution_end":
 			return { type: "tool_end", toolCallId: event.toolCallId, toolName: event.toolName, result: event.result, isError: event.isError };
+		case "tool_call":
+			return { type: "tool_call_delta", toolCallId: event.toolCallId, toolName: event.toolName, args: event.input };
 		default:
 			return null;
 	}
+}
+
+function toolCallStreamEventFromAssistantEvent(ev: any): unknown | null {
+	const content = Array.isArray(ev.partial?.content) ? ev.partial.content : [];
+	const block = typeof ev.contentIndex === "number" ? content[ev.contentIndex] : undefined;
+	if (!block || typeof block !== "object" || block.type !== "toolCall") return null;
+	const toolCallId = typeof block.id === "string" && block.id ? block.id : `content-${ev.contentIndex}`;
+	const toolName = typeof block.name === "string" ? block.name : "";
+	if (!toolName) return null;
+	const argsText = typeof block.partialJson === "string"
+		? block.partialJson
+		: typeof block.partialArgs === "string"
+			? block.partialArgs
+			: undefined;
+	return {
+		type: "tool_call_delta",
+		toolCallId,
+		toolName,
+		args: block.arguments,
+		argsText,
+		argsDelta: typeof ev.delta === "string" ? ev.delta : undefined,
+	};
+}
+
+function piEventToSseEvents(event: any): unknown[] {
+	const primary = piEventToSseEvent(event);
+	const events = primary ? [primary] : [];
+	if (event.type !== "message_update") return events;
+	const ev = event.assistantMessageEvent;
+	if (ev?.type === "toolcall_start" || ev?.type === "toolcall_delta" || ev?.type === "toolcall_end") return events;
+	const content = Array.isArray(event.message?.content) ? event.message.content : [];
+	for (const block of content) {
+		if (!block || typeof block !== "object" || block.type !== "toolCall") continue;
+		const toolCallId = typeof block.id === "string" ? block.id : "";
+		const toolName = typeof block.name === "string" ? block.name : "";
+		if (!toolCallId || !toolName) continue;
+		events.push({
+			type: "tool_call_delta",
+			toolCallId,
+			toolName,
+			args: block.arguments,
+		});
+	}
+	return events;
 }
 
 /** Convert a raw PI SDK event to a ChannelStreamEvent for channel streaming replies. */
@@ -202,6 +252,7 @@ async function ensureBootstrapped(): Promise<void> {
 
 		// ---- config (loaded lazily, not at process start) ----
 		config = loadConfig(paths.configPath);
+		applyProviderProxyBypass(config);
 
 		// ---- data directories ----
 		ensureDir(paths.learnerDataDir);
@@ -531,6 +582,9 @@ function buildSafeSettings() {
 				{
 					...providerConfig,
 					apiKey: maskSecret(providerConfig.apiKey),
+					headers: providerConfig.headers
+						? Object.fromEntries(Object.entries(providerConfig.headers).map(([key, value]) => [key, maskSecret(value)]))
+						: undefined,
 				},
 			]),
 		),
@@ -570,6 +624,18 @@ function parseModelConfig(value: unknown): InnoModelConfig {
 	};
 }
 
+function parseStringHeaders(value: unknown): Record<string, string> | undefined {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const headers: Record<string, string> = {};
+	for (const [key, headerValue] of Object.entries(value as Record<string, unknown>)) {
+		const normalizedKey = key.trim();
+		if (normalizedKey && typeof headerValue === "string") {
+			headers[normalizedKey] = headerValue;
+		}
+	}
+	return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
 function parseProviderPayload(body: Record<string, unknown>): {
 	providerId: string;
 	provider: InnoProviderConfig;
@@ -583,11 +649,20 @@ function parseProviderPayload(body: Record<string, unknown>): {
 	const baseUrl = typeof body.baseUrl === "string" ? body.baseUrl.trim() : "";
 	const apiKey = typeof body.apiKey === "string" ? body.apiKey : "";
 	const api = typeof body.api === "string" ? body.api.trim() : "openai-completions";
+	const headers = parseStringHeaders(body.headers);
 	const rawModels = Array.isArray(body.models) ? body.models : [];
 	const models = rawModels.map(parseModelConfig);
 	return {
 		providerId,
-		provider: { baseUrl, apiKey, api, models },
+		provider: {
+			baseUrl,
+			apiKey,
+			api,
+			...(headers && Object.keys(headers).length > 0 ? { headers } : {}),
+			...(body.authHeader === true ? { authHeader: true } : {}),
+			...(body.bypassProxy === true ? { bypassProxy: true } : {}),
+			models,
+		},
 		makeDefault: Boolean(body.makeDefault),
 		preserveApiKey: Boolean(body.preserveApiKey),
 	};
@@ -1331,6 +1406,97 @@ interface WorkspaceTreeNode {
 
 function workspaceRelativePath(rootDir: string, filePath: string): string {
 	return relative(rootDir, filePath) || "";
+}
+
+interface WorkspaceFileSnapshot {
+	files: Map<string, { mtimeMs: number; size: number }>;
+	truncated: boolean;
+}
+
+interface WorkspaceFileChange {
+	path: string;
+	change: "created" | "modified" | "deleted";
+}
+
+const WORKSPACE_SNAPSHOT_IGNORES = new Set([
+	...WORKSPACE_IGNORES,
+	".git",
+	"node_modules",
+	"dist",
+	".next",
+	".vite",
+	"coverage",
+]);
+const MAX_WORKSPACE_SNAPSHOT_FILES = 2500;
+const MAX_WORKSPACE_SNAPSHOT_DEPTH = 8;
+const MAX_WORKSPACE_CHANGE_EVENTS = 40;
+
+function snapshotWorkspaceFiles(rootDir: string | null): WorkspaceFileSnapshot | null {
+	if (!rootDir || !existsSync(rootDir)) return null;
+	const files = new Map<string, { mtimeMs: number; size: number }>();
+	let truncated = false;
+
+	const visit = (dir: string, depth: number) => {
+		if (truncated || depth > MAX_WORKSPACE_SNAPSHOT_DEPTH) return;
+		let entries: import("node:fs").Dirent[];
+		try {
+			entries = readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			if (truncated) return;
+			if (WORKSPACE_SNAPSHOT_IGNORES.has(entry.name)) continue;
+			const fullPath = join(dir, entry.name);
+			let stat: ReturnType<typeof statSync>;
+			try {
+				stat = statSync(fullPath);
+			} catch {
+				continue;
+			}
+			if (entry.isDirectory()) {
+				visit(fullPath, depth + 1);
+				continue;
+			}
+			if (!entry.isFile()) continue;
+			files.set(workspaceRelativePath(rootDir, fullPath), {
+				mtimeMs: stat.mtimeMs,
+				size: stat.size,
+			});
+			if (files.size >= MAX_WORKSPACE_SNAPSHOT_FILES) {
+				truncated = true;
+				return;
+			}
+		}
+	};
+
+	visit(rootDir, 0);
+	return { files, truncated };
+}
+
+function diffWorkspaceFileSnapshots(before: WorkspaceFileSnapshot | null, after: WorkspaceFileSnapshot | null): { changes: WorkspaceFileChange[]; truncated: boolean } {
+	if (!before || !after) return { changes: [], truncated: false };
+	const changes: WorkspaceFileChange[] = [];
+	for (const [path, next] of after.files) {
+		const prev = before.files.get(path);
+		if (!prev) {
+			changes.push({ path, change: "created" });
+		} else if (prev.size !== next.size || prev.mtimeMs !== next.mtimeMs) {
+			changes.push({ path, change: "modified" });
+		}
+		if (changes.length >= MAX_WORKSPACE_CHANGE_EVENTS) break;
+	}
+	if (changes.length < MAX_WORKSPACE_CHANGE_EVENTS) {
+		for (const path of before.files.keys()) {
+			if (after.files.has(path)) continue;
+			changes.push({ path, change: "deleted" });
+			if (changes.length >= MAX_WORKSPACE_CHANGE_EVENTS) break;
+		}
+	}
+	return {
+		changes,
+		truncated: before.truncated || after.truncated || changes.length >= MAX_WORKSPACE_CHANGE_EVENTS,
+	};
 }
 
 /** Build a tree node for an installed private skill directory under `<root>/.skills`. */
@@ -3680,6 +3846,7 @@ const server = createServer(async (req, res) => {
 					preserveApiKey: payload.preserveApiKey,
 				}),
 			);
+			applyProviderProxyBypass(config);
 			await refreshConfiguredProviders(config);
 			if (payload.makeDefault) {
 				await switchModel(config.defaultProvider, config.defaultModel);
@@ -4081,6 +4248,14 @@ const server = createServer(async (req, res) => {
 			// to the event stream after navigating away.
 			const broadcaster = new SessionEventBroadcaster();
 			sessionBroadcasters.set(capturedSessionId, broadcaster);
+			const publishStreamEvent = (event: unknown) => {
+				broadcaster.publish(event);
+				if (!aborted) sseWrite(event);
+			};
+
+			const streamWorkspaceId = workspaceRegistry.getSessionWorkspaceId(capturedSessionId);
+			const streamWorkspaceRoot = workspaceRegistry.resolveWorkspaceDir(streamWorkspaceId);
+			const toolWorkspaceSnapshots = new Map<string, WorkspaceFileSnapshot | null>();
 
 			// Track whether the model API surfaced an error this turn. The PI SDK
 			// does NOT throw on model API errors (e.g. HTTP 413 from an over-long
@@ -4091,6 +4266,7 @@ const server = createServer(async (req, res) => {
 			let emittedError = false;
 			let promptStartTime = 0;
 			const onEvent = (event: import("@earendil-works/pi-coding-agent").AgentSessionEvent) => {
+				let workspaceChangeEvent: unknown | null = null;
 				// Logging regardless of aborted state
 				switch (event.type) {
 					case "message_update": {
@@ -4115,12 +4291,29 @@ const server = createServer(async (req, res) => {
 						break;
 					}
 					case "tool_execution_start":
+						toolWorkspaceSnapshots.set(event.toolCallId, snapshotWorkspaceFiles(streamWorkspaceRoot));
 						logger.info(
 							{ toolName: event.toolName, toolCallId: event.toolCallId },
 							"tool call started: %s", event.toolName,
 						);
 						break;
 					case "tool_execution_end":
+						if (!event.isError) {
+							const before = toolWorkspaceSnapshots.get(event.toolCallId) ?? null;
+							const after = snapshotWorkspaceFiles(streamWorkspaceRoot);
+							const { changes, truncated } = diffWorkspaceFileSnapshots(before, after);
+							if (changes.length > 0) {
+								workspaceChangeEvent = {
+									type: "workspace_change",
+									toolCallId: event.toolCallId,
+									toolName: event.toolName,
+									workspaceId: streamWorkspaceId,
+									changes,
+									truncated,
+								};
+							}
+						}
+						toolWorkspaceSnapshots.delete(event.toolCallId);
 						if (event.isError) {
 							const errText = Array.isArray(event.result?.content)
 								? event.result.content.map((c: { text?: string }) => c.text ?? "").join(" ").slice(0, 500)
@@ -4151,12 +4344,11 @@ const server = createServer(async (req, res) => {
 						break;
 				}
 
-				// Convert to SSE event and publish to broadcaster + live client
-				const sseEvent = piEventToSseEvent(event);
-				if (sseEvent) {
-					broadcaster.publish(sseEvent);
-					if (!aborted) sseWrite(sseEvent);
+				// Convert to SSE events and publish to broadcaster + live client.
+				for (const sseEvent of piEventToSseEvents(event)) {
+					publishStreamEvent(sseEvent);
 				}
+				if (workspaceChangeEvent) publishStreamEvent(workspaceChangeEvent);
 			};
 
 			promptStartTime = Date.now();

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -5,9 +5,9 @@ import "source-map-support/register.js";
 import { createServer, type IncomingMessage as HttpReq, type ServerResponse } from "node:http";
 import { spawnSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, watch, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { loadConfig, saveConfig, setDefaultModel, upsertProvider, deleteProvider, deleteModel, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig, type InnoModelConfig, type InnoProviderConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
@@ -160,8 +160,6 @@ function piEventToSseEvent(event: any): unknown | null {
 			return { type: "tool_start", toolCallId: event.toolCallId, toolName: event.toolName, args: event.args };
 		case "tool_execution_end":
 			return { type: "tool_end", toolCallId: event.toolCallId, toolName: event.toolName, result: event.result, isError: event.isError };
-		case "tool_call":
-			return { type: "tool_call_delta", toolCallId: event.toolCallId, toolName: event.toolName, args: event.input };
 		default:
 			return null;
 	}
@@ -174,41 +172,16 @@ function toolCallStreamEventFromAssistantEvent(ev: any): unknown | null {
 	const toolCallId = typeof block.id === "string" && block.id ? block.id : `content-${ev.contentIndex}`;
 	const toolName = typeof block.name === "string" ? block.name : "";
 	if (!toolName) return null;
-	const argsText = typeof block.partialJson === "string"
-		? block.partialJson
-		: typeof block.partialArgs === "string"
-			? block.partialArgs
-			: undefined;
+	const args = ev.type === "toolcall_end"
+		? ev.toolCall?.arguments ?? block.arguments
+		: undefined;
 	return {
 		type: "tool_call_delta",
 		toolCallId,
 		toolName,
-		args: block.arguments,
-		argsText,
-		argsDelta: typeof ev.delta === "string" ? ev.delta : undefined,
+		...(args !== undefined ? { args } : {}),
+		...(ev.type === "toolcall_delta" && typeof ev.delta === "string" ? { argsDelta: ev.delta } : {}),
 	};
-}
-
-function piEventToSseEvents(event: any): unknown[] {
-	const primary = piEventToSseEvent(event);
-	const events = primary ? [primary] : [];
-	if (event.type !== "message_update") return events;
-	const ev = event.assistantMessageEvent;
-	if (ev?.type === "toolcall_start" || ev?.type === "toolcall_delta" || ev?.type === "toolcall_end") return events;
-	const content = Array.isArray(event.message?.content) ? event.message.content : [];
-	for (const block of content) {
-		if (!block || typeof block !== "object" || block.type !== "toolCall") continue;
-		const toolCallId = typeof block.id === "string" ? block.id : "";
-		const toolName = typeof block.name === "string" ? block.name : "";
-		if (!toolCallId || !toolName) continue;
-		events.push({
-			type: "tool_call_delta",
-			toolCallId,
-			toolName,
-			args: block.arguments,
-		});
-	}
-	return events;
 }
 
 /** Convert a raw PI SDK event to a ChannelStreamEvent for channel streaming replies. */
@@ -641,6 +614,7 @@ function parseProviderPayload(body: Record<string, unknown>): {
 	provider: InnoProviderConfig;
 	makeDefault: boolean;
 	preserveApiKey: boolean;
+	preserveHeaders: boolean;
 } {
 	const providerId = typeof body.providerId === "string" ? body.providerId.trim() : "";
 	if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(providerId)) {
@@ -665,6 +639,7 @@ function parseProviderPayload(body: Record<string, unknown>): {
 		},
 		makeDefault: Boolean(body.makeDefault),
 		preserveApiKey: Boolean(body.preserveApiKey),
+		preserveHeaders: !Object.prototype.hasOwnProperty.call(body, "headers"),
 	};
 }
 
@@ -1408,94 +1383,103 @@ function workspaceRelativePath(rootDir: string, filePath: string): string {
 	return relative(rootDir, filePath) || "";
 }
 
-interface WorkspaceFileSnapshot {
-	files: Map<string, { mtimeMs: number; size: number }>;
-	truncated: boolean;
-}
-
 interface WorkspaceFileChange {
 	path: string;
 	change: "created" | "modified" | "deleted";
 }
 
-const WORKSPACE_SNAPSHOT_IGNORES = new Set([
+interface WorkspaceChangeMonitor {
+	noteToolEnd(toolCallId: string, toolName: string): void;
+	close(): void;
+}
+
+const WORKSPACE_CHANGE_IGNORES = new Set([
 	...WORKSPACE_IGNORES,
-	".git",
-	"node_modules",
-	"dist",
 	".next",
 	".vite",
 	"coverage",
 ]);
-const MAX_WORKSPACE_SNAPSHOT_FILES = 2500;
-const MAX_WORKSPACE_SNAPSHOT_DEPTH = 8;
 const MAX_WORKSPACE_CHANGE_EVENTS = 40;
+const WORKSPACE_CHANGE_SETTLE_MS = 80;
 
-function snapshotWorkspaceFiles(rootDir: string | null): WorkspaceFileSnapshot | null {
+function createWorkspaceChangeMonitor(
+	rootDir: string | null,
+	publish: (event: unknown) => void,
+): WorkspaceChangeMonitor | null {
 	if (!rootDir || !existsSync(rootDir)) return null;
-	const files = new Map<string, { mtimeMs: number; size: number }>();
-	let truncated = false;
+	const root = resolve(rootDir);
+	const pending = new Map<string, "change" | "rename">();
+	let context: { toolCallId: string; toolName: string } | null = null;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let closed = false;
 
-	const visit = (dir: string, depth: number) => {
-		if (truncated || depth > MAX_WORKSPACE_SNAPSHOT_DEPTH) return;
-		let entries: import("node:fs").Dirent[];
-		try {
-			entries = readdirSync(dir, { withFileTypes: true });
-		} catch {
-			return;
+	const flush = () => {
+		if (timer) clearTimeout(timer);
+		timer = null;
+		if (pending.size === 0 || !context) return;
+		const entries = Array.from(pending.entries());
+		pending.clear();
+		const changes: WorkspaceFileChange[] = [];
+		for (const [path, eventType] of entries.slice(0, MAX_WORKSPACE_CHANGE_EVENTS)) {
+			const fullPath = resolve(root, path);
+			if (existsSync(fullPath)) {
+				try {
+					if (!statSync(fullPath).isFile()) continue;
+				} catch {
+					continue;
+				}
+				changes.push({ path, change: eventType === "rename" ? "created" : "modified" });
+			} else {
+				changes.push({ path, change: "deleted" });
+			}
 		}
-		for (const entry of entries) {
-			if (truncated) return;
-			if (WORKSPACE_SNAPSHOT_IGNORES.has(entry.name)) continue;
-			const fullPath = join(dir, entry.name);
-			let stat: ReturnType<typeof statSync>;
-			try {
-				stat = statSync(fullPath);
-			} catch {
-				continue;
-			}
-			if (entry.isDirectory()) {
-				visit(fullPath, depth + 1);
-				continue;
-			}
-			if (!entry.isFile()) continue;
-			files.set(workspaceRelativePath(rootDir, fullPath), {
-				mtimeMs: stat.mtimeMs,
-				size: stat.size,
+		if (changes.length > 0) {
+			publish({
+				type: "workspace_change",
+				...context,
+				changes,
+				truncated: entries.length > MAX_WORKSPACE_CHANGE_EVENTS,
 			});
-			if (files.size >= MAX_WORKSPACE_SNAPSHOT_FILES) {
-				truncated = true;
-				return;
-			}
 		}
 	};
 
-	visit(rootDir, 0);
-	return { files, truncated };
-}
+	const scheduleFlush = () => {
+		if (!context || closed) return;
+		if (timer) clearTimeout(timer);
+		timer = setTimeout(flush, WORKSPACE_CHANGE_SETTLE_MS);
+	};
 
-function diffWorkspaceFileSnapshots(before: WorkspaceFileSnapshot | null, after: WorkspaceFileSnapshot | null): { changes: WorkspaceFileChange[]; truncated: boolean } {
-	if (!before || !after) return { changes: [], truncated: false };
-	const changes: WorkspaceFileChange[] = [];
-	for (const [path, next] of after.files) {
-		const prev = before.files.get(path);
-		if (!prev) {
-			changes.push({ path, change: "created" });
-		} else if (prev.size !== next.size || prev.mtimeMs !== next.mtimeMs) {
-			changes.push({ path, change: "modified" });
-		}
-		if (changes.length >= MAX_WORKSPACE_CHANGE_EVENTS) break;
+	let watcher: ReturnType<typeof watch>;
+	try {
+		watcher = watch(root, { recursive: true }, (eventType, filename) => {
+			if (!filename || closed) return;
+			const fullPath = resolve(root, filename.toString());
+			const relativePath = relative(root, fullPath);
+			if (!relativePath || relativePath.startsWith("..") || isAbsolute(relativePath)) return;
+			const normalizedPath = relativePath.replaceAll("\\", "/");
+			if (normalizedPath.split("/").some((part) => WORKSPACE_CHANGE_IGNORES.has(part))) return;
+			pending.set(normalizedPath, eventType);
+			scheduleFlush();
+		});
+	} catch (err) {
+		logger.warn({ err, root }, "workspace file monitoring unavailable");
+		return null;
 	}
-	if (changes.length < MAX_WORKSPACE_CHANGE_EVENTS) {
-		for (const path of before.files.keys()) {
-			if (after.files.has(path)) continue;
-			changes.push({ path, change: "deleted" });
-			if (changes.length >= MAX_WORKSPACE_CHANGE_EVENTS) break;
-		}
-	}
+
+	watcher.on("error", (err) => {
+		logger.warn({ err, root }, "workspace file monitor failed");
+	});
+
 	return {
-		changes,
-		truncated: before.truncated || after.truncated || changes.length >= MAX_WORKSPACE_CHANGE_EVENTS,
+		noteToolEnd(toolCallId, toolName) {
+			context = { toolCallId, toolName };
+			scheduleFlush();
+		},
+		close() {
+			closed = true;
+			flush();
+			watcher.close();
+		},
 	};
 }
 
@@ -3844,6 +3828,7 @@ const server = createServer(async (req, res) => {
 				upsertProvider(config, payload.providerId, payload.provider, {
 					makeDefault: payload.makeDefault,
 					preserveApiKey: payload.preserveApiKey,
+					preserveHeaders: payload.preserveHeaders,
 				}),
 			);
 			applyProviderProxyBypass(config);
@@ -4255,7 +4240,7 @@ const server = createServer(async (req, res) => {
 
 			const streamWorkspaceId = workspaceRegistry.getSessionWorkspaceId(capturedSessionId);
 			const streamWorkspaceRoot = workspaceRegistry.resolveWorkspaceDir(streamWorkspaceId);
-			const toolWorkspaceSnapshots = new Map<string, WorkspaceFileSnapshot | null>();
+			const workspaceChangeMonitor = createWorkspaceChangeMonitor(streamWorkspaceRoot, publishStreamEvent);
 
 			// Track whether the model API surfaced an error this turn. The PI SDK
 			// does NOT throw on model API errors (e.g. HTTP 413 from an over-long
@@ -4266,7 +4251,6 @@ const server = createServer(async (req, res) => {
 			let emittedError = false;
 			let promptStartTime = 0;
 			const onEvent = (event: import("@earendil-works/pi-coding-agent").AgentSessionEvent) => {
-				let workspaceChangeEvent: unknown | null = null;
 				// Logging regardless of aborted state
 				switch (event.type) {
 					case "message_update": {
@@ -4291,29 +4275,13 @@ const server = createServer(async (req, res) => {
 						break;
 					}
 					case "tool_execution_start":
-						toolWorkspaceSnapshots.set(event.toolCallId, snapshotWorkspaceFiles(streamWorkspaceRoot));
 						logger.info(
 							{ toolName: event.toolName, toolCallId: event.toolCallId },
 							"tool call started: %s", event.toolName,
 						);
 						break;
 					case "tool_execution_end":
-						if (!event.isError) {
-							const before = toolWorkspaceSnapshots.get(event.toolCallId) ?? null;
-							const after = snapshotWorkspaceFiles(streamWorkspaceRoot);
-							const { changes, truncated } = diffWorkspaceFileSnapshots(before, after);
-							if (changes.length > 0) {
-								workspaceChangeEvent = {
-									type: "workspace_change",
-									toolCallId: event.toolCallId,
-									toolName: event.toolName,
-									workspaceId: streamWorkspaceId,
-									changes,
-									truncated,
-								};
-							}
-						}
-						toolWorkspaceSnapshots.delete(event.toolCallId);
+						workspaceChangeMonitor?.noteToolEnd(event.toolCallId, event.toolName);
 						if (event.isError) {
 							const errText = Array.isArray(event.result?.content)
 								? event.result.content.map((c: { text?: string }) => c.text ?? "").join(" ").slice(0, 500)
@@ -4344,11 +4312,9 @@ const server = createServer(async (req, res) => {
 						break;
 				}
 
-				// Convert to SSE events and publish to broadcaster + live client.
-				for (const sseEvent of piEventToSseEvents(event)) {
-					publishStreamEvent(sseEvent);
-				}
-				if (workspaceChangeEvent) publishStreamEvent(workspaceChangeEvent);
+				// Convert to an SSE event and publish to broadcaster + live client.
+				const sseEvent = piEventToSseEvent(event);
+				if (sseEvent) publishStreamEvent(sseEvent);
 			};
 
 			promptStartTime = Date.now();
@@ -4373,6 +4339,7 @@ const server = createServer(async (req, res) => {
 					sseWrite(errorEvent);
 				}
 			} finally {
+				workspaceChangeMonitor?.close();
 				// Always attribute this turn to the web channel — even on abort or
 				// error — so an interrupted first prompt keeps origin "web" instead
 				// of being mislabeled "cli" (which happens when no channels.json

--- a/apps/inno-agent/src/utils/fetch-logger.ts
+++ b/apps/inno-agent/src/utils/fetch-logger.ts
@@ -67,11 +67,31 @@ export function installFetchLogger(): void {
       );
     }
 
-    const response = (await originalFetch.call(
-      globalThis,
-      input,
-      init,
-    )) as Awaited<ReturnType<FetchFn>>;
+    let response: Awaited<ReturnType<FetchFn>>;
+    try {
+      response = (await originalFetch.call(
+        globalThis,
+        input,
+        init,
+      )) as Awaited<ReturnType<FetchFn>>;
+    } catch (err) {
+      if (isLlmCall) {
+        const elapsedMs = Date.now() - startTime;
+        const error = err instanceof Error
+          ? {
+              name: err.name,
+              message: err.message,
+              stack: err.stack,
+              cause: formatErrorCause(err.cause),
+            }
+          : { name: "Error", message: String(err), stack: undefined };
+        logger.warn(
+          { reqId, url, elapsedMs, error },
+          `[LLM ${reqId}] FETCH ERROR after ${elapsedMs}ms`,
+        );
+      }
+      throw err;
+    }
 
     // Log response for LLM API calls
     if (isLlmCall) {
@@ -97,6 +117,25 @@ function resolveURL(input: Parameters<FetchFn>[0]): string {
     return String((input as { url: unknown }).url);
   }
   return String(input);
+}
+
+function formatErrorCause(cause: unknown): Record<string, unknown> | undefined {
+  if (cause == null) return undefined;
+  if (cause instanceof Error) {
+    return {
+      name: cause.name,
+      message: cause.message,
+      stack: cause.stack,
+      ...("code" in cause ? { code: cause.code } : {}),
+    };
+  }
+  if (typeof cause === "object") {
+    return Object.fromEntries(
+      Object.entries(cause as Record<string, unknown>)
+        .filter(([, value]) => typeof value !== "function"),
+    );
+  }
+  return { message: String(cause) };
 }
 
 function extractBodyString(

--- a/apps/inno-agent/src/utils/proxy-bypass.ts
+++ b/apps/inno-agent/src/utils/proxy-bypass.ts
@@ -2,6 +2,7 @@ import type { InnoConfig } from "../config.js";
 import { logger } from "../logger.js";
 
 const NO_PROXY_KEYS = ["NO_PROXY", "no_proxy"] as const;
+let managedHosts = new Set<string>();
 
 export function applyProviderProxyBypass(config: InnoConfig): void {
 	const hosts = Object.values(config.providers)
@@ -9,25 +10,27 @@ export function applyProviderProxyBypass(config: InnoConfig): void {
 		.map((provider) => parseHostname(provider.baseUrl))
 		.filter((host): host is string => Boolean(host));
 
-	if (hosts.length === 0) return;
-
 	const current = splitNoProxy(process.env.NO_PROXY ?? process.env.no_proxy ?? "");
-	const merged = new Set(current);
-	const added: string[] = [];
+	const previousManagedHosts = managedHosts;
+	const merged = new Set(current.filter((host) => !managedHosts.has(host)));
+	const nextManagedHosts = new Set<string>();
 	for (const host of hosts) {
 		if (!merged.has(host)) {
 			merged.add(host);
-			added.push(host);
+			nextManagedHosts.add(host);
 		}
 	}
-
-	if (added.length === 0) return;
+	managedHosts = nextManagedHosts;
+	const added = Array.from(nextManagedHosts).filter((host) => !previousManagedHosts.has(host));
+	const removed = Array.from(previousManagedHosts).filter((host) => !nextManagedHosts.has(host));
 
 	const next = Array.from(merged).join(",");
 	for (const key of NO_PROXY_KEYS) {
 		process.env[key] = next;
 	}
-	logger.info({ hosts: added }, "[inno] provider proxy bypass applied");
+	if (added.length > 0 || removed.length > 0) {
+		logger.info({ added, removed }, "[inno] provider proxy bypass updated");
+	}
 }
 
 function parseHostname(baseUrl: string): string | undefined {

--- a/apps/inno-agent/src/utils/proxy-bypass.ts
+++ b/apps/inno-agent/src/utils/proxy-bypass.ts
@@ -1,0 +1,46 @@
+import type { InnoConfig } from "../config.js";
+import { logger } from "../logger.js";
+
+const NO_PROXY_KEYS = ["NO_PROXY", "no_proxy"] as const;
+
+export function applyProviderProxyBypass(config: InnoConfig): void {
+	const hosts = Object.values(config.providers)
+		.filter((provider) => provider.bypassProxy === true)
+		.map((provider) => parseHostname(provider.baseUrl))
+		.filter((host): host is string => Boolean(host));
+
+	if (hosts.length === 0) return;
+
+	const current = splitNoProxy(process.env.NO_PROXY ?? process.env.no_proxy ?? "");
+	const merged = new Set(current);
+	const added: string[] = [];
+	for (const host of hosts) {
+		if (!merged.has(host)) {
+			merged.add(host);
+			added.push(host);
+		}
+	}
+
+	if (added.length === 0) return;
+
+	const next = Array.from(merged).join(",");
+	for (const key of NO_PROXY_KEYS) {
+		process.env[key] = next;
+	}
+	logger.info({ hosts: added }, "[inno] provider proxy bypass applied");
+}
+
+function parseHostname(baseUrl: string): string | undefined {
+	try {
+		return new URL(baseUrl).hostname;
+	} catch {
+		return undefined;
+	}
+}
+
+function splitNoProxy(value: string): string[] {
+	return value
+		.split(",")
+		.map((part) => part.trim())
+		.filter(Boolean);
+}

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -421,6 +421,47 @@ inno-workspace-panel textarea {
 	line-height: 1;
 }
 
+.inno-stream-status-dot {
+	display: inline-block;
+	width: 7px;
+	height: 7px;
+	border-radius: 999px;
+	background: var(--inno-success);
+	box-shadow: 0 0 0 3px var(--inno-success-bg);
+}
+
+.inno-stream-status-dot.is-streaming {
+	animation: inno-stream-pulse 1.2s ease-in-out infinite;
+}
+
+.inno-stream-cursor {
+	display: inline-block;
+	width: 7px;
+	height: 1.1em;
+	margin-left: 2px;
+	vertical-align: -0.18em;
+	background: var(--inno-accent);
+	animation: inno-stream-caret 1s steps(1, end) infinite;
+}
+
+@keyframes inno-stream-pulse {
+	0%, 100% {
+		opacity: 0.45;
+	}
+	50% {
+		opacity: 1;
+	}
+}
+
+@keyframes inno-stream-caret {
+	0%, 49% {
+		opacity: 1;
+	}
+	50%, 100% {
+		opacity: 0;
+	}
+}
+
 .inno-sidebar-scope {
 	font-size: 12px;
 	line-height: 1.35;

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -35,6 +35,8 @@
 		"ok": "OK",
 		"saving": "Saving…",
 		"saved": "Saved",
+		"copy": "Copy",
+		"copied": "Copied",
 		"remove": "Remove",
 		"open": "Open",
 		"close": "Close",
@@ -148,8 +150,15 @@
 		"docxFailed": "Failed to render document",
 		"xlsxLoading": "Rendering spreadsheet...",
 		"xlsxFailed": "Failed to render spreadsheet",
-		"xlsxLargeSheetWarning": "Large sheet — showing first {{n}} rows"
-	},
+		"xlsxLargeSheetWarning": "Large sheet — showing first {{n}} rows",
+		"streamingGenerating": "Generating",
+		"streamingDone": "Generated",
+		"streamingError": "Interrupted",
+		"streamingLines": "lines",
+		"streamingHint": "Long output is rendering on the right; chat keeps a summary.",
+		"streamingWaiting": "Waiting for output…",
+		"streamingClose": "Close generation preview"
+		},
 	"profile": {
 		"title": "Learner Profile",
 		"subtitle": "Built from conversations and learning events; editable.",
@@ -409,6 +418,8 @@
 			"contextWindow": "Context window",
 			"maxTokens": "Max tokens",
 			"reasoning": "reasoning",
+			"authHeader": "use Bearer auth",
+			"bypassProxy": "bypass system proxy",
 			"makeDefault": "make default",
 			"preserveApiKey": "preserve key"
 		},
@@ -516,6 +527,10 @@
 		"errCreateSession": "Failed to create session",
 		"removeUpload": "Remove upload",
 		"removeImage": "Remove image",
+		"streamingInWorkspace": "Long output is generating in the file panel",
+		"longContentCollapsed": "Long content collapsed to keep the page responsive",
+		"expandFullContent": "Expand full content",
+		"collapseFullContent": "Collapse full content",
 		"composerPlaceholder": "Type a message…"
 	},
 	"question": {

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -35,6 +35,8 @@
 		"ok": "确定",
 		"saving": "保存中…",
 		"saved": "已保存",
+		"copy": "复制",
+		"copied": "已复制",
 		"remove": "移除",
 		"open": "打开",
 		"close": "关闭",
@@ -148,8 +150,15 @@
 		"docxFailed": "文档渲染失败",
 		"xlsxLoading": "正在渲染表格…",
 		"xlsxFailed": "表格渲染失败",
-		"xlsxLargeSheetWarning": "表格较大 — 仅显示前 {{n}} 行"
-	},
+		"xlsxLargeSheetWarning": "表格较大 — 仅显示前 {{n}} 行",
+		"streamingGenerating": "正在生成",
+		"streamingDone": "生成完成",
+		"streamingError": "生成中断",
+		"streamingLines": "行",
+		"streamingHint": "长内容正在右侧生成，聊天区只保留摘要。",
+		"streamingWaiting": "等待模型开始输出…",
+		"streamingClose": "关闭生成预览"
+		},
 	"profile": {
 		"title": "学习者画像",
 		"subtitle": "由对话与学习事件自动累积，可手动编辑",
@@ -409,6 +418,8 @@
 			"contextWindow": "上下文窗口",
 			"maxTokens": "最大 Tokens",
 			"reasoning": "支持推理",
+			"authHeader": "使用 Bearer 鉴权",
+			"bypassProxy": "绕过系统代理",
 			"makeDefault": "设为默认",
 			"preserveApiKey": "保留现有 Key"
 		},
@@ -516,6 +527,10 @@
 		"errCreateSession": "创建会话失败",
 		"removeUpload": "移除上传",
 		"removeImage": "移除图片",
+		"streamingInWorkspace": "长内容正在右侧文件区生成",
+		"longContentCollapsed": "内容较长，已折叠以保持页面流畅",
+		"expandFullContent": "展开完整内容",
+		"collapseFullContent": "收起完整内容",
 		"composerPlaceholder": "输入消息…"
 	},
 	"question": {

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -154,8 +154,8 @@ function ToolRecordDetails({ tool, className }: { tool: ChatToolRecord; classNam
 	const detail = useMemo(() => {
 		if (!open) return "";
 		return JSON.stringify({
-			args: compactForDisplay(tool.args),
-			result: compactForDisplay(tool.result),
+			args: tool.args,
+			result: tool.result,
 		}, null, 2);
 	}, [open, tool.args, tool.result]);
 
@@ -169,35 +169,6 @@ function ToolRecordDetails({ tool, className }: { tool: ChatToolRecord; classNam
 			) : null}
 		</details>
 	);
-}
-
-function compactForDisplay(value: unknown): unknown {
-	return compactDisplayValue(value, new WeakSet<object>(), 0);
-}
-
-function compactDisplayValue(value: unknown, seen: WeakSet<object>, depth: number): unknown {
-	if (typeof value === "string") {
-		if (value.length <= 1600) return value;
-		return `${value.slice(0, 1600)}\n\n[已省略 ${value.length - 1600} 个字符]`;
-	}
-	if (value == null || typeof value !== "object") return value;
-	if (seen.has(value)) return "[循环引用]";
-	seen.add(value);
-	if (depth >= 4) return "[内容层级较深，已折叠]";
-	if (Array.isArray(value)) {
-		const items = value.slice(0, 24).map((item) => compactDisplayValue(item, seen, depth + 1));
-		if (value.length > 24) items.push(`[已省略 ${value.length - 24} 项]`);
-		return items;
-	}
-	const record = value as Record<string, unknown>;
-	const entries = Object.entries(record).slice(0, 32);
-	const result: Record<string, unknown> = {};
-	for (const [key, item] of entries) {
-		result[key] = compactDisplayValue(item, seen, depth + 1);
-	}
-	const remaining = Object.keys(record).length - entries.length;
-	if (remaining > 0) result.__truncated = `已省略 ${remaining} 个字段`;
-	return result;
 }
 
 function MessageBubble({ message, showChannel }: { message: ChatMessage; showChannel?: boolean }) {

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -3,9 +3,9 @@ import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
-import { Paperclip, X, SendHorizonal, Square, RotateCcw, Image, AlertTriangle, Search } from "lucide-react";
+import { Paperclip, X, SendHorizonal, Square, RotateCcw, Image, AlertTriangle, Search, FileCode2, Sparkles } from "lucide-react";
 import { Spinner } from "./ui/Spinner.js";
-import type { ChatMessage } from "../types/chat.js";
+import type { ChatMessage, ChatToolRecord } from "../types/chat.js";
 import type { InlineImage } from "../api/chat.js";
 import { chatStore } from "../stores/chat-store.js";
 import { sessionsStore } from "../stores/sessions-store.js";
@@ -29,6 +29,8 @@ import "@earendil-works/pi-web-ui";
 // (a few paragraphs) stays inline, but dumping a whole file collapses.
 const PASTE_COLLAPSE_LINES = 20;
 const PASTE_COLLAPSE_CHARS = 2000;
+const LONG_ASSISTANT_CHARS = 6000;
+const LONG_ASSISTANT_LINES = 140;
 
 const CHANNEL_BADGE_CLASS: Record<string, string> = {
 	cli: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]",
@@ -105,6 +107,99 @@ function ErrorBlock({ error }: { error: string }) {
 	);
 }
 
+function shouldCollapseAssistantContent(content: string): boolean {
+	if (content.length > LONG_ASSISTANT_CHARS) return true;
+	return content.split(/\r\n|\r|\n/).length > LONG_ASSISTANT_LINES;
+}
+
+function AssistantContent({ content }: { content: string }) {
+	const { t } = useTranslation();
+	const [expanded, setExpanded] = useState(false);
+	const trimmed = content.trim();
+	if (!trimmed) return null;
+	if (!shouldCollapseAssistantContent(trimmed)) {
+		return <markdown-artifact content={normalizeMarkdownMath(trimmed)} />;
+	}
+	const lineCount = trimmed.split(/\r\n|\r|\n/).length;
+	const preview = trimmed.slice(0, 900);
+	return (
+		<div className="rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-2.5">
+			<div className="mb-2 flex min-w-0 items-center gap-2 text-xs text-[var(--inno-text-muted)]">
+				<FileCode2 size={14} className="shrink-0 text-[var(--inno-accent)]" />
+				<span className="min-w-0 flex-1 truncate">{t("chat.longContentCollapsed", "内容较长，已折叠以保持页面流畅")}</span>
+				<span className="shrink-0 tabular-nums">{lineCount} {t("preview.streamingLines", "行")}</span>
+			</div>
+			{expanded ? (
+				<div className="max-h-[60vh] overflow-auto rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] p-2">
+					<markdown-artifact content={normalizeMarkdownMath(trimmed)} />
+				</div>
+			) : (
+				<pre className="max-h-36 overflow-hidden whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-[var(--inno-text-muted)] [overflow-wrap:anywhere]">
+					{preview}
+					{trimmed.length > preview.length ? "\n\n…" : ""}
+				</pre>
+			)}
+			<button
+				className="mt-2 rounded-md border border-[var(--inno-border)] px-2.5 py-1 text-xs text-[var(--inno-text-muted)] transition-colors hover:bg-[var(--inno-surface)] hover:text-[var(--inno-text)]"
+				onClick={() => setExpanded((v) => !v)}
+			>
+				{expanded ? t("chat.collapseFullContent", "收起完整内容") : t("chat.expandFullContent", "展开完整内容")}
+			</button>
+		</div>
+	);
+}
+
+function ToolRecordDetails({ tool, className }: { tool: ChatToolRecord; className: string }) {
+	const [open, setOpen] = useState(false);
+	const detail = useMemo(() => {
+		if (!open) return "";
+		return JSON.stringify({
+			args: compactForDisplay(tool.args),
+			result: compactForDisplay(tool.result),
+		}, null, 2);
+	}, [open, tool.args, tool.result]);
+
+	return (
+		<details className={className} onToggle={(e) => setOpen(e.currentTarget.open)}>
+			<summary className={tool.isError ? "cursor-pointer break-words text-[var(--inno-danger)] [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>
+				{tool.toolName}
+			</summary>
+			{open ? (
+				<pre className="mt-1 max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] [overflow-wrap:anywhere]">{detail}</pre>
+			) : null}
+		</details>
+	);
+}
+
+function compactForDisplay(value: unknown): unknown {
+	return compactDisplayValue(value, new WeakSet<object>(), 0);
+}
+
+function compactDisplayValue(value: unknown, seen: WeakSet<object>, depth: number): unknown {
+	if (typeof value === "string") {
+		if (value.length <= 1600) return value;
+		return `${value.slice(0, 1600)}\n\n[已省略 ${value.length - 1600} 个字符]`;
+	}
+	if (value == null || typeof value !== "object") return value;
+	if (seen.has(value)) return "[循环引用]";
+	seen.add(value);
+	if (depth >= 4) return "[内容层级较深，已折叠]";
+	if (Array.isArray(value)) {
+		const items = value.slice(0, 24).map((item) => compactDisplayValue(item, seen, depth + 1));
+		if (value.length > 24) items.push(`[已省略 ${value.length - 24} 项]`);
+		return items;
+	}
+	const record = value as Record<string, unknown>;
+	const entries = Object.entries(record).slice(0, 32);
+	const result: Record<string, unknown> = {};
+	for (const [key, item] of entries) {
+		result[key] = compactDisplayValue(item, seen, depth + 1);
+	}
+	const remaining = Object.keys(record).length - entries.length;
+	if (remaining > 0) result.__truncated = `已省略 ${remaining} 个字段`;
+	return result;
+}
+
 function MessageBubble({ message, showChannel }: { message: ChatMessage; showChannel?: boolean }) {
 	const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
 
@@ -161,18 +256,13 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 						{message.tools?.length ? (
 							<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
 								{message.tools.map((tool) => (
-									<details key={tool.toolCallId} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1">
-										<summary className={tool.isError ? "cursor-pointer break-words text-[var(--inno-danger)] [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>
-											{tool.toolName}
-										</summary>
-										<pre className="mt-1 max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] [overflow-wrap:anywhere]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
-									</details>
+									<ToolRecordDetails key={tool.toolCallId} tool={tool} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1" />
 								))}
 							</div>
 						) : null}
 					</details>
 				) : null}
-				<markdown-artifact content={normalizeMarkdownMath(message.content)} />
+				<AssistantContent content={message.content} />
 				{message.error ? (
 					<div className={message.content.trim() ? "mt-2" : ""}>
 						<ErrorBlock error={message.error} />
@@ -378,6 +468,9 @@ export function ChatCenter() {
 		isLoadingHistory: chatStore.isLoadingHistory,
 		streamingText: chatStore.streamingText,
 		streamingThinking: chatStore.streamingThinking,
+		streamingTarget: chatStore.streamingTarget,
+		streamingActivity: chatStore.streamingActivity,
+		streamingActivityDetail: chatStore.streamingActivityDetail,
 		streamingError: chatStore.streamingError,
 		activeTools: chatStore.activeTools,
 		completedTools: chatStore.completedTools,
@@ -462,12 +555,14 @@ export function ChatCenter() {
 		}
 	}, [isWelcome, wsMode, wsExistingId]);
 
+	const scrollTextKey = chat.streamingTarget === "workspace" ? chat.streamingTarget : chat.streamingText;
+
 	useEffect(() => {
 		requestAnimationFrame(() => {
 			const el = scrollRef.current;
 			if (el) el.scrollTop = el.scrollHeight;
 		});
-	}, [chat.messages, chat.streamingText, chat.streamingThinking, chat.activeTools.length, chat.completedTools.length, chat.pendingQuestion]);
+	}, [chat.messages, scrollTextKey, chat.streamingThinking, chat.activeTools.length, chat.completedTools.length, chat.pendingQuestion]);
 
 	const handleInput = useCallback(() => {
 		const el = inputRef.current;
@@ -949,6 +1044,26 @@ export function ChatCenter() {
 						));
 					})()}
 
+					{chat.isSending && chat.streamingActivity ? (
+						<motion.div
+							className="flex justify-start"
+							initial={{ opacity: 0, y: 8 }}
+							animate={{ opacity: 1, y: 0 }}
+							transition={{ duration: 0.2, ease: "easeOut" }}
+						>
+							<div className="inno-message min-w-0 max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] text-[var(--inno-text-muted)] shadow-sm">
+								<div className="flex min-w-0 items-center gap-2">
+									<span className="inno-stream-status-dot is-streaming shrink-0" />
+									<Sparkles size={14} className="shrink-0 text-[var(--inno-accent)]" />
+									<span className="min-w-0 font-medium text-[var(--inno-text)]">{chat.streamingActivity}</span>
+									{chat.streamingActivityDetail ? (
+										<span className="min-w-0 truncate text-xs text-[var(--inno-text-subtle)]">{chat.streamingActivityDetail}</span>
+									) : null}
+								</div>
+							</div>
+						</motion.div>
+					) : null}
+
 					{chat.activeTools.length > 0 ? (
 						<motion.div
 							className="flex justify-start"
@@ -982,38 +1097,49 @@ export function ChatCenter() {
 					) : null}
 
 					{chat.completedTools.length > 0 ? (
-						<motion.div
-							className="flex justify-start"
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							transition={{ duration: 0.2 }}
-						>
-							<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
-								<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Completed tool calls · {chat.completedTools.length}</summary>
-								<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
-									{chat.completedTools.map((tool) => (
-										<details key={tool.toolCallId} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1">
-											<summary className={tool.isError ? "cursor-pointer break-words text-[var(--inno-danger)] [overflow-wrap:anywhere]" : "cursor-pointer break-words text-[var(--inno-text-muted)] [overflow-wrap:anywhere]"}>{tool.toolName}</summary>
-											<pre className="mt-1 max-h-40 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono text-[11px] [overflow-wrap:anywhere]">{JSON.stringify({ args: tool.args, result: tool.result }, null, 2)}</pre>
-										</details>
-									))}
-								</div>
-							</details>
-						</motion.div>
-					) : null}
+							<motion.div
+								className="flex justify-start"
+								initial={{ opacity: 0 }}
+								animate={{ opacity: 1 }}
+								transition={{ duration: 0.2 }}
+							>
+								<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
+									<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Completed tool calls · {chat.completedTools.length}</summary>
+									<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
+										{chat.completedTools.map((tool) => (
+											<ToolRecordDetails key={tool.toolCallId} tool={tool} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1" />
+										))}
+									</div>
+								</details>
+							</motion.div>
+						) : null}
 
-					{chat.streamingText ? (
-						<motion.div
-							className="flex justify-start"
-							initial={{ opacity: 0, y: 8 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.2, ease: "easeOut" }}
-						>
-							<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
-								<markdown-artifact content={normalizeMarkdownMath(chat.streamingText)} />
-							</div>
-						</motion.div>
-					) : null}
+						{chat.streamingText && chat.streamingTarget === "workspace" ? (
+							<motion.div
+								className="flex justify-start"
+								initial={{ opacity: 0, y: 8 }}
+								animate={{ opacity: 1, y: 0 }}
+								transition={{ duration: 0.2, ease: "easeOut" }}
+							>
+								<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] text-[var(--inno-text-muted)]">
+									<div className="flex min-w-0 items-center gap-2">
+										<span className="inno-stream-status-dot is-streaming shrink-0" />
+										<span className="min-w-0 break-words [overflow-wrap:anywhere]">{t("chat.streamingInWorkspace", "长内容正在右侧文件区生成")}</span>
+									</div>
+								</div>
+							</motion.div>
+						) : chat.streamingText ? (
+							<motion.div
+								className="flex justify-start"
+								initial={{ opacity: 0, y: 8 }}
+								animate={{ opacity: 1, y: 0 }}
+								transition={{ duration: 0.2, ease: "easeOut" }}
+							>
+								<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
+									<markdown-artifact content={normalizeMarkdownMath(chat.streamingText)} />
+								</div>
+							</motion.div>
+						) : null}
 
 					{chat.streamingError ? (
 						<motion.div

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -26,6 +26,8 @@ interface ProviderFormState {
 	contextWindow: string;
 	maxTokens: string;
 	reasoning: boolean;
+	authHeader: boolean;
+	bypassProxy: boolean;
 	makeDefault: boolean;
 	preserveApiKey: boolean;
 }
@@ -40,6 +42,8 @@ const emptyForm: ProviderFormState = {
 	contextWindow: "128000",
 	maxTokens: "8192",
 	reasoning: false,
+	authHeader: false,
+	bypassProxy: false,
 	makeDefault: true,
 	preserveApiKey: false,
 };
@@ -77,6 +81,8 @@ function ModelEditForm({ model, settings, onClose }: {
 		contextWindow: String(model.contextWindow),
 		maxTokens: String(model.maxTokens),
 		reasoning: model.reasoning,
+		authHeader: provider?.authHeader === true,
+		bypassProxy: provider?.bypassProxy === true,
 		makeDefault: settings.defaultProvider === model.provider && settings.defaultModel === model.id,
 		preserveApiKey: Boolean(provider?.apiKey),
 	});
@@ -106,6 +112,8 @@ function ModelEditForm({ model, settings, onClose }: {
 				baseUrl: form.baseUrl.trim(),
 				apiKey: form.apiKey,
 				api: form.api,
+				authHeader: form.authHeader,
+				bypassProxy: form.bypassProxy,
 				models: [providerModel],
 				makeDefault: form.makeDefault,
 				preserveApiKey: form.preserveApiKey,
@@ -164,6 +172,8 @@ function ModelEditForm({ model, settings, onClose }: {
 			</div>
 			<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
 				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
+				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.authHeader} onChange={(e) => setForm({ ...form, authHeader: e.target.checked })} /> {t("settings.form.authHeader")}</label>
+				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.bypassProxy} onChange={(e) => setForm({ ...form, bypassProxy: e.target.checked })} /> {t("settings.form.bypassProxy")}</label>
 				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
 				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.preserveApiKey} onChange={(e) => setForm({ ...form, preserveApiKey: e.target.checked })} /> {t("settings.form.preserveApiKey")}</label>
 			</div>
@@ -243,6 +253,8 @@ function NewProviderForm() {
 				baseUrl: form.baseUrl.trim(),
 				apiKey: form.apiKey,
 				api: form.api,
+				authHeader: form.authHeader,
+				bypassProxy: form.bypassProxy,
 				models: [model],
 				makeDefault: form.makeDefault,
 				preserveApiKey: false,
@@ -310,6 +322,8 @@ function NewProviderForm() {
 					</div>
 					<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
 						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
+						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.authHeader} onChange={(e) => setForm({ ...form, authHeader: e.target.checked })} /> {t("settings.form.authHeader")}</label>
+						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.bypassProxy} onChange={(e) => setForm({ ...form, bypassProxy: e.target.checked })} /> {t("settings.form.bypassProxy")}</label>
 						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
 					</div>
 					{formError ? <div className="mt-2 rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-xs text-[var(--inno-danger)]">{formError}</div> : null}

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -473,12 +473,11 @@ function StreamingPreviewPane({ preview, onToggleSidebar, sidebarOpen }: { previ
 					<Sparkles size={12} className="shrink-0 text-[var(--inno-accent)]" />
 					<span className="truncate">{t("preview.streamingHint", "长内容正在右侧生成，聊天区只保留摘要。")}</span>
 				</div>
-				{preview.content ? (
-					isMarkdownPreview ? (
-						<div className="px-4 py-3 text-[13px] leading-relaxed text-[var(--inno-text)] [overflow-wrap:anywhere]">
-							<markdown-artifact content={normalizeMarkdownMath(preview.content)} />
-							{isStreaming ? <span className="inno-stream-cursor" aria-hidden="true" /> : null}
-						</div>
+					{preview.content ? (
+						isMarkdownPreview && !isStreaming ? (
+							<div className="px-4 py-3 text-[13px] leading-relaxed text-[var(--inno-text)] [overflow-wrap:anywhere]">
+								<markdown-artifact content={normalizeMarkdownMath(preview.content)} />
+							</div>
 					) : (
 						<pre className="min-h-full whitespace-pre-wrap break-words px-4 py-3 font-mono text-[12px] leading-relaxed text-[var(--inno-text)] [overflow-wrap:anywhere]">
 							{preview.content}

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type DragEvent } from "react";
+import { lazy, memo, Suspense, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type DragEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Tree, type NodeRendererProps, type TreeApi, type CreateHandler, type RenameHandler, type DeleteHandler, type MoveHandler } from "react-arborist";
 import MDEditor from "@uiw/react-md-editor";
@@ -39,6 +39,58 @@ import "@uiw/react-markdown-preview/markdown.css";
 const PptxPreview = lazy(() => import("./office/PptxPreview.js"));
 const DocxPreview = lazy(() => import("./office/DocxPreview.js"));
 const XlsxPreview = lazy(() => import("./office/XlsxPreview.js"));
+
+const MAX_STREAMING_MARKDOWN_FORMAT_CHARS = 160_000;
+
+function streamingMarkdownInterval(contentLength: number): number {
+	if (contentLength < 40_000) return 240;
+	if (contentLength < 100_000) return 420;
+	return 700;
+}
+
+function useStreamingMarkdownSnapshot(content: string, enabled: boolean): string {
+	const [snapshot, setSnapshot] = useState(content);
+	const latestContentRef = useRef(content);
+	const timerRef = useRef<number | null>(null);
+	const lastSnapshotAtRef = useRef(0);
+	latestContentRef.current = content;
+
+	useEffect(() => {
+		if (!enabled) {
+			if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+			timerRef.current = null;
+			lastSnapshotAtRef.current = 0;
+			return;
+		}
+		if (timerRef.current !== null) return;
+
+		const elapsed = performance.now() - lastSnapshotAtRef.current;
+		const delay = Math.max(0, streamingMarkdownInterval(content.length) - elapsed);
+		timerRef.current = window.setTimeout(() => {
+			timerRef.current = null;
+			lastSnapshotAtRef.current = performance.now();
+			const next = latestContentRef.current;
+			setSnapshot((current) => current === next ? current : next);
+		}, delay);
+	}, [content, enabled]);
+
+	useEffect(() => () => {
+		if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+		timerRef.current = null;
+	}, []);
+
+	return enabled ? snapshot : content;
+}
+
+const MarkdownStreamSnapshot = memo(function MarkdownStreamSnapshot({ content, showCursor }: { content: string; showCursor: boolean }) {
+	const normalizedContent = useMemo(() => normalizeMarkdownMath(content), [content]);
+	return (
+		<div className="px-4 py-3 text-[13px] leading-relaxed text-[var(--inno-text)] [overflow-wrap:anywhere]">
+			<markdown-artifact content={normalizedContent} />
+			{showCursor ? <span className="inno-stream-cursor" aria-hidden="true" /> : null}
+		</div>
+	);
+});
 
 /* ---------- helpers ---------- */
 
@@ -405,8 +457,18 @@ function StreamingPreviewPane({ preview, onToggleSidebar, sidebarOpen }: { previ
 	const scrollRef = useRef<HTMLDivElement>(null);
 	const [copied, setCopied] = useState(false);
 	const isStreaming = preview.status === "streaming";
-	const lineCount = preview.content ? preview.content.split(/\r\n|\r|\n/).length : 0;
 	const isMarkdownPreview = isStreamingMarkdownPreview(preview);
+	const shouldFormatMarkdown = isMarkdownPreview
+		&& (!isStreaming || preview.content.length <= MAX_STREAMING_MARKDOWN_FORMAT_CHARS);
+	const markdownSnapshot = useStreamingMarkdownSnapshot(
+		preview.content,
+		isStreaming && shouldFormatMarkdown,
+	);
+	const visibleContent = shouldFormatMarkdown ? markdownSnapshot : preview.content;
+	const lineCount = useMemo(
+		() => visibleContent ? visibleContent.split(/\r\n|\r|\n/).length : 0,
+		[visibleContent],
+	);
 	const statusLabel = isStreaming
 		? preview.stage ?? t("preview.streamingGenerating", "正在生成")
 		: preview.status === "error"
@@ -417,7 +479,7 @@ function StreamingPreviewPane({ preview, onToggleSidebar, sidebarOpen }: { previ
 		if (!isStreaming) return;
 		const el = scrollRef.current;
 		if (el) el.scrollTop = el.scrollHeight;
-	}, [preview.content, isStreaming]);
+	}, [visibleContent, isStreaming]);
 
 	const copyContent = useCallback(() => {
 		if (!preview.content) return;
@@ -473,11 +535,9 @@ function StreamingPreviewPane({ preview, onToggleSidebar, sidebarOpen }: { previ
 					<Sparkles size={12} className="shrink-0 text-[var(--inno-accent)]" />
 					<span className="truncate">{t("preview.streamingHint", "长内容正在右侧生成，聊天区只保留摘要。")}</span>
 				</div>
-					{preview.content ? (
-						isMarkdownPreview && !isStreaming ? (
-							<div className="px-4 py-3 text-[13px] leading-relaxed text-[var(--inno-text)] [overflow-wrap:anywhere]">
-								<markdown-artifact content={normalizeMarkdownMath(preview.content)} />
-							</div>
+				{preview.content ? (
+					shouldFormatMarkdown ? (
+						<MarkdownStreamSnapshot content={visibleContent} showCursor={isStreaming} />
 					) : (
 						<pre className="min-h-full whitespace-pre-wrap break-words px-4 py-3 font-mono text-[12px] leading-relaxed text-[var(--inno-text)] [overflow-wrap:anywhere]">
 							{preview.content}
@@ -517,7 +577,7 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 	const canEdit = state.file != null && isEditable(state.file.kind);
 
 	if (state.streamingPreview) {
-		return <StreamingPreviewPane preview={state.streamingPreview} onToggleSidebar={onToggleSidebar} sidebarOpen={sidebarOpen} />;
+		return <StreamingPreviewPane key={state.streamingPreview.id} preview={state.streamingPreview} onToggleSidebar={onToggleSidebar} sidebarOpen={sidebarOpen} />;
 	}
 
 	if (state.isEditing && state.file) {

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -17,8 +17,8 @@ import { cpp } from "@codemirror/lang-cpp";
 import { rust } from "@codemirror/lang-rust";
 import { go } from "@codemirror/lang-go";
 import type { Extension } from "@codemirror/state";
-import { RefreshCw, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Sparkles, Download, FileCode2, Presentation, FileSpreadsheet } from "lucide-react";
-import { workspaceStore } from "../stores/workspace-store.js";
+import { RefreshCw, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Sparkles, Download, FileCode2, Presentation, FileSpreadsheet, Copy, Check } from "lucide-react";
+import { workspaceStore, type StreamingWorkspacePreview } from "../stores/workspace-store.js";
 import { workspaceFileUrl, workspaceFolderZipUrl, triggerDownload } from "../api/workspace.js";
 import { workspacesStore } from "../stores/workspaces-store.js";
 import { sessionsStore } from "../stores/sessions-store.js";
@@ -400,6 +400,106 @@ function CodeEditorPane({ value, onChange, lang }: { value: string; onChange: (v
 	);
 }
 
+function StreamingPreviewPane({ preview, onToggleSidebar, sidebarOpen }: { preview: StreamingWorkspacePreview; onToggleSidebar: () => void; sidebarOpen: boolean }) {
+	const { t } = useTranslation();
+	const scrollRef = useRef<HTMLDivElement>(null);
+	const [copied, setCopied] = useState(false);
+	const isStreaming = preview.status === "streaming";
+	const lineCount = preview.content ? preview.content.split(/\r\n|\r|\n/).length : 0;
+	const isMarkdownPreview = isStreamingMarkdownPreview(preview);
+	const statusLabel = isStreaming
+		? preview.stage ?? t("preview.streamingGenerating", "正在生成")
+		: preview.status === "error"
+			? t("preview.streamingError", "生成中断")
+			: t("preview.streamingDone", "生成完成");
+
+	useEffect(() => {
+		if (!isStreaming) return;
+		const el = scrollRef.current;
+		if (el) el.scrollTop = el.scrollHeight;
+	}, [preview.content, isStreaming]);
+
+	const copyContent = useCallback(() => {
+		if (!preview.content) return;
+		void navigator.clipboard?.writeText(preview.content).then(() => {
+			setCopied(true);
+			window.setTimeout(() => setCopied(false), 1200);
+		});
+	}, [preview.content]);
+
+	return (
+		<div className="flex h-full flex-col">
+			<div className="flex h-10 items-center justify-between border-b border-[var(--inno-border)] bg-[var(--inno-surface)] px-3">
+				<div className="flex min-w-0 flex-1 items-center gap-2">
+					<button
+						className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+						onClick={onToggleSidebar}
+						title={sidebarOpen ? t("common.collapseSidebar", "收起侧栏") : t("common.expandSidebar", "展开侧栏")}
+					>
+						{sidebarOpen ? <PanelLeftClose size={16} /> : <PanelLeftOpen size={16} />}
+					</button>
+					<span className={`inno-stream-status-dot ${isStreaming ? "is-streaming" : ""}`} />
+					<div className="min-w-0">
+						<div className="truncate text-sm font-medium">{preview.title}</div>
+						<div className="truncate text-[10px] text-[var(--inno-text-muted)]">
+							{statusLabel}
+							{preview.path ? ` · ${preview.path}` : ""}
+							{lineCount ? ` · ${lineCount} ${t("preview.streamingLines", "行")}` : ""}
+						</div>
+					</div>
+				</div>
+				<div className="flex items-center gap-1.5">
+					<button
+						disabled={!preview.content}
+						className="flex h-7 items-center gap-1 rounded-md border border-[var(--inno-border)] px-2.5 text-xs text-[var(--inno-text-muted)] transition-colors hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:cursor-not-allowed disabled:opacity-40"
+						onClick={copyContent}
+					>
+						{copied ? <Check size={12} /> : <Copy size={12} />}
+						{copied ? t("common.copied", "已复制") : t("common.copy", "复制")}
+					</button>
+					{isStreaming ? null : (
+						<button
+							className="flex h-7 w-7 items-center justify-center rounded-md text-[var(--inno-text-muted)] transition-colors hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+							title={t("preview.streamingClose", "关闭生成预览")}
+							onClick={() => workspaceStore.clearStreamingPreview(preview.id)}
+						>
+							<X size={14} />
+						</button>
+					)}
+				</div>
+			</div>
+			<div ref={scrollRef} className="workspace-scroll min-h-0 flex-1 overflow-auto bg-[var(--inno-surface)]">
+				<div className="sticky top-0 z-10 flex items-center gap-2 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-4 py-2 text-[10px] text-[var(--inno-text-muted)]">
+					<Sparkles size={12} className="shrink-0 text-[var(--inno-accent)]" />
+					<span className="truncate">{t("preview.streamingHint", "长内容正在右侧生成，聊天区只保留摘要。")}</span>
+				</div>
+				{preview.content ? (
+					isMarkdownPreview ? (
+						<div className="px-4 py-3 text-[13px] leading-relaxed text-[var(--inno-text)] [overflow-wrap:anywhere]">
+							<markdown-artifact content={normalizeMarkdownMath(preview.content)} />
+							{isStreaming ? <span className="inno-stream-cursor" aria-hidden="true" /> : null}
+						</div>
+					) : (
+						<pre className="min-h-full whitespace-pre-wrap break-words px-4 py-3 font-mono text-[12px] leading-relaxed text-[var(--inno-text)] [overflow-wrap:anywhere]">
+							{preview.content}
+							{isStreaming ? <span className="inno-stream-cursor" aria-hidden="true" /> : null}
+						</pre>
+					)
+				) : (
+					<div className="flex h-full items-center justify-center px-4 text-sm text-[var(--inno-text-muted)]">
+						{t("preview.streamingWaiting", "等待模型开始输出…")}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}
+
+function isStreamingMarkdownPreview(preview: StreamingWorkspacePreview): boolean {
+	const name = `${preview.path ?? ""} ${preview.title}`.toLowerCase();
+	return preview.language === "markdown" || name.includes(".md") || name.includes(".markdown");
+}
+
 /* ---------- File Content Pane (preview + edit) ---------- */
 
 function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: () => void; sidebarOpen: boolean }) {
@@ -412,9 +512,14 @@ function FileContentPane({ onToggleSidebar, sidebarOpen }: { onToggleSidebar: ()
 		editBuffer: workspaceStore.editBuffer,
 		isSaving: workspaceStore.isSaving,
 		error: workspaceStore.error,
+		streamingPreview: workspaceStore.streamingPreview,
 	}));
 
 	const canEdit = state.file != null && isEditable(state.file.kind);
+
+	if (state.streamingPreview) {
+		return <StreamingPreviewPane preview={state.streamingPreview} onToggleSidebar={onToggleSidebar} sidebarOpen={sidebarOpen} />;
+	}
 
 	if (state.isEditing && state.file) {
 		const isMd = state.file.kind === "markdown";

--- a/apps/inno-agent/web/src/stores/app-store.ts
+++ b/apps/inno-agent/web/src/stores/app-store.ts
@@ -23,6 +23,7 @@ class AppStoreImpl extends EventEmitter<AppStoreEvents> {
 	workspaceWidth = getInitialWorkspaceWidth();
 
 	setRightPanelTab(tab: RightPanelTab) {
+		if (this.rightPanelTab === tab) return;
 		this.rightPanelTab = tab;
 		this.emit("change", undefined);
 	}
@@ -43,12 +44,15 @@ class AppStoreImpl extends EventEmitter<AppStoreEvents> {
 	}
 
 	setWorkspaceMode(mode: WorkspaceMode) {
+		if (this.workspaceMode === mode) return;
 		this.workspaceMode = mode;
 		this.emit("change", undefined);
 	}
 
 	setWorkspaceWidth(width: number) {
-		this.workspaceWidth = Math.max(240, Math.min(920, Math.round(width)));
+		const next = Math.max(240, Math.min(920, Math.round(width)));
+		if (this.workspaceWidth === next) return;
+		this.workspaceWidth = next;
 		if (typeof window !== "undefined") {
 			window.localStorage.setItem("inno.workspaceWidth", String(this.workspaceWidth));
 		}

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -4,11 +4,13 @@ import type { InlineImage } from "../api/chat.js";
 import type { ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult, WorkspaceFileChange } from "../types/chat.js";
 import { notebookStore } from "./notebook-store.js";
 import { appStore } from "./app-store.js";
-import { workspaceStore } from "./workspace-store.js";
+import { workspaceStore, type StreamingWorkspacePreview } from "./workspace-store.js";
 
 type StreamingTarget = "chat" | "workspace";
 
 const STREAM_CHANGE_INTERVAL_MS = 80;
+
+type StreamingPreviewPatch = Partial<Pick<StreamingWorkspacePreview, "title" | "path" | "language" | "content" | "status" | "stage">>;
 
 interface ChatStoreEvents {
 	change: void;
@@ -42,15 +44,16 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	private workspacePreviewId: string | null = null;
 	private fileToolPaths = new Map<string, string>();
 	private fileToolArgText = new Map<string, string>();
+	private completedFileToolIds = new Set<string>();
+	private previewChangeTimer: ReturnType<typeof setTimeout> | null = null;
+	private pendingPreviewUpdate: { id: string; patch: StreamingPreviewPatch } | null = null;
 
 	async send(prompt: string, images?: InlineImage[]): Promise<void> {
 		if ((!prompt.trim() && !images?.length) || this.isSending) return;
 		this.detachMode = false;
 		this.resetStreamTimers();
 		this.streamingTarget = "chat";
-		this.workspacePreviewId = null;
-		this.fileToolPaths.clear();
-		this.fileToolArgText.clear();
+		this.resetWorkspaceStreamState();
 
 		// Capture the target session at send time to prevent misalignment
 		// if the user switches sessions while the request is queued.
@@ -130,9 +133,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			this.detachMode = false;
 			this.pendingQuestion = null;
 			this.resetStreamTimers();
-			this.workspacePreviewId = null;
-			this.fileToolPaths.clear();
-			this.fileToolArgText.clear();
+			this.resetWorkspaceStreamState({ flushPreview: true });
 			const shouldRefreshWiki = this.wikiInvalidated;
 			this.wikiInvalidated = false;
 			this.emit("change", undefined);
@@ -192,9 +193,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.activeTools = [];
 		this.completedTools = [];
 		this.detachMode = false;
-		this.workspacePreviewId = null;
-		this.fileToolPaths.clear();
-		this.fileToolArgText.clear();
+		this.resetWorkspaceStreamState();
 		const controller = new AbortController();
 		this.abortController = controller;
 		this.emit("change", undefined);
@@ -239,9 +238,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			this.detachMode = false;
 			this.pendingQuestion = null;
 			this.resetStreamTimers();
-			this.workspacePreviewId = null;
-			this.fileToolPaths.clear();
-			this.fileToolArgText.clear();
+			this.resetWorkspaceStreamState({ flushPreview: true });
 			this.emit("change", undefined);
 			void import("./sessions-store.js").then((m) => m.sessionsStore.refresh());
 		}
@@ -265,7 +262,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				this.scheduleStreamChange();
 				break;
 			case "tool_call_delta":
-				this.maybePrepareFileToolPreview(event.toolCallId, event.toolName, event.args, event.argsText, event.argsDelta);
+				this.maybePrepareFileToolPreview(event.toolCallId, event.toolName, event.args, event.argsDelta);
 				break;
 			case "tool_start":
 				this.flushStreamChange();
@@ -298,16 +295,14 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				if (mutatesWiki(event.toolName)) {
 					this.wikiInvalidated = true;
 				}
-				if (event.toolName === "create_practice_lab" && !event.isError) {
-					void handlePracticeLabResult(event.result);
-				}
 				this.emit("change", undefined);
 				break;
 			case "workspace_change":
-				this.handleWorkspaceChange(event.changes);
+				this.handleWorkspaceChange(event);
 				break;
 			case "error":
 				this.flushStreamChange();
+				this.flushPreviewChange();
 				// Keep the error separate from the reply text so the UI can render
 				// it as a distinct, collapsible block rather than inline markdown.
 				this.streamingError = this.streamingError
@@ -361,48 +356,58 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	}
 
 	private maybeStartFileToolPreview(toolCallId: string, toolName: string, args: unknown): void {
+		if (!isFileWritingTool(toolName)) {
+			this.setStreamingActivity("正在执行工具", toolName);
+			return;
+		}
+		this.maybePrepareFileToolPreview(toolCallId, toolName, args);
+		this.flushPreviewChange();
 		const rawArgsText = this.fileToolArgText.get(toolCallId);
-		const filePath = this.fileToolPaths.get(toolCallId) ?? extractToolFilePath(args) ?? (rawArgsText ? extractToolFilePath(rawArgsText) : undefined);
-		this.setStreamingActivity(filePath ? fileToolExecutionLabel(toolName) : "正在执行文件操作", filePath ?? "");
-		if (this.workspacePreviewId === `tool-${toolCallId}`) {
-			workspaceStore.updateStreamingPreview(this.workspacePreviewId, {
+		const filePath = this.fileToolPaths.get(toolCallId) ?? extractToolFilePath(args) ?? extractToolFilePath(rawArgsText);
+		this.setStreamingActivity(fileToolExecutionLabel(toolName), filePath ?? "");
+		const previewId = `tool-${toolCallId}`;
+		if (this.workspacePreviewId === previewId) {
+			workspaceStore.updateStreamingPreview(previewId, {
 				stage: fileToolExecutionLabel(toolName),
 				status: "streaming",
 			});
 		}
-		this.maybePrepareFileToolPreview(toolCallId, toolName, args);
 	}
 
-	private maybePrepareFileToolPreview(toolCallId: string, toolName: string, args: unknown, argsText?: string, argsDelta?: string): void {
+	private maybePrepareFileToolPreview(toolCallId: string, toolName: string, args: unknown, argsDelta?: string): void {
 		if (!isFileWritingTool(toolName)) return;
-		const rawArgsText = this.updateToolArgText(toolCallId, argsText, argsDelta);
-		const filePath = extractToolFilePath(args) ?? (rawArgsText ? extractToolFilePath(rawArgsText) : undefined);
+		const rawArgsText = this.updateToolArgText(toolCallId, argsDelta);
+		const filePath = extractToolFilePath(args) ?? extractToolFilePath(rawArgsText);
 		if (filePath) this.fileToolPaths.set(toolCallId, filePath);
-		const content = extractToolContent(args) ?? (rawArgsText ? extractToolContent(rawArgsText) : undefined);
+		const resolvedPath = this.fileToolPaths.get(toolCallId);
+		const content = extractToolContent(args) ?? extractToolContent(rawArgsText);
+		if (!resolvedPath && content === undefined) return;
 		const hasContent = typeof content === "string" && content.length > 0;
 		const id = `tool-${toolCallId}`;
-		const title = filePath
-			? `${fileToolActionLabel(toolName)} ${filePath}`
+		const title = resolvedPath
+			? `${fileToolActionLabel(toolName)} ${resolvedPath}`
 			: `${fileToolActionLabel(toolName)}文件`;
-		const language = filePath ? languageFromPath(filePath) : "plaintext";
+		const language = resolvedPath ? languageFromPath(resolvedPath) : "plaintext";
 		const stage = hasContent ? "正在生成内容" : "正在准备文件";
-		this.setStreamingActivity(stage, filePath ?? "");
+		this.setStreamingActivity(stage, resolvedPath ?? "");
+		this.streamingTarget = "workspace";
 		this.workspacePreviewId = id;
-		revealWorkspacePreview();
 		if (workspaceStore.streamingPreview?.id === id) {
-			workspaceStore.updateStreamingPreview(id, {
+			this.schedulePreviewChange(id, {
 				title,
-				path: filePath,
+				path: resolvedPath,
 				language,
 				content: content ?? workspaceStore.streamingPreview.content,
 				status: "streaming",
 				stage,
 			});
 		} else {
+			this.flushPreviewChange();
+			revealWorkspacePreview();
 			workspaceStore.startStreamingPreview({
 				id,
 				title,
-				path: filePath,
+				path: resolvedPath,
 				language,
 				content: content ?? "",
 				stage,
@@ -413,40 +418,76 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 
 	private maybeFinishFileToolPreview(toolCallId: string, toolName: string, result: unknown, isError: boolean): void {
 		if (!isFileWritingTool(toolName)) return;
+		this.flushPreviewChange();
 		const rawArgsText = this.fileToolArgText.get(toolCallId);
-		const filePath = this.fileToolPaths.get(toolCallId) ?? extractToolFilePath(result) ?? (rawArgsText ? extractToolFilePath(rawArgsText) : undefined);
+		const filePath = this.fileToolPaths.get(toolCallId) ?? extractToolFilePath(result) ?? extractToolFilePath(rawArgsText);
 		if (!filePath && this.workspacePreviewId !== `tool-${toolCallId}`) return;
 		const previewId = `tool-${toolCallId}`;
-		if (this.workspacePreviewId === previewId) {
+		const isActivePreview = this.workspacePreviewId === previewId;
+		if (isActivePreview) {
 			workspaceStore.finishStreamingPreview(previewId, isError ? "error" : "done");
 		}
+		this.fileToolArgText.delete(toolCallId);
+		this.fileToolPaths.delete(toolCallId);
+		if (isActivePreview) this.workspacePreviewId = null;
+		this.streamingTarget = "chat";
 		if (!isError && filePath) {
-			this.setStreamingActivity("正在检查文件变化", filePath);
-			this.streamingTarget = "chat";
+			this.completedFileToolIds.add(toolCallId);
+			this.setStreamingActivity("正在刷新文件预览", filePath);
+			void openChangedWorkspacePath(filePath, isActivePreview ? previewId : undefined);
 		}
 	}
 
-	private handleWorkspaceChange(changes: WorkspaceFileChange[]): void {
-		if (!changes.length) return;
-		const previewId = this.workspacePreviewId;
-		const target = pickOpenableWorkspaceChange(changes);
+	private handleWorkspaceChange(event: Extract<ChatStreamEvent, { type: "workspace_change" }>): void {
+		if (!event.changes.length || (event.toolCallId && this.completedFileToolIds.has(event.toolCallId))) return;
+		const eventPreviewId = event.toolCallId ? `tool-${event.toolCallId}` : null;
+		const previewId = eventPreviewId && this.workspacePreviewId === eventPreviewId ? eventPreviewId : null;
+		const target = pickOpenableWorkspaceChange(event.changes);
 		this.setStreamingActivity("正在刷新文件预览", target?.path ?? "");
 		if (previewId) workspaceStore.finishStreamingPreview(previewId, "done");
-		this.streamingTarget = "chat";
-		this.workspacePreviewId = null;
+		if (previewId) {
+			this.streamingTarget = "chat";
+			this.workspacePreviewId = null;
+		}
 		void openChangedWorkspacePath(target?.path, previewId ?? undefined);
 	}
 
-	private updateToolArgText(toolCallId: string, argsText?: string, argsDelta?: string): string {
+	private updateToolArgText(toolCallId: string, argsDelta?: string): string {
 		const previous = this.fileToolArgText.get(toolCallId) ?? "";
-		let next = previous;
-		if (typeof argsText === "string" && argsText.length >= previous.length) {
-			next = argsText;
-		} else if (typeof argsDelta === "string" && argsDelta.length > 0) {
-			next = previous + argsDelta;
-		}
+		const next = typeof argsDelta === "string" && argsDelta.length > 0 ? previous + argsDelta : previous;
 		if (next !== previous) this.fileToolArgText.set(toolCallId, next);
 		return next;
+	}
+
+	private schedulePreviewChange(id: string, patch: StreamingPreviewPatch): void {
+		if (this.pendingPreviewUpdate && this.pendingPreviewUpdate.id !== id) this.flushPreviewChange();
+		this.pendingPreviewUpdate = {
+			id,
+			patch: { ...(this.pendingPreviewUpdate?.patch ?? {}), ...patch },
+		};
+		if (this.previewChangeTimer) return;
+		this.previewChangeTimer = setTimeout(() => this.flushPreviewChange(), STREAM_CHANGE_INTERVAL_MS);
+	}
+
+	private flushPreviewChange(): void {
+		if (this.previewChangeTimer) clearTimeout(this.previewChangeTimer);
+		this.previewChangeTimer = null;
+		const pending = this.pendingPreviewUpdate;
+		this.pendingPreviewUpdate = null;
+		if (pending) workspaceStore.updateStreamingPreview(pending.id, pending.patch);
+	}
+
+	private resetWorkspaceStreamState(options: { flushPreview?: boolean } = {}): void {
+		if (options.flushPreview) this.flushPreviewChange();
+		else {
+			if (this.previewChangeTimer) clearTimeout(this.previewChangeTimer);
+			this.previewChangeTimer = null;
+			this.pendingPreviewUpdate = null;
+		}
+		this.workspacePreviewId = null;
+		this.fileToolPaths.clear();
+		this.fileToolArgText.clear();
+		this.completedFileToolIds.clear();
 	}
 
 	async submitQuestionResponse(questionId: string, result: QuestionnaireResult): Promise<void> {
@@ -485,9 +526,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.completedTools = [];
 		this.pendingQuestion = null;
 		this.resetStreamTimers();
-		this.workspacePreviewId = null;
-		this.fileToolPaths.clear();
-		this.fileToolArgText.clear();
+		this.resetWorkspaceStreamState();
 		this.emit("change", undefined);
 	}
 
@@ -504,9 +543,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.activeTools = [];
 		this.completedTools = [];
 		this.resetStreamTimers();
-		this.workspacePreviewId = null;
-		this.fileToolPaths.clear();
-		this.fileToolArgText.clear();
+		this.resetWorkspaceStreamState();
 		this.emit("change", undefined);
 	}
 
@@ -527,30 +564,6 @@ function mutatesWiki(toolName: string): boolean {
 	return toolName === "l2_archive" || toolName === "l2_link_pages" || toolName.startsWith("wiki_");
 }
 
-/**
- * Reaction to a successful create_practice_lab tool call: refresh the
- * workspace tree, open the main file in the preview panel, and switch the
- * right-side tab to "preview" so the user immediately sees the new lab.
- */
-async function handlePracticeLabResult(result: unknown): Promise<void> {
-	// Result is the details object as serialized by PI. Be defensive about shape.
-	let mainFile: string | undefined;
-	if (result && typeof result === "object") {
-		const r = result as Record<string, unknown>;
-		const details = (r.details && typeof r.details === "object" ? r.details : r) as Record<string, unknown>;
-		if (typeof details.mainFile === "string") mainFile = details.mainFile;
-	}
-	try {
-		appStore.setRightPanelTab("preview");
-		await workspaceStore.loadTree();
-		if (mainFile) {
-			await workspaceStore.selectFile(mainFile);
-		}
-	} catch {
-		// best-effort — non-fatal if any store import fails
-	}
-}
-
 const FILE_EXTENSIONS = [
 	"ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "md", "markdown", "html", "htm",
 	"css", "scss", "less", "json", "jsonl", "yaml", "yml", "toml", "sh", "bash",
@@ -568,16 +581,13 @@ function revealWorkspacePreview(): void {
 
 function isFileWritingTool(toolName: string): boolean {
 	const name = toolName.toLowerCase();
-	return name.includes("write")
-		|| name.includes("edit")
-		|| name.includes("patch")
-		|| name.includes("save")
-		|| name.includes("create")
-		|| name.includes("upload")
-		|| name.includes("rename")
-		|| name.includes("move")
-		|| name.includes("delete")
-		|| name.includes("remove");
+	if (["write", "edit", "patch", "apply_patch", "create_practice_lab"].includes(name)) return true;
+	const tokens = name.split(/[^a-z0-9]+/).filter(Boolean);
+	const hasFileTarget = tokens.some((token) => token === "file" || token === "files" || token === "workspace");
+	const hasWriteAction = tokens.some((token) => [
+		"write", "edit", "patch", "save", "create", "upload", "rename", "move", "delete", "remove",
+	].includes(token));
+	return hasFileTarget && hasWriteAction;
 }
 
 function fileToolActionLabel(toolName: string): string {
@@ -613,6 +623,12 @@ function extractToolContent(args: unknown): string | undefined {
 	for (const key of ["content", "text", "new_content", "file_content", "body"]) {
 		if (typeof record[key] === "string") return record[key];
 	}
+	if (Array.isArray(record.files)) {
+		const entries = record.files.filter((file): file is Record<string, unknown> => Boolean(file) && typeof file === "object");
+		const mainFile = typeof record.mainFile === "string" ? record.mainFile : undefined;
+		const selected = entries.find((file) => mainFile && file.path === mainFile) ?? entries[0];
+		if (selected && typeof selected.content === "string") return selected.content;
+	}
 	const editPreview = extractEditPreview(record);
 	if (editPreview) return editPreview;
 	return undefined;
@@ -624,6 +640,13 @@ function extractPathFromValue(value: unknown, seen: WeakSet<object>, depth: numb
 	if (typeof value !== "object") return undefined;
 	if (seen.has(value)) return undefined;
 	seen.add(value);
+	if (Array.isArray(value)) {
+		for (const child of value) {
+			const path = extractPathFromValue(child, seen, depth + 1, keyHint);
+			if (path) return path;
+		}
+		return undefined;
+	}
 	const record = value as Record<string, unknown>;
 	const priorityKeys = [
 		"targetPath", "target_path", "newPath", "new_path", "outputPath", "output_path",
@@ -640,12 +663,6 @@ function extractPathFromValue(value: unknown, seen: WeakSet<object>, depth: numb
 	for (const [key, child] of Object.entries(record)) {
 		const path = extractPathFromValue(child, seen, depth + 1, key);
 		if (path) return path;
-	}
-	if (Array.isArray(value)) {
-		for (const child of value) {
-			const path = extractPathFromValue(child, seen, depth + 1, keyHint);
-			if (path) return path;
-		}
 	}
 	return undefined;
 }
@@ -689,9 +706,8 @@ function extractPartialJsonStringField(source: string, fieldNames: string[]): st
 		const match = pattern.exec(source);
 		if (!match) continue;
 		const start = match.index + match[0].length;
-		const raw = readJsonStringFragment(source, start);
-		const decoded = decodeJsonStringFragment(raw);
-		if (decoded) return decoded;
+		const decoded = decodeJsonStringFragment(readJsonStringFragment(source, start));
+		if (decoded !== undefined) return decoded;
 	}
 	return undefined;
 }
@@ -700,29 +716,28 @@ function readJsonStringFragment(source: string, start: number): string {
 	let result = "";
 	let escaped = false;
 	for (let i = start; i < source.length; i += 1) {
-		const ch = source[i];
+		const char = source[i];
 		if (escaped) {
-			result += ch;
+			result += char;
 			escaped = false;
 			continue;
 		}
-		if (ch === "\\") {
-			result += ch;
+		if (char === "\\") {
+			result += char;
 			escaped = true;
 			continue;
 		}
-		if (ch === "\"") break;
-		result += ch;
+		if (char === "\"") break;
+		result += char;
 	}
 	return result;
 }
 
 function decodeJsonStringFragment(raw: string): string | undefined {
 	if (!raw) return undefined;
-	let fragment = raw;
-	if (fragment.endsWith("\\")) fragment = fragment.slice(0, -1);
+	const fragment = raw.endsWith("\\") ? raw.slice(0, -1) : raw;
 	try {
-		return JSON.parse(`"${fragment}"`);
+		return JSON.parse(`"${fragment}"`) as string;
 	} catch {
 		return fragment
 			.replace(/\\n/g, "\n")

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -1,8 +1,14 @@
 import { EventEmitter } from "./event-emitter.js";
 import { streamChat, abortChat, streamSessionEvents } from "../api/chat.js";
 import type { InlineImage } from "../api/chat.js";
-import type { ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult } from "../types/chat.js";
+import type { ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult, WorkspaceFileChange } from "../types/chat.js";
 import { notebookStore } from "./notebook-store.js";
+import { appStore } from "./app-store.js";
+import { workspaceStore } from "./workspace-store.js";
+
+type StreamingTarget = "chat" | "workspace";
+
+const STREAM_CHANGE_INTERVAL_MS = 80;
 
 interface ChatStoreEvents {
 	change: void;
@@ -15,6 +21,9 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	isLoadingHistory = false;
 	streamingText = "";
 	streamingThinking = "";
+	streamingTarget: StreamingTarget = "chat";
+	streamingActivity = "";
+	streamingActivityDetail = "";
 	/** Backend/model error for the in-flight turn, surfaced in the UI (collapsible). */
 	streamingError = "";
 	/** Active tool calls in progress */
@@ -29,10 +38,19 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	private abortController: AbortController | null = null;
 	private detachMode = false;
 	private wikiInvalidated = false;
+	private streamChangeTimer: ReturnType<typeof setTimeout> | null = null;
+	private workspacePreviewId: string | null = null;
+	private fileToolPaths = new Map<string, string>();
+	private fileToolArgText = new Map<string, string>();
 
 	async send(prompt: string, images?: InlineImage[]): Promise<void> {
 		if ((!prompt.trim() && !images?.length) || this.isSending) return;
 		this.detachMode = false;
+		this.resetStreamTimers();
+		this.streamingTarget = "chat";
+		this.workspacePreviewId = null;
+		this.fileToolPaths.clear();
+		this.fileToolArgText.clear();
 
 		// Capture the target session at send time to prevent misalignment
 		// if the user switches sessions while the request is queued.
@@ -53,6 +71,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.isSending = true;
 		this.streamingText = "";
 		this.streamingThinking = "";
+		this.setStreamingActivity("正在分析请求");
 		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
@@ -65,7 +84,9 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			for await (const event of streamChat(prompt, targetSessionId, controller.signal, images)) {
 				this._handleStreamEvent(event);
 			}
+			this.flushStreamChange();
 			const aborted = controller.signal.aborted;
+
 			// Finalize: add accumulated text as assistant message. Also finalize
 			// when the turn produced only an error (no text), so the error is
 			// preserved in history instead of vanishing when streaming state resets.
@@ -95,15 +116,23 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				];
 			}
 		} finally {
+			this.flushStreamChange();
 			this.isSending = false;
 			this.streamingText = "";
 			this.streamingThinking = "";
+			this.streamingTarget = "chat";
+			this.streamingActivity = "";
+			this.streamingActivityDetail = "";
 			this.streamingError = "";
 			this.activeTools = [];
 			this.completedTools = [];
 			this.abortController = null;
 			this.detachMode = false;
 			this.pendingQuestion = null;
+			this.resetStreamTimers();
+			this.workspacePreviewId = null;
+			this.fileToolPaths.clear();
+			this.fileToolArgText.clear();
 			const shouldRefreshWiki = this.wikiInvalidated;
 			this.wikiInvalidated = false;
 			this.emit("change", undefined);
@@ -152,13 +181,20 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	 */
 	async resumeStream(sessionId: string): Promise<void> {
 		if (this.isSending) return;
+		this.resetStreamTimers();
 		this.isSending = true;
 		this.streamingText = "";
 		this.streamingThinking = "";
+		this.streamingTarget = "chat";
+		this.streamingActivity = "正在恢复生成";
+		this.streamingActivityDetail = "";
 		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
 		this.detachMode = false;
+		this.workspacePreviewId = null;
+		this.fileToolPaths.clear();
+		this.fileToolArgText.clear();
 		const controller = new AbortController();
 		this.abortController = controller;
 		this.emit("change", undefined);
@@ -167,6 +203,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			for await (const event of streamSessionEvents(sessionId, controller.signal)) {
 				this._handleStreamEvent(event);
 			}
+			this.flushStreamChange();
 			// Finalize assistant message from accumulated streaming text
 			if (this.detachMode) {
 				// detached again — skip finalize
@@ -188,15 +225,23 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				console.warn("[chat-store] resumeStream error:", err);
 			}
 		} finally {
+			this.flushStreamChange();
 			this.isSending = false;
 			this.streamingText = "";
 			this.streamingThinking = "";
+			this.streamingTarget = "chat";
+			this.streamingActivity = "";
+			this.streamingActivityDetail = "";
 			this.streamingError = "";
 			this.activeTools = [];
 			this.completedTools = [];
 			this.abortController = null;
 			this.detachMode = false;
 			this.pendingQuestion = null;
+			this.resetStreamTimers();
+			this.workspacePreviewId = null;
+			this.fileToolPaths.clear();
+			this.fileToolArgText.clear();
 			this.emit("change", undefined);
 			void import("./sessions-store.js").then((m) => m.sessionsStore.refresh());
 		}
@@ -212,21 +257,29 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		switch (event.type) {
 			case "text_delta":
 				this.streamingText += event.delta;
-				this.emit("change", undefined);
+				if (!this.workspacePreviewId) this.setStreamingActivity("正在组织回复");
+				this.scheduleStreamChange();
 				break;
 			case "thinking_delta":
 				this.streamingThinking += event.delta;
-				this.emit("change", undefined);
+				this.scheduleStreamChange();
+				break;
+			case "tool_call_delta":
+				this.maybePrepareFileToolPreview(event.toolCallId, event.toolName, event.args, event.argsText, event.argsDelta);
 				break;
 			case "tool_start":
+				this.flushStreamChange();
+				this.maybeStartFileToolPreview(event.toolCallId, event.toolName, event.args);
 				this.activeTools = [...this.activeTools, {
 					toolCallId: event.toolCallId,
 					toolName: event.toolName,
-					args: event.args,
+					args: compactToolPayload(event.args),
 				}];
 				this.emit("change", undefined);
 				break;
 			case "tool_end":
+				this.flushStreamChange();
+				this.maybeFinishFileToolPreview(event.toolCallId, event.toolName, event.result, event.isError);
 				this.completedTools = [
 					...this.completedTools,
 					{
@@ -235,7 +288,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 							toolName: "tool",
 							args: undefined,
 						}),
-						result: event.result,
+						result: compactToolPayload(event.result),
 						isError: event.isError,
 					},
 				];
@@ -250,15 +303,21 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				}
 				this.emit("change", undefined);
 				break;
+			case "workspace_change":
+				this.handleWorkspaceChange(event.changes);
+				break;
 			case "error":
+				this.flushStreamChange();
 				// Keep the error separate from the reply text so the UI can render
 				// it as a distinct, collapsible block rather than inline markdown.
 				this.streamingError = this.streamingError
 					? `${this.streamingError}\n${event.message}`
 					: event.message;
 				this.emit("change", undefined);
+				if (this.workspacePreviewId) workspaceStore.finishStreamingPreview(this.workspacePreviewId, "error");
 				break;
 			case "question":
+				this.flushStreamChange();
 				this.pendingQuestion = {
 					questionId: event.questionId,
 					params: event.params,
@@ -266,6 +325,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				this.emit("change", undefined);
 				break;
 			case "done":
+				this.flushStreamChange();
 				// Final message set with full content
 				if (event.fullText) {
 					this.streamingText = event.fullText;
@@ -273,6 +333,120 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				this.emit("change", undefined);
 				break;
 		}
+	}
+
+	private scheduleStreamChange(): void {
+		if (this.streamChangeTimer) return;
+		this.streamChangeTimer = setTimeout(() => this.flushStreamChange(), STREAM_CHANGE_INTERVAL_MS);
+	}
+
+	private flushStreamChange(): void {
+		if (this.streamChangeTimer) {
+			clearTimeout(this.streamChangeTimer);
+			this.streamChangeTimer = null;
+		}
+		this.emit("change", undefined);
+	}
+
+	private resetStreamTimers(): void {
+		if (this.streamChangeTimer) clearTimeout(this.streamChangeTimer);
+		this.streamChangeTimer = null;
+	}
+
+	private setStreamingActivity(label: string, detail = ""): void {
+		if (this.streamingActivity === label && this.streamingActivityDetail === detail) return;
+		this.streamingActivity = label;
+		this.streamingActivityDetail = detail;
+		this.scheduleStreamChange();
+	}
+
+	private maybeStartFileToolPreview(toolCallId: string, toolName: string, args: unknown): void {
+		const rawArgsText = this.fileToolArgText.get(toolCallId);
+		const filePath = this.fileToolPaths.get(toolCallId) ?? extractToolFilePath(args) ?? (rawArgsText ? extractToolFilePath(rawArgsText) : undefined);
+		this.setStreamingActivity(filePath ? fileToolExecutionLabel(toolName) : "正在执行文件操作", filePath ?? "");
+		if (this.workspacePreviewId === `tool-${toolCallId}`) {
+			workspaceStore.updateStreamingPreview(this.workspacePreviewId, {
+				stage: fileToolExecutionLabel(toolName),
+				status: "streaming",
+			});
+		}
+		this.maybePrepareFileToolPreview(toolCallId, toolName, args);
+	}
+
+	private maybePrepareFileToolPreview(toolCallId: string, toolName: string, args: unknown, argsText?: string, argsDelta?: string): void {
+		if (!isFileWritingTool(toolName)) return;
+		const rawArgsText = this.updateToolArgText(toolCallId, argsText, argsDelta);
+		const filePath = extractToolFilePath(args) ?? (rawArgsText ? extractToolFilePath(rawArgsText) : undefined);
+		if (filePath) this.fileToolPaths.set(toolCallId, filePath);
+		const content = extractToolContent(args) ?? (rawArgsText ? extractToolContent(rawArgsText) : undefined);
+		const hasContent = typeof content === "string" && content.length > 0;
+		const id = `tool-${toolCallId}`;
+		const title = filePath
+			? `${fileToolActionLabel(toolName)} ${filePath}`
+			: `${fileToolActionLabel(toolName)}文件`;
+		const language = filePath ? languageFromPath(filePath) : "plaintext";
+		const stage = hasContent ? "正在生成内容" : "正在准备文件";
+		this.setStreamingActivity(stage, filePath ?? "");
+		this.workspacePreviewId = id;
+		revealWorkspacePreview();
+		if (workspaceStore.streamingPreview?.id === id) {
+			workspaceStore.updateStreamingPreview(id, {
+				title,
+				path: filePath,
+				language,
+				content: content ?? workspaceStore.streamingPreview.content,
+				status: "streaming",
+				stage,
+			});
+		} else {
+			workspaceStore.startStreamingPreview({
+				id,
+				title,
+				path: filePath,
+				language,
+				content: content ?? "",
+				stage,
+				source: "tool",
+			});
+		}
+	}
+
+	private maybeFinishFileToolPreview(toolCallId: string, toolName: string, result: unknown, isError: boolean): void {
+		if (!isFileWritingTool(toolName)) return;
+		const rawArgsText = this.fileToolArgText.get(toolCallId);
+		const filePath = this.fileToolPaths.get(toolCallId) ?? extractToolFilePath(result) ?? (rawArgsText ? extractToolFilePath(rawArgsText) : undefined);
+		if (!filePath && this.workspacePreviewId !== `tool-${toolCallId}`) return;
+		const previewId = `tool-${toolCallId}`;
+		if (this.workspacePreviewId === previewId) {
+			workspaceStore.finishStreamingPreview(previewId, isError ? "error" : "done");
+		}
+		if (!isError && filePath) {
+			this.setStreamingActivity("正在检查文件变化", filePath);
+			this.streamingTarget = "chat";
+		}
+	}
+
+	private handleWorkspaceChange(changes: WorkspaceFileChange[]): void {
+		if (!changes.length) return;
+		const previewId = this.workspacePreviewId;
+		const target = pickOpenableWorkspaceChange(changes);
+		this.setStreamingActivity("正在刷新文件预览", target?.path ?? "");
+		if (previewId) workspaceStore.finishStreamingPreview(previewId, "done");
+		this.streamingTarget = "chat";
+		this.workspacePreviewId = null;
+		void openChangedWorkspacePath(target?.path, previewId ?? undefined);
+	}
+
+	private updateToolArgText(toolCallId: string, argsText?: string, argsDelta?: string): string {
+		const previous = this.fileToolArgText.get(toolCallId) ?? "";
+		let next = previous;
+		if (typeof argsText === "string" && argsText.length >= previous.length) {
+			next = argsText;
+		} else if (typeof argsDelta === "string" && argsDelta.length > 0) {
+			next = previous + argsDelta;
+		}
+		if (next !== previous) this.fileToolArgText.set(toolCallId, next);
+		return next;
 	}
 
 	async submitQuestionResponse(questionId: string, result: QuestionnaireResult): Promise<void> {
@@ -303,10 +477,17 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.isSending = false;
 		this.streamingText = "";
 		this.streamingThinking = "";
+		this.streamingTarget = "chat";
+		this.streamingActivity = "";
+		this.streamingActivityDetail = "";
 		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
 		this.pendingQuestion = null;
+		this.resetStreamTimers();
+		this.workspacePreviewId = null;
+		this.fileToolPaths.clear();
+		this.fileToolArgText.clear();
 		this.emit("change", undefined);
 	}
 
@@ -316,9 +497,16 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.isSending = false;
 		this.streamingText = "";
 		this.streamingThinking = "";
+		this.streamingTarget = "chat";
+		this.streamingActivity = "";
+		this.streamingActivityDetail = "";
 		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
+		this.resetStreamTimers();
+		this.workspacePreviewId = null;
+		this.fileToolPaths.clear();
+		this.fileToolArgText.clear();
 		this.emit("change", undefined);
 	}
 
@@ -353,8 +541,6 @@ async function handlePracticeLabResult(result: unknown): Promise<void> {
 		if (typeof details.mainFile === "string") mainFile = details.mainFile;
 	}
 	try {
-		const { workspaceStore } = await import("./workspace-store.js");
-		const { appStore } = await import("./app-store.js");
 		appStore.setRightPanelTab("preview");
 		await workspaceStore.loadTree();
 		if (mainFile) {
@@ -363,4 +549,261 @@ async function handlePracticeLabResult(result: unknown): Promise<void> {
 	} catch {
 		// best-effort — non-fatal if any store import fails
 	}
+}
+
+const FILE_EXTENSIONS = [
+	"ts", "tsx", "js", "jsx", "mjs", "cjs", "py", "md", "markdown", "html", "htm",
+	"css", "scss", "less", "json", "jsonl", "yaml", "yml", "toml", "sh", "bash",
+	"zsh", "sql", "txt", "xml", "svg", "java", "go", "rs", "cpp", "c", "h",
+].join("|");
+const FILE_PATH_RE = new RegExp(`(?:^|[\\s"'\\\`“”‘’（(])((?:[\\w.-]+\\/)*[\\w.-]+\\.(${FILE_EXTENSIONS}))(?:$|[\\s"'\\\`“”‘’）),，。:：])`, "i");
+
+function revealWorkspacePreview(): void {
+	appStore.setRightPanelTab("preview");
+	if (appStore.workspaceWidth < 560) appStore.setWorkspaceWidth(640);
+	if (appStore.workspaceMode === "collapsed" || appStore.workspaceMode === "quarter") {
+		appStore.setWorkspaceMode("half");
+	}
+}
+
+function isFileWritingTool(toolName: string): boolean {
+	const name = toolName.toLowerCase();
+	return name.includes("write")
+		|| name.includes("edit")
+		|| name.includes("patch")
+		|| name.includes("save")
+		|| name.includes("create")
+		|| name.includes("upload")
+		|| name.includes("rename")
+		|| name.includes("move")
+		|| name.includes("delete")
+		|| name.includes("remove");
+}
+
+function fileToolActionLabel(toolName: string): string {
+	const name = toolName.toLowerCase();
+	if (name.includes("edit") || name.includes("patch")) return "正在修改";
+	if (name.includes("rename") || name.includes("move")) return "正在移动";
+	if (name.includes("delete") || name.includes("remove")) return "正在删除";
+	if (name.includes("upload")) return "正在上传";
+	return "正在写入";
+}
+
+function fileToolExecutionLabel(toolName: string): string {
+	const name = toolName.toLowerCase();
+	if (name.includes("edit") || name.includes("patch")) return "正在应用修改";
+	if (name.includes("rename") || name.includes("move")) return "正在移动文件";
+	if (name.includes("delete") || name.includes("remove")) return "正在删除文件";
+	if (name.includes("upload")) return "正在上传文件";
+	return "正在写入磁盘";
+}
+
+function extractToolFilePath(args: unknown): string | undefined {
+	return extractPathFromValue(args, new WeakSet<object>(), 0);
+}
+
+function extractToolContent(args: unknown): string | undefined {
+	if (typeof args === "string") {
+		const parsed = parseJsonObject(args);
+		if (parsed) return extractToolContent(parsed);
+		return extractPartialJsonStringField(args, ["content", "text", "new_content", "file_content", "body", "newText"]);
+	}
+	if (!args || typeof args !== "object") return undefined;
+	const record = args as Record<string, unknown>;
+	for (const key of ["content", "text", "new_content", "file_content", "body"]) {
+		if (typeof record[key] === "string") return record[key];
+	}
+	const editPreview = extractEditPreview(record);
+	if (editPreview) return editPreview;
+	return undefined;
+}
+
+function extractPathFromValue(value: unknown, seen: WeakSet<object>, depth: number, keyHint = ""): string | undefined {
+	if (depth > 5 || value == null) return undefined;
+	if (typeof value === "string") return extractPathFromString(value, keyHint);
+	if (typeof value !== "object") return undefined;
+	if (seen.has(value)) return undefined;
+	seen.add(value);
+	const record = value as Record<string, unknown>;
+	const priorityKeys = [
+		"targetPath", "target_path", "newPath", "new_path", "outputPath", "output_path",
+		"file_path", "filePath", "path", "filename", "fileName", "mainFile",
+		"destination", "dest", "to", "sourcePath", "source_path", "oldPath", "old_path",
+	];
+	for (const key of priorityKeys) {
+		const child = record[key];
+		if (typeof child === "string") {
+			const path = cleanPathString(child);
+			if (path) return path;
+		}
+	}
+	for (const [key, child] of Object.entries(record)) {
+		const path = extractPathFromValue(child, seen, depth + 1, key);
+		if (path) return path;
+	}
+	if (Array.isArray(value)) {
+		for (const child of value) {
+			const path = extractPathFromValue(child, seen, depth + 1, keyHint);
+			if (path) return path;
+		}
+	}
+	return undefined;
+}
+
+function extractPathFromString(value: string, keyHint: string): string | undefined {
+	const trimmed = value.trim();
+	if (!trimmed || /^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed)) return undefined;
+	const partialPath = extractPartialJsonStringField(trimmed, [
+		"targetPath", "target_path", "newPath", "new_path", "outputPath", "output_path",
+		"file_path", "filePath", "path", "filename", "fileName", "mainFile",
+	]);
+	if (partialPath) return cleanPathString(partialPath);
+	const keyLooksPathLike = /(path|file|filename|destination|source|target|main)/i.test(keyHint);
+	if (keyLooksPathLike) return cleanPathString(trimmed);
+	if (trimmed.length > 320 || trimmed.includes("\n")) return undefined;
+	const match = trimmed.match(FILE_PATH_RE);
+	return match?.[1] ? cleanPathString(match[1]) : undefined;
+}
+
+function cleanPathString(value: string): string | undefined {
+	const path = value.trim().replace(/^[`"']|[`"']$/g, "");
+	if (!path || path.length > 500 || path.includes("\n")) return undefined;
+	if (/^[a-z][a-z0-9+.-]*:\/\//i.test(path)) return undefined;
+	return path;
+}
+
+function parseJsonObject(value: string): Record<string, unknown> | undefined {
+	try {
+		const parsed = JSON.parse(value);
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? parsed as Record<string, unknown>
+			: undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function extractPartialJsonStringField(source: string, fieldNames: string[]): string | undefined {
+	for (const fieldName of fieldNames) {
+		const pattern = new RegExp(`"${escapeRegExp(fieldName)}"\\s*:\\s*"`, "i");
+		const match = pattern.exec(source);
+		if (!match) continue;
+		const start = match.index + match[0].length;
+		const raw = readJsonStringFragment(source, start);
+		const decoded = decodeJsonStringFragment(raw);
+		if (decoded) return decoded;
+	}
+	return undefined;
+}
+
+function readJsonStringFragment(source: string, start: number): string {
+	let result = "";
+	let escaped = false;
+	for (let i = start; i < source.length; i += 1) {
+		const ch = source[i];
+		if (escaped) {
+			result += ch;
+			escaped = false;
+			continue;
+		}
+		if (ch === "\\") {
+			result += ch;
+			escaped = true;
+			continue;
+		}
+		if (ch === "\"") break;
+		result += ch;
+	}
+	return result;
+}
+
+function decodeJsonStringFragment(raw: string): string | undefined {
+	if (!raw) return undefined;
+	let fragment = raw;
+	if (fragment.endsWith("\\")) fragment = fragment.slice(0, -1);
+	try {
+		return JSON.parse(`"${fragment}"`);
+	} catch {
+		return fragment
+			.replace(/\\n/g, "\n")
+			.replace(/\\r/g, "\r")
+			.replace(/\\t/g, "\t")
+			.replace(/\\"/g, "\"")
+			.replace(/\\\\/g, "\\");
+	}
+}
+
+function extractEditPreview(record: Record<string, unknown>): string | undefined {
+	const edits = record.edits;
+	if (!Array.isArray(edits)) return undefined;
+	const snippets = edits
+		.map((edit) => edit && typeof edit === "object" ? (edit as Record<string, unknown>).newText : undefined)
+		.filter((value): value is string => typeof value === "string" && value.length > 0);
+	if (!snippets.length) return undefined;
+	return snippets.join("\n\n");
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function pickOpenableWorkspaceChange(changes: WorkspaceFileChange[]): WorkspaceFileChange | undefined {
+	return changes.find((change) => change.change === "created")
+		?? changes.find((change) => change.change === "modified")
+		?? changes.find((change) => change.change !== "deleted");
+}
+
+async function openChangedWorkspacePath(filePath?: string, previewId?: string): Promise<void> {
+	try {
+		revealWorkspacePreview();
+		if (previewId) workspaceStore.clearStreamingPreview(previewId);
+		await workspaceStore.loadTree();
+		if (filePath) await workspaceStore.selectFile(filePath);
+	} catch {
+		if (previewId) workspaceStore.finishStreamingPreview(previewId, "error");
+	}
+}
+
+function compactToolPayload(value: unknown): unknown {
+	return compactValue(value, new WeakSet<object>(), 0);
+}
+
+function compactValue(value: unknown, seen: WeakSet<object>, depth: number): unknown {
+	if (typeof value === "string") {
+		if (value.length <= 1600) return value;
+		return `${value.slice(0, 1600)}\n\n[已省略 ${value.length - 1600} 个字符]`;
+	}
+	if (value == null || typeof value !== "object") return value;
+	if (seen.has(value)) return "[循环引用]";
+	seen.add(value);
+	if (depth >= 4) return "[内容层级较深，已折叠]";
+	if (Array.isArray(value)) {
+		const items = value.slice(0, 24).map((item) => compactValue(item, seen, depth + 1));
+		if (value.length > 24) items.push(`[已省略 ${value.length - 24} 项]`);
+		return items;
+	}
+	const record = value as Record<string, unknown>;
+	const entries = Object.entries(record).slice(0, 32);
+	const result: Record<string, unknown> = {};
+	for (const [key, item] of entries) {
+		result[key] = compactValue(item, seen, depth + 1);
+	}
+	const remaining = Object.keys(record).length - entries.length;
+	if (remaining > 0) result.__truncated = `已省略 ${remaining} 个字段`;
+	return result;
+}
+
+function languageFromPath(path: string): string {
+	const lower = path.toLowerCase();
+	if (lower.endsWith(".ts") || lower.endsWith(".tsx")) return "typescript";
+	if (lower.endsWith(".js") || lower.endsWith(".jsx") || lower.endsWith(".mjs") || lower.endsWith(".cjs")) return "javascript";
+	if (lower.endsWith(".py")) return "python";
+	if (lower.endsWith(".md") || lower.endsWith(".markdown")) return "markdown";
+	if (lower.endsWith(".html") || lower.endsWith(".htm")) return "html";
+	if (lower.endsWith(".css") || lower.endsWith(".scss") || lower.endsWith(".less")) return "css";
+	if (lower.endsWith(".json") || lower.endsWith(".jsonl")) return "json";
+	if (lower.endsWith(".yaml") || lower.endsWith(".yml")) return "yaml";
+	if (lower.endsWith(".sql")) return "sql";
+	if (lower.endsWith(".sh") || lower.endsWith(".bash") || lower.endsWith(".zsh")) return "bash";
+	return "plaintext";
 }

--- a/apps/inno-agent/web/src/stores/workspace-store.ts
+++ b/apps/inno-agent/web/src/stores/workspace-store.ts
@@ -132,6 +132,8 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 
 	updateStreamingPreview(id: string, patch: Partial<Pick<StreamingWorkspacePreview, "title" | "path" | "language" | "content" | "status" | "stage">>): void {
 		if (!this.streamingPreview || this.streamingPreview.id !== id) return;
+		const keys = ["title", "path", "language", "content", "status", "stage"] as const;
+		if (!keys.some((key) => key in patch && patch[key] !== this.streamingPreview?.[key])) return;
 		this.streamingPreview = {
 			...this.streamingPreview,
 			...patch,
@@ -142,6 +144,7 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 
 	finishStreamingPreview(id: string, status: "done" | "error" = "done"): void {
 		if (!this.streamingPreview || this.streamingPreview.id !== id) return;
+		if (this.streamingPreview.status === status) return;
 		this.streamingPreview = {
 			...this.streamingPreview,
 			status,

--- a/apps/inno-agent/web/src/stores/workspace-store.ts
+++ b/apps/inno-agent/web/src/stores/workspace-store.ts
@@ -13,6 +13,19 @@ import {
 } from "../api/workspace.js";
 import type { WorkspaceFileDetail, WorkspaceTree } from "../types/workspace.js";
 
+export interface StreamingWorkspacePreview {
+	id: string;
+	title: string;
+	path?: string;
+	language: string;
+	content: string;
+	status: "streaming" | "done" | "error";
+	stage?: string;
+	source: "assistant" | "tool";
+	createdAt: number;
+	updatedAt: number;
+}
+
 interface WorkspaceStoreEvents {
 	change: void;
 }
@@ -24,6 +37,7 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 	isLoadingFile = false;
 	isMutating = false;
 	error = "";
+	streamingPreview: StreamingWorkspacePreview | null = null;
 
 	/** The workspace currently shown in the panel. null → server default. */
 	activeWorkspaceId: string | null = null;
@@ -89,6 +103,57 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 			this.isLoadingFile = false;
 			this.emit("change", undefined);
 		}
+	}
+
+	startStreamingPreview(input: {
+		id: string;
+		title: string;
+		path?: string;
+		language?: string;
+		content?: string;
+		stage?: string;
+		source?: StreamingWorkspacePreview["source"];
+	}): void {
+		const now = Date.now();
+		this.streamingPreview = {
+			id: input.id,
+			title: input.title,
+			path: input.path,
+			language: input.language ?? languageFromPath(input.path ?? input.title),
+			content: input.content ?? "",
+			status: "streaming",
+			stage: input.stage,
+			source: input.source ?? "assistant",
+			createdAt: now,
+			updatedAt: now,
+		};
+		this.emit("change", undefined);
+	}
+
+	updateStreamingPreview(id: string, patch: Partial<Pick<StreamingWorkspacePreview, "title" | "path" | "language" | "content" | "status" | "stage">>): void {
+		if (!this.streamingPreview || this.streamingPreview.id !== id) return;
+		this.streamingPreview = {
+			...this.streamingPreview,
+			...patch,
+			updatedAt: Date.now(),
+		};
+		this.emit("change", undefined);
+	}
+
+	finishStreamingPreview(id: string, status: "done" | "error" = "done"): void {
+		if (!this.streamingPreview || this.streamingPreview.id !== id) return;
+		this.streamingPreview = {
+			...this.streamingPreview,
+			status,
+			updatedAt: Date.now(),
+		};
+		this.emit("change", undefined);
+	}
+
+	clearStreamingPreview(id?: string): void {
+		if (id && this.streamingPreview?.id !== id) return;
+		this.streamingPreview = null;
+		this.emit("change", undefined);
 	}
 
 	/* --- Edit lifecycle --- */
@@ -277,3 +342,18 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 }
 
 export const workspaceStore = new WorkspaceStoreImpl();
+
+function languageFromPath(path: string): string {
+	const lower = path.toLowerCase();
+	if (lower.endsWith(".ts") || lower.endsWith(".tsx")) return "typescript";
+	if (lower.endsWith(".js") || lower.endsWith(".jsx") || lower.endsWith(".mjs") || lower.endsWith(".cjs")) return "javascript";
+	if (lower.endsWith(".py")) return "python";
+	if (lower.endsWith(".md") || lower.endsWith(".markdown")) return "markdown";
+	if (lower.endsWith(".html") || lower.endsWith(".htm")) return "html";
+	if (lower.endsWith(".css") || lower.endsWith(".scss") || lower.endsWith(".less")) return "css";
+	if (lower.endsWith(".json") || lower.endsWith(".jsonl")) return "json";
+	if (lower.endsWith(".yaml") || lower.endsWith(".yml")) return "yaml";
+	if (lower.endsWith(".sql")) return "sql";
+	if (lower.endsWith(".sh") || lower.endsWith(".bash") || lower.endsWith(".zsh")) return "bash";
+	return "plaintext";
+}

--- a/apps/inno-agent/web/src/types/chat.ts
+++ b/apps/inno-agent/web/src/types/chat.ts
@@ -18,6 +18,11 @@ export interface ChatToolRecord {
 	isError?: boolean;
 }
 
+export interface WorkspaceFileChange {
+	path: string;
+	change: "created" | "modified" | "deleted";
+}
+
 // --- Question types ---
 
 export interface QuestionOption {
@@ -58,8 +63,10 @@ export interface QuestionnaireResult {
 export type ChatStreamEvent =
 	| { type: "text_delta"; delta: string }
 	| { type: "thinking_delta"; delta: string }
+	| { type: "tool_call_delta"; toolCallId: string; toolName: string; args?: unknown; argsText?: string; argsDelta?: string }
 	| { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
 	| { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+	| { type: "workspace_change"; changes: WorkspaceFileChange[]; toolCallId?: string; toolName?: string; workspaceId?: string; truncated?: boolean }
 	| { type: "question"; questionId: string; params: { questions: QuestionData[] } }
 	| { type: "done"; fullText: string }
 	| { type: "error"; message: string };

--- a/apps/inno-agent/web/src/types/chat.ts
+++ b/apps/inno-agent/web/src/types/chat.ts
@@ -63,7 +63,7 @@ export interface QuestionnaireResult {
 export type ChatStreamEvent =
 	| { type: "text_delta"; delta: string }
 	| { type: "thinking_delta"; delta: string }
-	| { type: "tool_call_delta"; toolCallId: string; toolName: string; args?: unknown; argsText?: string; argsDelta?: string }
+	| { type: "tool_call_delta"; toolCallId: string; toolName: string; args?: unknown; argsDelta?: string }
 	| { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
 	| { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
 	| { type: "workspace_change"; changes: WorkspaceFileChange[]; toolCallId?: string; toolName?: string; workspaceId?: string; truncated?: boolean }

--- a/apps/inno-agent/web/src/types/settings.ts
+++ b/apps/inno-agent/web/src/types/settings.ts
@@ -20,6 +20,9 @@ export interface InnoProviderSettings {
 	baseUrl: string;
 	apiKey: string; // masked
 	api?: string;
+	headers?: Record<string, string>;
+	authHeader?: boolean;
+	bypassProxy?: boolean;
 	models: InnoProviderModel[];
 }
 
@@ -28,6 +31,9 @@ export interface UpsertProviderRequest {
 	baseUrl: string;
 	apiKey: string;
 	api: string;
+	headers?: Record<string, string>;
+	authHeader?: boolean;
+	bypassProxy?: boolean;
 	models: InnoProviderModel[];
 	makeDefault?: boolean;
 	preserveApiKey?: boolean;

--- a/config.example.json
+++ b/config.example.json
@@ -6,6 +6,8 @@
 			"baseUrl": "https://api.innospark.cn",
 			"api": "anthropic-messages",
 			"apiKey": "replace-me",
+			"authHeader": false,
+			"bypassProxy": false,
 			"models": [
 				{
 					"id": "claude-sonnet-4-6",


### PR DESCRIPTION
## 背景

生成较长代码或文档时，聊天区会长时间停留在“思考中”，右侧文件区要等工具参数和文件写入全部完成后才出现内容，用户容易误以为页面失去响应。

## 本次改动

### 1. 打通文件工具参数的流式事件

- 将 PI SDK 的 `toolcall_start`、`toolcall_delta`、`toolcall_end` 转换为前端可消费的 `tool_call_delta` SSE 事件。
- 流式阶段只传递当前参数增量，工具参数结束时再传递完整参数，避免每个事件重复携带截至当前的全部文件内容。
- 所有事件继续进入会话广播器，页面切换或重连后仍可重建当前生成状态。
- 使用工作区文件监听收集真实的创建、修改和删除事件，替代每个工具执行前后同步遍历整个工作区。

### 2. 右侧文件区实时显示生成内容

- 一旦从文件工具参数中识别出文件路径，就自动打开右侧文件预览，不再等待工具执行结束。
- 持续解析 `write_file`、编辑、补丁和实践实验室工具的不完整 JSON 参数，逐步恢复文件路径和内容。
- 文件预览按 80 毫秒合并刷新；右侧面板只在首次识别文件时展开，避免每个参数碎片触发全局渲染。
- 增加写入状态、当前阶段、文件路径、行数、流式光标和复制按钮。
- 文件真正写入磁盘后刷新目录树和最终文件内容，保证预览与磁盘状态一致。

### 3. 低开销实时格式化 Markdown

- Markdown 在生成期间直接显示标题、列表、表格和代码块，不再等到生成结束才格式化。
- 自适应策略只依据当前已接收的内容长度，不预测最终文件长度：4 万字符以内每 240 毫秒格式化一次，4 万至 10 万字符每 420 毫秒一次，10 万至 16 万字符每 700 毫秒一次。
- 当前内容超过 16 万字符时，生成期间自动切换为纯文本预览；生成完成后立即执行一次完整 Markdown 格式化。
- 原始流式内容继续高频接收，但 Markdown 规范化和渲染只跟随采样快照更新，并使用组件记忆化减少重复计算。
- 行数统计和自动滚动跟随屏幕上实际显示的快照，避免每个参数碎片都触发布局计算。
- 清理并重建格式化定时器时兼容 React 严格模式，避免开发环境重复执行副作用后停止刷新。

### 4. 聊天区显示当前步骤

- 增加生成状态卡片，显示正在准备文件、生成内容、写入磁盘、应用修改、执行普通工具或同步工作区等阶段。
- 文件生成时将状态真正切换到右侧文件区，聊天区只保留简短提示。
- 使用明确的文件工具识别规则，避免把定时任务、学习者画像等名称中包含 `create`、`patch`、`delete` 的工具误判为文件操作。
- 对较长回复和工具详情采用折叠、按需渲染，并移除重复的工具参数压缩逻辑。

### 5. 补充供应商接入和诊断能力

- 供应商配置新增自定义请求头、鉴权头开关和代理绕过开关，并同步到主代理、服务端会话和子代理。
- 设置接口返回配置时对自定义请求头内容进行脱敏；编辑供应商但未提交请求头字段时保留已有请求头。
- 代理绕过地址由程序重新计算，关闭开关后会立即从本程序管理的 `NO_PROXY` 项中移除，同时保留用户原有配置。
- 请求日志补充网络异常、错误原因和底层错误信息，方便定位连接失败。
- 更新中英文界面文案、类型定义和示例配置。

## 当前已知限制

文件区能否逐字或小块更新，取决于模型服务是否对“工具调用参数”提供细粒度流式增量。普通聊天文本流式输出正常，不代表工具参数也会按相同粒度输出。

当前启智平台上通过 vLLM 部署的 OpenAI 兼容模型，在 `write_file` 场景中会把工具参数缓冲到接近完成后再一次性返回。实测一轮共收到 5 个工具参数增量，总计 1800 个字符，其中最大单块为 1771 个字符，占 98.4%，因此界面看起来仍像一次性出现。开启兼容层的工具流式选项后结果没有明显变化。

同一套代码接入 InnoSpark 的 Sonnet（Anthropic Messages 接口）时，可收到 219 个工具参数增量，总计 1662 个字符，最大单块仅 25 个字符，右侧文件区可以连续实时更新。

因此，目前剩余问题不在文件工具或前端渲染链路，而在启智平台 vLLM 服务对工具参数增量的输出粒度。要在该模型上获得同样效果，需要模型服务或兼容层支持细粒度工具参数流式输出；也可以改用已经支持这一能力的 Sonnet 接口。

对于不支持细粒度工具参数流式输出的模型，本次改动仍保留完整参数到达后的预览，并在工具完成后刷新最终文件。

## 验证

- `git diff --check`
- `npm run build`
- 逐字符输入完整文件工具参数，内容可完整恢复，文件区只触发 2 次合并更新。
- `create_scheduled_job` 等非文件工具不会打开文件预览。
- 自定义请求头和 API Key 在编辑供应商后保持不变；代理绕过开关可正常添加和移除地址。
- 对启智平台 vLLM 与 InnoSpark Sonnet 做了只生成工具参数、不实际写入文件的流式事件对比测试。
- 使用真实的 `megatron_tutorial.md` 模拟流式生成：128 次原始内容更新合并为 10 次 Markdown 格式化，浏览器未出现超过 50 毫秒的长任务。
- 使用 160001 字符内容验证超长保护：生成中切换为纯文本，完成后恢复完整格式化。
- 浏览器验证生成期间标题、目录、列表等格式可随内容逐步出现，控制台没有新增代码错误。

构建通过。Vite 仅保留项目原有的动态导入和大分块提示，没有新增构建错误，前端主包体积未因本次优化明显增加。
