### PR TITLE
feat: 学习者画像新增学习边界配置

### DIFF
--- a/apps/inno-agent/src/memory/learner/context-pack.ts
+++ b/apps/inno-agent/src/memory/learner/context-pack.ts
@@ -107,9 +107,63 @@ export function buildContextPack(profile: LearnerProfile, recentEvents: Learning
 		relevant_concepts: relevantConcepts,
 		active_misconceptions: activeMisconceptions,
 		teaching_hints: teachingHints,
+		boundary: profile.boundary,
 		recent_events: recentEventSummaries,
 		review_due_concepts: reviewDueConcepts,
 	};
+}
+
+const difficultyMap: Record<string, string> = {
+	school_exam: "校内考试水平",
+	foundation: "基础",
+	advanced: "拔高",
+	competition: "竞赛",
+};
+
+const beyondScopeMap: Record<string, string> = {
+	prompt_first: "需提示后再使用",
+	allowed: "可直接使用",
+	forbidden: "完全禁止",
+};
+
+const methodMap: Record<string, string> = {
+	textbook_first: "优先使用教材内方法",
+	textbook_only: "仅使用教材内方法",
+	unrestricted: "不限制",
+};
+
+/**
+ * Render the learning boundary as a markdown subsection for prompt injection.
+ * Returns an empty string when no boundary field has been set, so the section
+ * is omitted entirely for learners who haven't configured a boundary yet.
+ */
+function formatBoundaryForPrompt(boundary?: LearnerContextPack["boundary"]): string {
+	if (!boundary) return "";
+
+	const items: string[] = [];
+	if (boundary.stage) items.push(`当前阶段：${boundary.stage}`);
+	if (boundary.subjects.length > 0) items.push(`主要课程：${boundary.subjects.join("、")}`);
+	if (boundary.knowledge_scope) items.push(`知识范围：${boundary.knowledge_scope}`);
+	if (boundary.default_difficulty) {
+		items.push(`默认难度：${difficultyMap[boundary.default_difficulty] ?? boundary.default_difficulty}`);
+	}
+	if (boundary.beyond_scope_strategy) {
+		items.push(`超纲内容：${beyondScopeMap[boundary.beyond_scope_strategy] ?? boundary.beyond_scope_strategy}`);
+	}
+	if (boundary.method_constraint) {
+		items.push(`解题方法：${methodMap[boundary.method_constraint] ?? boundary.method_constraint}`);
+	}
+	if (boundary.notation_standard) items.push(`符号规范：${boundary.notation_standard}`);
+	if (boundary.reference_materials) items.push(`参考资料：${boundary.reference_materials}`);
+
+	if (items.length === 0) return "";
+
+	items.push(`使用超纲知识前先提醒：${boundary.warn_before_beyond_scope ? "是" : "否"}`);
+	items.push(`解题时标注使用的知识范围：${boundary.annotate_knowledge_scope ? "是" : "否"}`);
+
+	return `\n## 学习边界\n以上学习边界为长期约束，请在每次讲解与解题时严格遵守：只在设定的阶段、课程与知识范围内展开，优先使用教材内方法与符号；若必须使用超纲内容${
+		boundary.warn_before_beyond_scope ? "（须先征得学习者同意）" : ""
+	}，请明确标注其超出当前范围。\n- ${items.join("\n- ")}`;
 }
 
 /**
@@ -143,6 +197,11 @@ export function formatContextPackForPrompt(pack: LearnerContextPack): string {
 		for (const h of pack.teaching_hints) {
 			lines.push(`- ${h}`);
 		}
+	}
+
+	const boundarySection = formatBoundaryForPrompt(pack.boundary);
+	if (boundarySection) {
+		lines.push(boundarySection);
 	}
 
 	if (pack.review_due_concepts && pack.review_due_concepts.length > 0) {

--- a/apps/inno-agent/src/memory/learner/learner-tools.ts
+++ b/apps/inno-agent/src/memory/learner/learner-tools.ts
@@ -57,6 +57,19 @@ const PreferencesSchema = Type.Object({
 	avoid: Type.Optional(Type.Array(Type.String(), { description: "Things to avoid in teaching" })),
 });
 
+const BoundarySchema = Type.Object({
+	stage: Type.Optional(Type.String({ description: "当前阶段，如“高中二年级”，用于确定解释深度" })),
+	subjects: Type.Optional(Type.Array(Type.String(), { description: "主要课程，如 [\"数学\", \"物理\"]，限定学科范围" })),
+	knowledge_scope: Type.Optional(Type.String({ description: "知识范围，如“人教A版必修一至选择性必修二”，防止调用未学内容" })),
+	default_difficulty: Type.Optional(StringEnum(["school_exam", "foundation", "advanced", "competition"] as const, { description: "默认难度" })),
+	beyond_scope_strategy: Type.Optional(StringEnum(["prompt_first", "allowed", "forbidden"] as const, { description: "超纲内容策略" })),
+	method_constraint: Type.Optional(StringEnum(["textbook_first", "textbook_only", "unrestricted"] as const, { description: "解题方法约束" })),
+	notation_standard: Type.Optional(Type.String({ description: "符号规范，如“采用课本常用符号”" })),
+	reference_materials: Type.Optional(Type.String({ description: "参考资料，作为默认知识依据" })),
+	warn_before_beyond_scope: Type.Optional(Type.Boolean({ description: "使用超纲知识前先提醒" })),
+	annotate_knowledge_scope: Type.Optional(Type.Boolean({ description: "解题时标注使用的知识范围" })),
+});
+
 // ============================================================================
 // Tool Factory
 // ============================================================================
@@ -200,12 +213,13 @@ export function createLearnerTools(
 		name: "update_learner_profile",
 		label: "Update Learner Profile",
 		description:
-			"更新学习者画像的特定字段。可以更新目标、知识状态、误区、偏好和画像摘要。数组字段按 ID 合并（已存在则替换，不存在则新增）。",
+			"更新学习者画像的特定字段。可以更新目标、知识状态、误区、偏好、学习边界和画像摘要。数组字段按 ID 合并（已存在则替换，不存在则新增）。学习边界为整体替换。",
 		parameters: Type.Object({
 			goals: Type.Optional(Type.Array(LearningGoalSchema)),
 			knowledge_states: Type.Optional(Type.Array(KnowledgeStateSchema)),
 			misconceptions: Type.Optional(Type.Array(MisconceptionSchema)),
 			preferences: Type.Optional(PreferencesSchema),
+			boundary: Type.Optional(BoundarySchema),
 			profile_summary: Type.Optional(Type.String({ description: "Updated profile summary text" })),
 		}),
 		async execute(_toolCallId, params) {
@@ -263,6 +277,18 @@ export function createLearnerTools(
 				`- 练习风格: ${profile.preferences.practice_style.join(", ") || "未设定"}`,
 				`- 反馈语气: ${profile.preferences.feedback_tone.join(", ") || "未设定"}`,
 				`- 避免: ${profile.preferences.avoid.join(", ") || "未设定"}`,
+				``,
+				`## 学习边界`,
+				`- 当前阶段: ${profile.boundary.stage || "未设定"}`,
+				`- 主要课程: ${profile.boundary.subjects.join("、") || "未设定"}`,
+				`- 知识范围: ${profile.boundary.knowledge_scope || "未设定"}`,
+				`- 默认难度: ${(({ school_exam: "校内考试水平", foundation: "基础", advanced: "拔高", competition: "竞赛" } as Record<string, string>)[profile.boundary.default_difficulty] ?? profile.boundary.default_difficulty) || "未设定"}`,
+				`- 超纲策略: ${(({ prompt_first: "需提示后再使用", allowed: "可直接使用", forbidden: "完全禁止" } as Record<string, string>)[profile.boundary.beyond_scope_strategy] ?? profile.boundary.beyond_scope_strategy) || "未设定"}`,
+				`- 解题方法: ${(({ textbook_first: "优先教材方法", textbook_only: "仅教材方法", unrestricted: "不限制" } as Record<string, string>)[profile.boundary.method_constraint] ?? profile.boundary.method_constraint) || "未设定"}`,
+				`- 符号规范: ${profile.boundary.notation_standard || "未设定"}`,
+				`- 参考资料: ${profile.boundary.reference_materials || "未设定"}`,
+				`- 使用超纲前提醒: ${profile.boundary.warn_before_beyond_scope ? "是" : "否"}`,
+				`- 解题标注知识范围: ${profile.boundary.annotate_knowledge_scope ? "是" : "否"}`,
 				``,
 				`## 画像摘要`,
 				profile.profile_summary || "暂无摘要",

--- a/apps/inno-agent/src/memory/learner/profile-store.ts
+++ b/apps/inno-agent/src/memory/learner/profile-store.ts
@@ -8,9 +8,18 @@ const EVENTS_FILE = "events.jsonl";
 
 /**
  * Load the learner profile. Returns a default empty profile if not found.
+ * Backfills any top-level fields missing from an older on-disk profile so that
+ * newly added structures (e.g. boundary) always have valid defaults.
  */
 export function loadProfile(dataDir: string): LearnerProfile {
-	return readJson<LearnerProfile>(join(dataDir, PROFILE_FILE), createDefaultProfile());
+	const defaults = createDefaultProfile();
+	const loaded = readJson<Partial<LearnerProfile>>(join(dataDir, PROFILE_FILE), defaults);
+	return {
+		...defaults,
+		...loaded,
+		preferences: { ...defaults.preferences, ...(loaded.preferences ?? {}) },
+		boundary: { ...defaults.boundary, ...(loaded.boundary ?? {}) },
+	};
 }
 
 /**

--- a/apps/inno-agent/src/memory/learner/profile-updater.ts
+++ b/apps/inno-agent/src/memory/learner/profile-updater.ts
@@ -4,6 +4,7 @@ import type {
 	KnowledgeState,
 	Misconception,
 	LearnerPreferences,
+	LearningBoundary,
 } from "./types.js";
 import { loadProfile, saveProfile } from "./profile-store.js";
 
@@ -16,6 +17,7 @@ export interface ProfileUpdate {
 	knowledge_states?: KnowledgeState[];
 	misconceptions?: Misconception[];
 	preferences?: Partial<LearnerPreferences>;
+	boundary?: Partial<LearningBoundary>;
 	profile_summary?: string;
 }
 
@@ -102,6 +104,13 @@ export function updateProfile(dataDir: string, update: ProfileUpdate): LearnerPr
 		profile.preferences = {
 			...profile.preferences,
 			...update.preferences,
+		};
+	}
+
+	if (update.boundary) {
+		profile.boundary = {
+			...profile.boundary,
+			...update.boundary,
 		};
 	}
 

--- a/apps/inno-agent/src/memory/learner/types.ts
+++ b/apps/inno-agent/src/memory/learner/types.ts
@@ -12,6 +12,7 @@ export interface LearnerProfile {
 	knowledge_states: KnowledgeState[];
 	misconceptions: Misconception[];
 	preferences: LearnerPreferences;
+	boundary: LearningBoundary;
 	profile_summary: string;
 }
 
@@ -60,6 +61,33 @@ export interface LearnerPreferences {
 	avoid: string[];
 }
 
+/**
+ * 学习边界 (Learning Boundary) — 长期限定 AI 的讲解范围、术语与方法。
+ * 与 preferences（控制“怎么讲”）正交：boundary 控制“能讲到哪里、用什么方法”。
+ */
+export interface LearningBoundary {
+	/** 当前阶段，如“高中二年级”，用于确定解释深度 */
+	stage: string;
+	/** 主要课程，如 ["数学", "物理"]，限定学科范围 */
+	subjects: string[];
+	/** 知识范围，如“人教A版必修一至选择性必修二”，防止调用未学内容 */
+	knowledge_scope: string;
+	/** 默认难度，用于控制题目与讲解层级：school_exam / foundation / advanced / competition */
+	default_difficulty: string;
+	/** 超纲内容策略：prompt_first / allowed / forbidden */
+	beyond_scope_strategy: string;
+	/** 解题方法约束：textbook_first / textbook_only / unrestricted */
+	method_constraint: string;
+	/** 符号规范，如“采用课本常用符号” */
+	notation_standard: string;
+	/** 参考资料，作为默认知识依据，如“高中数学人教A版” */
+	reference_materials: string;
+	/** 开关：使用超纲知识前先提醒 */
+	warn_before_beyond_scope: boolean;
+	/** 开关：解题时标注使用的知识范围 */
+	annotate_knowledge_scope: boolean;
+}
+
 // ============================================================================
 // Learning Event Types
 // ============================================================================
