### PR TITLE
docs: add homepage link and hide unimplemented QQ channel

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -136,5 +136,5 @@ npm run web:dev        # 终端 2 — Vite :5173（代理 /api 到 :3000）
 
 - 完整文档见 [README.md](./README.md)
 - 自定义 skill：把 `<skill-name>.zip` 通过 Web UI 的 Skills 页面上传，或直接放进 `runtime/skills/<name>/`
-- 配 Feishu / QQ / WeChat 渠道：编辑 `runtime/config/config.json` 的 `channels` 块
+- 配 Feishu / WeChat 渠道：编辑 `runtime/config/config.json` 的 `channels` 块
 - 部署到生产：参考 README 的 Production Shape 一节，或用 `Dockerfile` / `docker-compose.yml`

--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20.6.0-brightgreen.svg)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-ESM-3178c6.svg)](https://www.typescriptlang.org/)
+[![Website](https://img.shields.io/badge/Website-Inno%20Agent-ff6b35.svg)](https://hhyqhh.github.io/inno-agent-website/)
+
+> 🌐 **Homepage:** [https://hhyqhh.github.io/inno-agent-website/](https://hhyqhh.github.io/inno-agent-website/) - project overview, feature walkthrough, and live demos.
 
 > 📄 **Technical Report:** [*Inno Agent: An Open-Source Personal Learning Agent with Layered Memory, Educational Post-Training, and Local Deployment*](./docs/inno-agent.pdf) (arXiv, June 2026) — covers the system design, three-layer memory architecture, instructional-design grounding, and preliminary educational post-training results on Qwen3.6 35B.
 >
@@ -14,7 +17,7 @@
   <img src="./docs/assets/l2-wiki.png" alt="Inno Agent — L2 wiki knowledge base and graph" width="100%" />
 </p>
 
-Inno Agent is a single-learner companion that organizes long-term learning support into three explicit memory layers — an **L1 learner profile**, an **L2 native wiki knowledge base**, and **L3 session records with cross-conversation retrieval** — and wraps them with a learning loop: a cron scheduler, personal IM channels (Feishu / QQ / WeChat), and a Practice Lab with an in-browser terminal.
+Inno Agent is a single-learner companion that organizes long-term learning support into three explicit memory layers — an **L1 learner profile**, an **L2 native wiki knowledge base**, and **L3 session records with cross-conversation retrieval** — and wraps them with a learning loop: a cron scheduler, personal IM channels (Feishu / WeChat), and a Practice Lab with an in-browser terminal.
 
 It ships in two forms that share the same `runtime/` and `workspace/` state:
 
@@ -43,7 +46,7 @@ Inno Agent takes a different stance:
   - **L2 — Native wiki**: human-readable, agent-queryable pages (sources, concepts, entities, analysis) with LLM-assisted summarization, entity/concept linking, and PDF/Office/image ingestion.
   - **L3 — Session records + cross-conversation retrieval**: Pi-SDK session history, indexed into SQLite with threshold-gated lexical recall so relevant past conversations can be surfaced across sessions.
 - ⏰ **Proactive scheduler** — cron-driven background jobs created in natural language, runnable from the agent, the UI, or the cron daemon.
-- 💬 **Personal IM channels** — Feishu (native) plus QQ / WeChat (bridge mode), with a unified dispatcher that pushes reminders back out.
+- 💬 **Personal IM channels** — Feishu (native) plus WeChat (bridge mode), with a unified dispatcher that pushes reminders back out.
 - 🧪 **Practice Lab** — a workspace-scoped web terminal (xterm.js over WebSocket) with run records the agent can read.
 - 🔌 **Pluggable providers** — any `openai-completions` or `anthropic-messages` endpoint (Anthropic, OpenAI, DeepSeek, Ollama, or a local model); switch models live in the UI.
 - 🖥️ **CLI and Web UI** — same runtime, same memory, same skills.
@@ -140,7 +143,6 @@ The included `restart-dev.sh` orchestrates both processes (build, start, stop, s
   "server": { "port": 3000 },
   "channels": {
     "feishu": { "enabled": false },
-    "qq":     { "enabled": false, "mode": "bridge", "sidecarBaseUrl": "http://127.0.0.1:4318" },
     "wechat": { "enabled": false, "mode": "bridge", "sidecarBaseUrl": "http://127.0.0.1:4319" }
   }
 }
@@ -223,7 +225,7 @@ The Pi SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`,
 Inno Agent is a single-user system with four layers: **user interfaces → application layer → Pi agent runtime → layered memory.**
 
 ```text
-User Interfaces      CLI · Web UI (React) · Feishu · WeChat · QQ
+User Interfaces      CLI · Web UI (React) · Feishu · WeChat
         ↓
 Application Layer    Channel adapters · HTTP API (SSE) · Memory orchestration
                      Cron scheduler · Practice Lab · WebSocket terminal
@@ -239,7 +241,7 @@ Layered Memory       L1 learner profile · L2 native wiki · L3 session records
 - **L2 — wiki memory** (`src/memory/l2/`): structured wiki pages with frontmatter, links, graph, summarizer, and document ingestion; exposed as agent tools and via `/api/wiki/*`.
 - **L3 — session memory** (`src/memory/l3/` + Pi `SessionManager`): the SDK owns session JSONL files; Inno layers a SQLite index (`node:sqlite` + FTS5) on top for cross-conversation recall, surfaced both automatically (above a relevance threshold) and via the `l3_recall` tool.
 - **Scheduler** (`src/scheduler/`): cron jobs persisted to `jobs.json` + `runs.jsonl`; runnable from the agent (`run_scheduled_job`), the UI, or the daemon.
-- **Channels** (`src/channels/`): `ChannelRegistry` with Feishu (and bridge-mode QQ / WeChat) so reminders can be pushed back out.
+- **Channels** (`src/channels/`): `ChannelRegistry` with Feishu (and bridge-mode WeChat) so reminders can be pushed back out.
 - **HTTP server** (`src/server.ts`): plain Node `http.createServer` with SSE for chat streaming and WebSocket for the in-browser terminal.
 - **Web UI** (`web/src/`): React 19 + Lit + Tailwind 4. State lives in framework-agnostic `EventEmitter` stores under `web/src/stores/`; REST/SSE calls in `web/src/api/`.
 

--- a/apps/inno-agent/README.md
+++ b/apps/inno-agent/README.md
@@ -1,6 +1,6 @@
 # Inno Agent
 
-基于 PI SDK 的个人学习 Agent，支持多渠道交互（CLI / Web UI / 飞书 / QQ / 微信）、三层记忆系统（L1 学习者画像 + L2 Wiki 知识库 + L3 会话记录及跨对话检索）、定时任务调度、Practice Lab 网页终端。
+基于 PI SDK 的个人学习 Agent，支持多渠道交互（CLI / Web UI / 飞书 / 微信）、三层记忆系统（L1 学习者画像 + L2 Wiki 知识库 + L3 会话记录及跨对话检索）、定时任务调度、Practice Lab 网页终端。
 
 > 本文档聚焦后端开发与运行细节。项目整体介绍、架构和定位见仓库根目录的 [README.md](../../README.md)。
 
@@ -144,7 +144,7 @@ src/                  # 后端 (Node.js)
 ├── server.ts         # HTTP Server + SSE + REST API
 ├── runtime.ts        # 运行时路径解析（CLI flag > env > 默认）
 ├── agent/            # PI SDK AgentSession 封装 + inno 扩展
-├── channels/         # 飞书 / QQ / 微信等渠道
+├── channels/         # 飞书 / 微信等渠道
 ├── scheduler/        # 定时任务
 ├── memory/           # L1 学习者 + L2 Wiki + L3 跨对话检索记忆
 │   ├── learner/      # L1 学习者画像

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -397,6 +397,8 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 	const [qqAllowedUsers, setQqAllowedUsers] = useState(
 		(qqConfig?.allowedUserIds ?? []).join("\n"),
 	);
+	// QQ channel is not yet implemented; flip to true when ready to expose settings.
+	const QQ_CHANNEL_READY = false;
 
 	// WeChat (iLink native mode)
 	const wechatConfig = settings.channels?.wechat;
@@ -528,7 +530,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 				</div>
 				<div className="flex items-center gap-2 text-xs text-[var(--inno-text-subtle)]">
 					{feishuEnabled && <span className="rounded bg-[var(--inno-success-bg)] px-1.5 py-0.5 text-[var(--inno-success)]">{t("settings.channels.feishu.title")}</span>}
-					{qqEnabled && <span className="rounded bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-[var(--inno-accent)]">{t("settings.channels.qq.title")}</span>}
+					{qqEnabled && QQ_CHANNEL_READY && <span className="rounded bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-[var(--inno-accent)]">{t("settings.channels.qq.title")}</span>}
 					{wechatEnabled && <span className="rounded bg-[var(--inno-success-bg)] px-1.5 py-0.5 text-[var(--inno-success)]">{t("settings.channels.wechat.title")}</span>}
 				</div>
 			</button>
@@ -611,7 +613,8 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 						)}
 					</div>
 
-					{/* QQ */}
+					{/* QQ (hidden: channel not yet implemented) */}
+					{QQ_CHANNEL_READY && (
 					<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 						<div className="mb-2 flex items-center justify-between">
 							<div>
@@ -642,6 +645,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 							</div>
 						)}
 					</div>
+					)}
 
 					{/* WeChat (iLink native) */}
 					<div className="rounded-lg bg-[var(--inno-surface)] p-3">
