### PR TITLE
fix: auto-topic 改为非阻塞，避免输入框禁用延迟

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ build/icon.iconset/
 
 # Docs (local only)
 apps/inno-agent/docs/
+.zcode/

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -2138,32 +2138,41 @@ ${excerpt}`;
 
 /**
  * Auto-generate a topic for a session if it doesn't already have one.
- * Runs asynchronously — fire and forget.
+ * Returns a deduplicated Promise so concurrent callers share one task.
  */
-const _pendingAutoTopics = new Set<string>();
+const _pendingAutoTopics = new Map<string, Promise<string | null>>();
 
-function maybeAutoGenerateTopic(sessionId: string): void {
-	if (!sessionId || _pendingAutoTopics.has(sessionId)) return;
+async function generateAutoTopic(sessionId: string): Promise<string | null> {
+	if (!sessionId) return null;
 	const topicMeta = readSessionTopicMetadata();
-	if (topicMeta[sessionId]) return; // already has a topic
+	if (topicMeta[sessionId]?.topic) return topicMeta[sessionId].topic;
+	const pending = _pendingAutoTopics.get(sessionId);
+	if (pending) return pending;
 
 	const sessionPath = sessionFileFromId(join(dataDir, "sessions"), sessionId);
-	if (!sessionPath || !existsSync(sessionPath)) return;
+	if (!sessionPath || !existsSync(sessionPath)) return null;
 
-	_pendingAutoTopics.add(sessionId);
-	void (async () => {
+	const task = (async (): Promise<string | null> => {
 		try {
 			const parsed = parseSessionFile(sessionPath);
-			if (!parsed || parsed.messages.length < 2) return;
+			if (!parsed || parsed.messages.length < 2) return null;
 			const topic = await generateSessionTopic(parsed.summary, parsed.messages);
 			writeSessionTopic(sessionId, topic, true);
 			logger.info(`[auto-topic] ${sessionId} → ${topic}`);
+			return topic;
 		} catch (err) {
 			logger.warn({ err }, `auto-topic generation failed for ${sessionId}`);
+			return null;
 		} finally {
 			_pendingAutoTopics.delete(sessionId);
 		}
 	})();
+	_pendingAutoTopics.set(sessionId, task);
+	return task;
+}
+
+function maybeAutoGenerateTopic(sessionId: string): void {
+	void generateAutoTopic(sessionId);
 }
 
 // ---------------------------------------------------------------------------
@@ -4464,13 +4473,23 @@ const server = createServer(async (req, res) => {
 				const fullText = targetSessionPath
 					? await runPromptStreamingInSession(targetSessionPath, promptWithHint, onEvent, imageArgs)
 					: await runPromptStreaming(promptWithHint, onEvent, imageArgs);
-				const doneEvent = { type: "done", fullText };
+				const doneEvent = { type: "done", fullText, sessionId: capturedSessionId };
 				broadcaster.publish(doneEvent);
 				if (!aborted) sseWrite(doneEvent);
-				// Skip topic auto-generation when the turn errored — there is no
-				// meaningful assistant reply to summarize and the model API is
-				// likely still failing (which would just block again).
-				if (!emittedError) maybeAutoGenerateTopic(capturedSessionId);
+				// Topic generation is a separate model call that can take several
+				// seconds. Run it AFTER the terminal event so the client unlocks
+				// input immediately; deliver the topic via a dedicated event when
+				// it resolves. Skipping on error: no reply to summarize and the
+				// model API is likely still failing.
+				if (!emittedError) {
+					void generateAutoTopic(capturedSessionId).then((topic) => {
+						if (topic) {
+							const topicEvent = { type: "session_topic", sessionId: capturedSessionId, topic };
+							broadcaster.publish(topicEvent);
+							if (!aborted) sseWrite(topicEvent);
+						}
+					});
+				}
 			} catch (err) {
 				logger.error({ err }, "SSE stream error");
 				const errorEvent = { type: "error", message: err instanceof Error ? err.message : "Unknown error" };

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -327,6 +327,16 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				}
 				this.emit("change", undefined);
 				break;
+			case "session_topic": {
+				// Auto-generated topic arrives after `done` (non-blocking). Update
+				// the sidebar name immediately without a refetch.
+				if (event.sessionId && event.topic) {
+					void import("./sessions-store.js").then((m) => {
+						m.sessionsStore.applyGeneratedTopic(event.sessionId!, event.topic!);
+					});
+				}
+				break;
+			}
 		}
 	}
 

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -116,6 +116,15 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		}
 	}
 
+	applyGeneratedTopic(id: string, topic: string): void {
+		const name = topic.trim();
+		if (!name) return;
+		this.sessions = this.sessions.map((session) =>
+			session.id === id ? { ...session, name } : session,
+		);
+		this.emit("change", undefined);
+	}
+
 	selectSession(id: string) {
 		this.currentSessionId = id;
 		this.emit("change", undefined);

--- a/apps/inno-agent/web/src/types/chat.ts
+++ b/apps/inno-agent/web/src/types/chat.ts
@@ -68,5 +68,6 @@ export type ChatStreamEvent =
 	| { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
 	| { type: "workspace_change"; changes: WorkspaceFileChange[]; toolCallId?: string; toolName?: string; workspaceId?: string; truncated?: boolean }
 	| { type: "question"; questionId: string; params: { questions: QuestionData[] } }
-	| { type: "done"; fullText: string }
+	| { type: "done"; fullText: string; sessionId?: string }
+	| { type: "session_topic"; sessionId: string; topic: string }
 	| { type: "error"; message: string };


### PR DESCRIPTION
从 #76 拆出。评审关切"auto-topic 随 done 下发——done 事件会延迟一个 LLM 标题调用（最坏 20s），期间输入框禁用"——本 PR 已按非阻塞方案重设计。

## 问题

原设计（#76 中的 commit 2fc6720）为了"侧栏即时显示标题"，把 auto-topic 生成塞进了 SSE 关闭路径：

1. 服务端在流式回复结束后 await generateAutoTopic(capturedSessionId)（一次额外 LLM 标题调用）
2. topic resolve 后才构造 doneEvent 并 sseWrite
3. 前端 isSending=true 要等 finally，finally 要等 for await 退出，for await 要等 SSE body 关闭，SSE 关闭要等 done 发送，done 要等 topic 生成

**结果**：LLM 回复已流完，但输入框继续禁用至标题生成完毕——冷启动/慢模型最坏可达 20s。

## 修复

**保留**：generateAutoTopic 返回 Promise + Map<string, Promise> 去重并发任务（这是独立价值，避免同一 session 短时间重复发起标题请求）。

**重设计 done 事件为非阻塞**（server.ts:4476）：
- done 事件不再 await topic，先立即发 done（含 sessionId）解锁前端输入
- 之后 fire-and-forget 启动 generateAutoTopic
- topic 生成完成后通过独立 session_topic 事件推送（broadcaster.publish + sseWrite）

**前端处理**：
- chat-store.ts 新增 case "session_topic"：收到后调 sessionsStore.applyGeneratedTopic 即时更新侧栏
- types/chat.ts 新增 session_topic 事件类型，done 加可选 sessionId
- sessions-store.ts 新增 applyGeneratedTopic(id, topic) 方法

## 代价

SSE 协议新增一种事件类型 session_topic。侧栏标题会比回复流完成晚几百毫秒到数秒更新（取决于标题生成耗时），但这远好于输入框被锁 20s。

## 与 #77 的关系

2fc6720 原含 4 项改动，其中"远程 preset 与本地 preset 合并去重"和"POST /api/sessions 立即记录 web origin"两项已被 #77 逐字抽走。本 PR 只含剩余的 auto-topic 部分，preset/web-origin 两块已通过 rebase 自动消化，无重复。

## 验证

- yarn build：通过
- 发消息后立即测试输入框：回复流完成即可输入，不再等标题生成
- 确认侧栏在 topic 生成完成后仍能更新名称（收到 session_topic 事件）
- 同一 session 短时间多次触发 auto-topic 只发一次请求（Map 去重）