### PR TITLE
feat: auto-create default learning reminders on first boot

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -8,7 +8,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { saveConfig, setDefaultModel, type InnoConfig } from "../config.js";
 import { createLearnerTools } from "../memory/learner/learner-tools.js";
-import { loadEvents, loadProfile } from "../memory/learner/profile-store.js";
+import { isProfileEmpty, loadEvents, loadProfile } from "../memory/learner/profile-store.js";
 import { buildContextPack, formatContextPackForPrompt } from "../memory/learner/context-pack.js";
 import { JobStore } from "../scheduler/job-store.js";
 import { createSchedulerTools } from "../scheduler/scheduler-tools.js";
@@ -19,7 +19,7 @@ import { createPracticeTools } from "./practice-tools.js";
 import { createDocumentTools } from "./document-tools.js";
 import { createOcrTools } from "./ocr-tools.js";
 import { checkWorkspaceMutationPath } from "./workspace-path-guard.js";
-import { INNO_SYSTEM_PROMPT } from "./system-prompt.js";
+import { INNO_SYSTEM_PROMPT, ONBOARDING_GUIDE } from "./system-prompt.js";
 import { syncProvidersForSubagents } from "./provider-sync.js";
 import { questionBridge } from "./question-bridge.js";
 import { logger } from "../logger.js";