@@ -724,7 +728,7 @@ function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 					</div>
 
 					{/* Bridge Token (used by QQ sidecar) */}
-					{qqEnabled && (
+					{QQ_CHANNEL_READY && qqEnabled && (
 						<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 							<div className="text-xs font-medium text-[var(--inno-text)] mb-1">{t("settings.channels.bridgeToken")}</div>
 							<div className="text-[10px] text-[var(--inno-text-subtle)] mb-2">{t("settings.channels.bridgeTokenHint")}</div>

--- a/config.example.json
+++ b/config.example.json
@@ -26,13 +26,6 @@
 			"personalOnly": true,
 			"allowedUserIds": []
 		},
-		"qq": {
-			"enabled": false,
-			"mode": "bridge",
-			"personalOnly": true,
-			"allowedUserIds": [],
-			"sidecarBaseUrl": "http://127.0.0.1:4318"
-		},
 		"wechat": {
 			"enabled": false,
 			"mode": "bridge",


### PR DESCRIPTION
## Summary

- Add project homepage badge and link (https://hhyqhh.github.io/inno-agent-website/) to a prominent position in README
- Remove QQ channel mentions from all user-facing docs (README, QUICKSTART, apps/inno-agent/README, config.example.json) since QQ integration is not yet implemented
- Hide QQ settings form card, collapsed-header badge, and bridge token section in the frontend SettingsPanel via a `QQ_CHANNEL_READY` feature flag — backend code is preserved untouched for future implementation

## Test plan

- [x] `npm run build` passes (both backend and frontend)
- [x] `grep -ri "qq"` in README.md / QUICKSTART.md / apps/inno-agent/README.md / config.example.json returns zero matches
- [ ] Visual check: Settings panel → Channels section shows no QQ form, no QQ badge, no Bridge Token section; Feishu and WeChat forms render normally