### PR TITLE
feat: 问题卡片全生命周期（持久化/挂起恢复/输入禁用）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build/icon.iconset/
 
 # Docs (local only)
 apps/inno-agent/docs/
+.zcode/

--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -541,7 +541,9 @@ export function createInnoExtension(
 					}
 
 					// Web mode: delegate to QuestionBridge
-					const bridgeResult = await questionBridge.ask(typed);
+					let currentSessionId: string | undefined;
+					if (deps?.getCurrentSessionId) currentSessionId = deps.getCurrentSessionId();
+					const bridgeResult = await questionBridge.ask(typed, currentSessionId);
 					return buildQuestionnaireResponse(bridgeResult, typed);
 				},
 			} as Parameters<typeof pi.registerTool>[0]);

--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -27,6 +27,13 @@ let _runtime: AgentSessionRuntime | null = null;
 let _queue: Promise<void> = Promise.resolve();
 let _workspaceDir = "";
 let _currentCwd = "";
+/**
+ * The SDK's session file is normally available through AgentSession, but a
+ * prompt can start while the runtime is replacing a session. Keep the
+ * explicitly targeted file visible to extension tools for the duration of
+ * that prompt so question persistence never depends on that timing window.
+ */
+let _activePromptSessionId: string | null = null;
 let _config: InnoConfig | null = null;
 let _configHolder: ConfigHolder | null = null;
 let _cwdResolver: ((sessionPath: string) => string | null) | null = null;
@@ -57,6 +64,17 @@ function resolveCwdFor(sessionPath: string | null | undefined): string {
 	return _workspaceDir;
 }
 
+function beginPromptSession(sessionPath?: string): () => void {
+	const previous = _activePromptSessionId;
+	const candidate = sessionPath ?? _runtime?.session.sessionFile;
+	if (candidate) {
+		_activePromptSessionId = basename(resolve(candidate));
+	}
+	return () => {
+		_activePromptSessionId = previous;
+	};
+}
+
 async function switchToSession(sessionPath: string, opts?: { force?: boolean }): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized");
 	const target = resolve(sessionPath);
@@ -73,6 +91,44 @@ function enqueue<T>(task: () => Promise<T>): Promise<T> {
 	const run = _queue.then(task, task);
 	_queue = run.then(() => undefined, () => undefined);
 	return run;
+}
+
+/**
+ * Enqueue a task with a timeout. If the shared prompt queue is still busy
+ * (e.g. a prompt is blocked waiting on an unanswered question card), the
+ * task resolves early with `fallback` instead of blocking indefinitely.
+ *
+ * Used by session-switch operations so that navigating between sessions
+ * doesn't stall behind a long-running prompt. The switch is not lost —
+ * it is retried lazily by the next prompt's own switchToSession call.
+ */
+function enqueueWithTimeout<T>(task: () => Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
+	return new Promise<T>((resolve) => {
+		let settled = false;
+		const timer = setTimeout(() => {
+			if (!settled) {
+				settled = true;
+				resolve(fallback);
+			}
+		}, timeoutMs);
+		const run = _queue.then(async () => {
+			try {
+				const result = await task();
+				if (!settled) {
+					settled = true;
+					resolve(result);
+				}
+			} catch (err) {
+				if (!settled) {
+					settled = true;
+					resolve(fallback);
+				}
+			} finally {
+				clearTimeout(timer);
+			}
+		});
+		_queue = run.then(() => undefined, () => undefined);
+	});
 }
 
 /**
@@ -347,6 +403,7 @@ export async function abortCurrentPrompt(): Promise<void> {
  * Return current runtime session id.
  */
 export function getCurrentSessionId(): string {
+	if (_activePromptSessionId) return _activePromptSessionId;
 	const sessionFile = getSession().sessionFile;
 	return sessionFile ? basename(sessionFile) : "";
 }
