### PR TITLE
fix: small bugfixes extracted from PR #47

### DIFF
--- a/apps/inno-agent/src/agent/document-tools.ts
+++ b/apps/inno-agent/src/agent/document-tools.ts
@@ -1,5 +1,6 @@
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
+import { existsSync } from "node:fs";
 import { resolve, isAbsolute } from "node:path";
 import { parseDocument, screenshotDocument, DocumentParseError } from "../memory/l2/document-parser.js";
 import { logger } from "../logger.js";
@@ -40,6 +41,14 @@ export function createDocumentTools(): ToolDefinition[] {
 			const resolvedPath = isAbsolute(typed.filePath)
 				? typed.filePath
 				: resolve(workspaceDir, typed.filePath);
+
+			// Check file existence before attempting parse
+			if (!existsSync(resolvedPath)) {
+				return {
+					content: [{ type: "text" as const, text: `文件不存在: ${typed.filePath}` }],
+					details: { error: "file_not_found", filePath: resolvedPath, pageCount: 0, textLength: 0 },
+				};
+			}
 
 			// Parse document
 			let parsed;

--- a/apps/inno-agent/src/agent/practice-tools.ts
+++ b/apps/inno-agent/src/agent/practice-tools.ts
@@ -1,7 +1,7 @@
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
 import type { WorkspaceRegistry } from "../workspace/workspace-registry.js";
 import { logger } from "../logger.js";
 
@@ -106,10 +106,6 @@ export function createPracticeTools(deps: PracticeToolDeps): ToolDefinition[] {
 			};
 		},
 	});
-
-	// Ensure dir helper not strictly required since mkdirSync covers it, but kept for clarity.
-	void existsSync;
-	void join;
 
 	return [createPracticeLab];
 }

--- a/apps/inno-agent/src/memory/l2/summarizer.ts
+++ b/apps/inno-agent/src/memory/l2/summarizer.ts
@@ -77,7 +77,7 @@ export async function summarizeContent(
 		);
 
 		if (response.stopReason === "error") {
-			logger.error({ errorMessage: response.errorMessage }, `[L2 summarizer] LLM error ?? "unknown"}`);
+			logger.error({ errorMessage: response.errorMessage }, `[L2 summarizer] LLM error: ${response.errorMessage ?? "unknown"}`);
 			return null;
 		}
 


### PR DESCRIPTION
## Summary

Three small, independent bugfixes hand-extracted from #47 (adapted to current main). The auto-review engine feature and the job-runner change from #47 are **not** included (see below).

- **l2/summarizer.ts**: the error log message contained a literal `?? "unknown"}` — the template interpolation was never applied, so LLM failures logged the raw placeholder instead of the error message
- **document-tools.ts**: check file existence before parsing and return a clear `文件不存在: <path>` tool result; previously a missing file surfaced as a raw ENOENT through the parser's generic failure path
- **practice-tools.ts**: remove the meaningless `void existsSync; void join;` dead-code statements plus the imports they were keeping alive

## Deliberately NOT extracted from #47
- **job-runner.ts `job.channel = inferredChannel` removal** — it is a regression, not a fix: `jobStore.update()` returns a new object and does not mutate the argument, so later code in `executeJob` (`const target = job.channel ? ...`) would read `undefined` and channel-inferred reminders would never be pushed
- **auto-review engine** (feature) — needs its own review: known issues include a cron timezone bug (local-time fields + hardcoded `Asia/Shanghai`) and missing `autoReviewEnabled` initial state in SettingsPanel
- **context-cache read** — filed as an issue for a design decision (read the cache vs delete the write-only cache machinery)

## Test plan
- [x] `npm run build` passes
- [ ] Smoke: call `parse_document` tool with a missing file → returns `文件不存在` instead of ENOENT dump