### PR TITLE
fix(web): clear stale chat retry state

### DIFF
--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -554,6 +554,11 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.abortController?.abort();
 		this.abortController = null;
 		this.messages = [];
+		// Retry state belongs to the conversation being cleared. Keeping it
+		// would expose the previous conversation's Retry button on a new chat
+		// and could resend that old prompt into the newly-created session.
+		this.lastUserPrompt = null;
+		this.lastImages = undefined;
 		this.isSending = false;
 		this.streamingText = "";
 		this.streamingThinking = "";


### PR DESCRIPTION
## What changed

- Clear the previous prompt and attached images when conversation state is reset.
- Remove the stale Retry action when starting or switching to an empty conversation.

## Why

Clearing messages reset the visible conversation but retained `lastUserPrompt` and `lastImages`, so the Retry action could resend content from the previous conversation.

## Impact

Starting a new conversation no longer exposes or retries the previous conversation's prompt and images.

## Validation

- `npm run build`
- `git diff --check`
