### PR TITLE
fix(web): 改进问卷答题交互（逐题推进/选项优先/草稿保留）

### DIFF
--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -542,7 +542,9 @@
 	"question": {
 		"typeSomething": "Type something…",
 		"chatAboutThis": "Chat about this",
-		"submit": "Submit"
+		"submit": "Submit",
+		"submitNext": "Next",
+		"optionSelectedHint": "Option selected; deselect to enter custom text"
 	},
 	"sidebar": {
 		"expand": "Expand",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -542,7 +542,9 @@
 	"question": {
 		"typeSomething": "输入自定义答案…",
 		"chatAboutThis": "直接聊聊",
-		"submit": "提交"
+		"submit": "提交",
+		"submitNext": "下一题",
+		"optionSelectedHint": "已选择选项，如需自定义请先取消选择"
 	},
 	"sidebar": {
 		"expand": "展开",

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -50,6 +50,8 @@ function QuestionTab({
 	onDismiss,
 	focusedOption,
 	setFocusedOption,
+	customDraft,
+	onCustomDraftChange,
 }: {
 	q: QuestionData;
 	questionIndex: number;
@@ -58,44 +60,61 @@ function QuestionTab({
 	onDismiss: () => void;
 	focusedOption: number;
 	setFocusedOption: (i: number) => void;
+	customDraft: string;
+	onCustomDraftChange: (text: string) => void;
 }) {
 	const { t } = useTranslation();
-	const [customText, setCustomText] = useState("");
 	const isMulti = q.multiSelect === true;
 	const hasPreview = q.options.some((o) => o.preview);
 	const selectedLabels = new Set(answer?.selected ?? (answer?.answer ? [answer.answer] : []));
+	// 选项优先：当前题已选了选项/多选时，文字输入框不生效
+	const hasOptionAnswer = answer?.kind === "option" || answer?.kind === "multi";
 
 	const handleOptionClick = (label: string) => {
 		if (isMulti) {
 			const next = new Set(selectedLabels);
 			if (next.has(label)) next.delete(label);
 			else next.add(label);
-			onAnswer({
-				questionIndex,
-				question: q.question,
-				kind: "multi",
-				answer: null,
-				selected: Array.from(next),
-			});
+			if (next.size === 0) {
+				// 多选全部脱选 → 撤回答案
+				onAnswer({ questionIndex, question: q.question, kind: "multi", answer: null, selected: [] });
+			} else {
+				onAnswer({
+					questionIndex,
+					question: q.question,
+					kind: "multi",
+					answer: null,
+					selected: Array.from(next),
+				});
+			}
 		} else {
-			onAnswer({
-				questionIndex,
-				question: q.question,
-				kind: "option",
-				answer: label,
-				preview: q.options.find((o) => o.label === label)?.preview,
-			});
+			// 单选：再次点击已选项 = 脱选，回到未答
+			if (selectedLabels.has(label)) {
+				onAnswer({ questionIndex, question: q.question, kind: "option", answer: null });
+			} else {
+				onAnswer({
+					questionIndex,
+					question: q.question,
+					kind: "option",
+					answer: label,
+					preview: q.options.find((o) => o.label === label)?.preview,
+				});
+			}
 		}
 	};
 
-	const handleCustomSubmit = () => {
-		if (!customText.trim()) return;
-		onAnswer({
-			questionIndex,
-			question: q.question,
-			kind: "custom",
-			answer: customText.trim(),
-		});
+	// 输入即作答：文字非空且未选选项时立刻同步为 custom 答案；清空则撤回。
+	// 草稿始终写入父组件（跨 tab 持久），但只在无选项答案时才成为正式答案。
+	const handleCustomChange = (text: string) => {
+		onCustomDraftChange(text);
+		if (hasOptionAnswer) return; // 选项优先，文字不生效
+		const trimmed = text.trim();
+		if (trimmed) {
+			onAnswer({ questionIndex, question: q.question, kind: "custom", answer: trimmed });
+		} else if (answer?.kind === "custom") {
+			// 文字清空：撤回 custom 作答
+			onAnswer({ questionIndex, question: q.question, kind: "custom", answer: null });
+		}
 	};
 
 	const preview = hasPreview ? q.options[focusedOption]?.preview : undefined;
@@ -118,23 +137,20 @@ function QuestionTab({
 						/>
 					))}
 
-					{!isMulti ? (
-						<div className="flex items-center gap-1.5 pt-1">
-							<input
-								type="text"
-								className="min-w-0 flex-1 rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-[13px] focus-visible:border-[var(--inno-focus-border)] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)]"
-								placeholder={t("question.typeSomething")}
-								value={customText}
-								onChange={(e) => setCustomText(e.target.value)}
-								onKeyDown={(e) => {
-									if (e.key === "Enter" && !e.nativeEvent.isComposing) {
-										e.preventDefault();
-										handleCustomSubmit();
-									}
-								}}
-							/>
-						</div>
-					) : null}
+					<div className="flex flex-col gap-1 pt-1">
+						<input
+							type="text"
+							className={`min-w-0 flex-1 rounded-md border px-2.5 py-1.5 text-[13px] focus-visible:outline-none focus-visible:shadow-[var(--inno-ring)] ${
+								hasOptionAnswer
+									? "cursor-not-allowed border-[var(--inno-border)] bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]"
+									: "border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text)] focus-visible:border-[var(--inno-focus-border)]"
+							}`}
+							placeholder={hasOptionAnswer ? t("question.optionSelectedHint") : t("question.typeSomething")}
+							value={customDraft}
+							disabled={hasOptionAnswer}
+							onChange={(e) => handleCustomChange(e.target.value)}
+						/>
+					</div>
 				</div>
 
 				{hasPreview && preview ? (
@@ -161,12 +177,22 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 	const [activeTab, setActiveTab] = useState(0);
 	const [answers, setAnswers] = useState<Map<number, QuestionAnswer>>(new Map());
 	const [focusedOptions, setFocusedOptions] = useState<number[]>(questions.map(() => 0));
+	// 每个 tab 的自定义文字草稿，提升到外层避免切换 tab 丢失
+	const [customDrafts, setCustomDrafts] = useState<Map<number, string>>(new Map());
 
 	const handleAnswer = useCallback(
 		(a: QuestionAnswer) => {
 			setAnswers((prev) => {
 				const next = new Map(prev);
-				next.set(a.questionIndex, a);
+				// custom/option 答案被撤回（answer 为 null）视为未答，移出 Map。
+				// 否则 allAnswered 会把空答案误判为已答。
+				if ((a.kind === "custom" || a.kind === "option") && a.answer === null) {
+					next.delete(a.questionIndex);
+				} else if (a.kind === "multi" && (!a.selected || a.selected.length === 0)) {
+					next.delete(a.questionIndex);
+				} else {
+					next.set(a.questionIndex, a);
+				}
 				return next;
 			});
 		},
@@ -177,16 +203,24 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 		void chatStore.dismissQuestion(questionId);
 	}, [questionId]);
 
-	const allAnswered = questions.every((_, i) => answers.has(i));
+	// 逐题推进：只要当前题答了，就能点按钮推进或提交。
+	const currentAnswered = answers.has(activeTab);
+	const isLast = activeTab === questions.length - 1;
 
-	const handleSubmit = useCallback(() => {
-		if (!allAnswered) return;
-		const result: QuestionnaireResult = {
-			answers: Array.from(answers.values()),
-			cancelled: false,
-		};
-		void chatStore.submitQuestionResponse(questionId, result);
-	}, [questionId, answers, allAnswered]);
+	const handleClick = useCallback(() => {
+		if (!answers.has(activeTab)) return;
+		if (isLast) {
+			// 最后一题（或单题）：提交全部已答题目。未答的题不在 answers 里，自然不发。
+			const result: QuestionnaireResult = {
+				answers: Array.from(answers.values()),
+				cancelled: false,
+			};
+			void chatStore.submitQuestionResponse(questionId, result);
+		} else {
+			// 暂存当前答案，跳到下一题
+			setActiveTab((prev) => Math.min(prev + 1, questions.length - 1));
+		}
+	}, [questionId, answers, activeTab, isLast, questions.length]);
 
 	const setFocusedForTab = useCallback(
 		(tab: number, optionIdx: number) => {
@@ -198,6 +232,14 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 		},
 		[],
 	);
+
+	const setCustomDraftForTab = useCallback((tab: number, text: string) => {
+		setCustomDrafts((prev) => {
+			const next = new Map(prev);
+			next.set(tab, text);
+			return next;
+		});
+	}, []);
 
 	return (
 		<motion.div
@@ -233,15 +275,22 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 					onDismiss={handleDismiss}
 					focusedOption={focusedOptions[activeTab]}
 					setFocusedOption={(i) => setFocusedForTab(activeTab, i)}
+					customDraft={customDrafts.get(activeTab) ?? ""}
+					onCustomDraftChange={(text) => setCustomDraftForTab(activeTab, text)}
 				/>
 
-				<div className="mt-3 flex justify-end">
+				<div className="mt-3 flex items-center justify-end gap-2">
+					{questions.length > 1 ? (
+						<span className="text-xs text-[var(--inno-text-subtle)]">
+							{activeTab + 1} / {questions.length}
+						</span>
+					) : null}
 					<button
-						className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${ allAnswered ? "inno-primary-button" : "cursor-not-allowed bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]" }`}
-						disabled={!allAnswered}
-						onClick={handleSubmit}
+						className={`rounded-lg px-4 py-1.5 text-sm font-medium transition-colors ${ currentAnswered ? "inno-primary-button" : "cursor-not-allowed bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]" }`}
+						disabled={!currentAnswered}
+						onClick={handleClick}
 					>
-						{t("question.submit")}
+						{isLast ? t("question.submit") : t("question.submitNext")}
 					</button>
 				</div>
 			</div>


### PR DESCRIPTION
从 #76 拆出。评审未提及，独立 bug 修复。

## 问题

旧问卷组件（QuestionDialog）存在多个交互不稳定问题：

1. **必须全部答完才能提交**：多题问卷要求所有题目完成后提交按钮才可用，用户无法在中途提交已答部分。
2. **切换题目丢草稿**：每道题的自定义文字草稿存在子组件 state，切换 tab 时草稿丢失。
3. **选项与文字答案冲突**：选项答案和自定义文字答案可能同时生效，状态不一致。
4. **单选无法撤销**：单选选中后再次点击不能取消。
5. **多选全空仍判已答**：多选全部取消后仍被判定为已回答，导致提交按钮误判。

## 修复（QuestionDialog.tsx，+104/-55）

- **逐题推进**：废弃 allAnswered 判断，改用 currentAnswered = answers.has(activeTab)。非末题点"下一题"前进，末题点"提交"。新增进度显示 {activeTab+1} / {questions.length}。
- **文字草稿上提**：customText 从 QuestionTab 内部 useState 提升到父组件 customDrafts: Map<number, string>，切换 tab 保留草稿。
- **选项优先**：已选选项/多选时，文字输入框 disabled 并切 placeholder 为提示文案。
- **单选撤销**：再次点击已选项发 onAnswer({kind:"option", answer:null}) 撤回。
- **多选空恢复未答**：多选全部取消时发 selected: []，父组件 handleAnswer 判断 multi 且 selected 为空时从 answers Map delete，避免误判。
- **custom 即答即存**：handleCustomChange 输入即作答（trim 非空→custom，空→撤回）。

## 补漏

本提交原引用了 question.submitNext 和 question.optionSelectedHint 两个 i18n key 但未添加，会导致合并后显示原始 key 字符串。本 PR 已补：

- zh-CN: submitNext="下一题"、optionSelectedHint="已选择选项，如需自定义请先取消选择"
- en: submitNext="Next"、optionSelectedHint="Option selected; deselect to enter custom text"

## 验证

- yarn build：通过
- 多题问卷逐题作答，切换 tab 草稿保留
- 单选点击-再点击-撤回；多选全取消后该题恢复未答状态
- 选项已选时文字框禁用并显示提示