### PR TITLE
feat(l2): 词法+图混合检索、知识图谱分析与两段式 CoT 摄入

### DIFF
--- a/apps/inno-agent/package.json
+++ b/apps/inno-agent/package.json
@@ -32,7 +32,10 @@
 		"source-map-support": "^0.5.21",
 		"typebox": "^1.1.24",
 		"undici": "^7.19.1",
-		"ws": "^8.21.0"
+		"ws": "^8.21.0",
+		"graphology": "^0.26.0",
+		"graphology-communities-louvain": "^2.0.2",
+		"yaml": "^2.6.1"
 	},
 	"engines": {
 		"node": ">=20.6.0"

--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -14,6 +14,7 @@ import { JobStore } from "../scheduler/job-store.js";
 import { createSchedulerTools } from "../scheduler/scheduler-tools.js";
 import { createChannelTools } from "../channels/channel-tools.js";
 import { createL2Tools } from "../memory/l2/l2-tools.js";
+import { getL2Memory } from "../memory/l2/l2-memory.js";
 import { L3Memory, createL3Tools, formatRecallForPrompt } from "../memory/l3/l3-tools.js";
 import { createPracticeTools } from "./practice-tools.js";
 import { createDocumentTools } from "./document-tools.js";
@@ -222,10 +223,13 @@ export function createInnoExtension(
 		}
 
 		// 4. Register L2 Wiki memory tools (gated on config.memory.l2Enabled)
-		const l2Tools = createL2Tools(paths.l2DataDir, isL2Enabled);
+		const l2Memory = getL2Memory(paths.l2DataDir);
+		const l2Tools = createL2Tools(paths.l2DataDir, isL2Enabled, l2Memory);
 		for (const tool of l2Tools) {
 			pi.registerTool(tool);
 		}
+		// Backfill the retrieval index from existing wiki pages; never block boot.
+		void l2Memory.backfill();
 
 		// 4a. Register L3 cross-conversation memory (sqlite-backed recall).
 		// Recall (auto-inject + the l3_recall tool) is gated at runtime on

--- a/apps/inno-agent/src/memory/l2/l2-index-store.ts
+++ b/apps/inno-agent/src/memory/l2/l2-index-store.ts
@@ -1,0 +1,306 @@
+/**
+ * L2 wiki retrieval index, backed by node:sqlite.
+ *
+ * A SEPARATE database from L3 (`index.db` here vs L3's `memory.db`): L2 indexes
+ * durable wiki *pages* (knowledge), L3 indexes past *conversations* — different
+ * corpora, kept isolated. This store provides lexical (FTS5/BM25) retrieval
+ * over pages (see l2-search.ts).
+ *
+ * Reuses {@link segmentForFts} from the L3 store so index/query CJK bigram
+ * tokenization stays identical across both layers. Degrades to null on
+ * Node < 22.5 (where node:sqlite is unavailable) exactly like the L3 store, so
+ * callers must treat a null store as "L2 index disabled" and fall back.
+ */
+
+import { logger } from "../../logger.js";
+import { join } from "node:path";
+import { mkdirSync } from "node:fs";
+import { segmentForFts } from "../l3/sqlite-store.js";
+
+/** One indexed wiki page (the document unit for retrieval — whole page). */
+export interface L2PageDoc {
+	/** Wiki-relative path, e.g. `wiki/entities/foo.md`. Primary key. */
+	path: string;
+	title: string;
+	/** WikiPageType as a string (source-summary | entity | concept | analysis). */
+	type: string;
+	tags: string[];
+	sourceIds: string[];
+	body: string;
+	/** sha256[:16] of the raw page file — detects staleness for incremental reindex. */
+	contentHash: string;
+	mtimeMs: number;
+}
+
+/** Page metadata as read back from the index (no body-less variant needed at our scale). */
+export interface L2PageMeta {
+	path: string;
+	title: string;
+	type: string;
+	tags: string[];
+	sourceIds: string[];
+	body: string;
+}
+
+/** A lexical search hit. `bm25` is the raw FTS5 score (lower = more relevant). */
+export interface L2LexHit {
+	path: string;
+	title: string;
+	type: string;
+	tags: string[];
+	sourceIds: string[];
+	bm25: number;
+}
+
+// node:sqlite has no stable public type export across Node versions; we keep
+// the surface we use minimal and locally typed (mirrors l3/sqlite-store.ts).
+interface SqliteStatement {
+	run(...params: unknown[]): { changes: number; lastInsertRowid: number | bigint };
+	get(...params: unknown[]): Record<string, unknown> | undefined;
+	all(...params: unknown[]): Record<string, unknown>[];
+}
+interface SqliteDatabase {
+	exec(sql: string): void;
+	prepare(sql: string): SqliteStatement;
+	close(): void;
+}
+
+/**
+ * Turn a user query into an FTS5 MATCH expression. Tokens are OR-combined so
+ * partial overlaps still recall; each token is quoted to avoid FTS operator
+ * injection from raw user text. (Copied from the L3 store, which keeps it
+ * private.)
+ */
+function buildMatchExpression(query: string): string {
+	const tokens = segmentForFts(query)
+		.split(" ")
+		.filter((t) => t.length > 0)
+		.map((t) => `"${t.replace(/"/g, '""')}"`);
+	return tokens.join(" OR ");
+}
+
+function parseJsonArray(value: unknown): string[] {
+	if (typeof value !== "string" || !value) return [];
+	try {
+		const parsed = JSON.parse(value) as unknown;
+		return Array.isArray(parsed) ? parsed.map((x) => String(x)) : [];
+	} catch {
+		return [];
+	}
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS pages (
+	path TEXT PRIMARY KEY,
+	title TEXT NOT NULL,
+	type TEXT NOT NULL,
+	tags TEXT NOT NULL,        -- JSON array
+	source_ids TEXT NOT NULL,  -- JSON array
+	body TEXT NOT NULL,
+	content_hash TEXT NOT NULL,
+	mtime_ms INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL
+);
+
+-- Regular (non-contentless) FTS5 table: rowid mirrors pages.rowid for joins.
+CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
+	tokens,
+	tokenize='unicode61'
+);
+
+-- Tracks how far each page file has been indexed (incremental skip).
+CREATE TABLE IF NOT EXISTS index_state (
+	path TEXT PRIMARY KEY,
+	content_hash TEXT NOT NULL,
+	mtime_ms INTEGER NOT NULL,
+	updated_at INTEGER NOT NULL
+);
+`;
+
+/**
+ * The L2 index store. Construct via {@link openL2IndexStore}, which returns
+ * null when node:sqlite is unavailable so callers can degrade gracefully.
+ */
+export class L2IndexStore {
+	private db: SqliteDatabase;
+
+	private constructor(db: SqliteDatabase) {
+		this.db = db;
+		this.db.exec(SCHEMA);
+	}
+
+	static async open(l2DataDir: string): Promise<L2IndexStore | null> {
+		let DatabaseSync: (new (path: string) => SqliteDatabase) | undefined;
+		try {
+			const mod = (await import("node:sqlite")) as unknown as {
+				DatabaseSync: new (path: string) => SqliteDatabase;
+			};
+			DatabaseSync = mod.DatabaseSync;
+		} catch (err) {
+			logger.warn({ err }, "[L2] node:sqlite not available on this runtime");
+			return null;
+		}
+		if (!DatabaseSync) return null;
+		try {
+			mkdirSync(l2DataDir, { recursive: true });
+			const db = new DatabaseSync(join(l2DataDir, "index.db"));
+			db.exec("PRAGMA journal_mode = WAL; PRAGMA foreign_keys = ON;");
+			return new L2IndexStore(db);
+		} catch (err) {
+			logger.warn({ err }, `[L2] failed to open sqlite index: ${err instanceof Error ? err.message : String(err)}`);
+			return null;
+		}
+	}
+
+	/** Insert or replace a page and its FTS row. */
+	upsertPage(doc: L2PageDoc): void {
+		const existing = this.db
+			.prepare("SELECT rowid FROM pages WHERE path = ?")
+			.get(doc.path) as { rowid?: number } | undefined;
+
+		const tokens = segmentForFts([doc.title, doc.tags.join(" "), doc.body].join(" "));
+		const tagsJson = JSON.stringify(doc.tags);
+		const idsJson = JSON.stringify(doc.sourceIds);
+		const now = Date.now();
+
+		if (existing && typeof existing.rowid === "number") {
+			this.db
+				.prepare(
+					"UPDATE pages SET title=?, type=?, tags=?, source_ids=?, body=?, content_hash=?, mtime_ms=?, updated_at=? WHERE path=?",
+				)
+				.run(doc.title, doc.type, tagsJson, idsJson, doc.body, doc.contentHash, doc.mtimeMs, now, doc.path);
+			this.db.prepare("DELETE FROM pages_fts WHERE rowid = ?").run(existing.rowid);
+			this.db.prepare("INSERT INTO pages_fts(rowid, tokens) VALUES (?, ?)").run(existing.rowid, tokens);
+			return;
+		}
+
+		const info = this.db
+			.prepare(
+				"INSERT INTO pages(path,title,type,tags,source_ids,body,content_hash,mtime_ms,updated_at) VALUES (?,?,?,?,?,?,?,?,?)",
+			)
+			.run(doc.path, doc.title, doc.type, tagsJson, idsJson, doc.body, doc.contentHash, doc.mtimeMs, now);
+		const rowid = Number(info.lastInsertRowid);
+		this.db.prepare("INSERT INTO pages_fts(rowid, tokens) VALUES (?, ?)").run(rowid, tokens);
+	}
+
+	/** Insert many pages inside a single transaction. */
+	upsertPages(docs: L2PageDoc[]): void {
+		if (docs.length === 0) return;
+		this.db.exec("BEGIN");
+		try {
+			for (const d of docs) this.upsertPage(d);
+			this.db.exec("COMMIT");
+		} catch (err) {
+			this.db.exec("ROLLBACK");
+			throw err;
+		}
+	}
+
+	/** Remove a page, its FTS row, and index state. */
+	deletePage(path: string): void {
+		const row = this.db.prepare("SELECT rowid FROM pages WHERE path = ?").get(path) as
+			| { rowid?: number }
+			| undefined;
+		this.db.exec("BEGIN");
+		try {
+			if (row && typeof row.rowid === "number") {
+				this.db.prepare("DELETE FROM pages_fts WHERE rowid = ?").run(row.rowid);
+			}
+			this.db.prepare("DELETE FROM pages WHERE path = ?").run(path);
+			this.db.prepare("DELETE FROM index_state WHERE path = ?").run(path);
+			this.db.exec("COMMIT");
+		} catch (err) {
+			this.db.exec("ROLLBACK");
+			throw err;
+		}
+	}
+
+	/** Lexical search over indexed pages, ordered by bm25 (most relevant first). */
+	searchLexical(query: string, limit = 30): L2LexHit[] {
+		const match = buildMatchExpression(query);
+		if (!match) return [];
+		try {
+			const rows = this.db
+				.prepare(
+					`SELECT p.path AS path, p.title AS title, p.type AS type, p.tags AS tags,
+					        p.source_ids AS source_ids, bm25(pages_fts) AS bm25
+					 FROM pages_fts
+					 JOIN pages p ON p.rowid = pages_fts.rowid
+					 WHERE pages_fts MATCH ?
+					 ORDER BY bm25
+					 LIMIT ?`,
+				)
+				.all(match, limit);
+			return rows.map((r) => ({
+				path: String(r.path),
+				title: String(r.title),
+				type: String(r.type),
+				tags: parseJsonArray(r.tags),
+				sourceIds: parseJsonArray(r.source_ids),
+				bm25: Number(r.bm25),
+			}));
+		} catch (err) {
+			logger.warn({ err }, `[L2] lexical search failed: ${err instanceof Error ? err.message : String(err)}`);
+			return [];
+		}
+	}
+
+	/** All page metadata (incl. body) — used to build the query-time link graph. */
+	getAllPages(): L2PageMeta[] {
+		const rows = this.db
+			.prepare("SELECT path, title, type, tags, source_ids, body FROM pages")
+			.all();
+		return rows.map((r) => ({
+			path: String(r.path),
+			title: String(r.title),
+			type: String(r.type),
+			tags: parseJsonArray(r.tags),
+			sourceIds: parseJsonArray(r.source_ids),
+			body: String(r.body),
+		}));
+	}
+
+	getIndexState(path: string): { contentHash: string; mtimeMs: number } | null {
+		const row = this.db
+			.prepare("SELECT content_hash, mtime_ms FROM index_state WHERE path = ?")
+			.get(path) as { content_hash?: string; mtime_ms?: number } | undefined;
+		if (!row) return null;
+		return { contentHash: String(row.content_hash ?? ""), mtimeMs: Number(row.mtime_ms ?? 0) };
+	}
+
+	setIndexState(path: string, contentHash: string, mtimeMs: number): void {
+		this.db
+			.prepare(
+				`INSERT INTO index_state(path, content_hash, mtime_ms, updated_at) VALUES (?, ?, ?, ?)
+				 ON CONFLICT(path) DO UPDATE SET
+				   content_hash = excluded.content_hash, mtime_ms = excluded.mtime_ms, updated_at = excluded.updated_at`,
+			)
+			.run(path, contentHash, mtimeMs, Date.now());
+	}
+
+	listIndexedPaths(): string[] {
+		const rows = this.db.prepare("SELECT path FROM pages").all();
+		return rows.map((r) => String(r.path));
+	}
+
+	pageCount(): number {
+		const row = this.db.prepare("SELECT COUNT(*) AS n FROM pages").get() as { n?: number } | undefined;
+		return Number(row?.n ?? 0);
+	}
+
+	close(): void {
+		try {
+			this.db.close();
+		} catch (err) {
+			logger.warn({ err }, "[L2] failed to close sqlite index (may already be closed)");
+		}
+	}
+}
+
+/**
+ * Open the L2 index store, returning null when node:sqlite is unavailable so
+ * callers can disable index-backed retrieval without failing the agent.
+ */
+export function openL2IndexStore(l2DataDir: string): Promise<L2IndexStore | null> {
+	return L2IndexStore.open(l2DataDir);
+}

--- a/apps/inno-agent/src/memory/l2/l2-indexer.ts
+++ b/apps/inno-agent/src/memory/l2/l2-indexer.ts
@@ -1,0 +1,101 @@
+/**
+ * L2 page indexer.
+ *
+ * Reads wiki pages from `wiki/{sources,entities,concepts,analysis}/`, parses
+ * their frontmatter, and upserts them into the L2 index store. Indexing is
+ * incremental by content hash: a page is re-indexed only when its bytes change.
+ * `indexAllPages` also prunes index rows whose file no longer exists, so it
+ * doubles as an idempotent backfill.
+ */
+
+import { createHash } from "node:crypto";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { readText, fileExists } from "../../storage/file-store.js";
+import { parseFrontmatter } from "./wiki-maintainer.js";
+import type { L2IndexStore, L2PageDoc } from "./l2-index-store.js";
+
+const WIKI_SUBDIRS = ["sources", "entities", "concepts", "analysis"] as const;
+
+function contentHashOf(s: string): string {
+	return createHash("sha256").update(s).digest("hex").slice(0, 16);
+}
+
+function inferTypeFromPath(wikiPath: string): string {
+	if (wikiPath.includes("entities/")) return "entity";
+	if (wikiPath.includes("concepts/")) return "concept";
+	if (wikiPath.includes("analysis/")) return "analysis";
+	return "source-summary";
+}
+
+/**
+ * Index one wiki page by its wiki-relative path. Returns true if the store was
+ * written (false when the file is missing/empty or unchanged since last index).
+ */
+export function indexPage(store: L2IndexStore, l2DataDir: string, wikiPath: string): boolean {
+	const abs = join(l2DataDir, wikiPath);
+	if (!fileExists(abs)) return false;
+	const content = readText(abs);
+	if (!content.trim()) return false;
+
+	const hash = contentHashOf(content);
+	const prev = store.getIndexState(wikiPath);
+	if (prev && prev.contentHash === hash) return false; // unchanged
+
+	const { frontmatter, body } = parseFrontmatter(content);
+	let mtimeMs = 0;
+	try {
+		mtimeMs = Math.floor(statSync(abs).mtimeMs);
+	} catch {
+		mtimeMs = 0;
+	}
+
+	const doc: L2PageDoc = {
+		path: wikiPath,
+		title: frontmatter?.title || wikiPath.split("/").pop()?.replace(/\.md$/, "") || wikiPath,
+		type: frontmatter?.type || inferTypeFromPath(wikiPath),
+		tags: frontmatter?.tags ?? [],
+		sourceIds: frontmatter?.source_ids ?? [],
+		body,
+		contentHash: hash,
+		mtimeMs,
+	};
+	store.upsertPage(doc);
+	store.setIndexState(wikiPath, hash, mtimeMs);
+	return true;
+}
+
+/**
+ * Index every wiki page, pruning index rows for files that no longer exist.
+ * Idempotent — unchanged pages are skipped, so re-runs are cheap.
+ */
+export function indexAllPages(store: L2IndexStore, l2DataDir: string): { indexed: number; pruned: number } {
+	const present = new Set<string>();
+	let indexed = 0;
+	for (const sub of WIKI_SUBDIRS) {
+		const dir = join(l2DataDir, "wiki", sub);
+		let files: string[];
+		try {
+			files = readdirSync(dir).filter((f) => f.endsWith(".md"));
+		} catch {
+			continue;
+		}
+		for (const f of files) {
+			const wikiPath = join("wiki", sub, f);
+			present.add(wikiPath);
+			if (indexPage(store, l2DataDir, wikiPath)) indexed++;
+		}
+	}
+	let pruned = 0;
+	for (const p of store.listIndexedPaths()) {
+		if (!present.has(p)) {
+			store.deletePage(p);
+			pruned++;
+		}
+	}
+	return { indexed, pruned };
+}
+
+export function removePageFromIndex(store: L2IndexStore, wikiPath: string): void {
+	store.deletePage(wikiPath);
+}

--- a/apps/inno-agent/src/memory/l2/l2-memory.ts
+++ b/apps/inno-agent/src/memory/l2/l2-memory.ts
@@ -1,0 +1,126 @@
+/**
+ * L2 wiki memory holder.
+ *
+ * Owns the lazily-opened {@link L2IndexStore} singleton for a data dir and keeps
+ * the index in sync with the wiki pages on disk. Retrieval (lexical + graph) is
+ * layered on in l2-search.ts and exposed via {@link L2Memory.search}.
+ *
+ * Everything degrades to a no-op when node:sqlite is unavailable so the agent
+ * keeps working on older runtimes (the query tool falls back to substring
+ * search in that case).
+ *
+ * Use {@link getL2Memory} to obtain a per-dir singleton so the agent extension
+ * and the HTTP server share ONE handle within a process.
+ */
+
+import { join } from "node:path";
+import { logger } from "../../logger.js";
+import { fileExists } from "../../storage/file-store.js";
+import { openL2IndexStore, type L2IndexStore } from "./l2-index-store.js";
+import { indexAllPages, indexPage, removePageFromIndex } from "./l2-indexer.js";
+import { searchL2, type L2SearchResult } from "./l2-search.js";
+import { regenerateOverview, OVERVIEW_PATH } from "./overview.js";
+
+export class L2Memory {
+	private store: L2IndexStore | null = null;
+	private opened = false;
+	private backfilled = false;
+
+	constructor(private readonly l2DataDir: string) {}
+
+	private async ensureStore(): Promise<L2IndexStore | null> {
+		if (this.opened) return this.store;
+		this.opened = true;
+		this.store = await openL2IndexStore(this.l2DataDir);
+		if (!this.store) {
+			logger.warn("[L2] node:sqlite unavailable — index-backed retrieval disabled (falling back to substring).");
+		}
+		return this.store;
+	}
+
+	/** Expose the store for the search layer; null when sqlite is unavailable. */
+	async getStore(): Promise<L2IndexStore | null> {
+		return this.ensureStore();
+	}
+
+	get dataDir(): string {
+		return this.l2DataDir;
+	}
+
+	/** One-time backfill of all existing wiki pages (cheap: skips unchanged files). */
+	async backfill(): Promise<void> {
+		if (this.backfilled) return;
+		const store = await this.ensureStore();
+		if (!store) return;
+		this.backfilled = true;
+		try {
+			const { indexed, pruned } = indexAllPages(store, this.l2DataDir);
+			if (indexed > 0 || pruned > 0) logger.info(`[L2] backfill indexed ${indexed} page(s), pruned ${pruned}.`);
+		} catch (err) {
+			logger.warn({ err }, `[L2] backfill failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+
+		// Ensure an overview page exists (deterministic core; an LLM narrative is
+		// added on the next archive, which has a model available).
+		try {
+			if (!fileExists(join(this.l2DataDir, OVERVIEW_PATH))) {
+				const rel = await regenerateOverview(this.l2DataDir);
+				if (rel) await this.indexPageByPath(rel);
+			}
+		} catch (err) {
+			logger.warn({ err }, "[L2] overview bootstrap failed");
+		}
+	}
+
+	/** Incrementally (re)index a single wiki page by its wiki-relative path. */
+	async indexPageByPath(wikiPath: string): Promise<void> {
+		if (!wikiPath) return;
+		const store = await this.ensureStore();
+		if (!store) return;
+		try {
+			indexPage(store, this.l2DataDir, wikiPath);
+		} catch (err) {
+			logger.warn({ err }, `[L2] index ${wikiPath} failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+
+	/**
+	 * Search indexed pages (lexical BM25 + graph expansion). Returns null when
+	 * the index store is unavailable, so callers can fall back to the legacy
+	 * substring search.
+	 */
+	async search(query: string, limit = 5): Promise<L2SearchResult[] | null> {
+		const store = await this.ensureStore();
+		if (!store) return null;
+		try {
+			return await searchL2(store, query, { limit });
+		} catch (err) {
+			logger.warn({ err }, `[L2] search failed: ${err instanceof Error ? err.message : String(err)}`);
+			return null;
+		}
+	}
+
+	/** Remove a page from the index (after the page file is deleted). */
+	async removePage(wikiPath: string): Promise<void> {
+		if (!wikiPath) return;
+		const store = await this.ensureStore();
+		if (!store) return;
+		try {
+			removePageFromIndex(store, wikiPath);
+		} catch (err) {
+			logger.warn({ err }, `[L2] remove ${wikiPath} failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
+	}
+}
+
+const registry = new Map<string, L2Memory>();
+
+/** Per-dir singleton so the agent extension and HTTP server share one handle. */
+export function getL2Memory(l2DataDir: string): L2Memory {
+	let mem = registry.get(l2DataDir);
+	if (!mem) {
+		mem = new L2Memory(l2DataDir);
+		registry.set(l2DataDir, mem);
+	}
+	return mem;
+}

--- a/apps/inno-agent/src/memory/l2/l2-search.ts
+++ b/apps/inno-agent/src/memory/l2/l2-search.ts
@@ -1,0 +1,150 @@
+/**
+ * L2 retrieval: lexical (BM25) candidate ranking, then one-hop graph expansion
+ * over the wiki link graph.
+ *
+ * The graph signals mirror llm_wiki's relevance model, scaled down for a
+ * personal-size wiki:
+ *   - DIRECT_LINK   — pages connected via `[[wikilinks]]` (out-links + backlinks)
+ *   - SOURCE_OVERLAP — pages sharing a raw source (frontmatter source_ids)
+ *   - ADAMIC_ADAR   — pages sharing neighbors, weighted toward rare (low-degree) ones
+ *   - TYPE_AFFINITY  — small bonus for same page type
+ * Two-hop expansion is intentionally avoided (explodes / dilutes on a small graph).
+ *
+ * Link resolution uses the shared alias index (wiki-links.ts) so retrieval and
+ * the graph viz resolve `[[links]]` identically. Everything runs in-memory from
+ * the index store; at personal scale (hundreds of short pages) this is cheap
+ * and keeps ranking logic out of SQL.
+ */
+
+import { buildAliasIndex, extractOutgoingLinks, pageStem } from "./wiki-links.js";
+import { OVERVIEW_PATH } from "./wiki-graph.js";
+import type { L2IndexStore, L2PageMeta } from "./l2-index-store.js";
+
+/** Rank-decay constant for turning a lexical rank into a base score. */
+const RANK_DECAY_K = 60;
+const LEX_CANDIDATES = 30;
+const GRAPH_SEEDS = 8;
+const WEIGHT_DIRECT_LINK = 0.5;
+const WEIGHT_SOURCE_OVERLAP = 0.4;
+const WEIGHT_ADAMIC_ADAR = 0.3;
+const WEIGHT_TYPE_AFFINITY = 0.1;
+
+export type L2SearchSignal = "lexical" | "graph";
+
+export interface L2SearchResult {
+	path: string;
+	title: string;
+	type: string;
+	score: number;
+	via: L2SearchSignal[];
+}
+
+/**
+ * Run the search: BM25 lexical candidates seed a one-hop graph expansion.
+ */
+export async function searchL2(
+	store: L2IndexStore,
+	query: string,
+	opts: { limit?: number } = {},
+): Promise<L2SearchResult[]> {
+	const q = query.trim();
+	if (!q) return [];
+	const limit = opts.limit ?? 5;
+
+	const pages = store.getAllPages();
+	if (pages.length === 0) return [];
+	const byPath = new Map<string, L2PageMeta>(pages.map((p) => [p.path, p]));
+
+	// Undirected resolved-link adjacency, via the shared alias index.
+	const alias = buildAliasIndex(pages);
+	const adj = new Map<string, Set<string>>();
+	for (const p of pages) adj.set(p.path, new Set());
+	for (const p of pages) {
+		if (p.path === OVERVIEW_PATH) continue; // meta page — keep it out of the link graph
+		for (const link of extractOutgoingLinks(p.body)) {
+			const target = alias.resolve(link);
+			if (!target || target === p.path || !adj.has(target)) continue;
+			adj.get(p.path)!.add(target);
+			adj.get(target)!.add(p.path);
+		}
+	}
+	const degree = (path: string): number => adj.get(path)?.size ?? 0;
+
+	// ---- 1. lexical candidates → rank-decay base score ----
+	const base = new Map<string, number>();
+	const via = new Map<string, Set<L2SearchSignal>>();
+	const addVia = (path: string, sig: L2SearchSignal) =>
+		(via.get(path) ?? via.set(path, new Set()).get(path)!).add(sig);
+
+	store.searchLexical(q, LEX_CANDIDATES).forEach((hit, rank) => {
+		base.set(hit.path, (base.get(hit.path) ?? 0) + 1 / (RANK_DECAY_K + rank));
+		addVia(hit.path, "lexical");
+	});
+
+	// ---- 2. one-hop graph expansion from top lexical seeds ----
+	const seeds = [...base.entries()].sort((a, b) => b[1] - a[1]).slice(0, GRAPH_SEEDS);
+	const graph = new Map<string, number>();
+	const bump = (path: string, amount: number) => {
+		graph.set(path, (graph.get(path) ?? 0) + amount);
+		addVia(path, "graph");
+	};
+	for (const [seedPath, seedScore] of seeds) {
+		const seed = byPath.get(seedPath);
+		if (!seed) continue;
+		const seedNeighbors = adj.get(seedPath) ?? new Set();
+
+		// direct-link + type-affinity neighbors
+		for (const nb of seedNeighbors) {
+			const nbPage = byPath.get(nb);
+			if (!nbPage) continue;
+			let w = WEIGHT_DIRECT_LINK;
+			if (nbPage.type === seed.type) w += WEIGHT_TYPE_AFFINITY;
+			bump(nb, seedScore * w);
+		}
+
+		// Adamic-Adar: pages sharing neighbors with the seed, weighted toward
+		// rare (low-degree) shared neighbors. Σ_{w∈N(seed)∩N(c)} 1/log(1+deg(w)).
+		const aa = new Map<string, number>();
+		for (const w of seedNeighbors) {
+			const wDeg = degree(w);
+			if (wDeg < 2) continue; // a neighbor shared by <2 pages carries no AA signal
+			const contribution = 1 / Math.log(1 + wDeg);
+			for (const c of adj.get(w) ?? []) {
+				if (c === seedPath || seedNeighbors.has(c)) continue; // skip seed + direct neighbors
+				aa.set(c, (aa.get(c) ?? 0) + contribution);
+			}
+		}
+		for (const [c, score] of aa) bump(c, seedScore * WEIGHT_ADAMIC_ADAR * score);
+
+		// source-overlap neighbors
+		if (seed.sourceIds.length > 0) {
+			const seedIds = new Set(seed.sourceIds);
+			for (const other of pages) {
+				if (other.path === seedPath) continue;
+				if (other.sourceIds.some((id) => seedIds.has(id))) {
+					bump(other.path, seedScore * WEIGHT_SOURCE_OVERLAP);
+				}
+			}
+		}
+	}
+
+	// ---- 3. combine + rank ----
+	const finalScore = new Map<string, number>();
+	for (const [path, s] of base) finalScore.set(path, (finalScore.get(path) ?? 0) + s);
+	for (const [path, s] of graph) finalScore.set(path, (finalScore.get(path) ?? 0) + s);
+
+	return [...finalScore.entries()]
+		.map(([path, score]) => {
+			const p = byPath.get(path);
+			return {
+				path,
+				title: p?.title ?? pageStem(path),
+				type: p?.type ?? "",
+				score,
+				via: [...(via.get(path) ?? [])],
+			};
+		})
+		.filter((r) => byPath.has(r.path))
+		.sort((a, b) => b.score - a.score)
+		.slice(0, limit);
+}

--- a/apps/inno-agent/src/memory/l2/l2-tools.ts
+++ b/apps/inno-agent/src/memory/l2/l2-tools.ts
@@ -15,19 +15,27 @@ import {
 	ensureL2Directories,
 	readMaintenanceContext,
 } from "./wiki-maintainer.js";
-import { queryWiki } from "./wiki-query.js";
+import { queryWikiHybrid } from "./wiki-query.js";
 import { summarizeContent } from "./summarizer.js";
 import { maintainLinkedWikiPages } from "./wiki-linker.js";
 import { readText } from "../../storage/file-store.js";
 import { parseDocument, DocumentParseError } from "./document-parser.js";
+import { getL2Memory, type L2Memory } from "./l2-memory.js";
+import { regenerateOverview } from "./overview.js";
 import { logger } from "../../logger.js";
 
 /**
  * Create L2 Wiki memory tools for the Inno Agent.
  * When `isEnabled` is provided and returns false, the archive/query tools
  * short-circuit to a disabled notice without touching the knowledge base.
+ * `l2Memory` keeps the retrieval index in sync; defaults to the per-dir
+ * singleton so callers that don't pass one still get index maintenance.
  */
-export function createL2Tools(l2DataDir: string, isEnabled?: () => boolean): ToolDefinition[] {
+export function createL2Tools(
+	l2DataDir: string,
+	isEnabled?: () => boolean,
+	l2Memory: L2Memory = getL2Memory(l2DataDir),
+): ToolDefinition[] {
 	const l2DisabledResult = () => ({
 		content: [{ type: "text" as const, text: "L2 Wiki 知识库已在设置中关闭，当前不归档也不检索知识库内容。" }],
 		details: { disabled: true },
@@ -180,6 +188,19 @@ export function createL2Tools(l2DataDir: string, isEnabled?: () => boolean): Too
 			const allEntries = readManifest(l2DataDir);
 			rebuildIndex(l2DataDir, allEntries);
 
+			// Keep the retrieval index in sync with the touched pages.
+			for (const wikiPath of entry.wikiPages) {
+				await l2Memory.indexPageByPath(wikiPath);
+			}
+
+			// Regenerate the knowledge-base overview (best-effort; never fails archive).
+			try {
+				const overviewPath = await regenerateOverview(l2DataDir, ctx.model, ctx.modelRegistry);
+				if (overviewPath) await l2Memory.indexPageByPath(overviewPath);
+			} catch (err) {
+				logger.warn({ err }, "l2_archive: overview regeneration failed");
+			}
+
 			// Append log
 			appendLog(
 				l2DataDir,
@@ -191,7 +212,7 @@ export function createL2Tools(l2DataDir: string, isEnabled?: () => boolean): Too
 					`- 原始文件: ${rawPath}`,
 					`- 提取文本: ${extractedPath}`,
 					`- Source 页面: ${wikiPagePath}`,
-					`- concepts/entities: 新建 ${linkMaintenance.created.length}, 更新 ${linkMaintenance.updated.length}, 不变 ${linkMaintenance.unchanged.length}`,
+					`- concepts/entities: 新建 ${linkMaintenance.created.length}, 更新 ${linkMaintenance.updated.length}, 不变 ${linkMaintenance.unchanged.length}, 争议 ${linkMaintenance.contested.length}`,
 					`- 维护前上下文: schema ${maintenanceContext.schema.length} chars, index ${maintenanceContext.index.length} chars, recent log ${maintenanceContext.recentLog.length} chars`,
 				].join("\n"),
 			);
@@ -237,7 +258,7 @@ export function createL2Tools(l2DataDir: string, isEnabled?: () => boolean): Too
 			if (isEnabled && !isEnabled()) return l2DisabledResult();
 			ensureL2Directories(l2DataDir);
 			const query = params.query ?? "";
-			const result = queryWiki(l2DataDir, query);
+			const result = await queryWikiHybrid(l2Memory, query);
 			appendLog(l2DataDir, "query", query, "- L2 query executed through l2_query.");
 			return {
 				content: [{ type: "text" as const, text: result }],

--- a/apps/inno-agent/src/memory/l2/overview.ts
+++ b/apps/inno-agent/src/memory/l2/overview.ts
@@ -1,0 +1,170 @@
+/**
+ * L2 knowledge-base overview generator.
+ *
+ * Regenerates `wiki/analysis/overview.md` — a durable `analysis`-type page that
+ * summarizes the whole knowledge base. The deterministic core (per-type counts
+ * + most-connected entities/concepts) always runs; an optional LLM narrative is
+ * prepended when a model is available. Idempotent (single file), and wrapped by
+ * callers so a failure never breaks an archive.
+ */
+
+import { join } from "node:path";
+import { complete } from "@earendil-works/pi-ai";
+import type { Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+
+import { ensureDir, writeText } from "../../storage/file-store.js";
+import { serializeFrontmatter, rebuildIndex } from "./wiki-maintainer.js";
+import { readManifest } from "./manifest-store.js";
+import { buildWikiGraph, computeWikiGraphStats, OVERVIEW_PATH, type WikiGraphStats } from "./wiki-graph.js";
+import { logger } from "../../logger.js";
+
+const OVERVIEW_TITLE = "知识库总览";
+
+const TYPE_LABELS: Record<string, string> = {
+	"source-summary": "资料摘要",
+	entity: "实体",
+	concept: "概念",
+	analysis: "分析",
+};
+
+function basename(path: string): string {
+	return (path.split("/").pop() ?? path).replace(/\.md$/, "");
+}
+
+function renderDeterministic(stats: WikiGraphStats): string {
+	const lines: string[] = ["## 概况", "", `- 页面总数：${stats.totalPages}`];
+	for (const [type, count] of Object.entries(stats.typeCounts).sort((a, b) => b[1] - a[1])) {
+		lines.push(`- ${TYPE_LABELS[type] ?? type}：${count}`);
+	}
+
+	const { communities } = stats;
+	lines.push(
+		"",
+		"## 主题社区",
+		"",
+		`- 社区数：${communities.count}（模块度 ${communities.modularity}）`,
+	);
+	if (communities.lowCohesion.length > 0) {
+		lines.push(`- ⚠️ 低内聚社区 ${communities.lowCohesion.length} 个（内聚度 < 0.15，建议拆分或补充连接）`);
+	}
+
+	lines.push("", "## 核心节点（按关联度）", "");
+	const top = stats.topByDegree.filter((t) => t.type === "entity" || t.type === "concept");
+	if (top.length === 0) {
+		lines.push("<!-- 暂无足够的双链关联 -->");
+	} else {
+		for (const t of top) {
+			lines.push(`- [[${t.title}]] — ${TYPE_LABELS[t.type] ?? t.type}，关联 ${t.degree}`);
+		}
+	}
+
+	const { maintenance } = stats;
+	const hasMaintenance =
+		maintenance.orphans.length + maintenance.missing.length + maintenance.duplicates.length + maintenance.contested.length >
+		0;
+	if (hasMaintenance) {
+		lines.push("", "## 维护建议", "");
+		if (maintenance.duplicates.length > 0) {
+			lines.push(`- 疑似重复页 ${maintenance.duplicates.length} 组（标题高度相近，建议合并）：`);
+			for (const group of maintenance.duplicates.slice(0, 5)) {
+				lines.push(`  - ${group.map((p) => `\`${basename(p)}\``).join(" ↔ ")}`);
+			}
+		}
+		if (maintenance.missing.length > 0) {
+			const links = [...new Set(maintenance.missing.map((m) => m.link))];
+			lines.push(`- 断链 ${links.length} 处（引用了不存在的页面，建议建页或修链接）：${links.slice(0, 8).map((l) => `[[${l}]]`).join("、")}`);
+		}
+		if (maintenance.orphans.length > 0) {
+			lines.push(`- 孤立页 ${maintenance.orphans.length} 个（无任何双链，建议补充关联）：${maintenance.orphans.slice(0, 8).map((p) => `[[${basename(p)}]]`).join("、")}`);
+		}
+		if (maintenance.contested.length > 0) {
+			lines.push(`- 存在争议的页面 ${maintenance.contested.length} 个：${maintenance.contested.slice(0, 8).map((p) => `[[${basename(p)}]]`).join("、")}`);
+		}
+	}
+
+	return lines.join("\n");
+}
+
+const NARRATIVE_PROMPT = `你是学习 Wiki 知识库的总览撰写助手。根据下面的统计信息，用一到两段简洁中文，概述这个知识库当前覆盖了哪些主题、核心线索是什么。只写概述段落，不要列表、不要标题、不要代码块。
+
+统计信息：
+{stats}`;
+
+async function generateNarrative(
+	model: Model<any>,
+	modelRegistry: ModelRegistry,
+	statsText: string,
+): Promise<string> {
+	try {
+		const auth = await modelRegistry.getApiKeyAndHeaders(model);
+		if (!auth.ok || !auth.apiKey) return "";
+		const response = await complete(
+			model,
+			{
+				messages: [
+					{
+						role: "user" as const,
+						content: [{ type: "text" as const, text: NARRATIVE_PROMPT.replace("{stats}", statsText) }],
+						timestamp: Date.now(),
+					},
+				],
+			},
+			{ apiKey: auth.apiKey, headers: auth.headers, maxTokens: 1024 },
+		);
+		if (response.stopReason === "error") return "";
+		return response.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map((c) => c.text)
+			.join("\n")
+			.trim();
+	} catch (err) {
+		logger.warn({ err }, "[L2 overview] narrative generation failed");
+		return "";
+	}
+}
+
+/**
+ * (Re)generate the overview page. Returns its wiki-relative path, or null when
+ * the knowledge base is empty or generation fails. Rebuilds `wiki/index.md` so
+ * the overview is listed under 分析.
+ */
+export async function regenerateOverview(
+	l2DataDir: string,
+	model?: Model<any>,
+	modelRegistry?: ModelRegistry,
+): Promise<string | null> {
+	try {
+		const stats = computeWikiGraphStats(buildWikiGraph(l2DataDir));
+		if (stats.totalPages === 0) return null;
+
+		const deterministic = renderDeterministic(stats);
+		let narrative = "";
+		if (model && modelRegistry) {
+			narrative = await generateNarrative(model, modelRegistry, deterministic);
+		}
+
+		const today = new Date().toISOString().slice(0, 10);
+		const fm = serializeFrontmatter({
+			title: OVERVIEW_TITLE,
+			created: today,
+			type: "analysis",
+			tags: ["analysis", "overview"],
+			sources: [],
+			source_ids: [],
+			updated: today,
+			status: "draft",
+			confidence: "medium",
+		});
+		const body = `\n# ${OVERVIEW_TITLE}\n\n${narrative ? `${narrative}\n\n` : ""}${deterministic}\n`;
+		ensureDir(join(l2DataDir, "wiki", "analysis"));
+		writeText(join(l2DataDir, OVERVIEW_PATH), fm + body);
+		rebuildIndex(l2DataDir, readManifest(l2DataDir));
+		return OVERVIEW_PATH;
+	} catch (err) {
+		logger.warn({ err }, `[L2 overview] regeneration failed: ${err instanceof Error ? err.message : String(err)}`);
+		return null;
+	}
+}
+
+export { OVERVIEW_PATH };

--- a/apps/inno-agent/src/memory/l2/wiki-graph.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-graph.ts
@@ -1,0 +1,283 @@
+/**
+ * Wiki link graph builder + graph analysis.
+ *
+ * Builds the `[[link]]` + tag graph for the `/api/wiki/graph` endpoint, and
+ * computes algorithmic graph metrics used for maintenance and the overview:
+ *   - link resolution via the shared alias index (fewer phantom nodes)
+ *   - node degree (resolved links only)
+ *   - Louvain communities + modularity + per-community cohesion
+ *   - maintenance signals: missing (dangling) links, orphan pages, possible
+ *     duplicate pages, and contested pages
+ *
+ * The output stays backward-compatible with the previous shape ({nodes, edges}
+ * with node {id,title,type,tags} and edge {source,target,type}); new fields are
+ * additive so the existing frontend keeps working.
+ */
+
+import { readdirSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+import { UndirectedGraph } from "graphology";
+import louvainImport from "graphology-communities-louvain";
+
+// The louvain package's default export is typed awkwardly under Node16 CJS/ESM
+// interop; pin the one method we use to a local type.
+type LouvainDetailed = (g: unknown) => { communities: Record<string, number>; modularity: number; count: number };
+const louvainDetailed = (louvainImport as unknown as { detailed: LouvainDetailed }).detailed;
+import { readText, fileExists } from "../../storage/file-store.js";
+import { parseFrontmatter } from "./wiki-maintainer.js";
+import { buildAliasIndex, extractOutgoingLinks, normalizeWikiLink, stripParenthetical } from "./wiki-links.js";
+
+const WIKI_SUBDIRS = ["sources", "entities", "concepts", "analysis"] as const;
+
+/** Cohesion below this (for communities of at least MIN_COMMUNITY_SIZE) is flagged. */
+const LOW_COHESION_THRESHOLD = 0.15;
+const MIN_COMMUNITY_SIZE = 3;
+
+/**
+ * The generated overview page. It is a meta/summary page (links to the top
+ * nodes it was derived from), so including it in the graph would add a
+ * "connects everything" super-node AND inflate the degree of exactly the nodes
+ * it ranks — a feedback loop. It is therefore excluded from the graph.
+ */
+export const OVERVIEW_PATH = join("wiki", "analysis", "overview.md");
+
+export interface WikiGraphNode {
+	id: string;
+	title: string;
+	type: string;
+	tags: string[];
+	/** Resolved-link degree (page nodes only). */
+	degree?: number;
+	/** Louvain community id (page nodes only). */
+	community?: number;
+}
+export interface WikiGraphEdge {
+	source: string;
+	target: string;
+	type: "link" | "tag";
+}
+export interface WikiGraphMaintenance {
+	/** `[[links]]` that resolve to no page. */
+	missing: { from: string; link: string }[];
+	/** Page paths with no resolved link in or out. */
+	orphans: string[];
+	/** Groups of page paths whose titles collapse to the same base (possible dups). */
+	duplicates: string[][];
+	/** Page paths flagged `contested: true`. */
+	contested: string[];
+}
+export interface WikiGraphCommunities {
+	count: number;
+	modularity: number;
+	lowCohesion: { community: number; cohesion: number; size: number }[];
+}
+export interface WikiGraph {
+	nodes: WikiGraphNode[];
+	edges: WikiGraphEdge[];
+	maintenance: WikiGraphMaintenance;
+	communities: WikiGraphCommunities;
+}
+
+interface PageRecord {
+	path: string;
+	title: string;
+	type: string;
+	tags: string[];
+	body: string;
+	contested: boolean;
+}
+
+function inferTypeFromPath(wikiPath: string): string {
+	if (wikiPath.includes("entities/")) return "entity";
+	if (wikiPath.includes("concepts/")) return "concept";
+	if (wikiPath.includes("analysis/")) return "analysis";
+	return "source-summary";
+}
+
+/** Read all wiki pages (excluding the generated overview). */
+function readAllPages(l2DataDir: string): PageRecord[] {
+	const pages: PageRecord[] = [];
+	for (const sub of WIKI_SUBDIRS) {
+		const dir = join(l2DataDir, "wiki", sub);
+		if (!fileExists(dir)) continue;
+		let files: string[];
+		try {
+			files = readdirSync(dir);
+		} catch {
+			continue;
+		}
+		for (const file of files) {
+			if (!file.endsWith(".md")) continue;
+			const wikiPath = join("wiki", sub, file);
+			if (wikiPath === OVERVIEW_PATH) continue;
+			const { frontmatter, body } = parseFrontmatter(readText(join(l2DataDir, wikiPath)));
+			if (!frontmatter) continue;
+			pages.push({
+				path: wikiPath,
+				title: frontmatter.title || basename(wikiPath, extname(wikiPath)),
+				type: frontmatter.type || inferTypeFromPath(wikiPath),
+				tags: frontmatter.tags ?? [],
+				body,
+				contested: frontmatter.contested === true,
+			});
+		}
+	}
+	return pages.sort((a, b) => a.path.localeCompare(b.path, "zh-CN"));
+}
+
+/**
+ * Build the wiki graph plus algorithmic analysis. Node ids are wiki-relative
+ * paths; `[[links]]` are resolved to page ids via the shared alias index, and
+ * unresolved links become synthetic nodes (and are reported under maintenance).
+ */
+export function buildWikiGraph(l2DataDir: string): WikiGraph {
+	const pages = readAllPages(l2DataDir);
+	const alias = buildAliasIndex(pages);
+	const pagePaths = new Set(pages.map((p) => p.path));
+
+	const nodes: WikiGraphNode[] = [];
+	const edges: WikiGraphEdge[] = [];
+	const missing: { from: string; link: string }[] = [];
+
+	// Resolved-link adjacency (undirected, distinct neighbors) for degree/community.
+	const neighbors = new Map<string, Set<string>>();
+	for (const p of pages) neighbors.set(p.path, new Set());
+
+	const unresolvedNodes = new Set<string>();
+
+	for (const p of pages) {
+		nodes.push({ id: p.path, title: p.title, type: p.type, tags: p.tags });
+		for (const rawLink of extractOutgoingLinks(p.body)) {
+			const target = alias.resolve(rawLink);
+			if (target && target !== p.path) {
+				edges.push({ source: p.path, target, type: "link" });
+				neighbors.get(p.path)!.add(target);
+				neighbors.get(target)!.add(p.path);
+			} else if (!target) {
+				// Dangling link → phantom node (backward compat) + maintenance signal.
+				const label = rawLink.split("|")[0].trim();
+				edges.push({ source: p.path, target: label, type: "link" });
+				unresolvedNodes.add(label);
+				missing.push({ from: p.path, link: label });
+			}
+		}
+		for (const tag of p.tags) edges.push({ source: p.path, target: `tag:${tag}`, type: "tag" });
+	}
+
+	// Synthetic nodes for tags and unresolved links.
+	const tagSeen = new Set<string>();
+	for (const e of edges) {
+		if (e.type === "tag" && !tagSeen.has(e.target)) {
+			tagSeen.add(e.target);
+			nodes.push({ id: e.target, title: e.target.replace("tag:", "#"), type: "tag", tags: [] });
+		}
+	}
+	for (const label of unresolvedNodes) {
+		if (!pagePaths.has(label)) nodes.push({ id: label, title: label, type: "concept", tags: [] });
+	}
+
+	// ---- community detection + degree over the resolved page graph ----
+	const g = new UndirectedGraph();
+	for (const p of pages) g.addNode(p.path);
+	for (const [src, set] of neighbors) {
+		for (const dst of set) {
+			if (src < dst && !g.hasEdge(src, dst)) g.addEdge(src, dst);
+		}
+	}
+
+	let community = new Map<string, number>();
+	let modularity = 0;
+	if (g.order > 0 && g.size > 0) {
+		try {
+			const detailed = louvainDetailed(g);
+			community = new Map(Object.entries(detailed.communities));
+			modularity = typeof detailed.modularity === "number" ? detailed.modularity : 0;
+		} catch {
+			community = new Map();
+		}
+	}
+
+	const degreeByPath = new Map<string, number>();
+	for (const [path, set] of neighbors) degreeByPath.set(path, set.size);
+
+	for (const node of nodes) {
+		if (pagePaths.has(node.id)) {
+			node.degree = degreeByPath.get(node.id) ?? 0;
+			const c = community.get(node.id);
+			if (c !== undefined) node.community = c;
+		}
+	}
+
+	// ---- maintenance signals ----
+	const orphans = pages.filter((p) => (degreeByPath.get(p.path) ?? 0) === 0).map((p) => p.path);
+	const contested = pages.filter((p) => p.contested).map((p) => p.path);
+
+	const baseGroups = new Map<string, string[]>();
+	for (const p of pages) {
+		const key = normalizeWikiLink(stripParenthetical(p.title));
+		if (!key) continue;
+		(baseGroups.get(key) ?? baseGroups.set(key, []).get(key)!).push(p.path);
+	}
+	const duplicates = [...baseGroups.values()].filter((g2) => g2.length > 1);
+
+	// ---- per-community cohesion ----
+	const commMembers = new Map<number, Set<string>>();
+	for (const [path, c] of community) {
+		(commMembers.get(c) ?? commMembers.set(c, new Set()).get(c)!).add(path);
+	}
+	const lowCohesion: { community: number; cohesion: number; size: number }[] = [];
+	for (const [c, members] of commMembers) {
+		if (members.size < MIN_COMMUNITY_SIZE) continue;
+		let intra = 0;
+		let incident = 0;
+		for (const path of members) {
+			for (const nb of neighbors.get(path) ?? []) {
+				incident++;
+				if (members.has(nb)) intra++;
+			}
+		}
+		const cohesion = incident > 0 ? intra / incident : 0;
+		if (cohesion < LOW_COHESION_THRESHOLD) {
+			lowCohesion.push({ community: c, cohesion: Number(cohesion.toFixed(3)), size: members.size });
+		}
+	}
+
+	return {
+		nodes,
+		edges,
+		maintenance: { missing, orphans, duplicates, contested },
+		communities: { count: commMembers.size, modularity: Number(modularity.toFixed(4)), lowCohesion },
+	};
+}
+
+export interface WikiGraphStats {
+	totalPages: number;
+	typeCounts: Record<string, number>;
+	topByDegree: { title: string; type: string; degree: number }[];
+	maintenance: WikiGraphMaintenance;
+	communities: WikiGraphCommunities;
+}
+
+/**
+ * Per-type counts + degree ranking over the real page nodes, plus the graph's
+ * maintenance/community analysis. Used by the overview generator.
+ */
+export function computeWikiGraphStats(graph: WikiGraph, topN = 15): WikiGraphStats {
+	const pageNodes = graph.nodes.filter((n) => n.type !== "tag" && n.id.startsWith("wiki/"));
+
+	const typeCounts: Record<string, number> = {};
+	for (const n of pageNodes) typeCounts[n.type] = (typeCounts[n.type] ?? 0) + 1;
+
+	const topByDegree = pageNodes
+		.map((n) => ({ title: n.title, type: n.type, degree: n.degree ?? 0 }))
+		.sort((a, b) => b.degree - a.degree || a.title.localeCompare(b.title, "zh-CN"))
+		.slice(0, topN);
+
+	return {
+		totalPages: pageNodes.length,
+		typeCounts,
+		topByDegree,
+		maintenance: graph.maintenance,
+		communities: graph.communities,
+	};
+}

--- a/apps/inno-agent/src/memory/l2/wiki-linker.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-linker.ts
@@ -7,7 +7,7 @@ import type { Model } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 
 import { ensureDir, readText, writeText } from "../../storage/file-store.js";
-import type { ManifestEntry, WikiPageType } from "./types.js";
+import type { ManifestEntry, WikiPageType, WikiPageFrontmatter } from "./types.js";
 import { parseFrontmatter, serializeFrontmatter } from "./wiki-maintainer.js";
 import { logger } from "../../logger.js";
 
@@ -23,6 +23,8 @@ export interface WikiLinkMaintenanceResult {
 	created: string[];
 	updated: string[];
 	unchanged: string[];
+	/** Pages where a contradiction with the new source was recorded. */
+	contested: string[];
 	pages: string[];
 }
 
@@ -250,73 +252,35 @@ function referenceBullet(entry: ManifestEntry, sourcePagePath: string): string {
 	return `- [[${entry.title}]] — \`${sourcePagePath}\``;
 }
 
-function addFrontmatterArrayItem(yamlBlock: string, key: string, value: string): { yaml: string; changed: boolean } {
-	const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-	const multilineItemPattern = new RegExp(`^\\s+-\\s+${escaped}\\s*$`, "m");
-	const inlineKeyPattern = new RegExp(`^${key}:\\s*\\[(.*)\\]\\s*$`, "m");
-	const multilineKeyPattern = new RegExp(`^${key}:\\s*$`, "m");
-
-	if (multilineItemPattern.test(yamlBlock)) return { yaml: yamlBlock, changed: false };
-
-	const inlineMatch = yamlBlock.match(inlineKeyPattern);
-	if (inlineMatch) {
-		const items = inlineMatch[1]
-			.split(",")
-			.map((item) => item.trim())
-			.filter(Boolean);
-		if (items.includes(value)) return { yaml: yamlBlock, changed: false };
-		const replacement = `${key}:\n${items.map((item) => `  - ${item}`).join("\n")}\n  - ${value}`;
-		return { yaml: yamlBlock.replace(inlineKeyPattern, replacement), changed: true };
-	}
-
-	const keyMatch = yamlBlock.match(multilineKeyPattern);
-	if (keyMatch && keyMatch.index !== undefined) {
-		const start = keyMatch.index + keyMatch[0].length;
-		const nextKeyMatch = yamlBlock.slice(start).match(/^\w+:\s*/m);
-		const insertAt = nextKeyMatch?.index === undefined ? yamlBlock.length : start + nextKeyMatch.index;
-		const before = yamlBlock.slice(0, insertAt).trimEnd();
-		const after = yamlBlock.slice(insertAt);
-		return { yaml: `${before}\n  - ${value}\n${after.replace(/^\n/, "")}`, changed: true };
-	}
-
-	return { yaml: `${yamlBlock.trimEnd()}\n${key}:\n  - ${value}`, changed: true };
+/**
+ * Parse a page's frontmatter, let `fn` mutate it, then re-serialize. Returns
+ * the original content unchanged (changed=false) when the page has no
+ * frontmatter or when the mutation produces no logical difference.
+ */
+function mutateFrontmatter(
+	content: string,
+	fn: (fm: WikiPageFrontmatter) => void,
+): { content: string; changed: boolean } {
+	const { frontmatter, body } = parseFrontmatter(content);
+	if (!frontmatter) return { content, changed: false };
+	const before = serializeFrontmatter(frontmatter);
+	fn(frontmatter);
+	const after = serializeFrontmatter(frontmatter);
+	if (after === before) return { content, changed: false };
+	return { content: `${after}\n${body}`, changed: true };
 }
 
 function updateFrontmatterReference(content: string, entry: ManifestEntry, sourcePagePath: string): {
 	content: string;
 	changed: boolean;
 } {
-	const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-	if (!match) return { content, changed: false };
-
-	let yamlBlock = match[1];
-	let changed = false;
-
-	if (!/^created:\s*.*$/m.test(yamlBlock)) {
-		const existingUpdated = yamlBlock.match(/^updated:\s*(.*)$/m)?.[1]?.trim();
-		yamlBlock = `${yamlBlock.trimEnd()}\ncreated: ${existingUpdated || new Date().toISOString().slice(0, 10)}`;
-		changed = true;
-	}
-
-	const sourceResult = addFrontmatterArrayItem(yamlBlock, "sources", sourcePagePath);
-	yamlBlock = sourceResult.yaml;
-	changed ||= sourceResult.changed;
-
-	const sourceIdResult = addFrontmatterArrayItem(yamlBlock, "source_ids", entry.id);
-	yamlBlock = sourceIdResult.yaml;
-	changed ||= sourceIdResult.changed;
-
 	const today = new Date().toISOString().slice(0, 10);
-	if (/^updated:\s*.*$/m.test(yamlBlock)) {
-		const nextYaml = yamlBlock.replace(/^updated:\s*.*$/m, `updated: ${today}`);
-		changed ||= nextYaml !== yamlBlock;
-		yamlBlock = nextYaml;
-	} else {
-		yamlBlock = `${yamlBlock.trimEnd()}\nupdated: ${today}`;
-		changed = true;
-	}
-
-	return { content: `---\n${yamlBlock}\n---\n${match[2]}`, changed };
+	return mutateFrontmatter(content, (fm) => {
+		if (!fm.sources.includes(sourcePagePath)) fm.sources.push(sourcePagePath);
+		if (!fm.source_ids.includes(entry.id)) fm.source_ids.push(entry.id);
+		if (!fm.created) fm.created = fm.updated || today;
+		fm.updated = today;
+	});
 }
 
 function addReferenceIfMissing(content: string, entry: ManifestEntry, sourcePagePath: string): string | null {
@@ -369,6 +333,11 @@ function upsertLinkedPage(
  * The source page keeps the original summary. This function creates or updates
  * linked entity/concept pages, then returns their paths so the manifest and
  * index can include them in the same archive transaction.
+ *
+ * With a model available this runs two-stage CoT: (1) extract candidates and
+ * read their existing page definitions, (2) plan create/update with merged
+ * definitions and contradiction detection, then write/merge. Without a model
+ * the original non-destructive behavior (create-or-append-reference) applies.
  */
 export async function maintainLinkedWikiPages(
 	l2DataDir: string,
@@ -378,13 +347,241 @@ export async function maintainLinkedWikiPages(
 	model?: Model<any>,
 	modelRegistry?: ModelRegistry,
 ): Promise<WikiLinkMaintenanceResult> {
-	const result: WikiLinkMaintenanceResult = { created: [], updated: [], unchanged: [], pages: [] };
+	const result: WikiLinkMaintenanceResult = { created: [], updated: [], unchanged: [], contested: [], pages: [] };
 	const items = await extractLinkedItems(model, modelRegistry, entry.title, sourcePageBody);
-	for (const item of items) {
-		const page = upsertLinkedPage(l2DataDir, item, entry, sourcePagePath);
-		result.pages.push(page.path);
-		result[page.status].push(page.path);
+
+	// Stage 1: read existing definitions for all candidates, build plan.
+	const candidates = items.map((it) => ({
+		title: it.title,
+		type: it.type,
+		existingDefinition: readExistingDefinition(l2DataDir, it),
+	}));
+	const plan = await planLinkedItems(model, modelRegistry, entry.title, sourcePageBody, candidates);
+
+	if (plan) {
+		// Stage 2: write/merge according to plan.
+		for (const p of plan) {
+			const page = upsertPlannedPage(l2DataDir, p, entry, sourcePagePath);
+			result.pages.push(page.path);
+			result[page.status].push(page.path);
+			if (page.contested) result.contested.push(page.path);
+		}
+	} else {
+		// Fallback: original non-destructive create-or-append-reference.
+		for (const item of items) {
+			const page = upsertLinkedPage(l2DataDir, item, entry, sourcePagePath);
+			result.pages.push(page.path);
+			result[page.status].push(page.path);
+		}
 	}
 	result.pages = [...new Set(result.pages)];
 	return result;
+}
+
+// ============================================================================
+// Two-stage CoT helpers
+// ============================================================================
+
+interface PlanItem {
+	title: string;
+	type: LinkablePageType;
+	action: "create" | "update";
+	definition: string;
+	contradiction?: string;
+}
+
+const STAGE1_PLAN_PROMPT = `你是学习 Wiki 知识库的维护规划助手。已知一份新资料的摘要，以及知识库中若干实体/概念页面的现有定义。请为每个条目规划如何维护。
+
+规则：
+- action=create：知识库尚无此条目（现有定义为空）。definition 写一到三句中文定义。
+- action=update：已有此条目。请把新资料的信息与现有定义**融合**，写出更完整、准确、无重复的 definition（融合后的完整定义，而不是仅追加）。
+- 若新资料与现有定义存在**事实冲突/矛盾**，将 contradiction 设为一句话冲突说明；否则设为 null。
+- definition 聚焦"是什么"，不要写入学习者个人状态、目标或偏好。
+- 最多处理 20 个条目。
+
+资料标题：{title}
+
+资料摘要：
+---
+{summary}
+---
+
+候选条目（existingDefinition 为空表示知识库暂无该条目）：
+{candidates}
+
+只返回 JSON，不要代码块：
+{"items":[{"title":"条目名","type":"concept","action":"update","definition":"融合后的完整定义","contradiction":null}]}`;
+
+function parsePlanItems(text: string): PlanItem[] {
+	const trimmed = text.trim().replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/i, "");
+	const start = trimmed.indexOf("{");
+	const end = trimmed.lastIndexOf("}");
+	if (start < 0 || end < start) return [];
+	let parsed: { items?: unknown };
+	try {
+		parsed = JSON.parse(trimmed.slice(start, end + 1)) as { items?: unknown };
+	} catch {
+		return [];
+	}
+	if (!Array.isArray(parsed.items)) return [];
+	const planItems: PlanItem[] = [];
+	const seen = new Set<string>();
+	for (const raw of parsed.items) {
+		if (!raw || typeof raw !== "object") continue;
+		const rec = raw as Record<string, unknown>;
+		const title = typeof rec.title === "string" ? cleanTitle(rec.title) : "";
+		const type = rec.type === "entity" ? "entity" : rec.type === "concept" ? "concept" : null;
+		if (!title || !type || !isUsefulTitle(title) || seen.has(title)) continue;
+		const definition = typeof rec.definition === "string" ? rec.definition.trim() : "";
+		if (!definition) continue;
+		seen.add(title);
+		planItems.push({
+			title,
+			type,
+			action: rec.action === "update" ? "update" : "create",
+			definition,
+			contradiction:
+				typeof rec.contradiction === "string" && rec.contradiction.trim() ? rec.contradiction.trim() : undefined,
+		});
+	}
+	return planItems;
+}
+
+function readExistingDefinition(l2DataDir: string, item: LinkedItem): string | undefined {
+	const rel = findExistingPage(l2DataDir, item);
+	const abs = join(l2DataDir, rel);
+	if (!existsSync(abs)) return undefined;
+	const { body } = parseFrontmatter(readText(abs));
+	const idx = body.indexOf("## 定义");
+	if (idx < 0) return undefined;
+	const rest = body.slice(idx + "## 定义".length);
+	const nextSec = rest.search(/\n## /);
+	const def = (nextSec >= 0 ? rest.slice(0, nextSec) : rest).trim();
+	return def || undefined;
+}
+
+async function planLinkedItems(
+	model: Model<any> | undefined,
+	modelRegistry: ModelRegistry | undefined,
+	title: string,
+	summary: string,
+	candidates: { title: string; type: LinkablePageType; existingDefinition?: string }[],
+): Promise<PlanItem[] | null> {
+	if (!model || !modelRegistry || candidates.length === 0) return null;
+	const candidateJson = JSON.stringify(
+		candidates.map((c) => ({
+			title: c.title,
+			type: c.type,
+			existingDefinition: c.existingDefinition ? c.existingDefinition.slice(0, 600) : "",
+		})),
+	);
+	const truncatedSummary =
+		summary.length > MAX_LINK_PROMPT_LENGTH ? summary.slice(0, MAX_LINK_PROMPT_LENGTH) + "\n\n...(内容已截断)" : summary;
+	const prompt = STAGE1_PLAN_PROMPT
+		.replace("{title}", title)
+		.replace("{summary}", truncatedSummary)
+		.replace("{candidates}", candidateJson);
+	try {
+		const auth = await modelRegistry.getApiKeyAndHeaders(model);
+		if (!auth.ok || !auth.apiKey) return null;
+		const response = await complete(
+			model,
+			{ messages: [{ role: "user" as const, content: [{ type: "text" as const, text: prompt }], timestamp: Date.now() }] },
+			{ apiKey: auth.apiKey, headers: auth.headers, maxTokens: 4096 },
+		);
+		if (response.stopReason === "error") return null;
+		const text = response.content
+			.filter((c): c is { type: "text"; text: string } => c.type === "text")
+			.map((c) => c.text)
+			.join("\n");
+		const plan = parsePlanItems(text);
+		return plan.length > 0 ? plan : null;
+	} catch (err) {
+		logger.warn({ err }, "LLM ingest planning failed, using fallback");
+		return null;
+	}
+}
+
+function replaceDefinitionSection(content: string, newDef: string): string {
+	const header = "## 定义";
+	const idx = content.indexOf(header);
+	if (idx < 0) {
+		const relIdx = content.indexOf("\n## 相关资料");
+		const section = `## 定义\n\n${newDef}\n\n`;
+		if (relIdx >= 0) return `${content.slice(0, relIdx + 1)}${section}${content.slice(relIdx + 1)}`;
+		return `${content.trimEnd()}\n\n${section}`;
+	}
+	const bodyStart = idx + header.length;
+	const rest = content.slice(bodyStart);
+	const nextSec = rest.search(/\n## /);
+	const insertEnd = nextSec >= 0 ? bodyStart + nextSec : content.length;
+	return `${content.slice(0, bodyStart)}\n\n${newDef}\n${content.slice(insertEnd)}`;
+}
+
+function applyContradiction(content: string, entry: ManifestEntry, note: string): string | null {
+	const fmResult = mutateFrontmatter(content, (fm) => {
+		fm.contested = true;
+		if (!fm.contradictions) fm.contradictions = [];
+		if (!fm.contradictions.includes(entry.id)) fm.contradictions.push(entry.id);
+	});
+	let next = fmResult.content;
+	let changed = fmResult.changed;
+	if (!next.includes(note)) {
+		const bullet = `- ${note}（来源 [[${entry.title}]] \`${entry.id}\`）`;
+		const header = "\n## 争议";
+		const idx = next.indexOf(header);
+		if (idx >= 0) {
+			const bodyStart = idx + header.length;
+			const rest = next.slice(bodyStart);
+			const nextSec = rest.search(/\n## /);
+			const insertAt = nextSec >= 0 ? bodyStart + nextSec : next.length;
+			next = `${next.slice(0, insertAt).trimEnd()}\n${bullet}${next.slice(insertAt)}`;
+		} else {
+			next = `${next.trimEnd()}\n\n## 争议\n\n${bullet}\n`;
+		}
+		changed = true;
+	}
+	return changed ? next : null;
+}
+
+function mergeIntoExistingPage(
+	content: string,
+	item: PlanItem,
+	entry: ManifestEntry,
+	sourcePagePath: string,
+): { content: string; contested: boolean } | null {
+	let next = content;
+	let changed = false;
+	let contested = false;
+	if (item.definition) {
+		const replaced = replaceDefinitionSection(next, item.definition);
+		if (replaced !== next) { next = replaced; changed = true; }
+	}
+	const withRef = addReferenceIfMissing(next, entry, sourcePagePath);
+	if (withRef) { next = withRef; changed = true; }
+	if (item.contradiction) {
+		const withContra = applyContradiction(next, entry, item.contradiction);
+		if (withContra) { next = withContra; changed = true; contested = true; }
+	}
+	return changed ? { content: next, contested } : null;
+}
+
+function upsertPlannedPage(
+	l2DataDir: string,
+	item: PlanItem,
+	entry: ManifestEntry,
+	sourcePagePath: string,
+): { path: string; status: "created" | "updated" | "unchanged"; contested: boolean } {
+	const linked: LinkedItem = { title: item.title, type: item.type, description: item.definition };
+	const relativePath = findExistingPage(l2DataDir, linked);
+	const absPath = join(l2DataDir, relativePath);
+	ensureDir(join(l2DataDir, "wiki", pageDirForType(item.type)));
+	if (!existsSync(absPath)) {
+		writeText(absPath, buildNewPage(linked, entry, sourcePagePath));
+		return { path: relativePath, status: "created", contested: false };
+	}
+	const merged = mergeIntoExistingPage(readText(absPath), item, entry, sourcePagePath);
+	if (!merged) return { path: relativePath, status: "unchanged", contested: false };
+	writeText(absPath, merged.content);
+	return { path: relativePath, status: "updated", contested: merged.contested };
 }

--- a/apps/inno-agent/src/memory/l2/wiki-links.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-links.ts
@@ -1,0 +1,94 @@
+/**
+ * Wiki link resolution — the single source of truth for turning a `[[link]]`
+ * into a page path. Shared by the graph builder (visualization) and the search
+ * layer (retrieval graph expansion) so the two never drift.
+ *
+ * Resolution is alias-based and tolerant of the mismatches seen in real data:
+ * full-width/half-width, case, whitespace, and — most importantly — trailing
+ * parenthetical suffixes, e.g. a body link `[[GRPO（Group Relative Policy
+ * Optimization）]]` resolving to a page titled `GRPO`. Ambiguous bases (two
+ * different pages normalizing to the same key) are recorded as unresolvable
+ * rather than mis-merged.
+ */
+
+/** Normalize a link/title: strip alias part, lowercase, full-width→half-width, collapse spaces. */
+export function normalizeWikiLink(s: string): string {
+	return s
+		.split("|")[0]
+		.trim()
+		.toLowerCase()
+		.replace(/[！-～]/g, (c) => String.fromCharCode(c.charCodeAt(0) - 0xfee0)) // full-width ASCII
+		.replace(/　/g, " ") // ideographic space
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+/** Strip a single trailing parenthetical suffix: `GRPO（Group…）` / `X (full name)` → base. */
+export function stripParenthetical(s: string): string {
+	return s.replace(/[（(][^（()）]*[)）]\s*$/, "").trim();
+}
+
+/** Filename stem of a wiki-relative path (no dir, no `.md`). */
+export function pageStem(path: string): string {
+	return (path.split("/").pop() ?? path).replace(/\.md$/, "");
+}
+
+/** Extract raw `[[link]]` targets (alias part stripped) from a page body. */
+export function extractOutgoingLinks(body: string): string[] {
+	const out: string[] = [];
+	const re = /\[\[([^\]]+)\]\]/g;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(body)) !== null) {
+		const t = m[1].split("|")[0].trim();
+		if (t) out.push(t);
+	}
+	return out;
+}
+
+export interface AliasIndex {
+	/** Resolve a link to a page path, or null when unresolved/ambiguous. */
+	resolve(link: string): string | null;
+}
+
+/**
+ * Build an alias index over pages. `primary` holds exact-ish keys (normalized
+ * title, stem, path); `base` holds parenthetical-stripped titles with a null
+ * sentinel when two pages collide (so we never mis-merge distinct pages).
+ */
+export function buildAliasIndex(pages: { path: string; title: string }[]): AliasIndex {
+	const primary = new Map<string, string>();
+	const base = new Map<string, string | null>();
+
+	const addBase = (key: string, path: string) => {
+		if (!key) return;
+		if (base.has(key)) {
+			if (base.get(key) !== path) base.set(key, null); // ambiguous
+		} else {
+			base.set(key, path);
+		}
+	};
+
+	for (const p of pages) {
+		const nTitle = normalizeWikiLink(p.title);
+		if (nTitle) primary.set(nTitle, p.path);
+		const nStem = normalizeWikiLink(pageStem(p.path));
+		if (nStem && !primary.has(nStem)) primary.set(nStem, p.path);
+		primary.set(p.path.toLowerCase(), p.path);
+		addBase(normalizeWikiLink(stripParenthetical(p.title)), p.path);
+	}
+
+	return {
+		resolve(link: string): string | null {
+			const n = normalizeWikiLink(link);
+			if (primary.has(n)) return primary.get(n)!;
+			const linkBase = normalizeWikiLink(stripParenthetical(link));
+			if (linkBase !== n && primary.has(linkBase)) return primary.get(linkBase)!;
+			// Match a (possibly-fuller) link against the parenthetical-stripped page index.
+			const b = base.get(n);
+			if (b) return b;
+			const bb = base.get(linkBase);
+			if (bb) return bb;
+			return null;
+		},
+	};
+}

--- a/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
@@ -1,7 +1,14 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
+import { parse as parseYaml, Document as YamlDocument } from "yaml";
 import { ensureDir, writeText, readText, appendText, fileExists } from "../../storage/file-store.js";
-import type { WikiPageFrontmatter, WikiPageType, ManifestEntry } from "./types.js";
+import type {
+	WikiPageFrontmatter,
+	WikiPageType,
+	WikiPageStatus,
+	ConfidenceLevel,
+	ManifestEntry,
+} from "./types.js";
 import { logger } from "../../logger.js";
 
 const L2_SCHEMA_VERSION = "1.0";
@@ -21,109 +28,77 @@ const TYPE_DIR_MAP: Record<WikiPageType, string> = {
 };
 
 // ============================================================================
-// Frontmatter serialization — values are JSON-quoted to avoid YAML ambiguity
+// Frontmatter serialization — backed by the `yaml` library
 // ============================================================================
 
-/** Quote a scalar for safe YAML output. */
-function yamlQuote(v: string): string {
-	// If value contains characters that could cause YAML parsing issues, quote it
-	if (/[:\[\]{},#&*!|>'"%@`\n]/.test(v) || v.trim() !== v || v === "") {
-		return JSON.stringify(v);
-	}
-	return v;
-}
-
+/**
+ * Serialize wiki frontmatter to a `---`-delimited YAML block. Keys are emitted
+ * in the historical on-disk order and `tags` is kept as an inline flow sequence
+ * so pages touched by an update produce minimal diffs.
+ */
 export function serializeFrontmatter(fm: WikiPageFrontmatter): string {
-	const lines = [
-		"---",
-		`title: ${yamlQuote(fm.title)}`,
-		`created: ${fm.created || fm.updated}`,
-		`type: ${fm.type}`,
-		`tags: [${fm.tags.map((t) => yamlQuote(t)).join(", ")}]`,
-		"sources:",
-		...fm.sources.map((s) => `  - ${yamlQuote(s)}`),
-		"source_ids:",
-		...fm.source_ids.map((id) => `  - ${id}`),
-		`updated: ${fm.updated}`,
-		`status: ${fm.status}`,
-		`confidence: ${fm.confidence}`,
-		...(fm.contested !== undefined ? [`contested: ${fm.contested ? "true" : "false"}`] : []),
-		...(fm.contradictions && fm.contradictions.length > 0
-			? ["contradictions:", ...fm.contradictions.map((id) => `  - ${yamlQuote(id)}`)]
-			: []),
-		"---",
-	];
-	return lines.join("\n");
+	const obj: Record<string, unknown> = {
+		title: fm.title,
+		created: fm.created || fm.updated,
+		type: fm.type,
+		tags: fm.tags,
+		sources: fm.sources,
+		source_ids: fm.source_ids,
+		updated: fm.updated,
+		status: fm.status,
+		confidence: fm.confidence,
+	};
+	if (fm.contested !== undefined) obj.contested = fm.contested;
+	if (fm.contradictions && fm.contradictions.length > 0) obj.contradictions = fm.contradictions;
+
+	const doc = new YamlDocument(obj);
+	const tagsNode = doc.get("tags", true) as { flow?: boolean } | undefined;
+	if (tagsNode && typeof tagsNode === "object") tagsNode.flow = true;
+
+	// The yaml lib pads flow collections (`[ a, b ]`); strip the inner padding
+	// to match the legacy `[a, b]` format and minimize diffs.
+	const yamlBody = doc.toString({ lineWidth: 0 }).replace(/^tags: \[ (.*) \]$/m, "tags: [$1]");
+	return `---\n${yamlBody}---`;
 }
 
 export function parseFrontmatter(content: string): { frontmatter: WikiPageFrontmatter | null; body: string } {
 	const match = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
 	if (!match) return { frontmatter: null, body: content };
 
-	const yamlBlock = match[1];
 	const body = match[2];
-	const fm: Record<string, unknown> = {};
-	let currentKey = "";
-	let currentArray: string[] = [];
-
-	for (const line of yamlBlock.split("\n")) {
-		const kvMatch = line.match(/^(\w+):\s*(.*)$/);
-		if (kvMatch) {
-			if (currentKey && currentArray.length > 0) {
-				fm[currentKey] = currentArray;
-				currentArray = [];
-			}
-			currentKey = kvMatch[1];
-			const value = kvMatch[2].trim();
-			if (value.startsWith("[") && value.endsWith("]")) {
-				fm[currentKey] = value
-					.slice(1, -1)
-					.split(",")
-					.map((s) => s.trim())
-					.filter(Boolean);
-				currentKey = "";
-			} else if (value === "") {
-				// Array items follow
-			} else {
-				fm[currentKey] = value;
-				currentKey = "";
-			}
-		} else {
-			const itemMatch = line.match(/^\s+-\s+(.+)$/);
-			if (itemMatch) {
-				currentArray.push(itemMatch[1]);
-			}
-		}
-	}
-	if (currentKey && currentArray.length > 0) {
-		fm[currentKey] = currentArray;
+	let raw: Record<string, unknown>;
+	try {
+		const parsed = parseYaml(match[1]) as unknown;
+		raw = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+	} catch (err) {
+		logger.warn({ err }, "failed to parse wiki frontmatter YAML");
+		raw = {};
 	}
 
-	function parseScalar(value: unknown): string {
-		if (typeof value !== "string") return "";
-		if (!value.startsWith("\"")) return value;
-		try {
-			const parsed = JSON.parse(value) as unknown;
-			return typeof parsed === "string" ? parsed : value;
-		} catch (err) {
-			logger.warn({ err, value }, "failed to parse frontmatter scalar");
-			return value;
-		}
-	}
+	const asString = (v: unknown): string => (typeof v === "string" ? v : v == null ? "" : String(v));
+	const asStringArray = (v: unknown): string[] =>
+		Array.isArray(v) ? v.map((x) => asString(x)).filter(Boolean) : [];
+	const contestedRaw = raw.contested;
+	const contested =
+		contestedRaw === true || contestedRaw === "true"
+			? true
+			: contestedRaw === false || contestedRaw === "false"
+				? false
+				: undefined;
 
 	return {
 		frontmatter: {
-			title: parseScalar(fm.title),
-			created: (fm.created as string) ?? (fm.updated as string) ?? "",
-			type: (fm.type as WikiPageType) ?? "source-summary",
-			tags: (fm.tags as string[]) ?? [],
-			sources: (fm.sources as string[]) ?? [],
-			source_ids: (fm.source_ids as string[]) ?? [],
-			updated: (fm.updated as string) ?? "",
-			status: (fm.status as "draft" | "reviewed" | "outdated") ?? "draft",
-			confidence: (fm.confidence as "low" | "medium" | "high") ?? "medium",
-			contested: fm.contested === "true" ? true : fm.contested === "false" ? false : undefined,
-			contradictions: (fm.contradictions as string[]) ?? [],
+			title: asString(raw.title),
+			created: asString(raw.created) || asString(raw.updated),
+			type: (raw.type as WikiPageType) ?? "source-summary",
+			tags: asStringArray(raw.tags),
+			sources: asStringArray(raw.sources),
+			source_ids: asStringArray(raw.source_ids),
+			updated: asString(raw.updated),
+			status: (raw.status as WikiPageStatus) ?? "draft",
+			confidence: (raw.confidence as ConfidenceLevel) ?? "medium",
+			contested,
+			contradictions: asStringArray(raw.contradictions),
 		},
 		body,
 	};

--- a/apps/inno-agent/src/memory/l2/wiki-query.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-query.ts
@@ -2,6 +2,7 @@ import { join } from "node:path";
 import { readText, fileExists } from "../../storage/file-store.js";
 import { readManifest } from "./manifest-store.js";
 import type { ManifestEntry } from "./types.js";
+import type { L2Memory } from "./l2-memory.js";
 
 /**
  * Read the wiki index.
@@ -77,5 +78,41 @@ export function queryWiki(l2DataDir: string, query: string): string {
 		}
 	}
 
+	return sections.join("\n");
+}
+
+/**
+ * Query wiki via hybrid retrieval (BM25 + vector + graph), falling back to
+ * the substring {@link queryWiki} when the index store is unavailable.
+ */
+export async function queryWikiHybrid(l2Memory: L2Memory, query: string): Promise<string> {
+	const l2DataDir = l2Memory.dataDir;
+	const index = readIndex(l2DataDir);
+	const trimmed = (query ?? "").trim();
+
+	if (!trimmed) {
+		return `## Wiki 索引\n\n${index}\n\n---\n\n提示：传入 query 参数（如「Python async」）可定位并返回相关页面内容。`;
+	}
+
+	const results = await l2Memory.search(trimmed, 5);
+	if (results === null) return queryWiki(l2DataDir, query);
+	if (results.length === 0) {
+		return `## Wiki 索引\n\n${index}\n\n---\n\n未找到与「${trimmed}」相关的内容。`;
+	}
+
+	const sections: string[] = [
+		`## Wiki 索引\n\n${index}`,
+		"---",
+		`## 查询结果: "${trimmed}" (${results.length} 条匹配)`,
+		"",
+	];
+	for (const r of results) {
+		const content = readWikiPage(l2DataDir, r.path);
+		if (content) {
+			sections.push(`### [[${r.title}]]  \`${r.path}\`  (${r.via.join("+")})\n`);
+			sections.push(content);
+			sections.push("---\n");
+		}
+	}
 	return sections.join("\n");
 }

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -9,6 +9,8 @@ import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, renameSync, r
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
+import { getL2Memory } from "./memory/l2/l2-memory.js";
+import { buildWikiGraph } from "./memory/l2/wiki-graph.js";
 import { loadConfig, saveConfig, setDefaultModel, upsertProvider, deleteProvider, deleteModel, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig, type InnoModelConfig, type InnoProviderConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
 import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
@@ -3048,6 +3050,7 @@ const server = createServer(async (req, res) => {
 				return;
 			}
 			writeText(fullPath, content);
+			await getL2Memory(l2DataDir).indexPageByPath(path);
 			json(res, 200, { path, saved: true });
 			return;
 		}
@@ -3071,6 +3074,7 @@ const server = createServer(async (req, res) => {
 			try {
 				rmSync(fullPath);
 				removeWikiPathFromManifest(l2DataDir, path);
+				await getL2Memory(l2DataDir).removePage(path);
 				json(res, 200, { path, deleted: true });
 			} catch (err) {
 				logger.warn({ err }, "failed to delete wiki page");
@@ -3081,61 +3085,7 @@ const server = createServer(async (req, res) => {
 
 		if (method === "GET" && url === "/api/wiki/graph") {
 			try {
-				const nodes: unknown[] = [];
-				const edges: unknown[] = [];
-				const titleToNodeId = new Map<string, string>();
-				const pendingLinks: { source: string; target: string }[] = [];
-
-				for (const wikiPath of listWikiPagePaths()) {
-					const fullPath = join(l2DataDir, wikiPath);
-					if (!existsSync(fullPath)) continue;
-					const content = readText(fullPath);
-					const { frontmatter, body } = parseFrontmatter(content);
-					if (!frontmatter) continue;
-
-					const nodeId = wikiPath;
-					titleToNodeId.set(frontmatter.title, nodeId);
-					titleToNodeId.set(wikiPath, nodeId);
-					titleToNodeId.set(basename(wikiPath, extname(wikiPath)), nodeId);
-					nodes.push({
-						id: nodeId,
-						title: frontmatter.title,
-						type: frontmatter.type,
-						tags: frontmatter.tags,
-					});
-
-					// Extract [[wiki links]] from body
-					const linkPattern = /\[\[([^\]]+)\]\]/g;
-					let match;
-					while ((match = linkPattern.exec(body)) !== null) {
-						const linkText = match[1].split("|")[0].trim();
-						pendingLinks.push({ source: nodeId, target: linkText });
-					}
-
-					// Shared tag edges
-					for (const tag of frontmatter.tags) {
-						edges.push({ source: nodeId, target: `tag:${tag}`, type: "tag" });
-					}
-				}
-
-				for (const link of pendingLinks) {
-					edges.push({ source: link.source, target: titleToNodeId.get(link.target) ?? link.target, type: "link" });
-				}
-
-				// Add tag and unresolved wiki-link nodes
-				const tagNodes = new Set<string>();
-				for (const edge of edges as { source: string; target: string; type: string }[]) {
-					if (edge.type === "tag" && !tagNodes.has(edge.target)) {
-						tagNodes.add(edge.target);
-						nodes.push({ id: edge.target, title: edge.target.replace("tag:", "#"), type: "tag", tags: [] });
-					}
-					if (edge.type === "link" && !titleToNodeId.has(edge.target)) {
-						titleToNodeId.set(edge.target, edge.target);
-						nodes.push({ id: edge.target, title: edge.target, type: "concept", tags: [] });
-					}
-				}
-
-				json(res, 200, { nodes, edges });
+				json(res, 200, buildWikiGraph(l2DataDir));
 			} catch (err) {
 				logger.warn({ err }, "failed to build wiki graph");
 				json(res, 200, { nodes: [], edges: [] });

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
 				"@types/ws": "^8.18.1",
 				"axios": "^1.16.1",
 				"cron-parser": "^5.5.0",
+				"graphology": "^0.26.0",
+				"graphology-communities-louvain": "^2.0.2",
 				"node-pty": "^1.0.0",
 				"pi-sandbox": "^0.4.3",
 				"pi-subagents": "^0.28.0",
@@ -48,7 +50,8 @@
 				"source-map-support": "^0.5.21",
 				"typebox": "^1.1.24",
 				"undici": "^7.19.1",
-				"ws": "^8.21.0"
+				"ws": "^8.21.0",
+				"yaml": "^2.6.1"
 			},
 			"bin": {
 				"inno": "dist/cli.js"
@@ -1860,7 +1863,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "dist/cli.js"
+				"pi-ai": "./dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
@@ -1976,6 +1979,9 @@
 			"cpu": [
 				"arm64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1991,6 +1997,9 @@
 			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
 			"cpu": [
 				"arm64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2008,6 +2017,9 @@
 			"cpu": [
 				"riscv64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2024,6 +2036,9 @@
 			"cpu": [
 				"x64"
 			],
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2039,6 +2054,9 @@
 			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
 			"cpu": [
 				"x64"
+			],
+			"libc": [
+				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -9033,6 +9051,15 @@
 				"@types/estree": "^1.0.0"
 			}
 		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmmirror.com/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
 		"node_modules/execa": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmmirror.com/execa/-/execa-1.0.0.tgz",
@@ -9812,6 +9839,62 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/graphology": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmmirror.com/graphology/-/graphology-0.26.0.tgz",
+			"integrity": "sha512-8SSImzgUUYC89Z042s+0r/vMibY7GX/Emz4LDO5e7jYXhuoWfHISPFJYjpRLUSJGq6UQ6xlenvX1p/hJdfXuXg==",
+			"license": "MIT",
+			"dependencies": {
+				"events": "^3.3.0"
+			},
+			"peerDependencies": {
+				"graphology-types": ">=0.24.0"
+			}
+		},
+		"node_modules/graphology-communities-louvain": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmmirror.com/graphology-communities-louvain/-/graphology-communities-louvain-2.0.2.tgz",
+			"integrity": "sha512-zt+2hHVPYxjEquyecxWXoUoIuN/UvYzsvI7boDdMNz0rRvpESQ7+e+Ejv6wK7AThycbZXuQ6DkG8NPMCq6XwoA==",
+			"license": "MIT",
+			"dependencies": {
+				"graphology-indices": "^0.17.0",
+				"graphology-utils": "^2.4.4",
+				"mnemonist": "^0.39.0",
+				"pandemonium": "^2.4.1"
+			},
+			"peerDependencies": {
+				"graphology-types": ">=0.19.0"
+			}
+		},
+		"node_modules/graphology-indices": {
+			"version": "0.17.0",
+			"resolved": "https://registry.npmmirror.com/graphology-indices/-/graphology-indices-0.17.0.tgz",
+			"integrity": "sha512-A7RXuKQvdqSWOpn7ZVQo4S33O0vCfPBnUSf7FwE0zNCasqwZVUaCXePuWo5HBpWw68KJcwObZDHpFk6HKH6MYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"graphology-utils": "^2.4.2",
+				"mnemonist": "^0.39.0"
+			},
+			"peerDependencies": {
+				"graphology-types": ">=0.20.0"
+			}
+		},
+		"node_modules/graphology-types": {
+			"version": "0.24.8",
+			"resolved": "https://registry.npmmirror.com/graphology-types/-/graphology-types-0.24.8.tgz",
+			"integrity": "sha512-hDRKYXa8TsoZHjgEaysSRyPdT6uB78Ci8WnjgbStlQysz7xR52PInxNsmnB7IBOM1BhikxkNyCVEFgmPKnpx3Q==",
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/graphology-utils": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmmirror.com/graphology-utils/-/graphology-utils-2.5.2.tgz",
+			"integrity": "sha512-ckHg8MXrXJkOARk56ZaSCM1g1Wihe2d6iTmz1enGOz4W/l831MBCKSayeFQfowgF8wd+PQ4rlch/56Vs/VZLDQ==",
+			"license": "MIT",
+			"peerDependencies": {
+				"graphology-types": ">=0.23.0"
+			}
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
@@ -12220,6 +12303,15 @@
 				"mkdirp": "bin/cmd.js"
 			}
 		},
+		"node_modules/mnemonist": {
+			"version": "0.39.8",
+			"resolved": "https://registry.npmmirror.com/mnemonist/-/mnemonist-0.39.8.tgz",
+			"integrity": "sha512-vyWo2K3fjrUw8YeeZ1zF0fy6Mu59RHokURlld8ymdUPjMlD9EC9ov1/YPqTgqRvUN9nTr3Gqfz29LYAmu0PHPQ==",
+			"license": "MIT",
+			"dependencies": {
+				"obliterator": "^2.0.1"
+			}
+		},
 		"node_modules/motion": {
 			"version": "12.40.0",
 			"resolved": "https://registry.npmmirror.com/motion/-/motion-12.40.0.tgz",
@@ -12548,6 +12640,12 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/obliterator": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmmirror.com/obliterator/-/obliterator-2.0.5.tgz",
+			"integrity": "sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==",
+			"license": "MIT"
+		},
 		"node_modules/ollama": {
 			"version": "0.6.3",
 			"resolved": "https://registry.npmmirror.com/ollama/-/ollama-0.6.3.tgz",
@@ -12677,6 +12775,15 @@
 			"resolved": "https://registry.npmmirror.com/pako/-/pako-1.0.11.tgz",
 			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"license": "(MIT AND Zlib)"
+		},
+		"node_modules/pandemonium": {
+			"version": "2.4.1",
+			"resolved": "https://registry.npmmirror.com/pandemonium/-/pandemonium-2.4.1.tgz",
+			"integrity": "sha512-wRqjisUyiUfXowgm7MFH2rwJzKIr20rca5FsHXCMNm1W5YPP1hCtrZfgmQ62kP7OZ7Xt+cR858aB28lu5NX55g==",
+			"license": "MIT",
+			"dependencies": {
+				"mnemonist": "^0.39.2"
+			}
 		},
 		"node_modules/parse-entities": {
 			"version": "4.0.2",
@@ -16081,6 +16188,21 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/yaml": {
+			"version": "2.9.0",
+			"resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.9.0.tgz",
+			"integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
 		},
 		"node_modules/yargs": {
 			"version": "17.7.2",


### PR DESCRIPTION
## 背景

L2 Wiki 是 Inno Agent 的持久知识记忆层，负责把学习资料转化为结构化 Wiki 页面供 Agent 检索。原实现的检索为朴素子串匹配、摄入为单段抽取且更新时仅追加引用。本 PR 从独立项目 llm_wiki 借鉴算法设计，对 L2 进行全面升级。**所有改动严格隔离于 L2 层**，不跨层共享数据（L2 拥有独立的 SQLite 检索索引，与 L3 的会话历史索引完全分开）。

> 向量/语义检索作为独立 PR 提交（含设置界面），不在本 PR 范围。本 PR 的检索为「BM25 词法 + 图扩展」。

---

## 变更详情

### 1. Frontmatter 解析器重构（`wiki-maintainer.ts`）
- 用 `yaml` 库替换手写逐行正则解析/序列化，消除特殊字符/嵌套等边界情况下的脆弱性
- 保持历史 key 顺序与 flow-sequence tags 格式，对现有页面保持 parse→serialize 幂等，尽量减少 diff churn
- 新增依赖：`yaml ^2.6.1`

### 2. 统一 `[[链接]]` 解析器（`wiki-links.ts`，新文件）
- `normalizeWikiLink`：全角/半角、大小写、空格归一化
- `stripParenthetical`：去括号后缀（例如把带全称括号的链接解析到简称页面）
- `buildAliasIndex`：多别名索引，含歧义防误合（两页面归一化冲突时均不解析，避免张冠李戴）
- 图可视化与检索图扩展共用同一解析器，消除两处解析逻辑漂移

### 3. 知识图谱重构（`wiki-graph.ts`，新文件）
- `/api/wiki/graph` 返回结构向后兼容扩展为 `{nodes, edges, maintenance, communities}`（原有 `nodes`/`edges` 字段与含义不变，前端无需改动）
- 每个页面节点新增 `degree`（已解析链接度）和 `community`（Louvain 社区 ID）
- **Louvain 社区检测**（via `graphology` + `graphology-communities-louvain`），附带模块度与每社区内聚度，低内聚社区自动标记
- **四类图维护信号**：`missing`（断链）/ `orphans`（孤立页）/ `duplicates`（标题归一化后疑似重复）/ `contested`（争议页）
- overview 页面从图谱中排除（否则它会作为"连接一切"的伪中心节点，并因自身链接抬高被引节点度数、与"按度数生成 overview"形成反馈循环）
- `server.ts` `/api/wiki/graph` 内联图构建重构为调用 `buildWikiGraph`，删除重复代码
- 新增依赖：`graphology ^0.26.0`、`graphology-communities-louvain ^2.0.2`

### 4. L2 检索索引（`l2-index-store.ts`、`l2-indexer.ts`，新文件）
- 独立 SQLite 数据库（`data/l2/index.db`），不触碰 L3 的 `memory.db`
- 复用 L3 的 `segmentForFts` 中文 bigram 分词，保证 index/query 分词一致
- Schema：`pages`（标题/类型/标签/body/hash）+ `pages_fts`（FTS5/BM25）+ `index_state`（增量跳过）
- `indexAllPages` 幂等，兼作一次性全量回填，并清理已删除页面的 stale 行
- 应用启动时 `L2Memory.backfill()` 自动运行，不阻塞启动

### 5. 检索管线（`l2-search.ts`，新文件）
替换原有朴素子串匹配：
1. **词法检索（FTS5/BM25）**：中文 bigram 分词，标题/标签/正文全文索引，按 rank 衰减打基础分
2. **1 跳图扩展**（种子取词法结果 top-N）：直链 ×0.5、同源重叠 ×0.4、Adamic-Adar ×0.3（共享邻居按度加权）、类型亲和 ×0.1

`queryWikiHybrid` 保持与原 `queryWiki` 相同的输出格式；SQLite 不可用（Node < 22.5）时自动回退子串检索。

### 6. L2Memory 持有者（`l2-memory.ts`，新文件）
- `getL2Memory(dir)` 按目录单例：Agent 扩展与 HTTP server 进程内共用一个句柄
- 懒加载，node:sqlite 不可用时优雅降级为 null
- 索引同步点：`l2_archive` 归档后 / `PUT /api/wiki/page` 保存后 / `DELETE /api/wiki/page` 删除后

### 7. Overview 自动生成（`overview.ts`，新文件）
- `wiki/analysis/overview.md`（type: analysis）在每次归档末尾 fire-and-forget 重生成
- 内容：各类型页面计数、社区数/模块度、按关联度排序的核心节点、**维护建议**（断链/孤立/重复/争议清单）
- 有模型时附 LLM 叙述段；无模型时仅确定性内容
- `try/catch` 包裹，任何失败不影响归档主流程

### 8. 两段式 CoT 摄入（`wiki-linker.ts`）
- **Stage 1（规划）**：读取候选实体/概念页面的现有 `## 定义`，发给 LLM 生成 create/update 计划（含融合后的 `definition` 与可选 `contradiction`）
- **Stage 2（执行）**：update 操作只替换 `## 定义` 段，保留其余段落，保证手工编辑不丢失
- **矛盾检测**：冲突时双方页面置 `contested: true`、互加 `contradictions[]`、追加 `## 争议` 段（含来源归因），正式激活原本声明但从未写入的字段
- `WikiLinkMaintenanceResult` 新增 `contested: string[]`
- 用 `mutateFrontmatter`（parse→mutate→serialize，走 yaml 库）替换手写正则的数组增量逻辑
- **无模型兜底**：退化为原有非破坏性追加引用行为

---

## 降级保证

| 条件 | 降级行为 |
|---|---|
| Node < 22.5（无 node:sqlite） | L2 索引禁用，`l2_query` 回退子串匹配，归档仍正常写页面 |
| Overview 生成失败 | try/catch，归档不受影响 |
| 无 LLM 模型（离线） | CoT 规划跳过，回退原有追加逻辑 |

## 数据兼容性
- Frontmatter 从手写正则切到 yaml 库，签名与输出格式保持不变，现有页面读取无损；页面仅在被新归档触及时才按新格式重写（`## 定义` 合并只替换该段）
- `index.db` 为派生产物，首次启动 backfill 自动建立，无需迁移脚本
- `wiki/analysis/overview.md` 首次 backfill 时自动生成

## 测试
- `npm run build` 通过（TypeScript + Vite）
- 无正式测试框架，建议评审关注点：
  - Frontmatter parse→serialize 幂等性
  - SQLite 不可用 / 无模型两条降级路径
  - 两段式摄入的正文合并与矛盾检测（需接入模型做端到端验证）