### PR TITLE
feat(l2): L2 向量检索（语义召回）+ 设置界面

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -15,6 +15,7 @@ import { createSchedulerTools } from "../scheduler/scheduler-tools.js";
 import { createChannelTools } from "../channels/channel-tools.js";
 import { createL2Tools } from "../memory/l2/l2-tools.js";
 import { getL2Memory } from "../memory/l2/l2-memory.js";
+import { createEmbedder } from "../memory/l2/embeddings-client.js";
 import { L3Memory, createL3Tools, formatRecallForPrompt } from "../memory/l3/l3-tools.js";
 import { createPracticeTools } from "./practice-tools.js";
 import { createDocumentTools } from "./document-tools.js";
@@ -224,6 +225,7 @@ export function createInnoExtension(
 
 		// 4. Register L2 Wiki memory tools (gated on config.memory.l2Enabled)
 		const l2Memory = getL2Memory(paths.l2DataDir);
+		l2Memory.setEmbedderFactory(() => createEmbedder(configHolder.current.embedding));
 		const l2Tools = createL2Tools(paths.l2DataDir, isL2Enabled, l2Memory);
 		for (const tool of l2Tools) {
 			pi.registerTool(tool);

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -50,6 +50,20 @@ export interface InnoMemoryConfig {
 }
 
 /**
+ * Optional embedding endpoint for L2 wiki vector search. When set (both
+ * `baseUrl` and `model` present), L2 retrieval adds semantic vector recall
+ * fused with lexical BM25; when absent, L2 falls back to lexical + graph only.
+ * Any OpenAI-compatible `/v1/embeddings` endpoint works.
+ */
+export interface InnoEmbeddingConfig {
+	baseUrl: string;
+	apiKey: string;
+	model: string;
+	/** Optional expected vector dimension (informational). */
+	dim?: number;
+}
+
+/**
  * Simple Mode. A global, opt-in switch (default OFF) that turns Inno into a
  * streamlined, ready-to-use experience: it force-locks the L1/L2/L3 memory
  * layers OFF at runtime (without overwriting the user's memory preferences, so
@@ -149,6 +163,8 @@ export interface InnoConfig {
 	contentHub?: InnoContentHubConfig;
 	subagents?: InnoSubagentsConfig;
 	memory?: InnoMemoryConfig;
+	/** Optional embedding endpoint enabling L2 wiki vector search. */
+	embedding?: InnoEmbeddingConfig;
 	simpleMode?: InnoSimpleModeConfig;
 	ui?: {
 		theme: string;
@@ -238,6 +254,24 @@ export function normalizeSimpleModeConfig(simpleMode: Partial<InnoSimpleModeConf
 }
 
 /**
+ * Normalize the optional embedding config. Returns undefined (= vector search
+ * disabled) unless both `baseUrl` and `model` are present.
+ */
+export function normalizeEmbeddingConfig(
+	embedding: Partial<InnoEmbeddingConfig> | undefined,
+): InnoEmbeddingConfig | undefined {
+	const baseUrl = embedding?.baseUrl?.trim() ?? "";
+	const model = embedding?.model?.trim() ?? "";
+	if (!baseUrl || !model) return undefined;
+	return {
+		baseUrl,
+		apiKey: embedding?.apiKey?.trim() ?? "",
+		model,
+		...(typeof embedding?.dim === "number" && embedding.dim > 0 ? { dim: embedding.dim } : {}),
+	};
+}
+
+/**
  * Normalize the Content Hub config, filling missing fields from the built-in
  * public-hub defaults. `legacyGithubToken` lets us migrate the older
  * `config.github.token` (which only fed the skill library) into the hub token
@@ -298,6 +332,7 @@ export function normalizeConfig(config: LegacyInnoConfig): InnoConfig {
 		contentHub: normalizeContentHubConfig(config.contentHub, config.github?.token),
 		subagents: config.subagents,
 		memory: normalizeMemoryConfig(config.memory),
+		embedding: normalizeEmbeddingConfig(config.embedding),
 		simpleMode: normalizeSimpleModeConfig(config.simpleMode),
 		ui: config.ui,
 		ocrApi: config.ocrApi,

--- a/apps/inno-agent/src/memory/l2/embeddings-client.ts
+++ b/apps/inno-agent/src/memory/l2/embeddings-client.ts
@@ -1,0 +1,87 @@
+/**
+ * OpenAI-compatible embeddings client for L2 wiki vector search.
+ *
+ * `pi-ai` provides no embedding API (its providers are chat-only), so L2 talks
+ * directly to any `/v1/embeddings`-style endpoint via undici. Vectors are
+ * L2-normalized so cosine similarity reduces to a dot product downstream.
+ *
+ * All failures are swallowed into an empty result — embedding is best-effort
+ * and must never throw into the archive/query path. When no endpoint is
+ * configured, {@link createEmbedder} returns null and vector search is simply
+ * off (retrieval degrades to lexical + graph).
+ */
+
+import { request } from "undici";
+import { logger } from "../../logger.js";
+import type { InnoEmbeddingConfig } from "../../config.js";
+
+const REQUEST_TIMEOUT_MS = 30000;
+/** Max texts per request — keeps payloads sane for large backfills. */
+const BATCH_SIZE = 64;
+
+export interface Embedder {
+	readonly model: string;
+	/** Embed texts → one L2-normalized vector each; [] on any failure. */
+	embed(texts: string[]): Promise<Float32Array[]>;
+}
+
+function l2normalize(vec: number[]): Float32Array {
+	let norm = 0;
+	for (const x of vec) norm += x * x;
+	norm = Math.sqrt(norm) || 1;
+	const out = new Float32Array(vec.length);
+	for (let i = 0; i < vec.length; i++) out[i] = vec[i] / norm;
+	return out;
+}
+
+/**
+ * Build an embedder from config, or null when no embedding endpoint is set.
+ */
+export function createEmbedder(cfg: InnoEmbeddingConfig | undefined): Embedder | null {
+	if (!cfg || !cfg.baseUrl || !cfg.model) return null;
+	const endpoint = `${cfg.baseUrl.replace(/\/+$/, "")}/embeddings`;
+
+	async function embedBatch(texts: string[]): Promise<Float32Array[]> {
+		try {
+			const res = await request(endpoint, {
+				method: "POST",
+				headers: {
+					"content-type": "application/json",
+					...(cfg!.apiKey ? { authorization: `Bearer ${cfg!.apiKey}` } : {}),
+				},
+				body: JSON.stringify({ model: cfg!.model, input: texts }),
+				headersTimeout: REQUEST_TIMEOUT_MS,
+				bodyTimeout: REQUEST_TIMEOUT_MS,
+			});
+			if (res.statusCode < 200 || res.statusCode >= 300) {
+				const body = await res.body.text();
+				logger.warn({ status: res.statusCode, body: body.slice(0, 300) }, "[L2] embeddings request failed");
+				return [];
+			}
+			const json = (await res.body.json()) as { data?: { embedding?: number[]; index?: number }[] };
+			const data = json.data;
+			if (!Array.isArray(data)) return [];
+			// Preserve input order (respect `index` if present).
+			const ordered = [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+			return ordered.map((d) => l2normalize(Array.isArray(d.embedding) ? d.embedding : []));
+		} catch (err) {
+			logger.warn({ err }, "[L2] embeddings request error");
+			return [];
+		}
+	}
+
+	return {
+		model: cfg.model,
+		async embed(texts: string[]): Promise<Float32Array[]> {
+			if (texts.length === 0) return [];
+			const out: Float32Array[] = [];
+			for (let i = 0; i < texts.length; i += BATCH_SIZE) {
+				const batch = texts.slice(i, i + BATCH_SIZE);
+				const vecs = await embedBatch(batch);
+				if (vecs.length !== batch.length) return []; // partial failure → treat as failure
+				out.push(...vecs);
+			}
+			return out;
+		},
+	};
+}

--- a/apps/inno-agent/src/memory/l2/l2-index-store.ts
+++ b/apps/inno-agent/src/memory/l2/l2-index-store.ts
@@ -4,7 +4,8 @@
  * A SEPARATE database from L3 (`index.db` here vs L3's `memory.db`): L2 indexes
  * durable wiki *pages* (knowledge), L3 indexes past *conversations* — different
  * corpora, kept isolated. This store provides lexical (FTS5/BM25) retrieval
- * over pages (see l2-search.ts).
+ * over pages and holds an `embeddings` table for optional vector search
+ * (see l2-search.ts).
  *
  * Reuses {@link segmentForFts} from the L3 store so index/query CJK bigram
  * tokenization stays identical across both layers. Degrades to null on
@@ -27,7 +28,7 @@ export interface L2PageDoc {
 	tags: string[];
 	sourceIds: string[];
 	body: string;
-	/** sha256[:16] of the raw page file — detects staleness for incremental reindex. */
+	/** sha256[:16] of the raw page file — detects staleness for re-embedding. */
 	contentHash: string;
 	mtimeMs: number;
 }
@@ -50,6 +51,15 @@ export interface L2LexHit {
 	tags: string[];
 	sourceIds: string[];
 	bm25: number;
+}
+
+/** A stored embedding row. */
+export interface L2EmbeddingRow {
+	path: string;
+	dim: number;
+	vec: Float32Array;
+	model: string;
+	contentHash: string;
 }
 
 // node:sqlite has no stable public type export across Node versions; we keep
@@ -89,6 +99,20 @@ function parseJsonArray(value: unknown): string[] {
 	}
 }
 
+/** Copy a sqlite BLOB (Uint8Array/Buffer) into a fresh Float32Array. */
+function blobToFloat32(v: unknown): Float32Array {
+	if (v instanceof Uint8Array) {
+		const u8 = Uint8Array.from(v); // copy → buffer aligned at offset 0
+		return new Float32Array(u8.buffer, 0, Math.floor(u8.byteLength / 4));
+	}
+	return new Float32Array(0);
+}
+
+/** Serialize a Float32Array to a Buffer for BLOB storage (copy to be safe). */
+function float32ToBlob(vec: Float32Array): Buffer {
+	return Buffer.from(new Uint8Array(vec.buffer, vec.byteOffset, vec.byteLength));
+}
+
 const SCHEMA = `
 CREATE TABLE IF NOT EXISTS pages (
 	path TEXT PRIMARY KEY,
@@ -106,6 +130,17 @@ CREATE TABLE IF NOT EXISTS pages (
 CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
 	tokens,
 	tokenize='unicode61'
+);
+
+-- Optional vector search. content_hash detects staleness; model detects a
+-- provider/model switch that requires re-embedding.
+CREATE TABLE IF NOT EXISTS embeddings (
+	path TEXT PRIMARY KEY,
+	dim INTEGER NOT NULL,
+	vec BLOB NOT NULL,
+	model TEXT NOT NULL,
+	content_hash TEXT NOT NULL,
+	FOREIGN KEY(path) REFERENCES pages(path) ON DELETE CASCADE
 );
 
 -- Tracks how far each page file has been indexed (incremental skip).
@@ -152,11 +187,11 @@ export class L2IndexStore {
 		}
 	}
 
-	/** Insert or replace a page and its FTS row. */
+	/** Insert or replace a page and its FTS row; drop stale embedding on change. */
 	upsertPage(doc: L2PageDoc): void {
 		const existing = this.db
-			.prepare("SELECT rowid FROM pages WHERE path = ?")
-			.get(doc.path) as { rowid?: number } | undefined;
+			.prepare("SELECT rowid, content_hash FROM pages WHERE path = ?")
+			.get(doc.path) as { rowid?: number; content_hash?: string } | undefined;
 
 		const tokens = segmentForFts([doc.title, doc.tags.join(" "), doc.body].join(" "));
 		const tagsJson = JSON.stringify(doc.tags);
@@ -171,6 +206,9 @@ export class L2IndexStore {
 				.run(doc.title, doc.type, tagsJson, idsJson, doc.body, doc.contentHash, doc.mtimeMs, now, doc.path);
 			this.db.prepare("DELETE FROM pages_fts WHERE rowid = ?").run(existing.rowid);
 			this.db.prepare("INSERT INTO pages_fts(rowid, tokens) VALUES (?, ?)").run(existing.rowid, tokens);
+			if (existing.content_hash !== doc.contentHash) {
+				this.db.prepare("DELETE FROM embeddings WHERE path = ?").run(doc.path);
+			}
 			return;
 		}
 
@@ -196,7 +234,7 @@ export class L2IndexStore {
 		}
 	}
 
-	/** Remove a page, its FTS row, and index state. */
+	/** Remove a page, its FTS row, its embedding (via cascade), and index state. */
 	deletePage(path: string): void {
 		const row = this.db.prepare("SELECT rowid FROM pages WHERE path = ?").get(path) as
 			| { rowid?: number }
@@ -206,7 +244,7 @@ export class L2IndexStore {
 			if (row && typeof row.rowid === "number") {
 				this.db.prepare("DELETE FROM pages_fts WHERE rowid = ?").run(row.rowid);
 			}
-			this.db.prepare("DELETE FROM pages WHERE path = ?").run(path);
+			this.db.prepare("DELETE FROM pages WHERE path = ?").run(path); // cascade → embeddings
 			this.db.prepare("DELETE FROM index_state WHERE path = ?").run(path);
 			this.db.exec("COMMIT");
 		} catch (err) {
@@ -257,6 +295,46 @@ export class L2IndexStore {
 			tags: parseJsonArray(r.tags),
 			sourceIds: parseJsonArray(r.source_ids),
 			body: String(r.body),
+		}));
+	}
+
+	/** All stored embeddings (in-memory cosine at personal scale). */
+	getEmbeddings(): L2EmbeddingRow[] {
+		const rows = this.db.prepare("SELECT path, dim, vec, model, content_hash FROM embeddings").all();
+		return rows.map((r) => ({
+			path: String(r.path),
+			dim: Number(r.dim),
+			vec: blobToFloat32(r.vec),
+			model: String(r.model),
+			contentHash: String(r.content_hash),
+		}));
+	}
+
+	upsertEmbedding(path: string, dim: number, vec: Float32Array, model: string, contentHash: string): void {
+		this.db
+			.prepare(
+				`INSERT INTO embeddings(path, dim, vec, model, content_hash) VALUES (?, ?, ?, ?, ?)
+				 ON CONFLICT(path) DO UPDATE SET
+				   dim = excluded.dim, vec = excluded.vec, model = excluded.model, content_hash = excluded.content_hash`,
+			)
+			.run(path, dim, float32ToBlob(vec), model, contentHash);
+	}
+
+	/** Pages that need (re)embedding for the given model: missing, stale, or wrong model. */
+	getPagesMissingEmbedding(model: string): { path: string; title: string; body: string; contentHash: string }[] {
+		const rows = this.db
+			.prepare(
+				`SELECT p.path AS path, p.title AS title, p.body AS body, p.content_hash AS content_hash
+				 FROM pages p
+				 LEFT JOIN embeddings e ON e.path = p.path
+				 WHERE e.path IS NULL OR e.content_hash != p.content_hash OR e.model != ?`,
+			)
+			.all(model);
+		return rows.map((r) => ({
+			path: String(r.path),
+			title: String(r.title),
+			body: String(r.body),
+			contentHash: String(r.content_hash),
 		}));
 	}
 

--- a/apps/inno-agent/src/memory/l2/l2-memory.ts
+++ b/apps/inno-agent/src/memory/l2/l2-memory.ts
@@ -2,8 +2,8 @@
  * L2 wiki memory holder.
  *
  * Owns the lazily-opened {@link L2IndexStore} singleton for a data dir and keeps
- * the index in sync with the wiki pages on disk. Retrieval (lexical + graph) is
- * layered on in l2-search.ts and exposed via {@link L2Memory.search}.
+ * the index in sync with the wiki pages on disk. Retrieval (lexical + vector +
+ * graph) is layered on in l2-search.ts and exposed via {@link L2Memory.search}.
  *
  * Everything degrades to a no-op when node:sqlite is unavailable so the agent
  * keeps working on older runtimes (the query tool falls back to substring
@@ -20,13 +20,36 @@ import { openL2IndexStore, type L2IndexStore } from "./l2-index-store.js";
 import { indexAllPages, indexPage, removePageFromIndex } from "./l2-indexer.js";
 import { searchL2, type L2SearchResult } from "./l2-search.js";
 import { regenerateOverview, OVERVIEW_PATH } from "./overview.js";
+import type { Embedder } from "./embeddings-client.js";
+
+/** Max chars of (title + body) fed to the embedder per page. */
+const EMBED_MAX_CHARS = 8000;
+
+function embedText(title: string, body: string): string {
+	const t = `${title}\n\n${body}`.trim();
+	return t.length > EMBED_MAX_CHARS ? t.slice(0, EMBED_MAX_CHARS) : t;
+}
 
 export class L2Memory {
 	private store: L2IndexStore | null = null;
 	private opened = false;
 	private backfilled = false;
+	private embedderFactory: (() => Embedder | null) | null = null;
 
 	constructor(private readonly l2DataDir: string) {}
+
+	/**
+	 * Provide a factory that builds the current embedder from config (called by
+	 * the agent extension, which owns the config holder). Vector search is off
+	 * until this is set and the factory returns a non-null embedder.
+	 */
+	setEmbedderFactory(fn: () => Embedder | null): void {
+		this.embedderFactory = fn;
+	}
+
+	getEmbedder(): Embedder | null {
+		return this.embedderFactory ? this.embedderFactory() : null;
+	}
 
 	private async ensureStore(): Promise<L2IndexStore | null> {
 		if (this.opened) return this.store;
@@ -59,6 +82,7 @@ export class L2Memory {
 		} catch (err) {
 			logger.warn({ err }, `[L2] backfill failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
+		await this.embedBackfill();
 
 		// Ensure an overview page exists (deterministic core; an LLM narrative is
 		// added on the next archive, which has a model available).
@@ -69,6 +93,29 @@ export class L2Memory {
 			}
 		} catch (err) {
 			logger.warn({ err }, "[L2] overview bootstrap failed");
+		}
+	}
+
+	/**
+	 * Embed any pages missing a current-hash vector for the active model.
+	 * No-op when no embedder is configured or on any embedding failure.
+	 */
+	async embedBackfill(): Promise<void> {
+		const store = await this.ensureStore();
+		if (!store) return;
+		const embedder = this.getEmbedder();
+		if (!embedder) return;
+		try {
+			const missing = store.getPagesMissingEmbedding(embedder.model);
+			if (missing.length === 0) return;
+			const vecs = await embedder.embed(missing.map((p) => embedText(p.title, p.body)));
+			if (vecs.length !== missing.length) return; // embedding failed → leave as-is
+			for (let i = 0; i < missing.length; i++) {
+				store.upsertEmbedding(missing[i].path, vecs[i].length, vecs[i], embedder.model, missing[i].contentHash);
+			}
+			logger.info(`[L2] embedded ${missing.length} page(s).`);
+		} catch (err) {
+			logger.warn({ err }, `[L2] embed backfill failed: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	}
 
@@ -85,15 +132,15 @@ export class L2Memory {
 	}
 
 	/**
-	 * Search indexed pages (lexical BM25 + graph expansion). Returns null when
-	 * the index store is unavailable, so callers can fall back to the legacy
-	 * substring search.
+	 * Hybrid search over indexed pages (lexical + vector + graph). Returns null
+	 * when the index store is unavailable, so callers can fall back to the
+	 * legacy substring search.
 	 */
 	async search(query: string, limit = 5): Promise<L2SearchResult[] | null> {
 		const store = await this.ensureStore();
 		if (!store) return null;
 		try {
-			return await searchL2(store, query, { limit });
+			return await searchL2(store, query, { embedder: this.getEmbedder(), limit });
 		} catch (err) {
 			logger.warn({ err }, `[L2] search failed: ${err instanceof Error ? err.message : String(err)}`);
 			return null;

--- a/apps/inno-agent/src/memory/l2/l2-search.ts
+++ b/apps/inno-agent/src/memory/l2/l2-search.ts
@@ -1,6 +1,6 @@
 /**
- * L2 retrieval: lexical (BM25) candidate ranking, then one-hop graph expansion
- * over the wiki link graph.
+ * L2 hybrid retrieval: lexical (BM25) + vector (cosine) fused via Reciprocal
+ * Rank Fusion, then one-hop graph expansion over the wiki link graph.
  *
  * The graph signals mirror llm_wiki's relevance model, scaled down for a
  * personal-size wiki:
@@ -12,24 +12,25 @@
  *
  * Link resolution uses the shared alias index (wiki-links.ts) so retrieval and
  * the graph viz resolve `[[links]]` identically. Everything runs in-memory from
- * the index store; at personal scale (hundreds of short pages) this is cheap
- * and keeps ranking logic out of SQL.
+ * the index store (getAllPages / getEmbeddings); at personal scale (hundreds of
+ * short pages) this is cheap and keeps ranking logic out of SQL.
  */
 
 import { buildAliasIndex, extractOutgoingLinks, pageStem } from "./wiki-links.js";
 import { OVERVIEW_PATH } from "./wiki-graph.js";
+import type { Embedder } from "./embeddings-client.js";
 import type { L2IndexStore, L2PageMeta } from "./l2-index-store.js";
 
-/** Rank-decay constant for turning a lexical rank into a base score. */
-const RANK_DECAY_K = 60;
+const RRF_K = 60;
 const LEX_CANDIDATES = 30;
+const VEC_CANDIDATES = 30;
 const GRAPH_SEEDS = 8;
 const WEIGHT_DIRECT_LINK = 0.5;
 const WEIGHT_SOURCE_OVERLAP = 0.4;
 const WEIGHT_ADAMIC_ADAR = 0.3;
 const WEIGHT_TYPE_AFFINITY = 0.1;
 
-export type L2SearchSignal = "lexical" | "graph";
+export type L2SearchSignal = "lexical" | "vector" | "graph";
 
 export interface L2SearchResult {
 	path: string;
@@ -39,13 +40,22 @@ export interface L2SearchResult {
 	via: L2SearchSignal[];
 }
 
+function cosine(a: Float32Array, b: Float32Array): number {
+	// Both vectors are L2-normalized at store time / query time → dot product.
+	const n = Math.min(a.length, b.length);
+	let dot = 0;
+	for (let i = 0; i < n; i++) dot += a[i] * b[i];
+	return dot;
+}
+
 /**
- * Run the search: BM25 lexical candidates seed a one-hop graph expansion.
+ * Run the hybrid search. `embedder` is optional — when absent (or it fails),
+ * vector recall is skipped and results come from lexical + graph only.
  */
 export async function searchL2(
 	store: L2IndexStore,
 	query: string,
-	opts: { limit?: number } = {},
+	opts: { embedder?: Embedder | null; limit?: number } = {},
 ): Promise<L2SearchResult[]> {
 	const q = query.trim();
 	if (!q) return [];
@@ -70,19 +80,40 @@ export async function searchL2(
 	}
 	const degree = (path: string): number => adj.get(path)?.size ?? 0;
 
-	// ---- 1. lexical candidates → rank-decay base score ----
-	const base = new Map<string, number>();
+	// ---- 1. lexical ----
+	const lex = store.searchLexical(q, LEX_CANDIDATES);
+
+	// ---- 2. vector ----
+	let vec: { path: string; score: number }[] = [];
+	if (opts.embedder) {
+		const qv = await opts.embedder.embed([q]);
+		if (qv.length === 1 && qv[0].length > 0) {
+			const qvec = qv[0];
+			vec = store
+				.getEmbeddings()
+				.map((e) => ({ path: e.path, score: cosine(qvec, e.vec) }))
+				.sort((a, b) => b.score - a.score)
+				.slice(0, VEC_CANDIDATES);
+		}
+	}
+
+	// ---- 3. RRF fusion ----
+	const rrf = new Map<string, number>();
 	const via = new Map<string, Set<L2SearchSignal>>();
 	const addVia = (path: string, sig: L2SearchSignal) =>
 		(via.get(path) ?? via.set(path, new Set()).get(path)!).add(sig);
 
-	store.searchLexical(q, LEX_CANDIDATES).forEach((hit, rank) => {
-		base.set(hit.path, (base.get(hit.path) ?? 0) + 1 / (RANK_DECAY_K + rank));
+	lex.forEach((hit, rank) => {
+		rrf.set(hit.path, (rrf.get(hit.path) ?? 0) + 1 / (RRF_K + rank));
 		addVia(hit.path, "lexical");
 	});
+	vec.forEach((hit, rank) => {
+		rrf.set(hit.path, (rrf.get(hit.path) ?? 0) + 1 / (RRF_K + rank));
+		addVia(hit.path, "vector");
+	});
 
-	// ---- 2. one-hop graph expansion from top lexical seeds ----
-	const seeds = [...base.entries()].sort((a, b) => b[1] - a[1]).slice(0, GRAPH_SEEDS);
+	// ---- 4. one-hop graph expansion from top fused seeds ----
+	const seeds = [...rrf.entries()].sort((a, b) => b[1] - a[1]).slice(0, GRAPH_SEEDS);
 	const graph = new Map<string, number>();
 	const bump = (path: string, amount: number) => {
 		graph.set(path, (graph.get(path) ?? 0) + amount);
@@ -128,12 +159,12 @@ export async function searchL2(
 		}
 	}
 
-	// ---- 3. combine + rank ----
+	// ---- 5. combine + rank ----
 	const finalScore = new Map<string, number>();
-	for (const [path, s] of base) finalScore.set(path, (finalScore.get(path) ?? 0) + s);
+	for (const [path, s] of rrf) finalScore.set(path, (finalScore.get(path) ?? 0) + s);
 	for (const [path, s] of graph) finalScore.set(path, (finalScore.get(path) ?? 0) + s);
 
-	return [...finalScore.entries()]
+	const results: L2SearchResult[] = [...finalScore.entries()]
 		.map(([path, score]) => {
 			const p = byPath.get(path);
 			return {
@@ -147,4 +178,6 @@ export async function searchL2(
 		.filter((r) => byPath.has(r.path))
 		.sort((a, b) => b.score - a.score)
 		.slice(0, limit);
+
+	return results;
 }

--- a/apps/inno-agent/src/memory/l2/l2-tools.ts
+++ b/apps/inno-agent/src/memory/l2/l2-tools.ts
@@ -188,10 +188,11 @@ export function createL2Tools(
 			const allEntries = readManifest(l2DataDir);
 			rebuildIndex(l2DataDir, allEntries);
 
-			// Keep the retrieval index in sync with the touched pages.
+			// Keep the retrieval index in sync; embed new/changed pages (no-op without endpoint).
 			for (const wikiPath of entry.wikiPages) {
 				await l2Memory.indexPageByPath(wikiPath);
 			}
+			await l2Memory.embedBackfill();
 
 			// Regenerate the knowledge-base overview (best-effort; never fails archive).
 			try {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -579,6 +579,9 @@ function buildSafeSettings() {
 				baseUrl: config.ocrApi.baseUrl,
 			}
 			: undefined,
+		embedding: config.embedding
+			? { ...config.embedding, apiKey: maskSecret(config.embedding.apiKey) }
+			: undefined,
 		contentHub: config.contentHub
 			? { ...config.contentHub, token: maskSecret(config.contentHub.token) }
 			: undefined,
@@ -4120,6 +4123,27 @@ const server = createServer(async (req, res) => {
 			}
 			config = saveConfig(paths.configPath, config);
 			syncConfig(config);
+			json(res, 200, buildSafeSettings());
+			return;
+		}
+
+		// --- Embedding settings (optional vector search for L2 wiki) ---
+		if (method === "PUT" && url === "/api/settings/embedding") {
+			const body = (await readBody(req)) as Record<string, unknown>;
+			const str = (key: string): string => (typeof body[key] === "string" ? (body[key] as string).trim() : "");
+			const baseUrl = str("baseUrl");
+			const model = str("model");
+			// A masked value (e.g. "****abcd") means "keep the existing apiKey".
+			const incomingKey = str("apiKey");
+			const apiKey = incomingKey.startsWith("****") ? (config.embedding?.apiKey ?? "") : incomingKey;
+			// Both baseUrl and model are required to enable; otherwise clear it.
+			config.embedding = baseUrl && model ? { baseUrl, apiKey, model } : undefined;
+			config = saveConfig(paths.configPath, config);
+			syncConfig(config);
+			// Embed existing pages against the new endpoint in the background
+			// (shares the same per-dir L2Memory the agent configured). No-op when
+			// cleared or when the endpoint is unreachable.
+			if (config.embedding) void getL2Memory(l2DataDir).embedBackfill();
 			json(res, 200, buildSafeSettings());
 			return;
 		}

--- a/apps/inno-agent/web/src/api/settings.ts
+++ b/apps/inno-agent/web/src/api/settings.ts
@@ -79,6 +79,19 @@ export async function saveOcrSettings(payload: OcrSettingsPayload): Promise<Inno
 	});
 }
 
+export interface EmbeddingSettingsPayload {
+	baseUrl: string;
+	apiKey: string;
+	model: string;
+}
+
+export async function saveEmbeddingSettings(payload: EmbeddingSettingsPayload): Promise<InnoSettings> {
+	return apiFetch<InnoSettings>("/api/settings/embedding", {
+		method: "PUT",
+		body: JSON.stringify(payload),
+	});
+}
+
 export interface ContentHubPayload {
 	type: "github" | "bundle";
 	owner?: string;

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -411,6 +411,16 @@
 			"saved": "Saved",
 			"clear": "Clear"
 		},
+		"embedding": {
+			"title": "Vector search (L2 semantic retrieval)",
+			"desc": "Optional. Point at any OpenAI-compatible /v1/embeddings endpoint to add semantic vector recall on top of lexical search for the L2 wiki. Leave empty for lexical + graph only.",
+			"unset": "Not configured",
+			"baseUrlPlaceholder": "https://api.example.com/v1",
+			"modelPlaceholder": "text-embedding-3-small",
+			"apiKeyPlaceholder": "API key (optional)",
+			"saved": "Saved",
+			"clear": "Clear"
+		},
 		"form": {
 			"providerId": "Provider id",
 			"baseUrl": "Base URL",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -411,6 +411,16 @@
 			"saved": "已保存",
 			"clear": "清除"
 		},
+		"embedding": {
+			"title": "向量检索 (L2 语义检索)",
+			"desc": "可选。配置任意 OpenAI 兼容的 /v1/embeddings 端点后，L2 知识库检索会在词法基础上叠加语义向量召回。留空则仅用词法+图检索。",
+			"unset": "未配置",
+			"baseUrlPlaceholder": "https://api.example.com/v1",
+			"modelPlaceholder": "text-embedding-3-small",
+			"apiKeyPlaceholder": "API Key (可选)",
+			"saved": "已保存",
+			"clear": "清除"
+		},
 		"form": {
 			"providerId": "提供方 ID",
 			"baseUrl": "Base URL",

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Trash2, Pencil, X, ChevronDown, ChevronRight, Plus, QrCode as QrCodeIcon, CheckCircle, Wifi, WifiOff, Database, KeyRound } from "lucide-react";
+import { Trash2, Pencil, X, ChevronDown, ChevronRight, Plus, QrCode as QrCodeIcon, CheckCircle, Wifi, WifiOff, Database, KeyRound, Sparkles } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { getWikiStats } from "../api/wiki.js";
 import { settingsStore } from "../stores/settings-store.js";
@@ -1029,6 +1029,136 @@ function OcrSettings({ settings }: { settings: InnoSettings }) {
 	);
 }
 
+/* ---------- Embedding Settings (optional vector search for L2 wiki) ---------- */
+
+function EmbeddingSettings({ settings }: { settings: InnoSettings }) {
+	const { t } = useTranslation();
+	const embedding = settings.embedding;
+	const [open, setOpen] = useState(false);
+	const [baseUrl, setBaseUrl] = useState("");
+	const [model, setModel] = useState("");
+	const [apiKey, setApiKey] = useState("");
+	const [saving, setSaving] = useState(false);
+	const [saved, setSaved] = useState(false);
+
+	const maskedKey = embedding?.apiKey ?? "";
+	const hasExisting = Boolean(embedding?.baseUrl && embedding?.model);
+	const [keyDirty, setKeyDirty] = useState(false);
+
+	useEffect(() => {
+		setBaseUrl(embedding?.baseUrl ?? "");
+		setModel(embedding?.model ?? "");
+		setApiKey("");
+		setKeyDirty(false);
+		setSaved(false);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [embedding?.baseUrl, embedding?.model, maskedKey]);
+
+	const dirty = keyDirty || baseUrl !== (embedding?.baseUrl ?? "") || model !== (embedding?.model ?? "");
+	const canSave = baseUrl.trim().length > 0 && model.trim().length > 0;
+
+	async function handleSave() {
+		setSaving(true);
+		setSaved(false);
+		try {
+			await settingsStore.saveEmbedding({
+				baseUrl: baseUrl.trim(),
+				model: model.trim(),
+				apiKey: keyDirty ? apiKey.trim() : maskedKey,
+			});
+			setSaved(true);
+			setApiKey("");
+			setKeyDirty(false);
+		} catch {
+			// error surfaced via store
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function handleClear() {
+		setSaving(true);
+		setSaved(false);
+		try {
+			await settingsStore.saveEmbedding({ baseUrl: "", model: "", apiKey: "" });
+			setSaved(true);
+			setApiKey("");
+			setKeyDirty(false);
+		} catch {
+			// error surfaced via store
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div className="min-w-0 rounded-lg bg-[var(--inno-surface)] p-4">
+			<button className="inno-settings-card-toggle flex w-full min-w-0 items-start gap-2 text-left" onClick={() => setOpen((v) => !v)}>
+				<Sparkles size={16} className="mt-0.5 shrink-0 text-[var(--inno-text)]" />
+				<div className="min-w-0 flex-1">
+					<h4 className="break-words text-sm font-medium text-[var(--inno-text)]">{t("settings.embedding.title", "向量检索 (L2 语义检索)")}</h4>
+					<p className="mt-1 max-w-full break-words text-xs leading-relaxed text-[var(--inno-text-muted)]">
+						{t("settings.embedding.desc", "可选。配置任意 OpenAI 兼容的 /v1/embeddings 端点后，L2 知识库检索会在词法基础上叠加语义向量召回。留空则仅用词法+图检索。")}
+					</p>
+					{!open && (
+						<p className="mt-1 break-all text-[11px] leading-relaxed text-[var(--inno-text-subtle)]">
+							{hasExisting ? `${embedding?.model} @ ${embedding?.baseUrl}` : t("settings.embedding.unset", "未配置")}
+						</p>
+					)}
+				</div>
+				<ChevronDown size={14} className={`mt-1 shrink-0 text-[var(--inno-text-subtle)] transition-transform ${open ? "rotate-180" : ""}`} />
+			</button>
+
+			{open ? (
+				<div className="mt-3 grid gap-2.5">
+					<div className="grid min-w-0 gap-2">
+						<input
+							className={inputCls}
+							value={baseUrl}
+							onChange={(e) => { setBaseUrl(e.target.value); setSaved(false); }}
+							placeholder={t("settings.embedding.baseUrlPlaceholder", "https://api.example.com/v1") ?? ""}
+							autoComplete="off"
+						/>
+						<input
+							className={inputCls}
+							value={model}
+							onChange={(e) => { setModel(e.target.value); setSaved(false); }}
+							placeholder={t("settings.embedding.modelPlaceholder", "text-embedding-3-small") ?? ""}
+							autoComplete="off"
+						/>
+						<input
+							className={inputCls}
+							type="password"
+							value={apiKey}
+							onChange={(e) => { setApiKey(e.target.value); setKeyDirty(true); setSaved(false); }}
+							placeholder={maskedKey || (t("settings.embedding.apiKeyPlaceholder", "API Key (可选)") ?? "")}
+							autoComplete="off"
+						/>
+					</div>
+					<div className="flex min-w-0 flex-wrap items-center gap-2">
+						<button
+							disabled={saving || !dirty || !canSave}
+							onClick={() => void handleSave()}
+							className="flex h-8 shrink-0 items-center rounded-md inno-primary-button px-3 text-xs text-white disabled:opacity-50"
+						>
+							{saving ? t("common.loading") : saved ? t("settings.embedding.saved", "已保存") : t("common.save")}
+						</button>
+						{hasExisting && (
+							<button
+								disabled={saving}
+								onClick={() => void handleClear()}
+								className="flex h-8 shrink-0 items-center rounded-md border border-[var(--inno-border)] px-3 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+							>
+								{t("settings.embedding.clear", "清除")}
+							</button>
+						)}
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
 /* ---------- Memory Settings (L1/L2/L3 layer toggles) ---------- */
 
 type MemoryLayer = "l1Enabled" | "l2Enabled" | "l3Enabled";
@@ -1304,6 +1434,9 @@ export function SettingsPanel() {
 
 						{/* Memory Settings (L3 cross-conversation recall) */}
 						{state.settings && <MemorySettings settings={state.settings} />}
+
+						{/* Embedding (optional vector search for L2 wiki) */}
+						{state.settings && <EmbeddingSettings settings={state.settings} />}
 
 						{/* Content Hub (source for skill library + presets; subsumes the
 						    legacy GitHub token) */}

--- a/apps/inno-agent/web/src/stores/settings-store.ts
+++ b/apps/inno-agent/web/src/stores/settings-store.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "./event-emitter.js";
-import { getSettings, switchBackendModel, upsertProvider, deleteProviderApi, deleteModelApi, saveChannelsSettings, saveMemorySettings, saveSimpleModeSettings, saveGithubSettings, saveOcrSettings, saveContentHubSettings, type MemorySettingsPatch, type ContentHubPayload, type OcrSettingsPayload } from "../api/settings.js";
+import { getSettings, switchBackendModel, upsertProvider, deleteProviderApi, deleteModelApi, saveChannelsSettings, saveMemorySettings, saveSimpleModeSettings, saveGithubSettings, saveOcrSettings, saveEmbeddingSettings, saveContentHubSettings, type MemorySettingsPatch, type ContentHubPayload, type OcrSettingsPayload, type EmbeddingSettingsPayload } from "../api/settings.js";
 import type { InnoSettings, UpsertProviderRequest, ChannelsSettingsPayload } from "../types/settings.js";
 
 interface SettingsStoreEvents {
@@ -15,6 +15,7 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 	isSavingMemory = false;
 	isSavingGithub = false;
 	isSavingOcr = false;
+	isSavingEmbedding = false;
 	isSavingContentHub = false;
 	isSavingSimpleMode = false;
 	error: string | null = null;
@@ -183,6 +184,22 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 			throw err;
 		} finally {
 			this.isSavingOcr = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async saveEmbedding(payload: EmbeddingSettingsPayload): Promise<void> {
+		this.isSavingEmbedding = true;
+		this.error = null;
+		this.emit("change", undefined);
+		try {
+			this.settings = await saveEmbeddingSettings(payload);
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : "Failed to save embedding settings";
+			this.emit("change", undefined);
+			throw err;
+		} finally {
+			this.isSavingEmbedding = false;
 			this.emit("change", undefined);
 		}
 	}

--- a/apps/inno-agent/web/src/types/settings.ts
+++ b/apps/inno-agent/web/src/types/settings.ts
@@ -101,6 +101,11 @@ export interface InnoSettings {
 		token: string; // masked
 	};
 	memory?: { l1Enabled: boolean; l2Enabled: boolean; l3Enabled: boolean };
+	embedding?: {
+		baseUrl: string;
+		apiKey: string; // masked
+		model: string;
+	};
 	simpleMode?: { enabled: boolean };
 	ui?: { theme: string };
 }


### PR DESCRIPTION
## 背景

在 PR #90「L2 词法+图检索」的基础上，叠加**可选的向量语义召回**，并补齐**设置界面**让用户可视化配置 embedding 端点（解决"仅能手改 config.json、无 UI"的问题）。

> ⚠️ **Stacked PR**：base 为 `feat/l2-hybrid-retrieval`（PR #90），请在 #90 合并后再合本 PR，或合并时注意顺序。本 PR 的 diff 仅为向量增量。

---

## 为什么单独拆出

向量检索需要用户自备一个 embedding 服务，属于进阶可选能力。PR #90 保证了「无 embedding 也完整可用」（词法+图）。本 PR 把向量作为独立增量，并配套设置界面，使其成为一个"完整、可被用户开启"的功能，而非藏在配置文件里的半成品。

---

## 变更详情

### 后端

**嵌入客户端（`embeddings-client.ts`，新文件）**
- 支持任意 OpenAI 兼容 `/v1/embeddings` 端点（via `undici`）
- 向量 L2 归一化（cosine 化为点积）；批量请求（每批 64 条）
- 任何 HTTP/超时错误返回 `[]` 并 warn，**不抛进归档/检索路径**

**检索索引（`l2-index-store.ts`）**
- 新增 `embeddings` 表（`vec` BLOB / `model` / `content_hash`）+ `getEmbeddings` / `upsertEmbedding` / `getPagesMissingEmbedding`
- 页面内容变更（content_hash 变化）时删除对应 stale 向量，触发重嵌

**检索管线（`l2-search.ts`）**
- 恢复向量阶段：对查询做嵌入，与库内向量做 cosine
- **RRF 融合**（`K=60`）：把词法 rank 与向量 rank 合并，再进入图扩展

**L2Memory（`l2-memory.ts`）**
- `setEmbedderFactory` 注入 embedder 工厂（读 `config.embedding`）
- `embedBackfill`：为缺当前-hash 向量的页补嵌；归档后调用

**配置（`config.ts`）**
- 新增 `InnoEmbeddingConfig { baseUrl, apiKey, model, dim? }`
- `normalizeEmbeddingConfig`：缺 `baseUrl`/`model` 时返回 `undefined`（关闭）

**API（`server.ts`）**
- 新增 `PUT /api/settings/embedding`：保存配置；apiKey 支持掩码保留（`****` 表示沿用旧值）；保存后后台触发 `embedBackfill` 为存量页立即补嵌
- `GET /api/settings` 对 `embedding.apiKey` 脱敏（与 providers/ocrApi 一致）

### 前端

- **设置面板新增「向量检索」配置区**（`SettingsPanel.tsx`）：baseUrl / model / apiKey 三输入 + 保存/清除，位于「记忆设置」之后；未配置时显示"未配置"，已配置时显示 `model @ baseUrl`
- settings store 新增 `saveEmbedding`；api client 新增 `saveEmbeddingSettings`；`InnoSettings` 类型加 `embedding` 字段
- 中英 i18n 文案（`settings.embedding.*`）

---

## 降级保证

| 条件 | 行为 |
|---|---|
| 未配置 embedding | 向量透明关闭，检索退化为词法 + 图 |
| 端点故障 / 超时 | `embed()` 返回 `[]`，静默降级为词法 + 图 |
| apiKey 输入掩码值 | 沿用已保存的 key，不覆盖 |

## 数据 / 安全
- `embeddings` 表为派生数据，配置端点后由 backfill 自动填充；清除配置后向量不参与检索（表可保留，无害）
- `embedding.apiKey` 在 `/api/settings` 返回中脱敏

## 测试
- `npm run build` 通过（TypeScript + Vite），中英 locale JSON 合法
- 建议评审关注：
  - 未配置 / 配置后 两种检索路径
  - `/api/settings` 不泄露 `embedding.apiKey`；掩码保留逻辑
  - 设置界面保存后是否触发存量补嵌（需真实 embedding 端点做端到端验证）