### PR TITLE
fix: keep file writes inside the active workspace

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -18,6 +18,7 @@ import { L3Memory, createL3Tools, formatRecallForPrompt } from "../memory/l3/l3-
 import { createPracticeTools } from "./practice-tools.js";
 import { createDocumentTools } from "./document-tools.js";
 import { createOcrTools } from "./ocr-tools.js";
+import { checkWorkspaceMutationPath } from "./workspace-path-guard.js";
 import { INNO_SYSTEM_PROMPT } from "./system-prompt.js";
 import { syncProvidersForSubagents } from "./provider-sync.js";
 import { questionBridge } from "./question-bridge.js";
@@ -118,6 +119,15 @@ function buildWorkspaceContextSections(workspaceDir: string): string[] {
 	}
 
 	return sections;
+}
+
+function formatWorkspaceFileInstructions(workspaceDir: string): string {
+	return [
+		"# 当前会话文件工作区",
+		`文件浏览器只显示此目录中的文件：\`${workspaceDir}\``,
+		"调用 write 或 edit 时必须使用相对于该目录的路径，例如 `notes.md` 或 `src/main.py`。",
+		"不要使用该目录之外的绝对路径，也不要通过 `..` 或符号链接越过该目录；越界修改会被拒绝。",
+	].join("\n");
 }
 
 export function createInnoExtension(
@@ -241,9 +251,40 @@ export function createInnoExtension(
 			}
 		}
 