@@ -105,6 +133,7 @@ export interface LearnerContextPack {
 	}[];
 	active_misconceptions: string[];
 	teaching_hints: string[];
+	boundary?: LearningBoundary;
 	recent_events?: {
 		event_id: string;
 		event_type: LearningEventType;
@@ -135,6 +164,18 @@ export function createDefaultProfile(learnerId?: string): LearnerProfile {
 			practice_style: [],
 			feedback_tone: [],
 			avoid: [],
+		},
+		boundary: {
+			stage: "",
+			subjects: [],
+			knowledge_scope: "",
+			default_difficulty: "",
+			beyond_scope_strategy: "",
+			method_constraint: "",
+			notation_standard: "",
+			reference_materials: "",
+			warn_before_beyond_scope: true,
+			annotate_knowledge_scope: false,
 		},
 		profile_summary: "",
 	};

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -46,7 +46,7 @@ import { validateCron } from "./scheduler/cron-utils.js";
 import { parseFrontmatter, serializeFrontmatter } from "./memory/l2/wiki-maintainer.js";
 import { readManifest, removeWikiPathFromManifest } from "./memory/l2/manifest-store.js";
 import { loadProfile, saveProfile } from "./memory/learner/profile-store.js";
-import type { LearnerProfile, LearningGoal, KnowledgeState, Misconception, LearnerPreferences } from "./memory/learner/types.js";
+import type { LearnerProfile, LearningGoal, KnowledgeState, Misconception, LearnerPreferences, LearningBoundary } from "./memory/learner/types.js";
 import { randomUUID } from "node:crypto";
 import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