@@ -521,9 +578,20 @@ export async function reloadResources(): Promise<void> {
  */
 export async function switchSessionFile(sessionPath: string): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
-	await enqueue(async () => {
-		await switchToSession(sessionPath);
-	});
+	// Session switching is a lightweight operation (change session file path +
+	// cwd). It must NOT block behind a long-running prompt — especially one
+	// that is stuck waiting on an unanswered question card, which holds the
+	// shared queue indefinitely. If the queue is busy for more than a short
+	// timeout, bail out: the next prompt will re-switch to the correct session
+	// via its own switchToSession call.
+	const done = await enqueueWithTimeout<boolean>(
+		async () => { await switchToSession(sessionPath); return true; },
+		500,
+		false,
+	);
+	if (!done) {
+		logger.warn({ sessionPath }, "switchSessionFile timed out waiting for the prompt queue");
+	}
 }
 
 /**
@@ -623,11 +691,13 @@ export async function runPrompt(prompt: string, images?: ImageContent[]): Promis
 		}
 	});
 
+	const restorePromptSession = beginPromptSession();
 	try {
 		await session.prompt(prompt, images?.length ? { images } : undefined);
 	} finally {
 		unsubscribe();
 		obsUnsub();
+		restorePromptSession();
 	}
 
 	if (streamError) {
@@ -787,11 +857,13 @@ export function runPromptStreaming(
 				}
 			}
 		});
+		const restorePromptSession = beginPromptSession();
 		try {
 			await session.prompt(prompt, images?.length ? { images } : undefined);
 		} finally {
 			unsubscribe();
 			obsUnsub();
+			restorePromptSession();
 		}
 
 		if (streamError) {
@@ -862,11 +934,13 @@ export function runPromptStreamingInSession(
 				}
 			}
 		});
+		const restorePromptSession = beginPromptSession(sessionPath);
 		try {
 			await session.prompt(prompt, images?.length ? { images } : undefined);
 		} finally {
 			unsubscribe();
 			obsUnsub();
+			restorePromptSession();
 		}
 
 		if (streamError) {

--- a/apps/inno-agent/src/agent/question-bridge.ts
+++ b/apps/inno-agent/src/agent/question-bridge.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { logger } from "../logger.js";
 
 export interface QuestionBridgeAnswer {
 	questionIndex: number;
@@ -20,49 +21,137 @@ type SseEmitter = (data: unknown) => void;
 
 interface PendingQuestion {
 	questionId: string;
+	params: unknown;
 	resolve: (result: QuestionBridgeResult) => void;
+}
+
+/** Snapshot of a pending question, exposed so a reconnecting SSE client can
+ *  re-render the card after a session switch. */
+export interface PendingQuestionSnapshot {
+	questionId: string;
+	params: unknown;
+}
+
+/** A persistable pending question (no resolve callback). */
+export interface PersistedQuestion {
+	questionId: string;
+	params: unknown;
+	createdAt: string;
+}
+
+/** Callbacks injected by the server to persist/restore pending questions
+ *  across process restarts. */
+export interface QuestionBridgePersistence {
+	save: (sessionId: string, question: PersistedQuestion) => void;
+	remove: (sessionId: string) => void;
 }
 
 class QuestionBridge {
 	private emitter: SseEmitter | null = null;
 	private pending: PendingQuestion | null = null;
+	private pendingSessionId: string | null = null;
+	private persistence: QuestionBridgePersistence | null = null;
 
 	setEmitter(fn: SseEmitter | null): void {
 		this.emitter = fn;
 	}
 
-	ask(params: unknown): Promise<QuestionBridgeResult> {
+	setPersistence(p: QuestionBridgePersistence | null): void {
+		this.persistence = p;
+	}
+
+	getPending(): PendingQuestionSnapshot | null {
+		if (!this.pending) return null;
+		return { questionId: this.pending.questionId, params: this.pending.params };
+	}
+
+	getPendingSessionId(): string | null {
+		return this.pendingSessionId;
+	}
+
+	ask(params: unknown, sessionId?: string): Promise<QuestionBridgeResult> {
 		if (!this.emitter) {
+			logger.warn("question: ask skipped because no emitter is registered");
 			return Promise.resolve({ answers: [], cancelled: true, error: "no_ui" });
 		}
 
 		if (this.pending) {
 			this.pending.resolve({ answers: [], cancelled: true, error: "superseded" });
+			if (this.pendingSessionId) this.persistence?.remove(this.pendingSessionId);
 			this.pending = null;
+			this.pendingSessionId = null;
 		}
 
 		const questionId = randomUUID();
 		const emitter = this.emitter;
+		const normalizedSessionId = typeof sessionId === "string" && sessionId.trim() ? sessionId.trim() : null;
+		this.pendingSessionId = normalizedSessionId;
+
+		if (normalizedSessionId) {
+			this.persistence?.save(normalizedSessionId, {
+				questionId,
+				params,
+				createdAt: new Date().toISOString(),
+			});
+		} else {
+			logger.warn({ questionId }, "question: missing sessionId; pending question is not restart-safe");
+		}
 
 		return new Promise<QuestionBridgeResult>((resolve) => {
-			this.pending = { questionId, resolve };
+			this.pending = { questionId, params, resolve };
 			emitter({ type: "question", questionId, params });
 		});
 	}
 
 	respond(questionId: string, result: QuestionBridgeResult): boolean {
-		if (!this.pending || this.pending.questionId !== questionId) return false;
+		if (!this.pending || this.pending.questionId !== questionId) {
+			return false;
+		}
 		const { resolve } = this.pending;
+		if (this.pendingSessionId) this.persistence?.remove(this.pendingSessionId);
 		this.pending = null;
+		this.pendingSessionId = null;
 		resolve(result);
 		return true;
+	}
+
+	/**
+	 * Stop waiting on the live UI prompt without deleting its persisted card.
+	 * The owning session can then be resumed through the persisted-question
+	 * path, just like a card that survived an app restart.
+	 */
+	suspendPending(): {
+		questionId: string;
+		params: PendingQuestion["params"];
+		sessionId: string | null;
+	} | null {
+		const pending = this.pending;
+		if (!pending) return null;
+
+		const sessionId = this.pendingSessionId;
+		this.pending = null;
+		this.pendingSessionId = null;
+		pending.resolve({ answers: [], cancelled: true, error: "session_switched" });
+		return {
+			questionId: pending.questionId,
+			params: pending.params,
+			sessionId,
+		};
 	}
 
 	cancel(): void {
 		if (!this.pending) return;
 		const { resolve } = this.pending;
+		if (this.pendingSessionId) this.persistence?.remove(this.pendingSessionId);
 		this.pending = null;
+		this.pendingSessionId = null;
 		resolve({ answers: [], cancelled: true, error: "disconnected" });
+	}
+
+	/** Whether a live prompt is waiting on a question (vs a question restored
+	 *  from disk after restart whose prompt no longer exists). */
+	hasLivePrompt(): boolean {
+		return this.pending !== null;
 	}
 }
 

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -50,7 +50,7 @@ import type { LearnerProfile, LearningGoal, KnowledgeState, Misconception, Learn
 import { randomUUID } from "node:crypto";
 import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
-import { questionBridge, type QuestionBridgeResult } from "./agent/question-bridge.js";
+import { questionBridge, type QuestionBridgeResult, type PendingQuestionSnapshot } from "./agent/question-bridge.js";
 import { DEFAULT_WORKSPACE_ID, TEMP_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
 import { listPresets, listRemotePresets, ensurePresetCached, instantiatePreset } from "./presets/preset-store.js";
 import { createContentSource, type RemoteContentSource } from "./content-source/index.js";
@@ -136,6 +136,15 @@ class SessionEventBroadcaster {
 }
 
 const sessionBroadcasters = new Map<string, SessionEventBroadcaster>();
+
+function retainSessionBroadcaster(sessionId: string, broadcaster: SessionEventBroadcaster): void {
+	setTimeout(() => {
+		if (sessionBroadcasters.get(sessionId) === broadcaster) {
+			broadcaster.close();
+			sessionBroadcasters.delete(sessionId);
+		}
+	}, 60_000);
+}
 
 function piEventToSseEvent(event: any): unknown | null {
 	switch (event.type) {
@@ -2013,6 +2022,29 @@ function sessionArchiveMetadataPath(): string {
 	return join(dataDir, "sessions", "archives.json");
 }
 
+// --- Pending question persistence (survives process restart) ---
+function sessionQuestionMetadataPath(): string {
+	return join(dataDir, "sessions", "questions.json");
+}
+
+type SessionQuestionMetadata = Record<string, import("./agent/question-bridge.js").PersistedQuestion>;
+
+/** In-memory cache of questions.json — read once at startup, updated on
+ *  every write. Avoids a synchronous readFileSync on every getSession call. */
+let _questionMetadataCache: SessionQuestionMetadata | null = null;
+
+function readSessionQuestionMetadata(): SessionQuestionMetadata {
+	if (_questionMetadataCache === null) {
+		_questionMetadataCache = readJson<SessionQuestionMetadata>(sessionQuestionMetadataPath(), {});
+	}
+	return _questionMetadataCache;
+}
+
+function writeSessionQuestionMetadata(meta: SessionQuestionMetadata): void {
+	_questionMetadataCache = meta;
+	writeJson(sessionQuestionMetadataPath(), meta);
+}
+
 function readSessionChannelMetadata(): SessionChannelMetadata {
 	return readJson<SessionChannelMetadata>(sessionChannelMetadataPath(), {});
 }
@@ -2800,7 +2832,12 @@ const server = createServer(async (req, res) => {
 				withRecordedChannels(parsed.summary, channelMetadata),
 				topicMetadata,
 			);
-			json(res, 200, { ...summary, messages: parsed.messages });
+			// Attach any persisted pending question so the frontend can restore
+			// the card after a full process restart.
+			const sessionId = basename(sessionPath);
+			const questionMeta = readSessionQuestionMetadata();
+			const pendingQuestion = questionMeta[sessionId] ?? undefined;
+			json(res, 200, { ...summary, messages: parsed.messages, pendingQuestion });
 			return;
 		}
 
@@ -2869,6 +2906,10 @@ const server = createServer(async (req, res) => {
 
 		if (method === "POST" && url === "/api/sessions") {
 			const body = await readBody(req).catch(() => ({})) as Record<string, unknown>;
+			const suspendedQuestion = questionBridge.suspendPending();
+			if (suspendedQuestion) {
+				await abortCurrentPrompt();
+			}
 			const id = await createNewSession();
 			// This endpoint is exclusively the Web UI's session-creation path.
 			// Record the origin immediately so Simple Mode includes the new empty
@@ -2954,6 +2995,11 @@ const server = createServer(async (req, res) => {
 				if (archiveMeta[sessionId]) {
 					delete archiveMeta[sessionId];
 					writeJson(sessionArchiveMetadataPath(), archiveMeta);
+				}
+				const questionMeta = readSessionQuestionMetadata();
+				if (questionMeta[sessionId]) {
+					delete questionMeta[sessionId];
+					writeSessionQuestionMetadata(questionMeta);
 				}
 				workspaceRegistry.unbindSession(sessionId);
 				if (shouldDropTempWorkspace) {
@@ -4268,7 +4314,72 @@ const server = createServer(async (req, res) => {
 				return;
 			}
 			const accepted = questionBridge.respond(questionId, result);
-			json(res, accepted ? 200 : 404, { accepted });
+			if (accepted) {
+				json(res, 200, { accepted: true });
+				return;
+			}
+			// No live prompt waiting on this question — the server was restarted
+			// after the question was asked. Reconstruct the answer as a plain user
+			// message and send it as a new prompt so the agent picks up from the
+			// session history.
+			const persistedMeta = readSessionQuestionMetadata();
+			const persisted = Object.entries(persistedMeta).find(([, q]) => q.questionId === questionId);
+			if (persisted) {
+				// Clean up the persisted question.
+				delete persistedMeta[persisted[0]];
+				writeSessionQuestionMetadata(persistedMeta);
+				// Build a user-readable summary of the answers.
+				const answerText = result.answers
+					.map((a) => {
+						if (a.kind === "multi" && a.selected?.length) return `${a.question}: ${a.selected.join(", ")}`;
+						return `${a.question}: ${a.answer ?? a.selected?.join(", ") ?? ""}`;
+					})
+					.join("\n");
+				const sessionId = persisted[0];
+				const sessionPath = sessionFileFromId(join(dataDir, "sessions"), sessionId);
+				if (!sessionPath || !existsSync(sessionPath)) {
+					logger.warn({ sessionId }, "resend: session file not found");
+					json(res, 404, { accepted: false });
+					return;
+				}
+				// resumeStream (triggered by the resent:true response) finds it
+				// already registered — no 404 race.
+				const bc = new SessionEventBroadcaster();
+				sessionBroadcasters.set(sessionId, bc);
+				questionBridge.setEmitter((data: unknown) => bc.publish(data));
+				// Fire-and-forget: run the prompt in the background.
+				void (async () => {
+					try {
+						const fullText = await runPromptStreamingInSession(
+							sessionPath!,
+							answerText,
+							(event) => {
+								// runPromptStreamingInSession emits PI AgentSessionEvents;
+								// the web client consumes the normalized SSE event shape.
+								const sseEvent = piEventToSseEvent(event);
+								if (sseEvent) bc.publish(sseEvent);
+							},
+						);
+						bc.publish({ type: "done", fullText, sessionId });
+						bc.close();
+					} catch (err) {
+						logger.error({ err, questionId }, "resend: failed to resume prompt");
+						bc.publish({
+							type: "error",
+							message: err instanceof Error ? err.message : "Failed to resume generation",
+						});
+						bc.close();
+					} finally {
+						questionBridge.setEmitter(null);
+						recordCurrentSessionChannel("web", sessionId, { setOriginIfEmpty: true });
+						persistPendingUserTurn(sessionId);
+						retainSessionBroadcaster(sessionId, bc);
+					}
+				})();
+				json(res, 200, { accepted: true, resent: true });
+			} else {
+				json(res, 404, { accepted: false });
+			}
 			return;
 		}
 
@@ -4301,7 +4412,40 @@ const server = createServer(async (req, res) => {
 				"Connection": "keep-alive",
 				"X-Accel-Buffering": "no",
 			});
+
 			let ended = false;
+			const writeEvent = (data: unknown) => {
+				if (!ended) res.write(`data: ${JSON.stringify(data)}\n\n`);
+			};
+
+			// Re-register the question bridge emitter onto this live connection.
+			// When the user answers (POST /api/chat/question-response), the agent
+			// run resumes and emits new events via publishStreamEvent → broadcaster
+			// → this subscriber. Without re-registering, the answer would resolve
+			// the promise but its follow-up events would still reach the (dead)
+			// original emitter. Note: the question event itself is NOT emitted via
+			// the emitter on resume — it is re-pushed explicitly below and/or via
+			// broadcaster replay — so the emitter only needs to handle later
+			// question events (rare, multi-step questionnaires).
+			questionBridge.setEmitter((data: unknown) => {
+				writeEvent(data);
+				// Also publish so any other subscribers (and replay) see it.
+				bc.publish(data);
+			});
+
+			// If the agent is still waiting on an answer for this session, re-push
+			// the question event immediately so the card reappears. The broadcaster
+			// replay (bc.subscribe below) already covers the normal case, but this
+			// is a deterministic guarantee that survives even if the original
+			// emitter ran before the broadcaster existed.
+			// Note: questionBridge is a global singleton, so we only re-push when
+			// a pending question actually exists (at most one turn runs at a time
+			// due to runPromptSerialized).
+			const pending = questionBridge.getPending() as PendingQuestionSnapshot | null;
+			if (pending) {
+				writeEvent({ type: "question", questionId: pending.questionId, params: pending.params });
+			}
+
 			const unsub = bc.subscribe((event: unknown) => {
 				if (ended) return;
 				res.write(`data: ${JSON.stringify(event)}\n\n`);
@@ -4315,7 +4459,10 @@ const server = createServer(async (req, res) => {
 				res.write("data: [DONE]\n\n");
 				res.end();
 			}
-			req.on("close", unsub);
+			req.on("close", () => {
+				unsub();
+				questionBridge.setEmitter(null);
+			});
 			return;
 		}
 
@@ -4364,10 +4511,14 @@ const server = createServer(async (req, res) => {
 			req.on("close", () => {
 				aborted = true;
 				questionBridge.setEmitter(null);
-				questionBridge.cancel();
+				// Do NOT cancel a pending question on disconnect. The agent run
+				// (session.prompt) is independent of this HTTP connection and keeps
+				// waiting on questionBridge.ask()'s promise. Cancelling here would
+				// resolve it as cancelled, ending the turn and dropping the card —
+				// the "card vanishes on session switch" bug. A reconnecting client
+				// (/api/chat/events/:id) re-registers the emitter and the question
+				// event is replayed so the card reappears.
 			});
-
-			questionBridge.setEmitter(sseWrite);
 
 			// Create a broadcaster for this session so clients can reconnect
 			// to the event stream after navigating away.
@@ -4377,6 +4528,12 @@ const server = createServer(async (req, res) => {
 				broadcaster.publish(event);
 				if (!aborted) sseWrite(event);
 			};
+
+			// Question emitter: deliver to the live SSE response AND publish to
+			// the broadcaster so reconnecting clients replay the question event.
+			questionBridge.setEmitter((data: unknown) => {
+				publishStreamEvent(data);
+			});
 
 			const streamWorkspaceId = workspaceRegistry.getSessionWorkspaceId(capturedSessionId);
 			const streamWorkspaceRoot = workspaceRegistry.resolveWorkspaceDir(streamWorkspaceId);
@@ -4494,12 +4651,7 @@ const server = createServer(async (req, res) => {
 				persistPendingUserTurn(capturedSessionId);
 				// Keep the broadcaster alive for 60s so reconnecting clients can
 				// replay the full event history, then clean up.
-				setTimeout(() => {
-					if (sessionBroadcasters.get(capturedSessionId) === broadcaster) {
-						broadcaster.close();
-						sessionBroadcasters.delete(capturedSessionId);
-					}
-				}, 60_000);
+				retainSessionBroadcaster(capturedSessionId, broadcaster);
 			}
 			if (!aborted) {
 				res.write("data: [DONE]\n\n");
@@ -4631,6 +4783,23 @@ function bindTerminalWs(ws: WebSocket, terminalId: string): void {
 // Start listening immediately — /health and static files work right away.
 // All other endpoints call ensureBootstrapped() lazily on first request.
 // ---------------------------------------------------------------------------
+
+// Inject persistence callbacks into questionBridge so pending questions
+// survive a full process restart.
+questionBridge.setPersistence({
+	save: (sessionId, question) => {
+		const meta = readSessionQuestionMetadata();
+		meta[sessionId] = question;
+		writeSessionQuestionMetadata(meta);
+	},
+	remove: (sessionId) => {
+		const meta = readSessionQuestionMetadata();
+		if (sessionId in meta) {
+			delete meta[sessionId];
+			writeSessionQuestionMetadata(meta);
+		}
+	},
+});
 
 server.listen(port, () => {
 	console.log(`[inno-server] listening on http://localhost:${port}`);

--- a/apps/inno-agent/web/src/api/client.ts
+++ b/apps/inno-agent/web/src/api/client.ts
@@ -10,18 +10,33 @@ export class ApiError extends Error {
 
 const BASE_URL = ""; // Same origin — Vite proxy in dev
 
+/**
+ * Timeout for regular (non-streaming) API calls. Prevents indefinite hangs
+ * when Chromium's per-origin connection pool (6 slots for HTTP/1.1) is
+ * exhausted by lingering SSE connections — the fetch would otherwise queue
+ * forever behind those connections.
+ */
+const API_TIMEOUT_MS = 15_000;
+
 export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
-	const res = await fetch(`${BASE_URL}${path}`, {
-		headers: { "Content-Type": "application/json", ...options?.headers },
-		...options,
-	});
-	if (!res.ok) {
-		const body = await res.json().catch(() => ({}));
-		throw new ApiError(res.status, (body as Record<string, string>).error || res.statusText);
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+	try {
+		const res = await fetch(`${BASE_URL}${path}`, {
+			...options,
+			headers: { "Content-Type": "application/json", ...options?.headers },
+			signal: controller.signal,
+		});
+		if (!res.ok) {
+			const body = await res.json().catch(() => ({}));
+			throw new ApiError(res.status, (body as Record<string, string>).error || res.statusText);
+		}
+		// 204 No Content
+		if (res.status === 204) return undefined as T;
+		return res.json() as Promise<T>;
+	} finally {
+		clearTimeout(timer);
 	}
-	// 204 No Content
-	if (res.status === 204) return undefined as T;
-	return res.json() as Promise<T>;
 }
 
 /**

--- a/apps/inno-agent/web/src/api/sessions.ts
+++ b/apps/inno-agent/web/src/api/sessions.ts
@@ -16,8 +16,16 @@ export interface SessionMeta {
 	archived?: boolean;
 }
 
+export interface PendingQuestionData {
+	questionId: string;
+	params: unknown;
+	createdAt: string;
+}
+
 export interface SessionDetail extends SessionMeta {
 	messages: ChatMessage[];
+	/** A pending question restored from the server (e.g. after restart). */
+	pendingQuestion?: PendingQuestionData;
 }
 
 export interface SessionActivationResult {

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -849,7 +849,7 @@ export function ChatCenter() {
 				onKeyDown={handleKeyDown}
 				onInput={handleInput}
 				onPaste={handlePaste}
-				disabled={chat.isSending || isUploading}
+				disabled={chat.isSending || isUploading || !!chat.pendingQuestion}
 			/>
 			{chat.isSending ? (
 				<button

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -37,6 +37,11 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	lastImages: InlineImage[] | undefined = undefined;
 	/** Pending question from agent's ask_user_question tool */
 	pendingQuestion: PendingQuestion | null = null;
+	/** Question IDs the user has already answered. Used to suppress stale
+	 *  replays from the backend (e.g. when reconnecting via resumeStream
+	 *  before the answer POST has been processed server-side) so an
+	 *  already-submitted card doesn't reappear. */
+	private answeredQuestionIds = new Set<string>();
 	private abortController: AbortController | null = null;
 	private detachMode = false;
 	private wikiInvalidated = false;
@@ -169,6 +174,16 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	/**
 	 * Detach from the current stream without stopping the backend task.
 	 * Used when the user navigates to a different session.
+	 */
+	/**
+	 * Detach from the current stream without stopping the backend task.
+	 * Used when the user navigates to a different session.
+	 *
+	 * Aborting the AbortController signals readSSEStream (via its abort
+	 * listener) to immediately cancel the response body reader, releasing
+	 * the underlying TCP connection back to Chromium's connection pool.
+	 * This prevents stale SSE connections from accumulating and exhausting
+	 * the per-origin connection limit during rapid session switching.
 	 */
 	detach(): void {
 		this.detachMode = true;
@@ -312,6 +327,12 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				if (this.workspacePreviewId) workspaceStore.finishStreamingPreview(this.workspacePreviewId, "error");
 				break;
 			case "question":
+				// Skip replays of questions the user has already answered. The
+				// backend questionBridge may still hold a pending question briefly
+				// after the answer POST is sent but before it is processed — a
+				// reconnecting SSE stream would replay it, re-showing a card the
+				// user already submitted.
+				if (this.answeredQuestionIds.has(event.questionId)) break;
 				this.flushStreamChange();
 				this.pendingQuestion = {
 					questionId: event.questionId,
@@ -491,14 +512,23 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	}
 
 	async submitQuestionResponse(questionId: string, result: QuestionnaireResult): Promise<void> {
+		this.answeredQuestionIds.add(questionId);
 		this.pendingQuestion = null;
 		this.emit("change", undefined);
 		try {
-			await fetch("/api/chat/question-response", {
+			const res = await fetch("/api/chat/question-response", {
 				method: "POST",
 				headers: { "Content-Type": "application/json" },
 				body: JSON.stringify({ questionId, result }),
 			});
+			const body = await res.json().catch(() => ({}));
+			// If the server resent the answer as a new prompt (restart scenario),
+			// connect to the broadcaster to receive the agent's response.
+			if (body.resent && !this.isSending) {
+				const { sessionsStore } = await import("./sessions-store.js");
+				const sessionId = sessionsStore.currentSessionId;
+				if (sessionId) void this.resumeStream(sessionId);
+			}
 		} catch {
 			// best-effort — the agent will time out or get cancelled if this fails
 		}
@@ -525,6 +555,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.activeTools = [];
 		this.completedTools = [];
 		this.pendingQuestion = null;
+		this.answeredQuestionIds.clear();
 		this.resetStreamTimers();
 		this.resetWorkspaceStreamState();
 		this.emit("change", undefined);
@@ -542,6 +573,14 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
+		// Clear any stale question card from the previous session. The correct
+		// card (if any) is restored AFTER loadHistory via restorePendingQuestion
+		// or from the server's pendingQuestion field.
+		this.pendingQuestion = null;
+		// NOTE: answeredQuestionIds is intentionally NOT cleared here.
+		// loadHistory is called when switching sessions; clearing it would
+		// forget which questions were already answered, causing stale
+		// cards to reappear via restorePendingQuestion / SSE replay.
 		this.resetStreamTimers();
 		this.resetWorkspaceStreamState();
 		this.emit("change", undefined);
@@ -550,6 +589,20 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	setLoadingHistory(loading: boolean) {
 		this.isLoadingHistory = loading;
 		this.emit("change", undefined);
+	}
+
+	/** Restore a previously-shown question card after switching back to a
+	 *  session. Lets the card reappear immediately instead of waiting for the
+	 *  backend replay on reconnect. No-op if a newer question is already shown
+	 *  (the replay/update path wins). */
+	restorePendingQuestion(question: PendingQuestion | null): void {
+		if (this.pendingQuestion) return;
+		// Don't restore a card the user already answered — the cache may be
+		// stale if the user answered, switched away, and switched back before
+		// the cache was cleared.
+		if (question && this.answeredQuestionIds.has(question.questionId)) return;
+		this.pendingQuestion = question;
+		if (question) this.emit("change", undefined);
 	}
 }
 

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -15,6 +15,7 @@ import {
 } from "../api/sessions.js";
 import { getSessionWorkspace } from "../api/workspaces.js";
 import { chatStore } from "./chat-store.js";
+import type { PendingQuestion } from "../types/chat.js";
 import { workspaceStore } from "./workspace-store.js";
 import { workspacesStore } from "./workspaces-store.js";
 import { terminalStore } from "./terminal-store.js";
@@ -36,6 +37,10 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	preselectedWorkspaceId: string | null = null;
 	private _openRequestId = 0;
 	private _messageCache = new Map<string, Awaited<ReturnType<typeof getSession>>["messages"]>();
+	/** Caches an unanswered question card across session switches so it can be
+	 *  restored instantly when switching back, before the backend reconnect
+	 *  replay re-delivers the question event. Keyed by session id. */
+	private _pendingQuestionCache = new Map<string, NonNullable<typeof chatStore.pendingQuestion>>();
 	private _backgroundRunningSessions = new Set<string>();
 
 	/**
@@ -131,8 +136,15 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 			if (chatStore.isSending) {
 				this._backgroundRunningSessions.add(prevSessionId);
 				this._messageCache.set(prevSessionId, chatStore.messages);
+				// Preserve an unanswered question card so it can be restored on return.
+				if (chatStore.pendingQuestion) {
+					this._pendingQuestionCache.set(prevSessionId, chatStore.pendingQuestion);
+				} else {
+					this._pendingQuestionCache.delete(prevSessionId);
+				}
 			} else {
 				this._messageCache.delete(prevSessionId);
+				this._pendingQuestionCache.delete(prevSessionId);
 			}
 		}
 
@@ -185,7 +197,31 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 
 			if (isBackground) {
 				this._backgroundRunningSessions.delete(id);
+				// Restore the question card before resuming the stream so the UI
+				// shows it immediately; the backend reconnect (re-push + replay)
+				// reconciles it once events arrive.
+				chatStore.restorePendingQuestion(this._pendingQuestionCache.get(id) ?? null);
 				void chatStore.resumeStream(id);
+			} else {
+				this._pendingQuestionCache.delete(id);
+				// Non-background session (e.g. opened after a full restart): if the
+				// server has a persisted pending question, restore the card.
+				if (session.pendingQuestion) {
+					chatStore.restorePendingQuestion({
+						questionId: session.pendingQuestion.questionId,
+						params: session.pendingQuestion.params as PendingQuestion["params"],
+					});
+				}
+			}
+		} catch (err) {
+			// getSession failed (timeout, network). Fall back to cached messages
+			// if available so the UI doesn't get stuck on "loading session…".
+			if (requestId === this._openRequestId) {
+				const fallback = this._messageCache.get(id);
+				if (fallback && fallback.length > 0) {
+					chatStore.loadHistory(fallback);
+				}
+				console.warn(`[sessions] failed to open session ${id}:`, err instanceof Error ? err.message : err);
 			}
 		} finally {
 			if (requestId === this._openRequestId) {
@@ -204,11 +240,21 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	 * can't keep `chatStore.isSending` true and block the chooser / input.
 	 */
 	beginNewSession(): void {
-		if (this.currentSessionId && chatStore.isSending) {
-			this._backgroundRunningSessions.add(this.currentSessionId);
-			this._messageCache.set(this.currentSessionId, chatStore.messages);
-		} else if (this.currentSessionId) {
-			this._messageCache.delete(this.currentSessionId);
+		const previousSessionId = this.currentSessionId;
+		if (previousSessionId && chatStore.isSending) {
+			this._messageCache.set(previousSessionId, chatStore.messages);
+			if (chatStore.pendingQuestion) {
+				// The card is persisted and will be resumed after an answer. It is
+				// no longer a live background stream once a new session is created.
+				this._backgroundRunningSessions.delete(previousSessionId);
+				this._pendingQuestionCache.set(previousSessionId, chatStore.pendingQuestion);
+			} else {
+				this._backgroundRunningSessions.add(previousSessionId);
+				this._pendingQuestionCache.delete(previousSessionId);
+			}
+		} else if (previousSessionId) {
+			this._messageCache.delete(previousSessionId);
+			this._pendingQuestionCache.delete(previousSessionId);
 		}
 		this.currentSessionId = null;
 		this.pendingNewSession = true;
@@ -244,9 +290,16 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		this.pendingNewSession = false;
 		this.preselectedWorkspaceId = null;
 		// Make sure no previous stream / terminal lingers.
-		if (this.currentSessionId && chatStore.isSending) {
-			this._backgroundRunningSessions.add(this.currentSessionId);
-			this._messageCache.set(this.currentSessionId, chatStore.messages);
+		const previousSessionId = this.currentSessionId;
+		if (previousSessionId && chatStore.isSending) {
+			this._messageCache.set(previousSessionId, chatStore.messages);
+			if (chatStore.pendingQuestion) {
+				this._backgroundRunningSessions.delete(previousSessionId);
+				this._pendingQuestionCache.set(previousSessionId, chatStore.pendingQuestion);
+			} else {
+				this._backgroundRunningSessions.add(previousSessionId);
+				this._pendingQuestionCache.delete(previousSessionId);
+			}
 		}
 		chatStore.detach();
 		void terminalStore.disconnect();
@@ -254,6 +307,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		try {
 			const created = await createSession(input);
 			this._messageCache.clear();
+			this._pendingQuestionCache.clear();
 			chatStore.clear();
 			// Refresh side panels so the new workspace shows up.
 			void workspacesStore.load();
@@ -301,6 +355,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	async deleteSession(id: string): Promise<void> {
 		const result = await deleteSession(id);
 		this._messageCache.delete(id);
+		this._pendingQuestionCache.delete(id);
 		this._backgroundRunningSessions.delete(id);
 		this.sessions = this.sessions.filter((session) => session.id !== id);
 		if (this.currentSessionId === id) {


### PR DESCRIPTION
从 #76 拆出，评审明确要求"问题卡片全生命周期需独立 PR 单独评审"。本 PR 已处理评审提出的 diag 日志和超时静默两个关切。

## 问题

1. **会话切换卡死**：旧 prompt 可能仍占用串行执行队列（因等待未答问题卡片），导致新会话或新请求卡住。
2. **问题卡片重复弹出**：回答完问题后切换走再切回来，后端可能先重放旧问题事件再处理答案，卡片再次出现。
3. **重启后待处理问题丢失**：问题卡片原来只存内存 Promise，重启即丢失。
4. **新建对话时旧卡片阻塞 + 无法恢复**：旧会话等待卡片期间点新建对话，createNewSession 经同一串行队列会被旧卡片阻塞；直接取消又删除持久化记录，用户之后无法重新提交。
5. **卡片待处理时仍可发送普通消息**：用户可同时发另一条消息，造成两个交互回合竞争同一个后台 prompt。

## 修复

**1. questions.json 持久化**（server.ts + question-bridge.ts）
- 待答问题写入 <dataDir>/sessions/questions.json（与 topic/channel 元数据同模式）
- 重启后重新打开会话时恢复卡片
- 若重启后没有活跃 prompt，提交答案作为新用户消息走 resend 路径重启 runPromptStreamingInSession

**2. suspendPending vs cancel 双语义**（question-bridge.ts）
- cancel()：清内存 + 删持久化（真正终止，用于断连）
- suspendPending()：清内存 + resolve 旧 prompt 等待，但保留 questions.json 记录。用户切回旧会话时通过持久化恢复路径继续

**3. live question vs persisted question 双路径**
- hasLivePrompt() 区分"活着的 prompt 还在等答案" vs "仅磁盘有持久化卡片但 prompt 已不在"
- POST /api/sessions 创建新会话前先 suspendPending 再 abortCurrentPrompt，避免队列阻塞

**4. session broadcaster 缓存重连事件**（server.ts）
- 流结束后保留 broadcaster 60 秒，重连客户端能 replay 期间事件，避免 404/事件丢失

**5. 前端状态同步**（chat-store.ts + sessions-store.ts + ChatCenter.tsx）
- answeredQuestionIds 跟踪已答问题，重放/恢复时跳过已答卡片
- pendingQuestion 存在时禁用聊天输入框（ChatCenter.tsx），避免并发回合

## 评审关切处理（已做）

**A. 删除 12 条 [diag] 调试日志**

question-bridge.ts（6 条）+ server.ts（6 条）全部清理。保留控制流，不删逻辑：
- 2 条降级为正式 warn（无 emitter / session file not found，属真实异常）
- 1 条升级为 logger.error（resend FAILED，真实失败值得保留）
- 其余 9 条调试噪音删除

**B. switchSessionFile 500ms 超时加 warn 埋点**（pi-runner.ts）

原设计超时分支完全静默（既无 warn 也无计数器），运维无法观测"会话切换被队列阻塞丢弃"发生多少次。本 PR 加 logger.warn 埋点。

## 未在本 PR 处理（需 follow-up）

**apiFetch 15s 超时**：评审指出会误伤合法长请求（jobs/:id/run、POST /api/sessions 排队、skill import、office-preview），需要 per-endpoint 豁免机制。本 PR 不实现豁免（属于独立设计，不该塞进问题卡片 PR），建议开 follow-up issue 单独处理。

## 验证

- yarn build：通过
- grep -rn "\[diag\]" apps/inno-agent/src/：无残留
- 旧会话产生未提交卡片 → 新建会话并发送消息 → 新会话正常回复 → 返回旧会话仍显示卡片 → 提交选项后旧会话继续生成