-		// 5. Log all tool execution errors centrally. This covers every tool
-			// registered with the PI SDK — both Inno's custom tools and the
-			// built-in bash/read/edit/write/grep/find/ls tools — without needing
+		// 5. Keep built-in file mutations inside the workspace bound to the
+		// active session. PI accepts absolute paths, so cwd alone is not a
+		// sufficient boundary when the model emits a stale parent path.
+		pi.on("tool_call", async (event) => {
+			if (event.toolName !== "write" && event.toolName !== "edit") return undefined;
+
+			const requestedPath = event.input.path;
+			const workspaceDir = resolveActiveWorkspaceDir(paths, deps);
+			if (typeof requestedPath !== "string") {
+				return { block: true, reason: "文件路径无效，请使用当前工作区内的相对路径。" };
+			}
+
+			const check = checkWorkspaceMutationPath(workspaceDir, requestedPath);
+			if (check.allowed) return undefined;
+
+			logger.warn(
+				{
+					toolName: event.toolName,
+					requestedPath,
+					resolvedPath: check.resolvedPath,
+					workspaceDir,
+					reason: check.reason,
+				},
+				"blocked file mutation outside active workspace",
+			);
+			return {
+				block: true,
+				reason: `文件路径不在当前工作区内。当前工作区是 ${workspaceDir}，请改用相对路径后重试。`,
+			};
+		});
+
+		// 5a. Log all tool execution errors centrally. This covers every tool
+				// registered with the PI SDK — both Inno's custom tools and the
+				// built-in bash/read/edit/write/grep/find/ls tools — without needing
 			// per-tool try/catch blocks.
 			pi.on("tool_result", async (event) => {
 				if (event.isError) {
@@ -275,6 +316,7 @@ export function createInnoExtension(
 
 				// Inject per-workspace context: agent.md + private skills.
 				const workspaceDir = resolveActiveWorkspaceDir(paths, deps);
+				sections.push(formatWorkspaceFileInstructions(workspaceDir));
 				sections.push(...buildWorkspaceContextSections(workspaceDir));
 
 				// Inject threshold-gated cross-conversation recall (L3). Only

--- a/apps/inno-agent/src/agent/workspace-path-guard.ts
+++ b/apps/inno-agent/src/agent/workspace-path-guard.ts
@@ -1,0 +1,70 @@
+import { existsSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface WorkspacePathCheck {
+	allowed: boolean;
+	resolvedPath?: string;
+	reason?: "invalid_path" | "outside_workspace" | "workspace_unavailable";
+}
+
+const UNICODE_SPACES = /[\u00A0\u2000-\u200A\u202F\u205F\u3000]/g;
+
+/** Match the normalization performed by PI's built-in file tools. */
+function normalizeToolPath(input: string): string {
+	let normalized = input.replace(UNICODE_SPACES, " ");
+	if (normalized.startsWith("@")) normalized = normalized.slice(1);
+	if (normalized === "~") return homedir();
+	if (normalized.startsWith("~/") || (process.platform === "win32" && normalized.startsWith("~\\"))) {
+		return join(homedir(), normalized.slice(2));
+	}
+	if (/^file:\/\//.test(normalized)) return fileURLToPath(normalized);
+	return normalized;
+}
+
+function isWithin(root: string, target: string): boolean {
+	const rel = relative(root, target);
+	return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`));
+}
+
+function findExistingAncestor(target: string): string | null {
+	let current = target;
+	while (!existsSync(current)) {
+		const parent = dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+	return current;
+}
+
+/**
+ * Check where a write/edit path will land after resolving existing symlinks.
+ * Non-existent suffixes are projected from the closest existing ancestor.
+ */
+export function checkWorkspaceMutationPath(workspaceDir: string, requestedPath: string): WorkspacePathCheck {
+	if (!requestedPath.trim()) return { allowed: false, reason: "invalid_path" };
+
+	try {
+		const workspaceRoot = realpathSync(workspaceDir);
+		const resolvedPath = resolve(workspaceDir, normalizeToolPath(requestedPath));
+		const existingAncestor = findExistingAncestor(resolvedPath);
+		if (!existingAncestor) {
+			return { allowed: false, resolvedPath, reason: "invalid_path" };
+		}
+
+		const canonicalAncestor = realpathSync(existingAncestor);
+		const unresolvedSuffix = relative(existingAncestor, resolvedPath);
+		const canonicalTarget = resolve(canonicalAncestor, unresolvedSuffix);
+		if (!isWithin(workspaceRoot, canonicalTarget)) {
+			return { allowed: false, resolvedPath, reason: "outside_workspace" };
+		}
+
+		return { allowed: true, resolvedPath };
+	} catch {
+		return {
+			allowed: false,
+			reason: existsSync(workspaceDir) ? "invalid_path" : "workspace_unavailable",
+		};
+	}
+}


### PR DESCRIPTION
## 背景

Web 会话可以绑定到独立工作区，例如 `workspace/.tmp`。但 PI 内置的 `write` 和 `edit` 工具同时接受相对路径与绝对路径；当模型沿用旧的上级目录绝对路径时，文件仍会写入成功，却落在当前会话工作区之外。

这会造成两个直接问题：

- 文件浏览器只读取当前会话工作区，因此看不到已经生成的文件。
- 工作区文件监听也只监听当前会话目录，因此无法发送对应的文件变化事件。

<img width="1144" height="612" alt="image" src="https://github.com/user-attachments/assets/2699d429-c3a6-45e0-a7cf-f56d958f79d5" />
<img width="592" height="1050" alt="image" src="https://github.com/user-attachments/assets/924feed1-7d88-4811-bc10-a388c18adc6c" />


本次修复在 Inno Agent 层补上工作区边界，不修改 PI SDK 依赖包。

## 修改内容

### 1. 新增文件修改路径校验器

新增 `workspace-path-guard.ts`，在文件真正修改前计算最终落盘位置：

- 按照 PI 文件工具的规则处理 Unicode 空格、`@` 前缀、`~` 用户目录和 `file://` 路径。
- 从最近存在的上级目录开始解析真实路径，兼容尚未创建的文件和多级目录。
- 解析符号链接后的最终位置，避免通过工作区内的符号链接写到外部目录。
- 仅允许最终位置位于当前会话工作区内。

### 2. 拦截越界的 `write` 和 `edit` 调用

在 Inno 扩展的 `tool_call` 阶段校验 PI 内置文件工具：

- 相对路径和工作区内的绝对路径正常放行。
- 上级目录、工作区外绝对路径和指向外部的符号链接会在执行前被拒绝。
- 拒绝结果会明确告知模型当前工作区，并要求改用相对路径重试。
- 服务端日志会记录工具名称、原始路径、解析路径、当前工作区和拦截原因，便于后续排查。

### 3. 向模型明确注入当前文件工作区

每轮对话开始前，系统提示会增加当前会话文件工作区及路径规则：

- 明确文件浏览器实际显示的目录。
- 要求 `write` 和 `edit` 使用相对于当前工作区的路径。
- 明确禁止使用工作区外绝对路径、`..` 越界路径和越界符号链接。

提示用于降低错误路径出现的概率，执行前校验负责最终兜底。

## 行为变化

- 模型使用 `notes.md`、`src/main.py` 等相对路径时，文件会写入当前会话绑定的工作区，并能被文件浏览器看到。
- 模型沿用 `workspace/file.md` 之类的旧上级绝对路径时，工具不会再把文件静默写到文件浏览器之外，而是返回可重试的错误。
- 本次边界检查只作用于 PI 内置的 `write` 和 `edit` 文件工具；命令行工具仍沿用项目现有的沙箱配置。

## 验证

- `npm run build`：后端 TypeScript 编译和前端生产构建通过。
- `npm --workspace inno-agent run build`：最终后端编译通过。
- 路径校验脚本覆盖 12 类场景并全部通过：
  - 相对文件路径
  - 尚不存在的多级相对路径
  - 工作区内绝对路径
  - 本次问题对应的工作区上级绝对路径
  - `../` 越界路径
  - 任意工作区外绝对路径
  - 指向外部目录的符号链接
  - 指向工作区内部的符号链接
  - `~/` 用户目录路径
  - `@` 前缀绝对路径
  - `file://` 文件路径
  - 不存在的工作区

## 影响范围

修改仅涉及 Inno 扩展的文件工具调用前检查和系统提示组装，不改变工作区接口、文件浏览器接口、会话绑定格式或 PI SDK 源码。
