### PR TITLE
fix: session/UX batch extracted from PR #76

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1842,7 +1842,7 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 		const messages: SessionMessageSummary[] = [];
 		const channels = new Set<SessionChannel>();
 		let createdAt = "";
-		let updatedAt = "";
+		let lastMessageAt = "";
 
 		// Aggregator for the in-progress assistant turn. PI splits one assistant
 		// turn into multiple JSONL entries (thinking + toolCalls + toolResults
@@ -1865,7 +1865,6 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 			const entry = JSON.parse(line) as Record<string, unknown>;
 			const timestamp = typeof entry.timestamp === "string" ? entry.timestamp : "";
 			if (!createdAt && timestamp) createdAt = timestamp;
-			if (timestamp) updatedAt = timestamp;
 			const entryText = line.toLowerCase();
 			// Detect channel from entry content
 			let entryChannel: SessionChannel | undefined;
@@ -1896,6 +1895,7 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 			}
 
 			if (entry.type !== "message" || !entry.message || typeof entry.message !== "object") continue;
+			if (timestamp) lastMessageAt = timestamp;
 			const message = entry.message as Record<string, unknown>;
 			const role = message.role;
 			const ts = timestamp ? Date.parse(timestamp) : Date.now();
@@ -1980,7 +1980,7 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 				id: basename(filePath),
 				name,
 				createdAt: createdAt || fallbackTime,
-				updatedAt: updatedAt || fallbackTime,
+				updatedAt: lastMessageAt || createdAt || fallbackTime,
 				messageCount: filtered.length,
 				preview,
 				channels: channels.size > 0 ? Array.from(channels) : [],