@@ -759,6 +759,39 @@ function normalizePreferences(input: Partial<LearnerPreferences>): LearnerPrefer
 		practice_style: arr(input.practice_style),
 		feedback_tone: arr(input.feedback_tone),
 		avoid: arr(input.avoid),
+	};
+}
+
+const DIFFICULTY_VALUES = new Set(["school_exam", "foundation", "advanced", "competition"]);
+const BEYOND_SCOPE_VALUES = new Set(["prompt_first", "allowed", "forbidden"]);
+const METHOD_VALUES = new Set(["textbook_first", "textbook_only", "unrestricted"]);
+
+/** Normalize and validate a learning boundary patch from the HTTP API. */
+function normalizeBoundary(input: Partial<LearningBoundary>): LearningBoundary {
+	function str(value: unknown): string {
+		return typeof value === "string" ? value.trim() : "";
+	}
+	function arr(value: unknown): string[] {
+		if (!Array.isArray(value)) return [];
+		return value.filter((s): s is string => typeof s === "string" && s.trim().length > 0);
+	}
+	function bool(value: unknown): boolean {
+		return value === true;
+	}
+	function pick(value: unknown, allowed: Set<string>): string {
+		return typeof value === "string" && allowed.has(value) ? value : "";
+	}
+	return {
+		stage: str(input.stage),
+		subjects: arr(input.subjects),
+		knowledge_scope: str(input.knowledge_scope),
+		default_difficulty: pick(input.default_difficulty, DIFFICULTY_VALUES),
+		beyond_scope_strategy: pick(input.beyond_scope_strategy, BEYOND_SCOPE_VALUES),
+		method_constraint: pick(input.method_constraint, METHOD_VALUES),
+		notation_standard: str(input.notation_standard),
+		reference_materials: str(input.reference_materials),
+		warn_before_beyond_scope: bool(input.warn_before_beyond_scope),
+		annotate_knowledge_scope: bool(input.annotate_knowledge_scope),
 	};
 }
 