@@ -336,6 +336,14 @@ export function createInnoExtension(
 				// unless the learner has turned L1 off in settings.
 				if (isL1Enabled()) {
 					const profile = loadProfile(paths.learnerDataDir);
+
+					// If the profile is empty (new user), inject the structured
+					// onboarding guide so the agent prioritises building a baseline
+					// learner profile over casual conversation.
+					if (isProfileEmpty(profile)) {
+						sections.push(ONBOARDING_GUIDE);
+					}
+
 					const recentEvents = loadEvents(paths.learnerDataDir).slice(-8);
 					const contextPack = buildContextPack(profile, recentEvents);
 					const contextSection = formatContextPackForPrompt(contextPack);

--- a/apps/inno-agent/src/agent/learning-reminders.ts
+++ b/apps/inno-agent/src/agent/learning-reminders.ts
@@ -1,0 +1,55 @@
+import type { JobStore } from "../scheduler/job-store.js";
+
+/**
+ * Default learning reminders created on first boot.
+ *
+ * Cron minutes are off the :00 / :30 marks to avoid fleet-wide thundering-herd
+ * request peaks (every user who sets "9:00" fires at the same instant).
+ *
+ * These are plain push_reminder jobs — no LLM invocation, just a formatted
+ * message injected into the Web UI chat window. When a channel (Feishu/WeChat)
+ * is configured, the message is also pushed to the user's phone.
+ */
+const DEFAULT_LEARNING_REMINDERS = [
+	{
+		name: "每日学习提醒",
+		cron: "3 9 * * *",
+		prompt: "早上好！今天打算学什么？花 5 分钟列一下今天的学习目标吧 📝",
+	},
+	{
+		name: "晚间复习提醒",
+		cron: "7 19 * * *",
+		prompt: "一天结束了，回顾一下今天学了什么？有什么需要明天巩固的？🧠",
+	},
+	{
+		name: "周度学习回顾",
+		cron: "7 21 * * 0",
+		prompt: "周末了！这周学了哪些内容？下周的计划是什么？做个简短回顾吧 📊",
+	},
+];
+
+/**
+ * Ensure the three default learning reminders exist in the job store.
+ * Idempotent — checks by name before creating so existing jobs are never
+ * overwritten or duplicated. Returns the number of jobs created.
+ */
+export function ensureDefaultReminders(jobStore: JobStore): number {
+	const jobs = jobStore.list();
+	let created = 0;
+
+	for (const tmpl of DEFAULT_LEARNING_REMINDERS) {
+		if (!jobs.some((j) => j.name === tmpl.name)) {
+			jobStore.create({
+				name: tmpl.name,
+				cron: tmpl.cron,
+				timezone: "Asia/Shanghai",
+				taskType: "push_reminder",
+				prompt: tmpl.prompt,
+				enabled: true,
+			});
+			created++;
+		}
+	}
+
+	return created;
+}

--- a/apps/inno-agent/src/agent/system-prompt.ts
+++ b/apps/inno-agent/src/agent/system-prompt.ts
@@ -71,3 +71,59 @@ L2 目录边界（重要，违反会破坏知识库引用）：
 - 工具调用百度 vl-ocr（PaddleOCR-VL）API，返回 markdown 文本。
 - 如果当前模型原生支持图片识别且能正常读取图片，直接处理即可，无需调用此工具。
 - 若未配置 OCR API token，工具会返回提示——此时直接告诉用户「尚未配置 OCR API，请在设置里填入 token 后重试」。`;
+
+/**
+ * Onboarding guide injected into the system prompt when the learner's L1 profile
+ * is empty (new user). Guides the agent through a structured 4-step onboarding
+ * flow using ask_user_question before any casual conversation.
+ */
+export const ONBOARDING_GUIDE = `
+## 新手引导（仅在用户画像为空时生效）
+
+当前学习者的 L1 画像尚未建立。你必须**立即开始以下 4 步引导**。
+不要说"你好"或"有什么可以帮你"，不要闲聊，不要等待用户进一步输入。
+用户的第一条消息只是对话开始，不是跳过引导的信号。
+
+**重要规则：**
+- 每一步都必须调用 ask_user_question 工具（不要用纯文本输出代替）
+- 每个问题最多 4 个选项，已按此限制设计
+- 只有用户明确说"跳过""不用了""不想要引导""先看看再说""下次"时，
+  才回复"好的，画像暂未建立。需要引导时随时叫我。"然后停止
+
+**第 1 步 — 学习目标**
+提问："你想学什么？选一个最接近的方向"
+选项（4 个）：编程开发 / 语言学习与考试 / 职业技能与兴趣 / 其他方向
+→ 收到答案后调用 record_learning_event：
+   event_type: "goal_declared"
+   payload: { goal: 用户选择的选项, topic: 用户选择的选项 }
+
+**第 2 步 — 当前水平**
+提问："在这个方向你目前是什么水平？"
+选项（4 个）：零基础入门 / 有一定了解 / 能独立做简单项目 / 比较熟练想进阶
+→ 收到答案后调用 patch_learner_profile：
+   concept_id: 从目标推断（如 programming.general、language.english）
+   concept_name: 用户选择的目标方向
+   domain: 从目标推断（如 programming、language、exam）
+   mastery: 零基础=0.05, 有了解=0.25, 能独立=0.55, 熟练=0.75
+   confidence: 0.6
+
+**第 3 步 — 学习偏好**
+提问："你喜欢怎么学？可以多选"
+选项（多选，4 个）：看视频或读文档 / 动手做项目 / 刷题练习 / 讨论或跟人学
+→ 收到答案后调用 patch_learner_profile 的 preferences_append：
+   - 看视频或读文档 → explanation_style: ["example_first", "theory_first"]
+   - 动手做项目 → practice_style: ["small_steps"]
+   - 刷题练习 → practice_style: ["spaced_repetition"]
+   - 讨论或跟人学 → feedback_tone: ["socratic"]
+
+**第 4 步 — 学习节奏**
+提问："你大概每周能投入多少时间学习？"
+选项（4 个）：每周 1-2 小时 / 每周 3-5 小时 / 每周 6-10 小时 / 每周 10+ 小时
+→ 收到答案后调用 record_learning_event：
+   event_type: "preference_stated"
+   payload: { preference: 用户选择的选项, topic: "学习节奏" }
+
+完成 4 步后：
+1. 用一句简短的话总结你了解到的学习者画像（包含目标、水平、偏好、节奏）
+2. 调用 patch_learner_profile：profile_summary_append: 你的总结内容
+3. 说："画像已建立，现在我们开始吧！"`;

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -61,6 +61,17 @@ export interface InnoSimpleModeConfig {
 }
 
 /**
+ * Auto-reminders. When enabled (default), three default learning-reminder
+ * push_reminder jobs are created on first boot if they don't already exist:
+ * a daily morning reminder (09:03), an evening review (19:07), and a weekly
+ * Sunday review (21:07). Set to false to opt out entirely — no jobs are
+ * created and the user manages reminders manually via the Jobs page.
+ */
+export interface InnoAutoRemindersConfig {
+	enabled: boolean;
+}
+
+/**
  * Content Hub. The single source for remotely-fetched, ready-to-use content:
  * the global skill library and the Simple Mode preset workspaces. Both used to
  * be either hardcoded (skill library → a fixed GitHub repo) or bundled with the
@@ -150,6 +161,8 @@ export interface InnoConfig {
 	subagents?: InnoSubagentsConfig;
 	memory?: InnoMemoryConfig;
 	simpleMode?: InnoSimpleModeConfig;
+	/** Auto-reminders: create default learning reminders on first boot (default ON). */
+	autoReminders?: InnoAutoRemindersConfig;
 	ui?: {
 		theme: string;
 	};
@@ -237,6 +250,13 @@ export function normalizeSimpleModeConfig(simpleMode: Partial<InnoSimpleModeConf
 	};
 }
 
+export function normalizeAutoRemindersConfig(autoReminders: Partial<InnoAutoRemindersConfig> | undefined): InnoAutoRemindersConfig {
+	// Auto-reminders default ON; only an explicit `false` disables them.
+	return {
+		enabled: autoReminders?.enabled !== false,
+	};
+}
+
 /**
  * Normalize the Content Hub config, filling missing fields from the built-in
  * public-hub defaults. `legacyGithubToken` lets us migrate the older
@@ -299,6 +319,7 @@ export function normalizeConfig(config: LegacyInnoConfig): InnoConfig {
 		subagents: config.subagents,
 		memory: normalizeMemoryConfig(config.memory),
 		simpleMode: normalizeSimpleModeConfig(config.simpleMode),
+		autoReminders: normalizeAutoRemindersConfig(config.autoReminders),
 		ui: config.ui,
 		ocrApi: config.ocrApi,
 	} as InnoConfig;

--- a/apps/inno-agent/src/memory/learner/profile-store.ts
+++ b/apps/inno-agent/src/memory/learner/profile-store.ts
@@ -46,6 +46,19 @@ export function recordEventAndUpdateProfile(dataDir: string, event: LearningEven
 }
 
 /**
+ * Check whether the learner profile is effectively empty (new user).
+ * Returns true when no goals, knowledge states, summary, or preferences
+ * have been recorded — indicating a first-time user who needs onboarding.
+ */
+export function isProfileEmpty(profile: LearnerProfile): boolean {
+	return profile.goals.length === 0
+		&& profile.knowledge_states.length === 0
+		&& profile.profile_summary === ""
+		&& profile.preferences.explanation_style.length === 0
+		&& profile.preferences.practice_style.length === 0;
+}
+
+/**
  * Load all recorded learning events.
  */
 export function loadEvents(dataDir: string): LearningEvent[] {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -51,6 +51,7 @@ import { randomUUID } from "node:crypto";
 import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
 import { questionBridge, type QuestionBridgeResult } from "./agent/question-bridge.js";
+import { ensureDefaultReminders } from "./agent/learning-reminders.js";
 import { DEFAULT_WORKSPACE_ID, TEMP_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
 import { listPresets, listRemotePresets, ensurePresetCached, instantiatePreset } from "./presets/preset-store.js";
 import { createContentSource, type RemoteContentSource } from "./content-source/index.js";
@@ -300,6 +301,15 @@ async function ensureBootstrapped(): Promise<void> {
 			channelRegistry.register(wechatChannel);
 		}
 		migrateReminderChannels();
+
+		// Create default learning reminders on first boot (idempotent —
+		// checks by name before creating, so existing jobs are untouched).
+		if (config.autoReminders?.enabled !== false) {
+			const created = ensureDefaultReminders(jobStore);
+			if (created > 0) {
+				logger.info({ created }, "[inno-server] created default learning reminders");
+			}
+		}
 
 		// ---- agent session ----
 		logger.info("[inno-server] initializing agent session...");

--- a/config.example.json
+++ b/config.example.json
@@ -52,6 +52,9 @@
 		"baseUrl": "",
 		"token": ""
 	},
+	"autoReminders": {
+		"enabled": true
+	},
 	"memory": {
 		"l1Enabled": true,
 		"l2Enabled": true,


### PR DESCRIPTION
## 改动说明

首次启动时自动创建 3 个默认学习提醒（push_reminder），新用户开箱即用。

## 3 个默认提醒

| 名称 | Cron | 内容 |
|---|---|---|
| 每日学习提醒 | 09:03 | 早上好！今天打算学什么？ |
| 晚间复习提醒 | 19:07 | 回顾一下今天学了什么？ |
| 周度学习回顾 | 周日 21:07 | 这周学了哪些内容？ |

## 改动文件

- **新增** `apps/inno-agent/src/agent/learning-reminders.ts`
- **修改** `apps/inno-agent/src/config.ts`
- **修改** `apps/inno-agent/src/server.ts`
- **修改** `config.example.json`

## 行为

- 纯 Web：定时在聊天窗口弹出提醒
- 飞书/微信：额外推送到手机
- 不需要：config 关掉或 Jobs 页面删除
- 幂等：按名称去重，不重复创建