### PR TITLE
fix(web): sidebar filter row overflow + Done button hover blank

### DIFF
--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -289,6 +289,14 @@ inno-workspace-panel textarea {
 	background-clip: padding-box;
 }
 
+/* Horizontal chip rows (sidebar channel filters): scroll without a visible scrollbar. */
+.chip-scroll {
+	scrollbar-width: none;
+}
+.chip-scroll::-webkit-scrollbar {
+	display: none;
+}
+
 /* Office previews: make injected SVG / docx pages fit the preview width. */
 /* pptx: the converter emits <svg width="960" height="540">; override so it
    scales to the slide card instead of overflowing at its intrinsic size. */

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -1054,21 +1054,25 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 				{/* Channel filters + workspace ordering — hidden in Simple Mode. */}
 				{!simpleMode && (
 					<div className="relative flex items-center gap-1">
-						{state.availableChannels.length > 1 ? orderedChannels.map((ch) => (
-							<button
-								key={ch}
-								className={`inno-channel-filter-chip inno-sidebar-meta rounded-full px-1.5 py-px font-medium transition-colors ${channelFilterClass(ch, state.channelFilter === ch)}`}
-								onClick={() => sessionsStore.setChannelFilter(state.channelFilter === ch ? null : ch)}
-							>
-								{channelLabel(ch)}
-							</button>
-						)) : null}
-						{state.availableChannels.length > 1 ? <button
-							className={`inno-channel-filter-chip inno-sidebar-meta rounded-full px-1.5 py-px font-medium transition-colors ${channelFilterClass(null, state.channelFilter === null)}`}
-							onClick={() => sessionsStore.setChannelFilter(null)}
-						>
-							{t("sidebar.all")}
-						</button> : null}
+						{state.availableChannels.length > 1 ? (
+							<div className="chip-scroll flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+								<button
+									className={`inno-channel-filter-chip inno-sidebar-meta shrink-0 whitespace-nowrap rounded-full px-1.5 py-px font-medium transition-colors ${channelFilterClass(null, state.channelFilter === null)}`}
+									onClick={() => sessionsStore.setChannelFilter(null)}
+								>
+									{t("sidebar.all")}
+								</button>
+								{orderedChannels.map((ch) => (
+									<button
+										key={ch}
+										className={`inno-channel-filter-chip inno-sidebar-meta shrink-0 whitespace-nowrap rounded-full px-1.5 py-px font-medium transition-colors ${channelFilterClass(ch, state.channelFilter === ch)}`}
+										onClick={() => sessionsStore.setChannelFilter(state.channelFilter === ch ? null : ch)}
+									>
+										{channelLabel(ch)}
+									</button>
+								))}
+							</div>
+						) : null}
 						<div className="ml-auto flex shrink-0 items-center gap-1">
 							{isCustomSorting ? (
 								<>
@@ -1081,7 +1085,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 									</button>
 									<button
 										type="button"
-										className="inno-sidebar-meta rounded-md bg-[var(--inno-accent)] px-1.5 py-0.5 font-medium text-white transition-opacity hover:opacity-90"
+										className="inno-primary-button inno-sidebar-meta rounded-md px-1.5 py-0.5 font-medium"
 										onClick={finishCustomSort}
 									>
 										{t("common.done")}


### PR DESCRIPTION
## Summary
- Channel filter chips now scroll horizontally (hidden scrollbar) so the workspace sort button no longer squeezes the "All" chip; the sort button stays pinned outside the scroll area.
- "All" chip moved to the front of the filter row (before "web").
- Custom-sort "Done" button uses `.inno-primary-button`, fixing the innospark theme's global sidebar hover rule painting it white-on-white.

## Test plan
- [x] `npm run build` passes (tsc + vite)
- [ ] Sidebar with multiple channels: chips scroll, sort button fixed
- [ ] Custom sort mode: hover Done button under innospark theme — no longer blanks out