@@ -3178,6 +3211,9 @@ const server = createServer(async (req, res) => {
 			}
 			if (body.preferences && typeof body.preferences === "object") {
 				profile.preferences = normalizePreferences(body.preferences as Partial<LearnerPreferences>);
+			}
+			if (body.boundary && typeof body.boundary === "object") {
+				profile.boundary = normalizeBoundary(body.boundary as Partial<LearningBoundary>);
 			}
 			saveProfile(paths.learnerDataDir, profile);
 			json(res, 200, profile);

--- a/apps/inno-agent/web/src/api/learner.ts
+++ b/apps/inno-agent/web/src/api/learner.ts
@@ -1,11 +1,11 @@
 import { apiFetch } from "./client.js";
-import type { LearnerProfile, LearningGoal, KnowledgeState, Misconception, LearnerPreferences } from "../types/learner.js";
+import type { LearnerProfile, LearningGoal, KnowledgeState, Misconception, LearnerPreferences, LearningBoundary } from "../types/learner.js";
 
 export async function getLearnerProfile(): Promise<LearnerProfile> {
 	return apiFetch<LearnerProfile>("/api/learner/profile");
 }
 
-export async function patchLearnerProfile(patch: { profile_summary?: string; preferences?: LearnerPreferences }): Promise<LearnerProfile> {
+export async function patchLearnerProfile(patch: { profile_summary?: string; preferences?: LearnerPreferences; boundary?: LearningBoundary }): Promise<LearnerProfile> {
 	return apiFetch<LearnerProfile>("/api/learner/profile", {
 		method: "PATCH",
 		body: JSON.stringify(patch),

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -173,7 +173,8 @@
 			"goals": "Goals",
 			"knowledge": "Knowledge",
 			"misconceptions": "Misconceptions",
-			"preferences": "Preferences"
+			"preferences": "Preferences",
+			"boundary": "Learning boundary"
 		},
 		"summary": {
 			"placeholder": "Agent's high-level summary of the learner…",
@@ -239,6 +240,39 @@
 			"feedbackTone": "Feedback tone",
 			"avoid": "Avoid",
 			"addPlaceholder": "Press Enter to add…"
+		},
+		"boundary": {
+			"stage": "Current stage",
+			"stagePlaceholder": "e.g. Grade 11",
+			"subjects": "Main subjects",
+			"knowledgeScope": "Knowledge scope",
+			"knowledgeScopePlaceholder": "e.g. PEP Edition Vol. 1 to Selective Vol. 2",
+			"defaultDifficulty": "Default difficulty",
+			"beyondScopeStrategy": "Beyond-scope strategy",
+			"methodConstraint": "Method constraint",
+			"notationStandard": "Notation standard",
+			"notationStandardPlaceholder": "e.g. Follow textbook conventions",
+			"referenceMaterials": "Reference materials",
+			"referenceMaterialsPlaceholder": "e.g. PEP Edition high school math",
+			"warnBeforeBeyondScope": "Warn before using beyond-scope knowledge",
+			"annotateKnowledgeScope": "Annotate knowledge scope when solving",
+			"unset": "Not set",
+			"difficultyOptions": {
+				"school_exam": "School exam level",
+				"foundation": "Foundation",
+				"advanced": "Advanced",
+				"competition": "Competition"
+			},
+			"beyondScopeOptions": {
+				"prompt_first": "Prompt before use",
+				"allowed": "Allowed directly",
+				"forbidden": "Forbidden"
+			},
+			"methodOptions": {
+				"textbook_first": "Textbook methods first",
+				"textbook_only": "Textbook methods only",
+				"unrestricted": "Unrestricted"
+			}
 		}
 	},
 	"jobs": {
@@ -542,7 +576,9 @@
 	"question": {
 		"typeSomething": "Type something…",
 		"chatAboutThis": "Chat about this",
-		"submit": "Submit"
+		"submit": "Submit",
+		"submitNext": "Submit & Next",
+		"optionSelectedHint": "Option selected — this text won't be submitted"
 	},
 	"sidebar": {
 		"expand": "Expand",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -173,7 +173,8 @@
 			"goals": "学习目标",
 			"knowledge": "知识状态",
 			"misconceptions": "误解记录",
-			"preferences": "学习偏好"
+			"preferences": "学习偏好",
+			"boundary": "学习边界"
 		},
 		"summary": {
 			"placeholder": "Agent 对学习者的整体认知摘要…",
@@ -239,6 +240,39 @@
 			"feedbackTone": "反馈语气",
 			"avoid": "应避免",
 			"addPlaceholder": "回车添加…"
+		},
+		"boundary": {
+			"stage": "当前阶段",
+			"stagePlaceholder": "例如：高中二年级",
+			"subjects": "主要课程",
+			"knowledgeScope": "知识范围",
+			"knowledgeScopePlaceholder": "例如：人教A版必修一至选择性必修二",
+			"defaultDifficulty": "默认难度",
+			"beyondScopeStrategy": "超纲策略",
+			"methodConstraint": "解题方法",
+			"notationStandard": "符号规范",
+			"notationStandardPlaceholder": "例如：采用课本常用符号",
+			"referenceMaterials": "参考资料",
+			"referenceMaterialsPlaceholder": "例如：高中数学人教A版",
+			"warnBeforeBeyondScope": "使用超纲知识前先提醒",
+			"annotateKnowledgeScope": "解题时标注使用的知识范围",
+			"unset": "未设定",
+			"difficultyOptions": {
+				"school_exam": "校内考试水平",
+				"foundation": "基础",
+				"advanced": "拔高",
+				"competition": "竞赛"
+			},
+			"beyondScopeOptions": {
+				"prompt_first": "需提示后再使用",
+				"allowed": "可直接使用",
+				"forbidden": "完全禁止"
+			},
+			"methodOptions": {
+				"textbook_first": "优先教材方法",
+				"textbook_only": "仅教材方法",
+				"unrestricted": "不限制"
+			}
 		}
 	},
 	"jobs": {
@@ -542,7 +576,9 @@
 	"question": {
 		"typeSomething": "输入自定义答案…",
 		"chatAboutThis": "直接聊聊",
-		"submit": "提交"
+		"submit": "提交",
+		"submitNext": "提交并下一题",
+		"optionSelectedHint": "已选选项，此文字不生效"
 	},
 	"sidebar": {
 		"expand": "展开",

--- a/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
+++ b/apps/inno-agent/web/src/react/LearnerProfilePanel.tsx
@@ -3,11 +3,13 @@ import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "motion/react";
 import { ChevronRight } from "lucide-react";
 import { Spinner } from "./ui/Spinner.js";
+import { Switch } from "./ui/Switch.js";
 import { learnerStore } from "../stores/learner-store.js";
 import type {
 	GoalStatus,
 	GoalType,
 	KnowledgeState,
+	LearningBoundary,
 	LearningGoal,
 	Misconception,
 	MisconceptionStatus,
@@ -17,6 +19,22 @@ import { useStoreSnapshot } from "./hooks.js";
 const GOAL_TYPES: GoalType[] = ["skill", "concept", "project", "exam", "habit"];
 const GOAL_STATUSES: GoalStatus[] = ["active", "paused", "completed", "archived"];
 const MISC_STATUSES: MisconceptionStatus[] = ["active", "repairing", "resolved", "stale"];
+const DIFFICULTY_OPTIONS = ["school_exam", "foundation", "advanced", "competition"] as const;
+const BEYOND_SCOPE_OPTIONS = ["prompt_first", "allowed", "forbidden"] as const;
+const METHOD_OPTIONS = ["textbook_first", "textbook_only", "unrestricted"] as const;
+
+const DEFAULT_BOUNDARY: LearningBoundary = {
+	stage: "",
+	subjects: [],
+	knowledge_scope: "",
+	default_difficulty: "",
+	beyond_scope_strategy: "",
+	method_constraint: "",
+	notation_standard: "",
+	reference_materials: "",
+	warn_before_beyond_scope: true,
+	annotate_knowledge_scope: false,
+};
 
 function formatDate(iso?: string): string {
 	if (!iso) return "-";
@@ -800,6 +818,162 @@ function PreferencesSection() {
 	);
 }
 
+function BoundarySection() {
+	const { t } = useTranslation();
+	const state = useStoreSnapshot(learnerStore, () => ({ profile: learnerStore.profile, isSaving: learnerStore.isSaving }));
+	const boundary = state.profile?.boundary ?? DEFAULT_BOUNDARY;
+	const [draft, setDraft] = useState<LearningBoundary>(boundary);
+	const [dirty, setDirty] = useState(false);
+
+	useEffect(() => {
+		if (!dirty) setDraft(boundary);
+	}, [state.profile, dirty, boundary]);
+
+	function update<K extends keyof LearningBoundary>(key: K, value: LearningBoundary[K]) {
+		setDraft((prev) => ({ ...prev, [key]: value }));
+		setDirty(true);
+	}
+
+	async function save() {
+		await learnerStore.patchBoundary(draft);
+		setDirty(false);
+	}
+
+	// Build the summary line shown under the section title, e.g.
+	// "高中数学 · 人教A版 · 校内考试难度 · 优先课内方法"
+	const summaryParts: string[] = [];
+	if (draft.subjects.length > 0) summaryParts.push(draft.subjects.join("/"));
+	if (draft.reference_materials) summaryParts.push(draft.reference_materials);
+	if (draft.default_difficulty) summaryParts.push(t(`profile.boundary.difficultyOptions.${draft.default_difficulty}`));
+	if (draft.method_constraint && draft.method_constraint !== "unrestricted") {
+		summaryParts.push(t(`profile.boundary.methodOptions.${draft.method_constraint}`));
+	}
+	const summary = summaryParts.join(" · ");
+
+	const inputClsStr = "w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]";
+	const selectClsStr = "w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-sm focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]";
+
+	return (
+		<Section title={t("profile.sections.boundary")}>
+			{summary ? (
+				<p className="mb-3 rounded-md bg-[var(--inno-accent-soft)] px-3 py-1.5 text-xs text-[var(--inno-accent)]">{summary}</p>
+			) : null}
+			<div className="grid gap-3 sm:grid-cols-2">
+				<label className="block text-sm">
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.boundary.stage")}</span>
+					<input
+						className={inputClsStr}
+						placeholder={t("profile.boundary.stagePlaceholder")}
+						value={draft.stage}
+						onChange={(e) => update("stage", e.target.value)}
+					/>
+				</label>
+				<div>
+					<div className="mb-1 text-xs font-medium text-[var(--inno-text)]">{t("profile.boundary.subjects")}</div>
+					<ChipInput
+						label=""
+						values={draft.subjects}
+						onChange={(v) => update("subjects", v)}
+						placeholder={t("profile.preferences.addPlaceholder") ?? ""}
+					/>
+				</div>
+				<label className="block text-sm">
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.boundary.knowledgeScope")}</span>
+					<input
+						className={inputClsStr}
+						placeholder={t("profile.boundary.knowledgeScopePlaceholder")}
+						value={draft.knowledge_scope}
+						onChange={(e) => update("knowledge_scope", e.target.value)}
+					/>
+				</label>
+				<label className="block text-sm">
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.boundary.defaultDifficulty")}</span>
+					<select
+						className={selectClsStr}
+						value={draft.default_difficulty}
+						onChange={(e) => update("default_difficulty", e.target.value)}
+					>
+						<option value="">{t("profile.boundary.unset")}</option>
+						{DIFFICULTY_OPTIONS.map((o) => (
+							<option key={o} value={o}>
+								{t(`profile.boundary.difficultyOptions.${o}`)}
+							</option>
+						))}
+					</select>
+				</label>
+				<label className="block text-sm">
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.boundary.beyondScopeStrategy")}</span>
+					<select
+						className={selectClsStr}
+						value={draft.beyond_scope_strategy}
+						onChange={(e) => update("beyond_scope_strategy", e.target.value)}
+					>
+						<option value="">{t("profile.boundary.unset")}</option>
+						{BEYOND_SCOPE_OPTIONS.map((o) => (
+							<option key={o} value={o}>
+								{t(`profile.boundary.beyondScopeOptions.${o}`)}
+							</option>
+						))}
+					</select>
+				</label>
+				<label className="block text-sm">
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.boundary.methodConstraint")}</span>
+					<select
+						className={selectClsStr}
+						value={draft.method_constraint}
+						onChange={(e) => update("method_constraint", e.target.value)}
+					>
+						<option value="">{t("profile.boundary.unset")}</option>
+						{METHOD_OPTIONS.map((o) => (
+							<option key={o} value={o}>
+								{t(`profile.boundary.methodOptions.${o}`)}
+							</option>
+						))}
+					</select>
+				</label>
+				<label className="block text-sm">
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.boundary.notationStandard")}</span>
+					<input
+						className={inputClsStr}
+						placeholder={t("profile.boundary.notationStandardPlaceholder")}
+						value={draft.notation_standard}
+						onChange={(e) => update("notation_standard", e.target.value)}
+					/>
+				</label>
+				<label className="block text-sm">
+					<span className="mb-1 block font-medium text-[var(--inno-text)]">{t("profile.boundary.referenceMaterials")}</span>
+					<input
+						className={inputClsStr}
+						placeholder={t("profile.boundary.referenceMaterialsPlaceholder")}
+						value={draft.reference_materials}
+						onChange={(e) => update("reference_materials", e.target.value)}
+					/>
+				</label>
+			</div>
+			<div className="mt-3 grid gap-2 sm:grid-cols-2">
+				<label className="flex items-center gap-2 text-sm text-[var(--inno-text)]">
+					<Switch checked={draft.warn_before_beyond_scope} onChange={(v) => update("warn_before_beyond_scope", v)} aria-label={t("profile.boundary.warnBeforeBeyondScope")} />
+					{t("profile.boundary.warnBeforeBeyondScope")}
+				</label>
+				<label className="flex items-center gap-2 text-sm text-[var(--inno-text)]">
+					<Switch checked={draft.annotate_knowledge_scope} onChange={(v) => update("annotate_knowledge_scope", v)} aria-label={t("profile.boundary.annotateKnowledgeScope")} />
+					{t("profile.boundary.annotateKnowledgeScope")}
+				</label>
+			</div>
+			{dirty ? (
+				<div className="mt-3 flex justify-end gap-2">
+					<button className="rounded-md bg-[var(--inno-surface-muted)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)]" onClick={() => setDirty(false)}>
+						{t("common.cancel")}
+					</button>
+					<button className="rounded-md inno-primary-button px-3 py-1.5 text-sm text-white disabled:opacity-50" disabled={state.isSaving} onClick={() => void save()}>
+						{state.isSaving ? t("common.saving") : t("common.save")}
+					</button>
+				</div>
+			) : null}
+		</Section>
+	);
+}
+
 function ChipInput({ label, values, onChange, placeholder }: { label: string; values: string[]; onChange(next: string[]): void; placeholder: string }) {
 	const [input, setInput] = useState("");
 	function add() {
@@ -887,6 +1061,7 @@ export function LearnerProfilePanel() {
 						<KnowledgeSection />
 						<MisconceptionsSection />
 						<PreferencesSection />
+						<BoundarySection />
 					</>
 				) : null}
 			</div>

--- a/apps/inno-agent/web/src/stores/learner-store.ts
+++ b/apps/inno-agent/web/src/stores/learner-store.ts
@@ -14,6 +14,7 @@ import type {
 	KnowledgeState,
 	Misconception,
 	LearnerPreferences,
+	LearningBoundary,
 } from "../types/learner.js";
 
 interface LearnerStoreEvents {
@@ -56,6 +57,17 @@ class LearnerStoreImpl extends EventEmitter<LearnerStoreEvents> {
 		this.emit("change", undefined);
 		try {
 			this.profile = await patchLearnerProfile({ preferences: prefs });
+		} finally {
+			this.isSaving = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async patchBoundary(boundary: LearningBoundary): Promise<void> {
+		this.isSaving = true;
+		this.emit("change", undefined);
+		try {
+			this.profile = await patchLearnerProfile({ boundary });
 		} finally {
 			this.isSaving = false;
 			this.emit("change", undefined);

--- a/apps/inno-agent/web/src/types/learner.ts
+++ b/apps/inno-agent/web/src/types/learner.ts
@@ -6,6 +6,7 @@ export interface LearnerProfile {
 	knowledge_states: KnowledgeState[];
 	misconceptions: Misconception[];
 	preferences: LearnerPreferences;
+	boundary: LearningBoundary;
 	profile_summary: string;
 }
 
@@ -57,4 +58,17 @@ export interface LearnerPreferences {
 	practice_style: string[];
 	feedback_tone: string[];
 	avoid: string[];
+}
+
+export interface LearningBoundary {
+	stage: string;
+	subjects: string[];
+	knowledge_scope: string;
+	default_difficulty: string;
+	beyond_scope_strategy: string;
+	method_constraint: string;
+	notation_standard: string;
+	reference_materials: string;
+	warn_before_beyond_scope: boolean;
+	annotate_knowledge_scope: boolean;
 }


### PR DESCRIPTION
从 #76 拆出。评审反馈："完整度不错，可独立成 PR"。

## 问题

原有学习者画像可以记录目标、知识状态和偏好，但**不能明确限定学习阶段、课程范围、难度、超纲策略、解题方法和符号规范**。模型可能使用超出学习者当前范围的内容（例如给初中生用大学方法、讲解超纲知识点、用非教材符号）。

## 修复

新增 LearningBoundary 数据结构，贯穿画像存储、API、Agent 工具和提示词上下文。

字段（types.ts，+41）：stage（阶段）、subjects（课程）、knowledge_scope（范围）、default_difficulty（难度：school_exam/foundation/advanced/competition）、beyond_scope_strategy（超纲策略：prompt_first/allowed/forbidden）、method_constraint（方法约束：textbook_first/textbook_only/unrestricted）、notation_standard（符号）、reference_materials、两个开关。

后端（6 文件）：
- profile-store.ts：loadProfile 对旧画像自动补全 boundary 默认字段，兼容历史数据
- profile-updater.ts：updateProfile 支持 boundary 合并更新
- context-pack.ts：buildContextPack 把 boundary 渲染为 markdown 注入每轮 prompt
- learner-tools.ts：Agent 可通过 update_learner_profile 工具读取和整体更新边界
- server.ts：新增 normalizeBoundary 校验 + PATCH /api/learner/profile 支持 boundary

前端（5 文件）：LearnerProfilePanel 配置界面（编辑/保存/取消/摘要展示）、learner-store.patchBoundary()、i18n 中英文文案。

## 验证

- yarn build：通过
- 旧画像文件（无 boundary 字段）启动后自动补默认值，无报错
- 编辑器修改字段保存后重新打开数据保留
- Agent 在对话中受边界约束（forbidden 策略下不再主动讲超纲内容）

## 备注

rebase 到含 #80 的 main 时，profile-updater.ts 原有的 refreshContextCache 调用已被 #80 删除，本 PR 不再引用，无冲突。