### PR TITLE
feat: auto-onboarding flow for new users with empty L1 profile

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -8,7 +8,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { saveConfig, setDefaultModel, type InnoConfig } from "../config.js";
 import { createLearnerTools } from "../memory/learner/learner-tools.js";
-import { loadEvents, loadProfile } from "../memory/learner/profile-store.js";
+import { isProfileEmpty, loadEvents, loadProfile } from "../memory/learner/profile-store.js";
 import { buildContextPack, formatContextPackForPrompt } from "../memory/learner/context-pack.js";
 import { JobStore } from "../scheduler/job-store.js";
 import { createSchedulerTools } from "../scheduler/scheduler-tools.js";
@@ -19,7 +19,7 @@ import { createPracticeTools } from "./practice-tools.js";
 import { createDocumentTools } from "./document-tools.js";
 import { createOcrTools } from "./ocr-tools.js";
 import { checkWorkspaceMutationPath } from "./workspace-path-guard.js";
-import { INNO_SYSTEM_PROMPT } from "./system-prompt.js";
+import { INNO_SYSTEM_PROMPT, ONBOARDING_GUIDE } from "./system-prompt.js";
 import { syncProvidersForSubagents } from "./provider-sync.js";
 import { questionBridge } from "./question-bridge.js";
 import { logger } from "../logger.js";
@@ -336,6 +336,14 @@ export function createInnoExtension(
 				// unless the learner has turned L1 off in settings.
 				if (isL1Enabled()) {
 					const profile = loadProfile(paths.learnerDataDir);
+
+					// If the profile is empty (new user), inject the structured
+					// onboarding guide so the agent prioritises building a baseline
+					// learner profile over casual conversation.
+					if (isProfileEmpty(profile)) {
+						sections.push(ONBOARDING_GUIDE);
+					}
+
 					const recentEvents = loadEvents(paths.learnerDataDir).slice(-8);
 					const contextPack = buildContextPack(profile, recentEvents);
 					const contextSection = formatContextPackForPrompt(contextPack);

--- a/apps/inno-agent/src/agent/system-prompt.ts
+++ b/apps/inno-agent/src/agent/system-prompt.ts
@@ -71,3 +71,54 @@ L2 目录边界（重要，违反会破坏知识库引用）：
 - 工具调用百度 vl-ocr（PaddleOCR-VL）API，返回 markdown 文本。
 - 如果当前模型原生支持图片识别且能正常读取图片，直接处理即可，无需调用此工具。
 - 若未配置 OCR API token，工具会返回提示——此时直接告诉用户「尚未配置 OCR API，请在设置里填入 token 后重试」。`;
+
+export const ONBOARDING_GUIDE = `
+## 新手引导（仅在用户画像为空时生效）
+
+当前学习者的 L1 画像尚未建立。你必须**立即开始以下 4 步引导**。
+不要说"你好"或"有什么可以帮你"，不要闲聊，不要等待用户进一步输入。
+用户的第一条消息只是对话开始，不是跳过引导的信号。
+
+**重要规则：**
+- 每一步都必须调用 ask_user_question 工具（不要用纯文本输出代替）
+- 每个问题最多 4 个选项，已按此限制设计
+- 只有用户明确说"跳过""不用了""不想要引导""先看看再说""下次"时，
+  才回复"好的，画像暂未建立。需要引导时随时叫我。"然后停止
+
+**第 1 步 — 学习目标**
+提问："你想学什么？选一个最接近的方向"
+选项（4 个）：编程开发 / 语言学习与考试 / 职业技能与兴趣 / 其他方向
+→ 收到答案后调用 record_learning_event：
+   event_type: "goal_declared"
+   payload: { goal: 用户选择的选项, topic: 用户选择的选项 }
+
+**第 2 步 — 当前水平**
+提问："在这个方向你目前是什么水平？"
+选项（4 个）：零基础入门 / 有一定了解 / 能独立做简单项目 / 比较熟练想进阶
+→ 收到答案后调用 patch_learner_profile：
+   concept_id: 从目标推断（如 programming.general、language.english）
+   concept_name: 用户选择的目标方向
+   domain: 从目标推断（如 programming、language、exam）
+   mastery: 零基础=0.05, 有了解=0.25, 能独立=0.55, 熟练=0.75
+   confidence: 0.6
+
+**第 3 步 — 学习偏好**
+提问："你喜欢怎么学？可以多选"
+选项（多选，4 个）：看视频或读文档 / 动手做项目 / 刷题练习 / 讨论或跟人学
+→ 收到答案后调用 patch_learner_profile 的 preferences_append：
+   - 看视频或读文档 → explanation_style: ["example_first", "theory_first"]
+   - 动手做项目 → practice_style: ["small_steps"]
+   - 刷题练习 → practice_style: ["spaced_repetition"]
+   - 讨论或跟人学 → feedback_tone: ["socratic"]
+
+**第 4 步 — 学习节奏**
+提问："你大概每周能投入多少时间学习？"
+选项（4 个）：每周 1-2 小时 / 每周 3-5 小时 / 每周 6-10 小时 / 每周 10+ 小时
+→ 收到答案后调用 record_learning_event：
+   event_type: "preference_stated"
+   payload: { preference: 用户选择的选项, topic: "学习节奏" }
+
+完成 4 步后：
+1. 用一句简短的话总结你了解到的学习者画像（包含目标、水平、偏好、节奏）
+2. 调用 patch_learner_profile：profile_summary_append: 你的总结内容
+3. 说："画像已建立，现在我们开始吧！"`;

--- a/apps/inno-agent/src/memory/learner/profile-store.ts
+++ b/apps/inno-agent/src/memory/learner/profile-store.ts
@@ -46,6 +46,19 @@ export function recordEventAndUpdateProfile(dataDir: string, event: LearningEven
 }
 
 /**
+ * Check whether the learner profile is effectively empty (new user).
+ * Returns true when no goals, knowledge states, summary, or preferences
+ * have been recorded — indicating a first-time user who needs onboarding.
+ */
+export function isProfileEmpty(profile: LearnerProfile): boolean {
+	return profile.goals.length === 0
+		&& profile.knowledge_states.length === 0
+		&& profile.profile_summary === ""
+		&& profile.preferences.explanation_style.length === 0
+		&& profile.preferences.practice_style.length === 0;
+}
+
+/**
  * Load all recorded learning events.
  */
 export function loadEvents(dataDir: string): LearningEvent[] {


### PR DESCRIPTION
## Summary

新用户首次对话时 L1 画像为空，agent 没有明确指引。注入 4 步结构化引导脚本，优先建立画像。

## Changes

3 files, +74 / -2

- `profile-store.ts` — `isProfileEmpty()` 空画像检测（5 维度）
- `system-prompt.ts` — `ONBOARDING_GUIDE` 引导脚本（含退出机制、4 选项适配）
- `inno-extension.ts` — `before_agent_start` 条件注入

## Flow

目标 → 水平 → 偏好 → 节奏 → 画像建立

全程通过 `ask_user_question` 工具交互，`record_learning_event` / `patch_learner_profile` 写 L1。Simple Mode / L1 关闭时自动跳过。