### PR TITLE
修复 L2 重复归档产生孤立原始文件

### DIFF
--- a/apps/inno-agent/src/memory/l2/l2-tools.ts
+++ b/apps/inno-agent/src/memory/l2/l2-tools.ts
@@ -68,20 +68,20 @@ export function createL2Tools(l2DataDir: string, isEnabled?: () => boolean): Too
 
 			// Resolve content: either from params.content or by parsing a file
 			let content: string;
-			let rawPath: string;
+			let resolvedFilePath: string | undefined;
 
 			if (isFileType && params.filePath) {
 				// File-based: parse with LiteParse
 				const workspaceDir = process.env.INNO_WORKSPACE_DIR || process.cwd();
-				const resolvedPath = isAbsolute(params.filePath)
+				resolvedFilePath = isAbsolute(params.filePath)
 					? params.filePath
 					: resolve(workspaceDir, params.filePath);
 
 				let parsed;
 				try {
-					parsed = await parseDocument(resolvedPath);
+					parsed = await parseDocument(resolvedFilePath);
 				} catch (err) {
-					logger.warn({ err, filePath: resolvedPath }, "l2_archive: failed to parse document");
+					logger.warn({ err, filePath: resolvedFilePath }, "l2_archive: failed to parse document");
 					const msg = err instanceof DocumentParseError ? err.message : String(err);
 					return {
 						content: [{ type: "text" as const, text: `文件解析失败: ${msg}` }],
@@ -90,12 +90,9 @@ export function createL2Tools(l2DataDir: string, isEnabled?: () => boolean): Too
 				}
 
 				content = parsed.text;
-				// Copy original file to raw storage
-				rawPath = saveRawFile(l2DataDir, params.title, resolvedPath, sourceType);
 			} else if (params.content) {
 				// Text-based: use content directly
 				content = params.content;
-				rawPath = saveRaw(l2DataDir, params.title, content, sourceType, params.url);
 			} else {
 				return {
 					content: [{ type: "text" as const, text: "参数错误：必须提供 content（文本内容）或 filePath（文件路径）。" }],
@@ -125,6 +122,10 @@ export function createL2Tools(l2DataDir: string, isEnabled?: () => boolean): Too
 					};
 				}
 			}
+
+			const rawPath = resolvedFilePath
+				? saveRawFile(l2DataDir, params.title, resolvedFilePath, sourceType)
+				: saveRaw(l2DataDir, params.title, content, sourceType, params.url);
 
 			const id = `l2src_${randomUUID().slice(0, 8)}`;
 			const tags = params.tags ?? [];


### PR DESCRIPTION
## 问题

L2 归档流程在内容查重之前就保存原始文件。重复归档相同内容时，接口虽然返回“已归档”，但仍会留下未被清单和知识库页面引用的孤立文件。

## 修改

- 先解析或读取归档内容
- 保持现有内容摘要算法和查重规则不变
- 仅在确认内容未重复后保存原始文件
- 保持强制归档、知识库生成和返回结构的原有行为

## 验证

- 全项目构建通过
- 相同文本使用不同标题重复归档后，原始文件和清单数量均不增加
- 文件类型重复归档后，原始文件和清单数量均不增加
- 不同内容仍可正常归档
- 强制归档仍可正常新增
- 缺少内容和关闭 L2 时不会产生原始文件