@@ -2727,6 +2727,7 @@ const server = createServer(async (req, res) => {
 			const channelMetadata = readSessionChannelMetadata();
 			const topicMetadata = readSessionTopicMetadata();
 			const archiveMetadata = readJson<Record<string, boolean>>(sessionArchiveMetadataPath(), {});
+			const currentSessionId = getCurrentSessionId();
 			const sessions = existsSync(sessionDir)
 				? readdirSync(sessionDir)
 						.filter((file) => file.endsWith(".jsonl"))
@@ -2736,6 +2737,7 @@ const server = createServer(async (req, res) => {
 						.map((summary) => bindCliSessionWorkspace(summary))
 						.map((summary) => withRecordedTopic(summary, topicMetadata))
 						.map((summary) => ({ ...summary, archived: archiveMetadata[summary.id] === true }))
+						.filter((summary) => summary.messageCount > 0 || (summary.id === currentSessionId && summary.origin === "web"))
 						.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
 				: [];
 			json(res, 200, sessions);
@@ -2857,6 +2859,10 @@ const server = createServer(async (req, res) => {
 		if (method === "POST" && url === "/api/sessions") {
 			const body = await readBody(req).catch(() => ({})) as Record<string, unknown>;
 			const id = await createNewSession();
+			// This endpoint is exclusively the Web UI's session-creation path.
+			// Record the origin immediately so Simple Mode includes the new empty
+			// session before the first assistant response has finished streaming.
+			recordCurrentSessionChannel("web", id, { setOriginIfEmpty: true });
 
 			// Determine target workspace. The UI chooser always sends an explicit
 			// choice (new/existing); temp is only a safety fallback. A presetId
@@ -3673,7 +3679,9 @@ const server = createServer(async (req, res) => {
 			try {
 				const remote = await listRemotePresets(getContentSource(), forceRefresh);
 				if (remote.length > 0) {
-					json(res, 200, remote);
+					const merged = new Map(listPresets(paths).map((preset) => [preset.id, preset]));
+					for (const preset of remote) merged.set(preset.id, preset);
+					json(res, 200, Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name)));
 				} else {
 					json(res, 200, listPresets(paths));
 				}

--- a/apps/inno-agent/web/src/api/client.ts
+++ b/apps/inno-agent/web/src/api/client.ts
@@ -27,11 +27,21 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
 /**
  * Shared SSE body-reading loop. Yields parsed JSON objects from `data:` lines.
  * When the signal is aborted the generator returns normally.
+ *
+ * Connection hygiene: when the caller aborts (e.g. via detach()), we
+ * proactively cancel the reader via an abort listener so the underlying TCP
+ * connection is released immediately, rather than waiting for the pending
+ * reader.read() to reject on the next chunk. Without this, rapidly switching
+ * sessions can accumulate stale SSE connections that exhaust Chromium's
+ * 6-connection-per-origin pool, causing all subsequent fetch() calls to hang.
  */
 async function* readSSEStream<T>(res: Response, signal?: AbortSignal): AsyncGenerator<T> {
 	const reader = res.body!.getReader();
 	const decoder = new TextDecoder();
 	let buffer = "";
+
+	const onAbort = () => { void reader.cancel().catch(() => {}); };
+	signal?.addEventListener("abort", onAbort);
 
 	try {
 		while (true) {
@@ -59,6 +69,7 @@ async function* readSSEStream<T>(res: Response, signal?: AbortSignal): AsyncGene
 			}
 		}
 	} finally {
+		signal?.removeEventListener("abort", onAbort);
 		try {
 			await reader.cancel();
 		} catch {
@@ -105,7 +116,13 @@ export async function* streamSSEGet<T>(url: string, signal?: AbortSignal): Async
 		if (signal?.aborted) return;
 		throw err;
 	}
-	if (res.status === 404) return;
+	if (res.status === 404) {
+		// Consume the body so the connection is returned to the pool immediately
+		// rather than lingering until GC. A 404 here is expected (no active
+		// backend stream for this session) but the response still holds a socket.
+		void res.body?.cancel().catch(() => {});
+		return;
+	}
 	if (!res.ok) {
 		const errBody = await res.json().catch(() => ({}));
 		throw new ApiError(res.status, (errBody as Record<string, string>).error || res.statusText);

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -750,6 +750,34 @@ inno-workspace-panel textarea {
 	}
 }
 
+/* Settings lives in a resizable workspace panel, so its responsive layout
+   must follow the panel width rather than the browser viewport width. */
+.settings-panel {
+	container: settings-panel / inline-size;
+}
+
+.settings-stats-grid {
+	grid-template-columns: minmax(0, 1fr);
+}
+
+@container settings-panel (min-width: 30rem) {
+	.settings-stats-grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}
+
+@container settings-panel (min-width: 40rem) {
+	.settings-panel-header {
+		align-items: center;
+		flex-direction: row;
+		justify-content: space-between;
+	}
+
+	.settings-panel-controls {
+		flex-wrap: nowrap;
+	}
+}
+
 /* Sidebar scrollbar */
 .sidebar-scroll {
 	scrollbar-width: thin;

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -510,6 +510,9 @@
 	},
 	"chat": {
 		"welcomePlaceholder": "What would you like to learn or build? Send a message to start…",
+		"loadingSession": "Loading session…",
+		"emptySessionTitle": "No messages in this conversation",
+		"emptySessionHint": "Type a message below to start the conversation.",
 		"uploadFiles": "Upload files to workspace",
 		"uploadHint": "Select an existing workspace or start a conversation before uploading files",
 		"attachImage": "Attach image",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -510,6 +510,9 @@
 	},
 	"chat": {
 		"welcomePlaceholder": "有什么想学习或实践的?发送消息开始…",
+		"loadingSession": "正在加载会话…",
+		"emptySessionTitle": "此会话暂无消息",
+		"emptySessionHint": "在下方输入消息，开始新的对话。",
 		"uploadFiles": "上传文件到工作区",
 		"uploadHint": "请先选择已有工作区或开始对话后再上传文件",
 		"attachImage": "添加图片",

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -396,6 +396,7 @@ function PresetPicker({
 export function ChatCenter() {
 	const { t } = useTranslation();
 	const inputRef = useRef<HTMLTextAreaElement | null>(null);
+	const draftRef = useRef("");
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const imageInputRef = useRef<HTMLInputElement | null>(null);
 	const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -538,6 +539,7 @@ export function ChatCenter() {
 	const handleInput = useCallback(() => {
 		const el = inputRef.current;
 		if (!el) return;
+		draftRef.current = el.value;
 		const maxHeight = 200;
 		el.style.height = "auto";
 		const h = Math.min(el.scrollHeight, maxHeight);
@@ -612,6 +614,7 @@ export function ChatCenter() {
 			: undefined;
 
 		const resetComposer = () => {
+			draftRef.current = "";
 			if (inputRef.current) {
 				inputRef.current.value = "";
 				inputRef.current.style.height = "auto";
@@ -839,6 +842,7 @@ export function ChatCenter() {
 			<textarea
 				ref={inputRef}
 				id="chat-input"
+				defaultValue={draftRef.current}
 				className="min-h-[36px] max-h-[200px] flex-1 resize-none overflow-hidden rounded-md border-0 bg-transparent px-2 py-2 text-sm leading-5 text-[var(--inno-text)] outline-none placeholder:text-[var(--inno-text-subtle)] disabled:opacity-60"
 				placeholder={placeholder}
 				rows={1}
@@ -1003,7 +1007,17 @@ export function ChatCenter() {
 					{chat.isLoadingHistory && chat.messages.length === 0 ? (
 						<div className="flex h-full flex-col items-center justify-center pt-20 text-[var(--inno-text-muted)]">
 							<Spinner size={20} className="mb-3 text-[var(--inno-border-strong)]" />
-							<p className="text-sm">Loading session…</p>
+							<p className="text-sm">{t("chat.loadingSession")}</p>
+						</div>
+					) : null}
+
+					{!chat.isLoadingHistory && chat.messages.length === 0 && !chat.isSending ? (
+						<div className="flex flex-col items-center justify-center pt-20 text-center text-[var(--inno-text-muted)]">
+							<div className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]">
+								<Sparkles size={18} />
+							</div>
+							<p className="text-sm font-medium text-[var(--inno-text)]">{t("chat.emptySessionTitle")}</p>
+							<p className="mt-1 text-xs">{t("chat.emptySessionHint")}</p>
 						</div>
 					) : null}
 

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -196,7 +196,7 @@ function ThemeSettings() {
 	const { t } = useTranslation();
 	const state = useStoreSnapshot(themeStore, () => ({ current: themeStore.current }));
 	return (
-		<div className="flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
+		<div className="flex shrink-0 items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
 			<span>{t("settings.theme")}</span>
 			<div className="flex gap-1">
 				{THEME_IDS.map((id) => {
@@ -1185,15 +1185,15 @@ export function SettingsPanel() {
 	const models = state.settings?.availableModels ?? state.settings?.configuredModels ?? [];
 
 	return (
-		<div className="h-full overflow-y-auto p-3">
+		<div className="settings-panel h-full overflow-y-auto p-3">
 			<div className="grid gap-3">
 				{/* Status cards */}
 				<div className="rounded-lg bg-[var(--inno-surface)] p-4">
-					<div className="mb-3 flex items-center justify-between">
+					<div className="settings-panel-header mb-3 flex flex-col items-stretch gap-3">
 						<h3 className="text-sm font-medium text-[var(--inno-text)]">{t("settings.title")}</h3>
-						<div className="flex items-center gap-2">
+						<div className="settings-panel-controls flex flex-wrap items-center gap-2">
 							<ThemeSettings />
-							<label className="flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
+							<label className="flex shrink-0 items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
 								<span>{t("settings.language")}</span>
 								<select
 									className="rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1 text-xs"
@@ -1204,23 +1204,23 @@ export function SettingsPanel() {
 									<option value="en">{t("settings.languageOptions.en")}</option>
 								</select>
 							</label>
-							<button className="rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void settingsStore.load()}>
+							<button className="shrink-0 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={() => void settingsStore.load()}>
 								{t("settings.refresh")}
 							</button>
 						</div>
 					</div>
 					{state.isLoading ? <div className="text-sm text-[var(--inno-text-muted)]">{t("settings.loading")}</div> : null}
 					{state.error ? <div className="rounded bg-[var(--inno-danger-bg)] p-2 text-sm text-[var(--inno-danger)]">{state.error}</div> : null}
-					<div className="grid grid-cols-3 gap-3 text-sm">
+					<div className="settings-stats-grid grid gap-3 text-sm">
 						<div className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
 							<div className="text-xs text-[var(--inno-text-muted)]">{t("settings.stats.server")}</div>
 							<div className={healthOk ? "font-medium text-[var(--inno-success)]" : "font-medium text-[var(--inno-danger)]"}>
 								{healthOk ? t("settings.stats.healthy") : t("settings.stats.offline")}
 							</div>
 						</div>
-						<div className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
+						<div className="min-w-0 rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
 							<div className="text-xs text-[var(--inno-text-muted)]">{t("settings.stats.defaultModel")}</div>
-							<div className="font-medium text-[var(--inno-text)]">{state.settings ? `${state.settings.defaultProvider}/${state.settings.defaultModel}` : "-"}</div>
+							<div className="font-medium text-[var(--inno-text)] [overflow-wrap:anywhere]">{state.settings ? `${state.settings.defaultProvider}/${state.settings.defaultModel}` : "-"}</div>
 						</div>
 						<div className="rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] p-3">
 							<div className="text-xs text-[var(--inno-text-muted)]">{t("settings.stats.wiki")}</div>

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -23,6 +23,7 @@ import { workspaceFileUrl, workspaceFolderZipUrl, triggerDownload } from "../api
 import { workspacesStore } from "../stores/workspaces-store.js";
 import { sessionsStore } from "../stores/sessions-store.js";
 import { settingsStore } from "../stores/settings-store.js";
+import { appStore } from "../stores/app-store.js";
 import { getSessionWorkspace } from "../api/workspaces.js";
 import { TerminalDrawer } from "./terminal/TerminalDrawer.js";
 import { RunButton } from "./terminal/RunButton.js";
@@ -41,6 +42,9 @@ const DocxPreview = lazy(() => import("./office/DocxPreview.js"));
 const XlsxPreview = lazy(() => import("./office/XlsxPreview.js"));
 
 const MAX_STREAMING_MARKDOWN_FORMAT_CHARS = 160_000;
+const TREE_PANE_WIDTH = 260;
+const CONTENT_REVEAL_WIDTH = TREE_PANE_WIDTH + 150;
+const DEFAULT_PREVIEW_PANEL_WIDTH = 560;
 
 function streamingMarkdownInterval(contentLength: number): number {
 	if (contentLength < 40_000) return 240;
@@ -682,6 +686,13 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 				if (isDir) node.toggle();
 				else {
 					node.select();
+					workspaceStore.clearStreamingPreview();
+					if (appStore.workspaceWidth < CONTENT_REVEAL_WIDTH) {
+						appStore.setWorkspaceWidth(DEFAULT_PREVIEW_PANEL_WIDTH);
+					}
+					if (appStore.workspaceMode === "quarter") {
+						appStore.setWorkspaceMode("half");
+					}
 					void workspaceStore.selectFile(node.data.path);
 				}
 			}}
@@ -829,8 +840,6 @@ export function WorkspaceBrowser() {
 	const simpleMode = useStoreSnapshot(settingsStore, () => settingsStore.settings?.simpleMode?.enabled === true);
 	// The file tree pane keeps a fixed width; the content preview pane appears
 	// only once the panel is dragged wide enough to fit it beside the tree.
-	const TREE_PANE_WIDTH = 260;
-	const CONTENT_REVEAL_WIDTH = TREE_PANE_WIDTH + 150;
 	const showContent = sidebarOpen ? panelWidth >= CONTENT_REVEAL_WIDTH : true;
 
 	// Measure the panel width to decide whether the content pane fits.


### PR DESCRIPTION
## Summary

Extracts the independently valuable bug fixes from #76 into a small, reviewable PR (adapted by hand to current main). The coupled question-card lifecycle rework and other feature blocks from #76 are **not** included.

**Backend (`server.ts`)**
- `/api/preset-library`: merge bundled + remote presets (remote wins on id conflict) — previously bundled presets vanished whenever the hub was reachable
- `POST /api/sessions`: record `web` origin immediately, so new empty sessions appear in Simple Mode and in the sidebar before the first response streams
- `GET /api/sessions`: filter out ghost sessions (`messageCount === 0`, e.g. 0-byte / header-only files), except the current web session
- `parseSessionFile`: `updatedAt` now tracks the last **message** timestamp, so metadata events (`model_change`, etc.) no longer bump sessions to the top of the list

**Frontend**
- `api/client.ts`: release SSE connections promptly — abort listener cancels the reader immediately, and 404 responses consume their body. Prevents stale SSE connections from exhausting Chromium's 6-connection-per-origin pool (which made all subsequent fetch calls hang)
- `WorkspaceBrowser`: auto-widen the panel / switch quarter→half when opening a file in a panel too narrow to show the preview (previously the click appeared to do nothing)
- `ChatCenter`: keep the composer draft across welcome ↔ session view switches; i18n `Loading session…`; add empty-session placeholder
- `SettingsPanel` + `app.css`: container-query based responsiveness for the resizable settings panel (header controls wrap, stats grid collapses) instead of fixed `grid-cols-3`

## Deliberately NOT extracted from #76
- apiFetch 15s timeout (would break legitimately long requests: `jobs/:id/run`, `POST /api/sessions` queueing, skill import — needs per-endpoint exemptions)
- auto-topic delivered with the done event (delays `done` by an LLM call, up to 20s worst case)
- `switchSessionFile` 500ms enqueue timeout (silently drops state changes; unreliable fallback)
- question-card persistence/suspend/resume lifecycle (tightly coupled feature block, needs its own PR)
- model `input` capability field (silently downgrades existing configs to text-only; needs migration)
- L1 LearningBoundary, sidebar sorting, root `skills/` directory

## Test plan
- [x] `npm run build` (backend tsc + frontend Vite) passes
- [ ] Smoke: create session in Simple Mode → appears in sidebar immediately
- [ ] Smoke: preset library lists bundled + remote presets together
- [ ] Smoke: open file with narrow workspace panel → panel auto-expands
- [ ] Smoke: switch sessions rapidly → no fetch hangs