### PR TITLE
fix(server): 加固工作区与技能目录树遍历

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -5,9 +5,10 @@ import "source-map-support/register.js";
 import { createServer, type IncomingMessage as HttpReq, type ServerResponse } from "node:http";
 import { spawnSync, execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync, watch, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, realpathSync, renameSync, rmSync, statSync, watch, writeFileSync } from "node:fs";
+import type { Dirent } from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { loadConfig, saveConfig, setDefaultModel, upsertProvider, deleteProvider, deleteModel, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig, type InnoModelConfig, type InnoProviderConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
@@ -1496,27 +1497,59 @@ function workspaceSkillNode(root: string, skillName: string): { name: string; pa
 	};
 }
 
-function readWorkspaceTree(rootDir: string, dir: string, depth = 0): WorkspaceTreeNode[] {
-	if (depth > 4) return [];
-	return readdirSync(dir, { withFileTypes: true })
+// Deep enough to cover nested output conventions (e.g. skill runs that nest
+// <skill>/<slug>/<timestamp>/<artifact>/<file>), while still bounded so a
+// pathological tree cannot hang the request.
+const WORKSPACE_TREE_MAX_DEPTH = 8;
+
+function readWorkspaceTree(rootDir: string, dir: string, depth = 0, seen: ReadonlySet<string> = new Set()): WorkspaceTreeNode[] {
+	if (depth > WORKSPACE_TREE_MAX_DEPTH) return [];
+	let entries: Dirent<string>[];
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return [];
+	}
+	return entries
 		.filter((entry) => !WORKSPACE_IGNORES.has(entry.name))
 		.sort((a, b) => Number(b.isDirectory()) - Number(a.isDirectory()) || a.name.localeCompare(b.name, "zh-CN"))
 		.slice(0, 200)
-		.map((entry) => {
+		.map((entry): WorkspaceTreeNode | null => {
 			const fullPath = join(dir, entry.name);
-			const stat = statSync(fullPath);
+			// statSync follows symlinks, so a directory symlink (e.g. a `latest`
+			// pointer) resolves to its target type. A broken symlink throws here
+			// and is skipped instead of crashing the whole tree with a 500.
+			let stat: ReturnType<typeof statSync>;
+			try {
+				stat = statSync(fullPath);
+			} catch {
+				return null;
+			}
+			const isDir = stat.isDirectory();
 			const node: WorkspaceTreeNode = {
 				name: entry.name,
 				path: workspaceRelativePath(rootDir, fullPath),
-				type: entry.isDirectory() ? "directory" : "file",
+				type: isDir ? "directory" : "file",
 				size: stat.size,
 				updatedAt: stat.mtime.toISOString(),
 			};
-			if (entry.isDirectory()) {
-				node.children = readWorkspaceTree(rootDir, fullPath, depth + 1);
+			if (isDir) {
+				// Resolve the real path to (a) keep symlink traversal inside the
+				// workspace root and (b) guard against symlink cycles.
+				let real: string;
+				try {
+					real = realpathSync(fullPath);
+				} catch {
+					real = fullPath;
+				}
+				const withinRoot = real === rootDir || real.startsWith(rootDir + sep);
+				node.children = withinRoot && !seen.has(real)
+					? readWorkspaceTree(rootDir, fullPath, depth + 1, new Set([...seen, real]))
+					: [];
 			}
 			return node;
-		});
+		})
+		.filter((node): node is WorkspaceTreeNode => node !== null);
 }
 
 function contentTypeForWorkspaceFile(filePath: string): string {
@@ -2618,25 +2651,49 @@ const server = createServer(async (req, res) => {
 				json(res, 404, { error: "Skill not found" });
 				return;
 			}
-			function readSkillTree(dir: string, depth = 0): WorkspaceTreeNode[] {
-				if (depth > 4) return [];
-				return readdirSync(dir, { withFileTypes: true })
+			function readSkillTree(dir: string, depth = 0, seen: ReadonlySet<string> = new Set()): WorkspaceTreeNode[] {
+				if (depth > WORKSPACE_TREE_MAX_DEPTH) return [];
+				let entries: Dirent<string>[];
+				try {
+					entries = readdirSync(dir, { withFileTypes: true });
+				} catch {
+					return [];
+				}
+				return entries
 					.filter((e) => !e.name.startsWith(".") && e.name !== "__MACOSX" && e.name !== "node_modules")
 					.sort((a, b) => Number(b.isDirectory()) - Number(a.isDirectory()) || a.name.localeCompare(b.name, "zh-CN"))
 					.slice(0, 200)
-					.map((entry) => {
+					.map((entry): WorkspaceTreeNode | null => {
 						const fullPath = join(dir, entry.name);
-						const st = statSync(fullPath);
+						let st: ReturnType<typeof statSync>;
+						try {
+							st = statSync(fullPath);
+						} catch {
+							return null;
+						}
+						const isDir = st.isDirectory();
 						const node: WorkspaceTreeNode = {
 							name: entry.name,
 							path: relative(skillDir, fullPath),
-							type: entry.isDirectory() ? "directory" : "file",
+							type: isDir ? "directory" : "file",
 							size: st.size,
 							updatedAt: st.mtime.toISOString(),
 						};
-						if (entry.isDirectory()) node.children = readSkillTree(fullPath, depth + 1);
+						if (isDir) {
+							let real: string;
+							try {
+								real = realpathSync(fullPath);
+							} catch {
+								real = fullPath;
+							}
+							const withinRoot = real === skillDir || real.startsWith(skillDir + sep);
+							node.children = withinRoot && !seen.has(real)
+								? readSkillTree(fullPath, depth + 1, new Set([...seen, real]))
+								: [];
+						}
 						return node;
-					});
+					})
+					.filter((node): node is WorkspaceTreeNode => node !== null);
 			}
 			const st = statSync(skillDir);
 			json(res, 200, {


### PR DESCRIPTION
## 背景

`readWorkspaceTree`（工作区文件树，`GET /api/workspace/tree`）和 `readSkillTree`（技能目录树，`GET /api/skills/:name/tree`）两个函数存在相同的可靠性问题，本 PR 对其进行一致性修复。

---

## 变更详情

### 深度上限 4 → 8
- 原限制会静默截断 skill 产出的典型路径，如 `<skill>/<slug>/<timestamp>/<artifact>/<file>`，注释中已明确说明
- 提取为具名常量 `WORKSPACE_TREE_MAX_DEPTH = 8`，语义清晰

### 断链 symlink 不再崩溃（500 → 跳过）
- `statSync` 跟随 symlink，遇到断链时直接抛出异常，原来会导致整个树接口返回 500
- 现在 `try/catch` 包裹后跳过该条目，其余内容正常返回

### `readdirSync` 加防御性 try/catch
- 目录在遍历期间因权限变更或竞态变为不可读时，返回 `[]` 而非抛出

### symlink 循环防御 + 根目录逃逸防护
- 递归前用 `realpathSync` 解析真实路径
- `seen` 集合记录已访问路径，防止 A→B→A 型循环导致无限递归
- `withinRoot` 检查确保 symlink 不会跳出根目录（`..` 型逃逸）

### null 过滤
- map 回调返回类型收窄为 `WorkspaceTreeNode | null`，末尾 `.filter` 过滤，防止 broken 条目污染响应数组

---

## 测试

- [ ] 工作区文件浏览器正常渲染，至少 5 层深的目录可见
- [ ] 技能编辑器目录树正常渲染
- [ ] 在工作区内创建断链（`ln -s /nonexistent workspace/broken`），树接口返回 200，断链条目缺失，无 500
- [ ] `npm run build` 通过