### PR TITLE
fix(chat): 修复会话流恢复、精确取消与跨会话状态隔离

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.test.ts
+++ b/apps/inno-agent/src/agent/pi-runner.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+import { finalizePromptRun, type PromptRunLifecycle, type PromptRunOutcome } from "./pi-runner.js";
+
+const completed: PromptRunOutcome = { type: "completed", fullText: "ok" };
+
+describe("prompt run finalization", () => {
+	it("waits for onFinish before resolving the finalization boundary", async () => {
+		let release!: () => void;
+		const gate = new Promise<void>((resolve) => { release = resolve; });
+		let resolved = false;
+		const lifecycle: PromptRunLifecycle = {
+			onFinish: () => gate,
+			onFinalizeFailure: vi.fn(),
+		};
+		const finalizing = finalizePromptRun(completed, lifecycle).then(() => { resolved = true; });
+		await Promise.resolve();
+		expect(resolved).toBe(false);
+		release();
+		await finalizing;
+		expect(resolved).toBe(true);
+	});
+
+	it("runs forced finalization when the primary finalizer throws", async () => {
+		const failure = new Error("persistence failed");
+		const fallback = vi.fn().mockResolvedValue(undefined);
+		await finalizePromptRun(completed, {
+			onFinish: vi.fn().mockRejectedValue(failure),
+			onFinalizeFailure: fallback,
+		});
+		expect(fallback).toHaveBeenCalledWith(completed, failure);
+	});
+});

--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -12,7 +12,7 @@ import {
 	type ExtensionFactory,
 	type SessionStartEvent,
 } from "@earendil-works/pi-coding-agent";
-import { complete, type AssistantMessage, type ImageContent, type Model } from "@earendil-works/pi-ai";
+import { complete, type AssistantMessage, type ImageContent, type Model, type UserMessage } from "@earendil-works/pi-ai";
 import { basename, join, resolve } from "node:path";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createInnoExtension, type ConfigHolder, type InnoExtensionDeps } from "./inno-extension.js";
@@ -30,6 +30,7 @@ let _currentCwd = "";
 let _config: InnoConfig | null = null;
 let _configHolder: ConfigHolder | null = null;
 let _cwdResolver: ((sessionPath: string) => string | null) | null = null;
+let _activePromptToken: string | null = null;
 /** Provider IDs registered into the active model registry by Inno's config. */
 const _registeredProviderIds = new Set<string>();
 
@@ -57,11 +58,11 @@ function resolveCwdFor(sessionPath: string | null | undefined): string {
 	return _workspaceDir;
 }
 
-async function switchToSession(sessionPath: string, opts?: { force?: boolean }): Promise<void> {
+async function switchToSession(sessionPath: string, opts?: { force?: boolean; cwdOverride?: string }): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized");
 	const target = resolve(sessionPath);
 	const current = _runtime.session.sessionFile ? resolve(_runtime.session.sessionFile) : null;
-	const desiredCwd = resolveCwdFor(target);
+	const desiredCwd = opts?.cwdOverride ? resolve(opts.cwdOverride) : resolveCwdFor(target);
 	const needsPathSwitch = current !== target;
 	const needsCwdSwitch = desiredCwd !== _currentCwd;
 	if (!needsPathSwitch && !needsCwdSwitch && !opts?.force) return;
@@ -343,6 +344,13 @@ export async function abortCurrentPrompt(): Promise<void> {
 	}
 }
 
+/** Abort only when the caller owns the prompt currently executing in the PI runtime. */
+export async function abortPromptForTurnToken(token: string): Promise<boolean> {
+	if (!token || _activePromptToken !== token) return false;
+	await abortCurrentPrompt();
+	return true;
+}
+
 /**
  * Return current runtime session id.
  */
@@ -468,14 +476,12 @@ export function persistPendingUserTurn(expectedSessionId?: string): boolean {
 		// user message. If an assistant message already exists the SDK has (or
 		// will) flush normally, so there is nothing to rescue.
 		let lastMessageRole: string | undefined;
-		let hasAssistant = false;
 		for (const entry of entries) {
 			if (entry.type !== "message") continue;
 			const role = (entry as { message?: { role?: string } }).message?.role;
-			if (role === "assistant") hasAssistant = true;
 			lastMessageRole = role;
 		}
-		if (hasAssistant || lastMessageRole !== "user") return false;
+		if (lastMessageRole !== "user") return false;
 
 		const placeholder: AssistantMessage = {
 			role: "assistant",
@@ -499,6 +505,24 @@ export function persistPendingUserTurn(expectedSessionId?: string): boolean {
 	} catch (err) {
 		logger.warn({ err }, "persistPendingUserTurn failed (best-effort)");
 		// best-effort — never let a persistence hiccup break the abort path
+		return false;
+	}
+}
+
+/** Persist a queued turn that was cancelled before Session.prompt() received it. */
+export function persistCancelledQueuedTurn(prompt: string, expectedSessionId: string, images?: ImageContent[]): boolean {
+	try {
+		const session = getSession();
+		if (!session.sessionFile || basename(session.sessionFile) !== expectedSessionId) return false;
+		const user: UserMessage = {
+			role: "user",
+			content: [{ type: "text", text: prompt }, ...(images ?? [])],
+			timestamp: Date.now(),
+		};
+		session.sessionManager.appendMessage(user);
+		return persistPendingUserTurn(expectedSessionId);
+	} catch (err) {
+		logger.warn({ err, expectedSessionId }, "persistCancelledQueuedTurn failed");
 		return false;
 	}
 }
@@ -814,69 +838,100 @@ export function runPromptStreamingInSession(
 	prompt: string,
 	onEvent: StreamEventCallback,
 	images?: ImageContent[],
+	lifecycle?: PromptRunLifecycle,
+	cwdOverride?: string,
 ): Promise<string> {
 	return enqueue(async () => {
-		await switchToSession(sessionPath);
-		const session = getSession();
 		let output = "";
 		let streamError: string | undefined;
-		const promptStartTime = Date.now();
-
-		// Observability: agent lifecycle + tool-call details
-		const promptObserver = createPromptObserver({ promptStartTime });
-		const obsUnsub = session.subscribe(promptObserver);
-
-		const unsubscribe = session.subscribe((event) => {
-			onEvent(event);
-			if (event.type === "message_update") {
-				const ev = event.assistantMessageEvent;
-				if (ev.type === "text_delta") {
-					output += ev.delta;
-				} else if (ev.type === "error") {
-					streamError = ev.error.errorMessage || `LLM API error (stopReason: ${ev.error.stopReason})`;
-					logger.error({ errorMessage: streamError, stopReason: ev.error.stopReason, sessionPath, elapsedMs: Date.now() - promptStartTime }, "LLM API stream error in runPromptStreamingInSession");
+		let outcome: PromptRunOutcome = { type: "error", error: new Error("Prompt did not start") };
+		try {
+			await switchToSession(sessionPath, { cwdOverride });
+			if (lifecycle?.shouldStart && !(await lifecycle.shouldStart())) {
+				outcome = { type: "aborted", reason: "cancelled_before_start", fullText: "" };
+			} else {
+				_activePromptToken = lifecycle?.token ?? null;
+				await lifecycle?.onStart?.();
+				const session = getSession();
+				const promptStartTime = Date.now();
+				const promptObserver = createPromptObserver({ promptStartTime });
+				const obsUnsub = session.subscribe(promptObserver);
+				const unsubscribe = session.subscribe((event) => {
+					onEvent(event);
+					if (event.type === "message_update") {
+						const ev = event.assistantMessageEvent;
+						if (ev.type === "text_delta") output += ev.delta;
+						else if (ev.type === "error") {
+							streamError = ev.error.errorMessage || `LLM API error (stopReason: ${ev.error.stopReason})`;
+							logger.error({ errorMessage: streamError, stopReason: ev.error.stopReason, sessionPath, elapsedMs: Date.now() - promptStartTime }, "LLM API stream error in runPromptStreamingInSession");
+						}
+					}
+				});
+				try {
+					await session.prompt(prompt, images?.length ? { images } : undefined);
+				} finally {
+					unsubscribe();
+					obsUnsub();
 				}
-			} else if (event.type === "auto_retry_start") {
-				obsLogger.warn({
-					event: "auto_retry_start",
-					attempt: event.attempt,
-					maxAttempts: event.maxAttempts,
-					delayMs: event.delayMs,
-					errorMessage: event.errorMessage,
-					elapsedMs: Date.now() - promptStartTime,
-				}, "LLM API call failed, auto-retrying...");
-			} else if (event.type === "auto_retry_end") {
-				if (event.success) {
-					obsLogger.info({
-						event: "auto_retry_end",
-						success: true,
-						attempt: event.attempt,
-					}, "LLM API auto-retry succeeded");
+				if (lifecycle?.isCancellationRequested?.()) {
+					outcome = { type: "aborted", reason: "cancelled", fullText: output.trim() };
+				} else if (streamError) {
+					outcome = { type: "error", error: new Error(streamError), fullText: output.trim() };
 				} else {
-					obsLogger.error({
-						event: "auto_retry_end",
-						success: false,
-						finalError: event.finalError,
-						elapsedMs: Date.now() - promptStartTime,
-					}, "LLM API auto-retry failed");
+					outcome = { type: "completed", fullText: output.trim() };
 				}
 			}
-		});
+		} catch (error) {
+			outcome = lifecycle?.isCancellationRequested?.()
+				? { type: "aborted", reason: "cancelled", error, fullText: output.trim() }
+				: { type: "error", error, fullText: output.trim() };
+		}
+
+		// Finalization is deliberately inside the enqueue slot. The active token
+		// remains bound until persistence confirmation, resource teardown and the
+		// unique terminal event have all completed.
 		try {
-			await session.prompt(prompt, images?.length ? { images } : undefined);
+			await finalizePromptRun(outcome, lifecycle, sessionPath);
 		} finally {
-			unsubscribe();
-			obsUnsub();
+			if (_activePromptToken === lifecycle?.token) _activePromptToken = null;
 		}
-
-		if (streamError) {
-			throw new Error(streamError);
-		}
-
-		if (!output.trim()) {
-			obsLogger.warn({ event: "empty_output", fn: "runPromptStreamingInSession", sessionPath }, "runPromptStreamingInSession returned empty output — the model may have produced no text or an API error may have been swallowed");
-		}
-
-		return output.trim();
+		if (outcome.type === "error") throw outcome.error instanceof Error ? outcome.error : new Error("Prompt failed");
+		return outcome.fullText ?? "";
 	});
+}
+
+export type PromptRunOutcome =
+	| { type: "completed"; fullText: string }
+	| { type: "error"; error: unknown; fullText?: string }
+	| { type: "aborted"; reason: string; error?: unknown; fullText?: string };
+
+export interface PromptRunLifecycle {
+	token?: string;
+	shouldStart?: () => boolean | Promise<boolean>;
+	isCancellationRequested?: () => boolean;
+	onStart?: () => void | Promise<void>;
+	onFinish: (outcome: PromptRunOutcome) => void | Promise<void>;
+	onFinalizeFailure: (outcome: PromptRunOutcome, error: unknown) => void | Promise<void>;
+}
+
+/** Complete primary/fallback finalization before the caller releases its queue slot. */
+export async function finalizePromptRun(
+	outcome: PromptRunOutcome,
+	lifecycle: PromptRunLifecycle | undefined,
+	sessionPath = "",
+): Promise<void> {
+	if (!lifecycle) return;
+	try {
+		await lifecycle.onFinish(outcome);
+	} catch (error) {
+		try {
+			await lifecycle.onFinalizeFailure(outcome, error);
+		} catch (finalizeError) {
+			try {
+				logger.error({ error, finalizeError, sessionPath }, "prompt finalization fallback failed");
+			} catch {
+				// Logging must not widen the serialized finalization boundary.
+			}
+		}
+	}
 }

--- a/apps/inno-agent/src/agent/question-bridge.test.ts
+++ b/apps/inno-agent/src/agent/question-bridge.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { QuestionBridge } from "./question-bridge.js";
+
+describe("QuestionBridge", () => {
+	it("validates session, turn and question ids and accepts only the first response", async () => {
+		const bridge = new QuestionBridge();
+		const events: Array<Record<string, unknown>> = [];
+		bridge.bindTurn({ sessionId: "s1", turnId: "t1", emit: (event) => events.push(event), timeoutMs: 10_000 });
+		const answerPromise = bridge.ask({ questions: [] });
+		const questionId = events[0].questionId as string;
+
+		expect(bridge.respond({ sessionId: "wrong", turnId: "t1", questionId, result: { answers: [], cancelled: false } })).toBe("scope_mismatch");
+		expect(bridge.respond({ sessionId: "s1", turnId: "t1", questionId, result: { answers: [], cancelled: false } })).toBe("accepted");
+		expect(bridge.respond({ sessionId: "s1", turnId: "t1", questionId, result: { answers: [], cancelled: false } })).toBe("already_resolved");
+		await expect(answerPromise).resolves.toEqual({ answers: [], cancelled: false });
+		expect(events.at(-1)).toMatchObject({ type: "question_resolved", questionId });
+	});
+
+	it("times out a pending question and releases it", async () => {
+		vi.useFakeTimers();
+		try {
+			const bridge = new QuestionBridge();
+			bridge.bindTurn({ sessionId: "s1", turnId: "t1", emit: () => {}, timeoutMs: 25 });
+			const answerPromise = bridge.ask({ questions: [] });
+			await vi.advanceTimersByTimeAsync(25);
+			await expect(answerPromise).resolves.toMatchObject({ cancelled: true, error: "timeout" });
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("does not carry a pending question into a different turn", async () => {
+		const bridge = new QuestionBridge();
+		const firstEvents: Array<Record<string, unknown>> = [];
+		bridge.bindTurn({ sessionId: "s1", turnId: "t1", emit: (event) => firstEvents.push(event), timeoutMs: 10_000 });
+		const firstAnswer = bridge.ask({ questions: [] });
+		const oldQuestionId = firstEvents[0].questionId as string;
+		bridge.bindTurn({ sessionId: "s2", turnId: "t2", emit: () => {}, timeoutMs: 10_000 });
+		await expect(firstAnswer).resolves.toMatchObject({ cancelled: true, error: "superseded" });
+		expect(bridge.respond({ sessionId: "s2", turnId: "t2", questionId: oldQuestionId, result: { answers: [], cancelled: false } })).toBe("not_found");
+	});
+});

--- a/apps/inno-agent/src/agent/question-bridge.ts
+++ b/apps/inno-agent/src/agent/question-bridge.ts
@@ -16,53 +16,83 @@ export interface QuestionBridgeResult {
 	error?: string;
 }
 
-type SseEmitter = (data: unknown) => void;
+interface TurnBinding {
+	sessionId: string;
+	turnId: string;
+	emit: (event: Record<string, unknown> & { type: string }) => void;
+	timeoutMs: number;
+}
 
 interface PendingQuestion {
 	questionId: string;
+	sessionId: string;
+	turnId: string;
 	resolve: (result: QuestionBridgeResult) => void;
+	timer: ReturnType<typeof setTimeout>;
 }
 
-class QuestionBridge {
-	private emitter: SseEmitter | null = null;
-	private pending: PendingQuestion | null = null;
+export type QuestionResponseStatus = "accepted" | "not_found" | "scope_mismatch" | "already_resolved";
 
-	setEmitter(fn: SseEmitter | null): void {
-		this.emitter = fn;
+export class QuestionBridge {
+	private binding: TurnBinding | null = null;
+	private pending: PendingQuestion | null = null;
+	private lastResolved: Pick<PendingQuestion, "questionId" | "sessionId" | "turnId"> | null = null;
+
+	bindTurn(binding: TurnBinding): void {
+		if (this.binding && (this.binding.sessionId !== binding.sessionId || this.binding.turnId !== binding.turnId)) {
+			this.unbindTurn({ ...this.binding, reason: "superseded" });
+		}
+		this.binding = binding;
 	}
 
 	ask(params: unknown): Promise<QuestionBridgeResult> {
-		if (!this.emitter) {
-			return Promise.resolve({ answers: [], cancelled: true, error: "no_ui" });
-		}
-
-		if (this.pending) {
-			this.pending.resolve({ answers: [], cancelled: true, error: "superseded" });
-			this.pending = null;
-		}
+		const binding = this.binding;
+		if (!binding) return Promise.resolve({ answers: [], cancelled: true, error: "no_ui" });
+		if (this.pending) this.resolvePending({ answers: [], cancelled: true, error: "superseded" }, false);
 
 		const questionId = randomUUID();
-		const emitter = this.emitter;
-
 		return new Promise<QuestionBridgeResult>((resolve) => {
-			this.pending = { questionId, resolve };
-			emitter({ type: "question", questionId, params });
+			const timer = setTimeout(() => {
+				if (this.pending?.questionId !== questionId) return;
+				this.resolvePending({ answers: [], cancelled: true, error: "timeout" }, true);
+			}, binding.timeoutMs);
+			this.pending = { questionId, sessionId: binding.sessionId, turnId: binding.turnId, resolve, timer };
+			binding.emit({ type: "question", questionId, params });
 		});
 	}
 
-	respond(questionId: string, result: QuestionBridgeResult): boolean {
-		if (!this.pending || this.pending.questionId !== questionId) return false;
-		const { resolve } = this.pending;
-		this.pending = null;
-		resolve(result);
-		return true;
+	respond(input: { sessionId: string; turnId: string; questionId: string; result: QuestionBridgeResult }): QuestionResponseStatus {
+		const pending = this.pending;
+		if (!pending || pending.questionId !== input.questionId) {
+			return this.lastResolved?.questionId === input.questionId
+				&& this.lastResolved.sessionId === input.sessionId
+				&& this.lastResolved.turnId === input.turnId
+				? "already_resolved"
+				: "not_found";
+		}
+		if (pending.sessionId !== input.sessionId || pending.turnId !== input.turnId) return "scope_mismatch";
+		this.resolvePending(input.result, true);
+		return "accepted";
 	}
 
-	cancel(): void {
-		if (!this.pending) return;
-		const { resolve } = this.pending;
+	unbindTurn(input: { sessionId: string; turnId: string; reason: string }): void {
+		if (!this.binding || this.binding.sessionId !== input.sessionId || this.binding.turnId !== input.turnId) return;
+		if (this.pending?.sessionId === input.sessionId && this.pending.turnId === input.turnId) {
+			this.resolvePending({ answers: [], cancelled: true, error: input.reason }, true);
+		}
+		this.binding = null;
+	}
+
+	private resolvePending(result: QuestionBridgeResult, emitResolved: boolean): void {
+		const pending = this.pending;
+		if (!pending) return;
+		clearTimeout(pending.timer);
 		this.pending = null;
-		resolve({ answers: [], cancelled: true, error: "disconnected" });
+		this.lastResolved = { questionId: pending.questionId, sessionId: pending.sessionId, turnId: pending.turnId };
+		if (emitResolved && this.binding?.sessionId === pending.sessionId && this.binding.turnId === pending.turnId) {
+			this.binding.emit({ type: "question_resolved", questionId: pending.questionId, cancelled: result.cancelled, error: result.error });
+		}
+		pending.resolve(result);
 	}
 }
 

--- a/apps/inno-agent/src/chat/stream-registry.test.ts
+++ b/apps/inno-agent/src/chat/stream-registry.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import { StreamRegistry } from "./stream-registry.js";
+
+function create(registry: StreamRegistry, sessionId = "session.jsonl") {
+	return registry.createTurn({
+		sessionId,
+		clientRequestId: "client-1",
+		workspaceId: "workspace-1",
+		workspaceRoot: "/tmp/workspace-1",
+		inputSnapshot: { prompt: "hello", submittedAt: new Date().toISOString(), images: [] },
+		baselineMessageCount: 2,
+		baselineSessionRevision: "10:1",
+	});
+}
+
+describe("StreamRegistry", () => {
+	it("assigns monotonic event ids and replays only events after the cursor", () => {
+		const registry = new StreamRegistry();
+		const state = create(registry);
+		registry.publishStreamEvent(state, { type: "stream_state", status: "queued" });
+		registry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+		registry.publishStreamEvent(state, { type: "text_delta", delta: "hello" });
+		const replayed: number[] = [];
+		registry.subscribe(state, 1, (event) => replayed.push(event.eventId))();
+		expect(replayed).toEqual([2, 3]);
+		expect(state.status).toBe("running");
+	});
+
+	it("reduces duplicate tool ids without duplicating aggregate state", () => {
+		const registry = new StreamRegistry();
+		const state = create(registry);
+		registry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+		registry.publishStreamEvent(state, { type: "tool_start", toolCallId: "tool-1", toolName: "read", args: { path: "a" } });
+		registry.publishStreamEvent(state, { type: "tool_start", toolCallId: "tool-1", toolName: "read", args: { path: "b" } });
+		expect(state.activeTools).toHaveLength(1);
+		registry.publishStreamEvent(state, { type: "tool_end", toolCallId: "tool-1", toolName: "read", result: "ok", isError: false });
+		registry.publishStreamEvent(state, { type: "tool_end", toolCallId: "tool-1", toolName: "read", result: "ok", isError: false });
+		expect(state.activeTools).toHaveLength(0);
+		expect(state.completedTools).toHaveLength(1);
+	});
+
+	it("allows only the first terminal transition", () => {
+		const registry = new StreamRegistry();
+		const state = create(registry);
+		registry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+		const first = registry.finishTurn(state, "completed", { type: "done", fullText: "ok" }, { persisted: true, finalMessageCount: 4, finalSessionRevision: "20:2" });
+		const duplicate = registry.finishTurn(state, "error", { type: "error", message: "late" }, { persisted: false });
+		expect(first?.eventId).toBe(2);
+		expect(duplicate).toBeUndefined();
+		expect(state.status).toBe("completed");
+		expect(state.history).toHaveLength(2);
+	});
+
+	it("never expires active turns and keeps a newer latest mapping", () => {
+		const registry = new StreamRegistry();
+		const active = create(registry, "active.jsonl");
+		expect(registry.cleanupExpiredTurns(Date.now() + 1_000_000, 1)).toBe(0);
+		expect(registry.getLatest("active.jsonl")).toBe(active);
+
+		const old = create(registry, "shared.jsonl");
+		registry.publishStreamEvent(old, { type: "stream_state", status: "running" });
+		registry.finishTurn(old, "completed", { type: "done", fullText: "" }, { persisted: true });
+		old.finishedAt = new Date(0).toISOString();
+		const latest = create(registry, "shared.jsonl");
+		expect(registry.cleanupExpiredTurns(Date.now(), 1)).toBe(1);
+		expect(registry.getLatest("shared.jsonl")).toBe(latest);
+	});
+
+	it("isolates failing subscribers and still records the terminal event", () => {
+		const registry = new StreamRegistry();
+		const state = create(registry);
+		const received: number[] = [];
+		registry.subscribe(state, 0, () => { throw new Error("closed response"); });
+		registry.subscribe(state, 0, (event) => received.push(event.eventId));
+		registry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+		registry.finishTurn(state, "completed", { type: "done", fullText: "ok" }, { persisted: true });
+		expect(received).toEqual([1, 2]);
+		expect(state.history.at(-1)?.event.type).toBe("done");
+		expect(state.status).toBe("completed");
+	});
+
+	it("rejects illegal or duplicate transitions", () => {
+		const registry = new StreamRegistry();
+		const state = create(registry);
+		expect(() => registry.finishTurn(state, "completed", { type: "done", fullText: "" }, { persisted: true })).toThrow(/invalid stream transition/);
+		registry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+		expect(() => registry.publishStreamEvent(state, { type: "stream_state", status: "running" })).toThrow(/invalid stream transition/);
+		expect(() => registry.publishStreamEvent(state, { type: "stream_state", status: "queued" })).toThrow(/invalid stream transition/);
+		registry.finishTurn(state, "aborted", { type: "aborted" }, { persisted: false });
+		expect(() => registry.publishStreamEvent(state, { type: "text_delta", delta: "late" })).toThrow(/after terminal/);
+	});
+
+	it("compacts terminal text and public image snapshots", () => {
+		const registry = new StreamRegistry();
+		const state = registry.createTurn({
+			sessionId: "session.jsonl",
+			clientRequestId: "client-1",
+			workspaceId: "workspace one",
+			workspaceRoot: "/private/workspace",
+			inputSnapshot: {
+				prompt: "hello",
+				submittedAt: new Date().toISOString(),
+				images: [{ mimeType: "image/png", workspacePath: ".chat-images/a.png" }],
+			},
+			baselineMessageCount: 0,
+			baselineSessionRevision: "0:0",
+		});
+		registry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+		const terminal = registry.finishTurn(state, "completed", { type: "done", fullText: "x".repeat(300_000) }, { persisted: true });
+		expect((terminal?.event.fullText as string).length).toBeLessThan(300_000);
+		const snapshot = registry.toPublicSnapshot(state);
+		expect(snapshot).not.toHaveProperty("workspaceRoot");
+		expect(snapshot.inputSnapshot.images[0].previewUrl).toContain("/api/workspace/raw?");
+		expect(snapshot.inputSnapshot.images[0].previewUrl).not.toContain("/private/workspace");
+	});
+});

--- a/apps/inno-agent/src/chat/stream-registry.ts
+++ b/apps/inno-agent/src/chat/stream-registry.ts
@@ -1,0 +1,360 @@
+import { randomUUID } from "node:crypto";
+import { logger } from "../logger.js";
+
+export type StreamStatus = "queued" | "running" | "completed" | "error" | "aborted";
+
+export type ChatStreamEvent = Record<string, unknown> & { type: string };
+
+export interface StreamEventEnvelope {
+	eventId: number;
+	sessionId: string;
+	turnId: string;
+	clientRequestId: string;
+	event: ChatStreamEvent;
+}
+
+export interface StreamInputSnapshot {
+	prompt: string;
+	submittedAt: string;
+	images: Array<{ mimeType: string; workspacePath: string; previewUrl?: string }>;
+}
+
+export interface ActiveStreamTool {
+	toolCallId: string;
+	toolName: string;
+	args?: unknown;
+	startedAt: string;
+}
+
+export interface CompletedStreamTool extends ActiveStreamTool {
+	result?: unknown;
+	isError: boolean;
+	finishedAt: string;
+}
+
+export interface PendingQuestionSnapshot {
+	questionId: string;
+	params: unknown;
+	createdAt: string;
+}
+
+export interface StreamPersistence {
+	persisted: boolean;
+	finalMessageCount?: number;
+	finalSessionRevision?: string;
+}
+
+export interface SessionStreamState {
+	sessionId: string;
+	turnId: string;
+	clientRequestId: string;
+	workspaceId: string;
+	/** Server-only; omitted from public snapshots. */
+	workspaceRoot: string;
+	status: StreamStatus;
+	createdAt: string;
+	startedAt?: string;
+	finishedAt?: string;
+	inputSnapshot: StreamInputSnapshot;
+	activeTools: ActiveStreamTool[];
+	completedTools: CompletedStreamTool[];
+	pendingQuestion?: PendingQuestionSnapshot;
+	lastEventId: number;
+	history: StreamEventEnvelope[];
+	subscribers: Set<(event: StreamEventEnvelope) => void>;
+	cancelRequested: boolean;
+	terminalEventPublished: boolean;
+	terminalReason?: string;
+	baselineMessageCount: number;
+	baselineSessionRevision: string;
+	persisted: boolean;
+	finalMessageCount?: number;
+	finalSessionRevision?: string;
+}
+
+export interface CreateTurnInput {
+	sessionId: string;
+	clientRequestId: string;
+	workspaceId: string;
+	workspaceRoot: string;
+	inputSnapshot: StreamInputSnapshot;
+	baselineMessageCount: number;
+	baselineSessionRevision: string;
+}
+
+const TERMINAL_TYPES = new Set(["done", "error", "aborted"]);
+const ACTIVE_STATUSES = new Set<StreamStatus>(["queued", "running"]);
+const MAX_TEXT = 256_000;
+const MAX_PAYLOAD = 64_000;
+
+function compact(value: unknown, limit = MAX_PAYLOAD): unknown {
+	if (typeof value === "string") return value.length > limit ? `${value.slice(0, limit)}…[truncated]` : value;
+	try {
+		const json = JSON.stringify(value);
+		if (json.length <= limit) return value;
+		return { truncated: true, preview: json.slice(0, limit) };
+	} catch {
+		return String(value).slice(0, limit);
+	}
+}
+
+function compactEvent(event: ChatStreamEvent): ChatStreamEvent {
+	const next = { ...event };
+	if (typeof next.delta === "string") next.delta = compact(next.delta, MAX_TEXT);
+	if (typeof next.fullText === "string") next.fullText = compact(next.fullText, MAX_TEXT);
+	if ("args" in next) next.args = compact(next.args);
+	if ("result" in next) next.result = compact(next.result);
+	if ("params" in next) next.params = compact(next.params);
+	if (Array.isArray(next.changes)) {
+		const changes: unknown[] = [];
+		let size = 2;
+		for (const change of next.changes) {
+			const item = compact(change, 8_000);
+			const itemSize = (JSON.stringify(item) ?? "").length + 1;
+			if (size + itemSize > MAX_PAYLOAD) break;
+			changes.push(item);
+			size += itemSize;
+		}
+		if (changes.length < next.changes.length) next.truncated = true;
+		next.changes = changes;
+	} else if ("changes" in next) {
+		next.changes = compact(next.changes);
+	}
+	if ("preview" in next) next.preview = compact(next.preview);
+	if ("content" in next) next.content = compact(next.content);
+	return next;
+}
+
+function notifySubscriber(
+	state: SessionStreamState,
+	subscriber: (event: StreamEventEnvelope) => void,
+	envelope: StreamEventEnvelope,
+): boolean {
+	try {
+		subscriber(envelope);
+		return true;
+	} catch (error) {
+		state.subscribers.delete(subscriber);
+		try {
+			logger.warn({ error, sessionId: state.sessionId, turnId: state.turnId }, "chat stream subscriber failed");
+		} catch {
+			// Observability must never break stream delivery or finalization.
+		}
+		return false;
+	}
+}
+
+function reduceStreamState(state: SessionStreamState, event: ChatStreamEvent): void {
+	if (event.type === "stream_state") {
+		const status = event.status;
+		if (status === "running" && state.status === "queued") {
+			state.status = "running";
+			state.startedAt = new Date().toISOString();
+		}
+		return;
+	}
+	if (event.type === "tool_start") {
+		const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+		if (!toolCallId) return;
+		const tool: ActiveStreamTool = {
+			toolCallId,
+			toolName: typeof event.toolName === "string" ? event.toolName : "tool",
+			args: event.args,
+			startedAt: new Date().toISOString(),
+		};
+		state.activeTools = [...state.activeTools.filter((item) => item.toolCallId !== toolCallId), tool];
+		return;
+	}
+	if (event.type === "tool_end") {
+		const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+		if (!toolCallId) return;
+		const active = state.activeTools.find((item) => item.toolCallId === toolCallId);
+		state.activeTools = state.activeTools.filter((item) => item.toolCallId !== toolCallId);
+		const completed: CompletedStreamTool = {
+			...(active ?? {
+				toolCallId,
+				toolName: typeof event.toolName === "string" ? event.toolName : "tool",
+				startedAt: new Date().toISOString(),
+			}),
+			result: event.result,
+			isError: event.isError === true,
+			finishedAt: new Date().toISOString(),
+		};
+		state.completedTools = [...state.completedTools.filter((item) => item.toolCallId !== toolCallId), completed];
+		return;
+	}
+	if (event.type === "question") {
+		if (typeof event.questionId === "string") {
+			state.pendingQuestion = {
+				questionId: event.questionId,
+				params: event.params,
+				createdAt: new Date().toISOString(),
+			};
+		}
+		return;
+	}
+	if (event.type === "question_resolved" && state.pendingQuestion?.questionId === event.questionId) {
+		state.pendingQuestion = undefined;
+	}
+}
+
+export class StreamRegistry {
+	private readonly streamsByTurn = new Map<string, SessionStreamState>();
+	private readonly latestTurnBySession = new Map<string, string>();
+
+	createTurn(input: CreateTurnInput): SessionStreamState {
+		const existing = this.getLatest(input.sessionId);
+		if (existing && ACTIVE_STATUSES.has(existing.status)) throw new Error("active_turn_exists");
+		const now = new Date().toISOString();
+		const state: SessionStreamState = {
+			...input,
+			turnId: randomUUID(),
+			status: "queued",
+			createdAt: now,
+			activeTools: [],
+			completedTools: [],
+			lastEventId: 0,
+			history: [],
+			subscribers: new Set(),
+			cancelRequested: false,
+			terminalEventPublished: false,
+			persisted: false,
+		};
+		this.streamsByTurn.set(state.turnId, state);
+		this.latestTurnBySession.set(state.sessionId, state.turnId);
+		return state;
+	}
+
+	getByTurn(turnId: string): SessionStreamState | undefined { return this.streamsByTurn.get(turnId); }
+
+	getLatest(sessionId: string): SessionStreamState | undefined {
+		const turnId = this.latestTurnBySession.get(sessionId);
+		return turnId ? this.streamsByTurn.get(turnId) : undefined;
+	}
+
+	getActiveForSession(sessionId: string): SessionStreamState | undefined {
+		const state = this.getLatest(sessionId);
+		return state && ACTIVE_STATUSES.has(state.status) ? state : undefined;
+	}
+
+	getActiveForWorkspace(workspaceId: string): SessionStreamState | undefined {
+		for (const state of this.streamsByTurn.values()) {
+			if (state.workspaceId === workspaceId && ACTIVE_STATUSES.has(state.status)) return state;
+		}
+		return undefined;
+	}
+
+	publishStreamEvent(state: SessionStreamState, event: ChatStreamEvent): StreamEventEnvelope {
+		if (TERMINAL_TYPES.has(event.type)) throw new Error(`terminal event ${event.type} must use finishTurn()`);
+		if (state.terminalEventPublished) throw new Error("cannot publish after terminal event");
+		if (event.type === "stream_state") {
+			const nextStatus = event.status;
+			const alreadyPublishedQueued = state.history.some((item) => item.event.type === "stream_state" && item.event.status === "queued");
+			if (nextStatus === "queued" && state.status === "queued" && !alreadyPublishedQueued) {
+				// Initial state announcement; createTurn already owns the queued state.
+			} else if (nextStatus === "running" && state.status === "queued") {
+				// The only non-terminal state transition.
+			} else {
+				throw new Error(`invalid stream transition ${state.status} -> ${String(nextStatus)}`);
+			}
+		} else if (state.status !== "running") {
+			throw new Error(`cannot publish ${event.type} while stream is ${state.status}`);
+		}
+		const compacted = compactEvent(event);
+		reduceStreamState(state, compacted);
+		const envelope: StreamEventEnvelope = {
+			eventId: ++state.lastEventId,
+			sessionId: state.sessionId,
+			turnId: state.turnId,
+			clientRequestId: state.clientRequestId,
+			event: compacted,
+		};
+		state.history.push(envelope);
+		for (const subscriber of [...state.subscribers]) notifySubscriber(state, subscriber, envelope);
+		return envelope;
+	}
+
+	finishTurn(
+		state: SessionStreamState,
+		status: Exclude<StreamStatus, "queued" | "running">,
+		event: ChatStreamEvent,
+		persistence: StreamPersistence,
+	): StreamEventEnvelope | undefined {
+		if (state.terminalEventPublished) return undefined;
+		const validTransition = state.status === "queued"
+			? status === "aborted"
+			: state.status === "running" && (status === "completed" || status === "error" || status === "aborted");
+		if (!validTransition) throw new Error(`invalid stream transition ${state.status} -> ${status}`);
+		const expectedType = status === "completed" ? "done" : status;
+		if (event.type !== expectedType) throw new Error(`terminal status ${status} requires ${expectedType} event`);
+		state.terminalEventPublished = true;
+		state.status = status;
+		state.finishedAt = new Date().toISOString();
+		state.terminalReason = typeof event.message === "string" ? event.message : undefined;
+		state.persisted = persistence.persisted;
+		state.finalMessageCount = persistence.finalMessageCount;
+		state.finalSessionRevision = persistence.finalSessionRevision;
+		state.pendingQuestion = undefined;
+		const terminalEvent = compactEvent({ ...event, ...persistence });
+		const envelope: StreamEventEnvelope = {
+			eventId: ++state.lastEventId,
+			sessionId: state.sessionId,
+			turnId: state.turnId,
+			clientRequestId: state.clientRequestId,
+			event: terminalEvent,
+		};
+		state.history.push(envelope);
+		for (const subscriber of [...state.subscribers]) notifySubscriber(state, subscriber, envelope);
+		state.subscribers.clear();
+		return envelope;
+	}
+
+	subscribe(state: SessionStreamState, after: number, subscriber: (event: StreamEventEnvelope) => void): () => void {
+		// JS execution is single-threaded: replay and registration are atomic with
+		// respect to publishStreamEvent(), so no event can fall into a gap here.
+		let healthy = true;
+		for (const event of state.history) {
+			if (event.eventId > after && !notifySubscriber(state, subscriber, event)) {
+				healthy = false;
+				break;
+			}
+		}
+		if (healthy && !state.terminalEventPublished) state.subscribers.add(subscriber);
+		return () => state.subscribers.delete(subscriber);
+	}
+
+	requestCancel(state: SessionStreamState): boolean {
+		if (!ACTIVE_STATUSES.has(state.status)) return false;
+		state.cancelRequested = true;
+		return true;
+	}
+
+	toPublicSnapshot(state: SessionStreamState) {
+		const { workspaceRoot: _workspaceRoot, history: _history, subscribers: _subscribers, ...snapshot } = state;
+		return {
+			...snapshot,
+			inputSnapshot: {
+				...snapshot.inputSnapshot,
+				images: snapshot.inputSnapshot.images.map((image) => ({
+					...image,
+					previewUrl: `/api/workspace/raw?workspaceId=${encodeURIComponent(snapshot.workspaceId)}&path=${encodeURIComponent(image.workspacePath)}`,
+				})),
+			},
+		};
+	}
+
+	cleanupExpiredTurns(now = Date.now(), ttlMs = 300_000): number {
+		let removed = 0;
+		for (const [turnId, state] of this.streamsByTurn) {
+			if (ACTIVE_STATUSES.has(state.status)) continue;
+			const finishedAt = Date.parse(state.finishedAt ?? "");
+			if (!Number.isFinite(finishedAt) || now - finishedAt < ttlMs) continue;
+			this.streamsByTurn.delete(turnId);
+			if (this.latestTurnBySession.get(state.sessionId) === turnId) this.latestTurnBySession.delete(state.sessionId);
+			removed++;
+		}
+		return removed;
+	}
+}
+
+export const streamRegistry = new StreamRegistry();

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -31,7 +31,7 @@ import {
 	applyWorkspaceCwd,
 	setWorkspaceCwdResolver,
 } from "./agent/pi-runner.js";
-import { completePromptOnce, runPromptSerialized, runPromptStreaming, runPromptStreamingInSession, runPromptInSession, abortCurrentPrompt, persistPendingUserTurn } from "./agent/pi-runner.js";
+import { completePromptOnce, runPromptSerialized, runPromptStreamingInSession, runPromptInSession, abortPromptForTurnToken, persistPendingUserTurn, persistCancelledQueuedTurn, type PromptRunOutcome } from "./agent/pi-runner.js";
 import type { ImageContent } from "@earendil-works/pi-ai";
 import { ChannelRegistry } from "./channels/channel.js";
 import type { ChannelStreamEvent } from "./channels/channel.js";
@@ -54,6 +54,7 @@ import { randomUUID } from "node:crypto";
 import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
 import { questionBridge, type QuestionBridgeResult } from "./agent/question-bridge.js";
+import { streamRegistry, type SessionStreamState, type StreamPersistence } from "./chat/stream-registry.js";
 import { DEFAULT_WORKSPACE_ID, TEMP_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
 import { listPresets, listRemotePresets, ensurePresetCached, instantiatePreset } from "./presets/preset-store.js";
 import { createContentSource, type RemoteContentSource } from "./content-source/index.js";
@@ -112,34 +113,6 @@ let bootstrapped = false;
 let bootstrapPromise: Promise<void> | null = null;
 let bridgeToken: string | undefined;
 
-// ---------------------------------------------------------------------------
-// Session Event Broadcaster — allows clients to reconnect to in-progress
-// streams after navigating away and back.
-// ---------------------------------------------------------------------------
-
-class SessionEventBroadcaster {
-	private history: unknown[] = [];
-	private subscribers = new Set<(event: unknown) => void>();
-	private _closed = false;
-
-	publish(event: unknown): void {
-		if (this._closed) return;
-		this.history.push(event);
-		for (const sub of this.subscribers) sub(event);
-	}
-
-	subscribe(cb: (event: unknown) => void): () => void {
-		for (const event of this.history) cb(event);
-		if (!this._closed) this.subscribers.add(cb);
-		return () => { this.subscribers.delete(cb); };
-	}
-
-	close(): void { this._closed = true; this.subscribers.clear(); }
-	get closed(): boolean { return this._closed; }
-}
-
-const sessionBroadcasters = new Map<string, SessionEventBroadcaster>();
-
 function piEventToSseEvent(event: any): unknown | null {
 	switch (event.type) {
 		case "message_update": {
@@ -149,13 +122,13 @@ function piEventToSseEvent(event: any): unknown | null {
 			if (ev.type === "toolcall_start" || ev.type === "toolcall_delta" || ev.type === "toolcall_end") {
 				return toolCallStreamEventFromAssistantEvent(ev);
 			}
-			if (ev.type === "error") return { type: "error", message: ev.error.errorMessage || `LLM API error (stopReason: ${ev.error.stopReason})` };
+			if (ev.type === "error") return null;
 			return null;
 		}
 		case "message_end": {
 			const msg = event.message;
 			if (msg && typeof msg === "object" && "stopReason" in msg && msg.stopReason === "error") {
-				return { type: "error", message: msg.errorMessage || "The model request failed." };
+				return null;
 			}
 			return null;
 		}
@@ -466,10 +439,9 @@ function maskSecret(value: string | undefined): string {
  * paths. When the chat model cannot natively recognize images, the agent is
  * steered (via the system prompt) to call `ocr_image` with these paths.
  */
-function persistInlineImages(images: Array<{ data: string; mimeType: string }>): string[] {
+function persistInlineImages(images: Array<{ data: string; mimeType: string }>, workspaceRoot: string): string[] {
 	if (images.length === 0) return [];
-	const workspaceDir = process.env.INNO_WORKSPACE_DIR || process.cwd();
-	const chatImagesDir = join(workspaceDir, ".chat-images");
+	const chatImagesDir = join(workspaceRoot, ".chat-images");
 	try {
 		if (!existsSync(chatImagesDir)) mkdirSync(chatImagesDir, { recursive: true });
 	} catch (err) {
@@ -490,6 +462,52 @@ function persistInlineImages(images: Array<{ data: string; mimeType: string }>):
 		}
 	});
 	return paths;
+}
+
+function sessionRevision(filePath: string): string {
+	try {
+		const stat = statSync(filePath);
+		return `${stat.size}:${stat.mtimeMs}`;
+	} catch {
+		return "missing";
+	}
+}
+
+function readSessionBaseline(filePath: string): { messageCount: number; revision: string } {
+	return {
+		messageCount: parseSessionFile(filePath)?.messages.length ?? 0,
+		revision: sessionRevision(filePath),
+	};
+}
+
+function confirmTurnPersistence(
+	state: SessionStreamState,
+	sessionPath: string,
+	outcome: PromptRunOutcome,
+): StreamPersistence {
+	const parsed = parseSessionFile(sessionPath);
+	const revision = sessionRevision(sessionPath);
+	if (!parsed) return { persisted: false, finalSessionRevision: revision };
+	const tail = parsed.messages.slice(state.baselineMessageCount);
+	const structurallyComplete = tail[0]?.role === "user" && tail[1]?.role === "assistant";
+	const revisionChanged = revision !== state.baselineSessionRevision;
+	const persisted = structurallyComplete && revisionChanged && parsed.messages.length > state.baselineMessageCount;
+	if (!persisted) {
+		logger.error({
+			sessionId: state.sessionId,
+			turnId: state.turnId,
+			outcome: outcome.type,
+			baselineMessageCount: state.baselineMessageCount,
+			finalMessageCount: parsed.messages.length,
+			baselineSessionRevision: state.baselineSessionRevision,
+			finalSessionRevision: revision,
+		}, "chat turn persistence confirmation failed");
+	}
+	return {
+		persisted,
+		finalMessageCount: parsed.messages.length,
+		finalSessionRevision: revision,
+	};
 }
 
 function mimeTypeToExtension(mimeType: string): string {
@@ -2880,7 +2898,12 @@ const server = createServer(async (req, res) => {
 				withRecordedChannels(parsed.summary, channelMetadata),
 				topicMetadata,
 			);
-			json(res, 200, { ...summary, messages: parsed.messages });
+			json(res, 200, {
+				...summary,
+				messages: parsed.messages,
+				messageCount: parsed.messages.length,
+				sessionRevision: sessionRevision(sessionPath),
+			});
 			return;
 		}
 
@@ -2999,6 +3022,10 @@ const server = createServer(async (req, res) => {
 		const deleteSessionMatch = matchRoute("DELETE", method, url, "/api/sessions/:id");
 		if (deleteSessionMatch) {
 			const id = decodeURIComponent(deleteSessionMatch.id);
+			if (streamRegistry.getActiveForSession(id)) {
+				json(res, 409, { error: "Cannot delete a session with an active chat turn" });
+				return;
+			}
 			const sessionPath = sessionFileFromId(join(dataDir, "sessions"), id);
 			if (!sessionPath || !existsSync(sessionPath)) {
 				json(res, 404, { error: "Session not found" });
@@ -3769,6 +3796,10 @@ const server = createServer(async (req, res) => {
 		const workspaceDeleteMatch = matchRoute("DELETE", method, url.split("?")[0], "/api/workspaces/:id");
 		if (workspaceDeleteMatch) {
 			const id = decodeURIComponent(workspaceDeleteMatch.id);
+			if (streamRegistry.getActiveForWorkspace(id)) {
+				json(res, 409, { error: "Cannot delete a workspace with an active chat turn" });
+				return;
+			}
 			if (id === TEMP_WORKSPACE_ID) {
 				json(res, 400, { error: "Cannot delete the shared tmp workspace" });
 				return;
@@ -3794,6 +3825,10 @@ const server = createServer(async (req, res) => {
 		const sessionWorkspacePutMatch = matchRoute("PUT", method, url, "/api/sessions/:id/workspace");
 		if (sessionWorkspacePutMatch) {
 			const sessionId = decodeURIComponent(sessionWorkspacePutMatch.id);
+			if (streamRegistry.getActiveForSession(sessionId)) {
+				json(res, 409, { error: "Cannot rebind a session with an active chat turn" });
+				return;
+			}
 			const body = (await readBody(req)) as Record<string, unknown>;
 			const workspaceId = typeof body.workspaceId === "string" ? body.workspaceId.trim() : "";
 			if (!workspaceId) { json(res, 400, { error: "Missing workspaceId" }); return; }
@@ -4257,12 +4292,13 @@ const server = createServer(async (req, res) => {
 				.filter((img): img is { data: string; mimeType: string } =>
 					img && typeof img.data === "string" && typeof img.mimeType === "string")
 				.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
-			// Persist inline images to the workspace so file-path tools (ocr_image,
-			// parse_document) can read them when the chat model can't see images.
-			const imagePaths = persistInlineImages(images);
+			const requestedSessionId = typeof body.sessionId === "string" ? body.sessionId : null;
+			const imageSessionId = requestedSessionId || getCurrentSessionId();
+			const imageWorkspaceId = workspaceRegistry.getSessionWorkspaceId(imageSessionId);
+			const imageWorkspaceRoot = workspaceRegistry.resolveWorkspaceDir(imageWorkspaceId) ?? paths.workspaceDir;
+			const imagePaths = persistInlineImages(images, imageWorkspaceRoot);
 			const promptWithHint = prependImagePathsHint(prompt, imagePaths);
 			// Use atomic switch+prompt when a specific session is requested.
-			const requestedSessionId = typeof body.sessionId === "string" ? body.sessionId : null;
 			let output: string;
 			try {
 				if (requestedSessionId) {
@@ -4289,38 +4325,64 @@ const server = createServer(async (req, res) => {
 		// --- Question response (from web UI) ---
 		if (method === "POST" && url === "/api/chat/question-response") {
 			const body = (await readBody(req)) as Record<string, unknown>;
+			const sessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+			const turnId = typeof body.turnId === "string" ? body.turnId : "";
 			const questionId = typeof body.questionId === "string" ? body.questionId : "";
 			const result = body.result as QuestionBridgeResult | undefined;
-			if (!questionId || !result) {
-				json(res, 400, { error: "Missing questionId or result" });
+			if (!sessionId || !turnId || !questionId || !result) {
+				json(res, 400, { error: "Missing sessionId, turnId, questionId or result" });
 				return;
 			}
-			const accepted = questionBridge.respond(questionId, result);
-			json(res, accepted ? 200 : 404, { accepted });
+			const status = questionBridge.respond({ sessionId, turnId, questionId, result });
+			json(res, status === "accepted" ? 200 : status === "scope_mismatch" || status === "already_resolved" ? 409 : 404, { accepted: status === "accepted" });
 			return;
 		}
 
-		// --- Chat Abort (explicit stop from UI) ---
-		// The SSE req.on("close") handler also aborts, but connection-close is
-		// unreliable through dev proxies and during rapid terminate→switch flows.
-		// This gives the client a deterministic way to stop the backend stream so
-		// the shared prompt queue is released immediately (otherwise new-session /
-		// switch-session block behind a still-running turn).
 		if (method === "POST" && url === "/api/chat/abort") {
-			await abortCurrentPrompt();
-			json(res, 200, { aborted: true });
+			json(res, 400, { error: "Scoped abort requires sessionId and turnId" });
 			return;
 		}
 
-		// --- Chat Events Reconnect (SSE) ---
-		// Allows a client that navigated away to reconnect to an in-progress
-		// session's event stream and replay all events from the beginning.
+		const chatAbortMatch = matchRoute("POST", method, url, "/api/chat/:sessionId/:turnId/abort");
+		if (chatAbortMatch) {
+			const state = streamRegistry.getByTurn(chatAbortMatch.turnId);
+			if (!state || state.sessionId !== chatAbortMatch.sessionId) {
+				json(res, 404, { error: "Chat turn not found" });
+				return;
+			}
+			if (state.status !== "queued" && state.status !== "running") {
+				json(res, 200, { status: state.status, cancelRequested: state.cancelRequested });
+				return;
+			}
+			streamRegistry.requestCancel(state);
+			if (state.status === "running") await abortPromptForTurnToken(state.turnId);
+			json(res, 202, { status: state.status, cancelRequested: true });
+			return;
+		}
+
+		const chatStatusMatch = matchRoute("GET", method, url, "/api/chat/status/:sessionId");
+		if (chatStatusMatch) {
+			streamRegistry.cleanupExpiredTurns();
+			const state = streamRegistry.getLatest(chatStatusMatch.sessionId);
+			json(res, 200, state
+				? { found: true, stream: streamRegistry.toPublicSnapshot(state) }
+				: { found: false });
+			return;
+		}
+
 		const chatEventsMatch = matchRoute("GET", method, url, "/api/chat/events/:id");
 		if (chatEventsMatch) {
 			const sessionId = chatEventsMatch.id;
-			const bc = sessionBroadcasters.get(sessionId);
-			if (!bc) {
-				json(res, 404, { error: "No active stream" });
+			const params = new URL(url, "http://localhost").searchParams;
+			const turnId = params.get("turnId") ?? "";
+			const after = Number.parseInt(params.get("after") ?? "0", 10);
+			if (!turnId || !Number.isFinite(after) || after < 0) {
+				json(res, 400, { error: "turnId and a non-negative after value are required" });
+				return;
+			}
+			const state = streamRegistry.getByTurn(turnId);
+			if (!state || state.sessionId !== sessionId) {
+				json(res, 404, { error: "Chat turn not found" });
 				return;
 			}
 			res.writeHead(200, {
@@ -4340,22 +4402,20 @@ const server = createServer(async (req, res) => {
 					}
 				}
 			}, 15_000);
-			const unsub = bc.subscribe((event: unknown) => {
+			const finishResponse = () => {
 				if (ended) return;
-				res.write(`data: ${JSON.stringify(event)}\n\n`);
-				if ((event as any).type === "done" || ((event as any).type === "error" && !(event as any).toolCallId)) {
-					clearInterval(eventsHeartbeat);
-					res.write("data: [DONE]\n\n");
-					ended = true;
-					res.end();
-				}
-			});
-			if (bc.closed && !ended) {
+				ended = true;
 				clearInterval(eventsHeartbeat);
 				res.write("data: [DONE]\n\n");
 				res.end();
-			}
-			req.on("close", () => { clearInterval(eventsHeartbeat); unsub(); });
+			};
+			const unsub = streamRegistry.subscribe(state, after, (envelope) => {
+				if (ended) return;
+				res.write(`data: ${JSON.stringify(envelope)}\n\n`);
+				if (["done", "error", "aborted"].includes(envelope.event.type)) finishResponse();
+			});
+			if (state.terminalEventPublished && !ended) finishResponse();
+			res.on("close", () => { clearInterval(eventsHeartbeat); unsub(); });
 			return;
 		}
 
@@ -4363,8 +4423,25 @@ const server = createServer(async (req, res) => {
 		if (method === "POST" && url === "/api/chat/stream") {
 			const body = (await readBody(req)) as Record<string, unknown>;
 			const prompt = body.prompt as string | undefined;
-			if (!prompt) {
-				json(res, 400, { error: "Missing prompt" });
+			const requestedSessionId = typeof body.sessionId === "string" ? body.sessionId : "";
+			const clientRequestId = typeof body.clientRequestId === "string" ? body.clientRequestId : "";
+			if (!prompt || !requestedSessionId || !clientRequestId) {
+				json(res, 400, { error: "Missing prompt, sessionId or clientRequestId" });
+				return;
+			}
+			if (streamRegistry.getActiveForSession(requestedSessionId)) {
+				json(res, 409, { error: "Session already has an active chat turn" });
+				return;
+			}
+			const targetSessionPath = sessionFileFromId(join(dataDir, "sessions"), requestedSessionId);
+			if (!targetSessionPath || !existsSync(targetSessionPath)) {
+				json(res, 404, { error: "Session not found" });
+				return;
+			}
+			const streamWorkspaceId = workspaceRegistry.getSessionWorkspaceId(requestedSessionId);
+			const streamWorkspaceRoot = workspaceRegistry.resolveWorkspaceDir(streamWorkspaceId);
+			if (!streamWorkspaceRoot) {
+				json(res, 404, { error: "Session workspace not found" });
 				return;
 			}
 			const rawImages = Array.isArray(body.images) ? body.images : [];
@@ -4374,20 +4451,30 @@ const server = createServer(async (req, res) => {
 				.map((img) => ({ type: "image" as const, data: img.data, mimeType: img.mimeType }));
 			// Persist inline images to the workspace so file-path tools (ocr_image,
 			// parse_document) can read them when the chat model can't see images.
-			const imagePaths = persistInlineImages(images);
+			const imagePaths = persistInlineImages(images, streamWorkspaceRoot);
 			const promptWithHint = prependImagePathsHint(prompt, imagePaths);
 			const imageArgs = images.length ? images : undefined;
-
-			// Resolve target session path for atomic switch+stream.
-			const requestedSessionId = typeof body.sessionId === "string" ? body.sessionId : null;
-			let targetSessionPath: string | null = null;
-			if (requestedSessionId) {
-				const sessionPath = sessionFileFromId(join(dataDir, "sessions"), requestedSessionId);
-				if (sessionPath && existsSync(sessionPath)) {
-					targetSessionPath = sessionPath;
-				}
+			const baseline = readSessionBaseline(targetSessionPath);
+			let state: SessionStreamState;
+			try {
+				state = streamRegistry.createTurn({
+					sessionId: requestedSessionId,
+					clientRequestId,
+					workspaceId: streamWorkspaceId,
+					workspaceRoot: streamWorkspaceRoot,
+					inputSnapshot: {
+						prompt,
+						submittedAt: new Date().toISOString(),
+						images: imagePaths.map((workspacePath, index) => ({ mimeType: images[index]?.mimeType ?? "image/png", workspacePath })),
+					},
+					baselineMessageCount: baseline.messageCount,
+					baselineSessionRevision: baseline.revision,
+				});
+			} catch {
+				json(res, 409, { error: "Session already has an active chat turn" });
+				return;
 			}
-			const capturedSessionId = requestedSessionId || getCurrentSessionId();
+			streamRegistry.publishStreamEvent(state, { type: "stream_state", status: "queued" });
 
 			res.writeHead(200, {
 				"Content-Type": "text/event-stream",
@@ -4396,44 +4483,39 @@ const server = createServer(async (req, res) => {
 				"X-Accel-Buffering": "no",
 			});
 
-			const sseWrite = (data: unknown) => {
-				res.write(`data: ${JSON.stringify(data)}\n\n`);
-			};
-
-			let aborted = false;
+			let disconnected = false;
+			let responseEnded = false;
 
 			const heartbeatInterval = setInterval(() => {
-				if (!aborted) {
+				if (!disconnected && !responseEnded) {
 					try {
 						res.write(": heartbeat\n\n");
-						logger.debug({ sessionId: capturedSessionId }, "SSE heartbeat sent");
+						logger.debug({ sessionId: requestedSessionId, turnId: state.turnId }, "SSE heartbeat sent");
 					} catch (err) {
-						logger.warn({ sessionId: capturedSessionId, err }, "SSE heartbeat write failed");
+						logger.warn({ sessionId: requestedSessionId, turnId: state.turnId, err }, "SSE heartbeat write failed");
 					}
 				}
 			}, 15_000);
-
-			req.on("close", () => {
-				aborted = true;
+			const finishResponse = () => {
+				if (responseEnded || disconnected) return;
+				responseEnded = true;
 				clearInterval(heartbeatInterval);
-				questionBridge.setEmitter(null);
-				questionBridge.cancel();
+				res.write("data: [DONE]\n\n");
+				res.end();
+			};
+			const unsubscribeResponse = streamRegistry.subscribe(state, 0, (envelope) => {
+				if (disconnected || responseEnded) return;
+				res.write(`data: ${JSON.stringify(envelope)}\n\n`);
+				if (["done", "error", "aborted"].includes(envelope.event.type)) finishResponse();
+			});
+			res.on("close", () => {
+				disconnected = true;
+				clearInterval(heartbeatInterval);
+				unsubscribeResponse();
 			});
 
-			questionBridge.setEmitter(sseWrite);
-
-			// Create a broadcaster for this session so clients can reconnect
-			// to the event stream after navigating away.
-			const broadcaster = new SessionEventBroadcaster();
-			sessionBroadcasters.set(capturedSessionId, broadcaster);
-			const publishStreamEvent = (event: unknown) => {
-				broadcaster.publish(event);
-				if (!aborted) sseWrite(event);
-			};
-
-			const streamWorkspaceId = workspaceRegistry.getSessionWorkspaceId(capturedSessionId);
-			const streamWorkspaceRoot = workspaceRegistry.resolveWorkspaceDir(streamWorkspaceId);
-			const workspaceChangeMonitor = createWorkspaceChangeMonitor(streamWorkspaceRoot, publishStreamEvent);
+			let workspaceChangeMonitor: ReturnType<typeof createWorkspaceChangeMonitor> = null;
+			const closeWorkspaceChangeMonitor = () => workspaceChangeMonitor?.close();
 
 			// Track whether the model API surfaced an error this turn. The PI SDK
 			// does NOT throw on model API errors (e.g. HTTP 413 from an over-long
@@ -4441,7 +4523,6 @@ const server = createServer(async (req, res) => {
 			// stopReason "error" + errorMessage, delivered via message_end. If we
 			// don't forward that, runPromptStreaming resolves with empty text and
 			// the UI shows nothing. So we detect it here and emit an error event.
-			let emittedError = false;
 			let promptStartTime = 0;
 			const onEvent = (event: import("@earendil-works/pi-coding-agent").AgentSessionEvent) => {
 				// Logging regardless of aborted state
@@ -4460,7 +4541,6 @@ const server = createServer(async (req, res) => {
 							msg && typeof msg === "object" && "stopReason" in msg &&
 							(msg as { stopReason?: string }).stopReason === "error"
 						) {
-							emittedError = true;
 							const detail = (msg as { errorMessage?: string }).errorMessage;
 							const errorMsg = detail || "The model request failed.";
 							logger.error({ stopReason: "error", errorMessage: errorMsg, message: msg, elapsedMs: Date.now() - promptStartTime }, "Model request failed (message_end stopReason=error)");
@@ -4507,59 +4587,90 @@ const server = createServer(async (req, res) => {
 
 				// Convert to an SSE event and publish to broadcaster + live client.
 				const sseEvent = piEventToSseEvent(event);
-				if (sseEvent) publishStreamEvent(sseEvent);
+				if (sseEvent) streamRegistry.publishStreamEvent(state, sseEvent as { type: string });
 			};
 
 			promptStartTime = Date.now();
 			try {
-				// Use atomic switch+stream when a specific session is requested,
-				// preventing race conditions with channel session switches.
-				const fullText = targetSessionPath
-					? await runPromptStreamingInSession(targetSessionPath, promptWithHint, onEvent, imageArgs)
-					: await runPromptStreaming(promptWithHint, onEvent, imageArgs);
-				const doneEvent = { type: "done", fullText };
-				broadcaster.publish(doneEvent);
-				if (!aborted) sseWrite(doneEvent);
-				// Skip topic auto-generation when the turn errored — there is no
-				// meaningful assistant reply to summarize and the model API is
-				// likely still failing (which would just block again).
-				if (!emittedError) maybeAutoGenerateTopic(capturedSessionId);
+				await runPromptStreamingInSession(targetSessionPath, promptWithHint, onEvent, imageArgs, {
+					token: state.turnId,
+					shouldStart: () => !state.cancelRequested,
+					isCancellationRequested: () => state.cancelRequested,
+					onStart: () => {
+						streamRegistry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+						questionBridge.bindTurn({
+							sessionId: state.sessionId,
+							turnId: state.turnId,
+							emit: (event) => streamRegistry.publishStreamEvent(state, event),
+							timeoutMs: 30 * 60_000,
+						});
+						workspaceChangeMonitor = createWorkspaceChangeMonitor(streamWorkspaceRoot, (event) => {
+							streamRegistry.publishStreamEvent(state, event as { type: string });
+						});
+					},
+					onFinish: async (outcome) => {
+						if (outcome.type === "aborted" && outcome.reason === "cancelled_before_start") {
+							persistCancelledQueuedTurn(prompt, state.sessionId, imageArgs);
+						} else if (outcome.type !== "completed") {
+							persistPendingUserTurn(state.sessionId);
+						}
+						const persistence = confirmTurnPersistence(state, targetSessionPath, outcome);
+						questionBridge.unbindTurn({ sessionId: state.sessionId, turnId: state.turnId, reason: outcome.type });
+						closeWorkspaceChangeMonitor();
+						workspaceChangeMonitor = null;
+						recordCurrentSessionChannel("web", state.sessionId, { setOriginIfEmpty: true });
+						if (outcome.type === "completed" && persistence.persisted) {
+							streamRegistry.finishTurn(state, "completed", { type: "done", fullText: outcome.fullText }, persistence);
+							maybeAutoGenerateTopic(state.sessionId);
+						} else if (outcome.type === "completed") {
+							streamRegistry.finishTurn(state, "error", { type: "error", message: "Final chat history could not be confirmed.", code: "persistence_confirmation_failed" }, persistence);
+						} else if (outcome.type === "aborted") {
+							streamRegistry.finishTurn(state, "aborted", { type: "aborted", message: "Stopped by user" }, persistence);
+						} else {
+							const message = outcome.error instanceof Error ? outcome.error.message : "Unknown error";
+							if (state.status === "queued") {
+								streamRegistry.finishTurn(state, "aborted", { type: "aborted", message: `Prompt failed before start: ${message}` }, persistence);
+							} else {
+								streamRegistry.finishTurn(state, "error", { type: "error", message }, persistence);
+							}
+						}
+					},
+					onFinalizeFailure: async (outcome, error) => {
+						try {
+							logger.error({ error, outcome: outcome.type, sessionId: state.sessionId, turnId: state.turnId }, "chat turn finalization failed");
+						} catch {
+							// Observability must not block the forced terminal path.
+						}
+						try {
+							questionBridge.unbindTurn({ sessionId: state.sessionId, turnId: state.turnId, reason: "finalization_failed" });
+						} catch {
+							// Continue to the unique terminal event even if question cleanup fails.
+						}
+						try {
+							closeWorkspaceChangeMonitor();
+						} catch {
+							// Continue to the unique terminal event even if monitor cleanup fails.
+						}
+						workspaceChangeMonitor = null;
+						if (!state.terminalEventPublished) {
+							const message = error instanceof Error ? error.message : "Finalization failed";
+							if (state.status === "queued") {
+								streamRegistry.finishTurn(state, "aborted", { type: "aborted", message: `Prompt failed before start: ${message}` }, { persisted: false });
+							} else {
+								streamRegistry.finishTurn(state, "error", { type: "error", message, code: "finalization_failed" }, { persisted: false });
+							}
+						}
+					},
+				}, streamWorkspaceRoot);
 			} catch (err) {
-				logger.error({ err }, "SSE stream error");
-				const errorEvent = { type: "error", message: err instanceof Error ? err.message : "Unknown error" };
-				broadcaster.publish(errorEvent);
-				if (!aborted) {
-					sseWrite(errorEvent);
-				}
+				logger.error({ err, sessionId: state.sessionId, turnId: state.turnId }, "SSE chat turn failed");
 			} finally {
 				clearInterval(heartbeatInterval);
-				workspaceChangeMonitor?.close();
-				// Always attribute this turn to the web channel — even on abort or
-				// error — so an interrupted first prompt keeps origin "web" instead
-				// of being mislabeled "cli" (which happens when no channels.json
-				// entry exists) and grouped/lost incorrectly in the sidebar.
-				recordCurrentSessionChannel("web", capturedSessionId, { setOriginIfEmpty: true });
-				// If the turn was interrupted before any assistant content was
-				// committed, the PI SDK never flushes the session to disk (it stays
-				// header-only / 0-byte), so the conversation disappears once the user
-				// switches away. Force a flush of the header + user message so the
-				// session stays in the sidebar and can be reopened. No-op when an
-				// assistant message already exists (normal/errored turns).
-				persistPendingUserTurn(capturedSessionId);
-				// Keep the broadcaster alive for 5 minutes so reconnecting
-				// clients (e.g. after gateway timeout) can replay event history.
-				setTimeout(() => {
-					if (sessionBroadcasters.get(capturedSessionId) === broadcaster) {
-						broadcaster.close();
-						sessionBroadcasters.delete(capturedSessionId);
-					}
-				}, 300_000);
+				closeWorkspaceChangeMonitor();
+				unsubscribeResponse();
+				streamRegistry.cleanupExpiredTurns();
 			}
-			if (!aborted) {
-				res.write("data: [DONE]\n\n");
-			}
-			questionBridge.setEmitter(null);
-			res.end();
+			finishResponse();
 			return;
 		}
 

--- a/apps/inno-agent/web/src/api/chat.ts
+++ b/apps/inno-agent/web/src/api/chat.ts
@@ -1,5 +1,5 @@
 import { apiFetch, streamSSE, streamSSEGet } from "./client.js";
-import type { ChatStreamEvent } from "../types/chat.js";
+import type { QuestionnaireResult, StreamEventEnvelope, StreamSnapshot } from "../types/chat.js";
 
 export interface InlineImage {
 	data: string;
@@ -14,8 +14,8 @@ export async function postChat(prompt: string, sessionId?: string | null, images
 	return res.response;
 }
 
-export function streamChat(prompt: string, sessionId?: string | null, signal?: AbortSignal, images?: InlineImage[]): AsyncGenerator<ChatStreamEvent> {
-	return streamSSE<ChatStreamEvent>("/api/chat/stream", { prompt, sessionId: sessionId ?? undefined, images: images?.length ? images : undefined }, signal);
+export function streamChat(prompt: string, sessionId: string, clientRequestId: string, signal?: AbortSignal, images?: InlineImage[]): AsyncGenerator<StreamEventEnvelope> {
+	return streamSSE<StreamEventEnvelope>("/api/chat/stream", { prompt, sessionId, clientRequestId, images: images?.length ? images : undefined }, signal);
 }
 
 /**
@@ -23,18 +23,25 @@ export function streamChat(prompt: string, sessionId?: string | null, signal?: A
  * connection-close from aborting the SSE fetch is unreliable through dev proxies,
  * so the UI calls this to deterministically release the server's prompt queue.
  */
-export async function abortChat(): Promise<void> {
-	try {
-		await fetch("/api/chat/abort", { method: "POST" });
-	} catch {
-		// best-effort — the SSE close handler is a fallback
-	}
+export async function abortChat(sessionId: string, turnId: string): Promise<void> {
+	await apiFetch(`/api/chat/${encodeURIComponent(sessionId)}/${encodeURIComponent(turnId)}/abort`, { method: "POST" });
 }
 
 /**
  * Reconnect to an in-progress session's event stream. Returns silently
  * if the session has no active stream (404).
  */
-export function streamSessionEvents(sessionId: string, signal?: AbortSignal): AsyncGenerator<ChatStreamEvent> {
-	return streamSSEGet<ChatStreamEvent>(`/api/chat/events/${encodeURIComponent(sessionId)}`, signal);
+export function streamSessionEvents(sessionId: string, turnId: string, after: number, signal?: AbortSignal): AsyncGenerator<StreamEventEnvelope> {
+	return streamSSEGet<StreamEventEnvelope>(`/api/chat/events/${encodeURIComponent(sessionId)}?turnId=${encodeURIComponent(turnId)}&after=${after}`, signal, { allowNotFound: false });
+}
+
+export async function getChatStatus(sessionId: string): Promise<{ found: boolean; stream?: StreamSnapshot }> {
+	return apiFetch(`/api/chat/status/${encodeURIComponent(sessionId)}`);
+}
+
+export async function submitChatQuestion(sessionId: string, turnId: string, questionId: string, result: QuestionnaireResult): Promise<void> {
+	await apiFetch("/api/chat/question-response", {
+		method: "POST",
+		body: JSON.stringify({ sessionId, turnId, questionId, result }),
+	});
 }

--- a/apps/inno-agent/web/src/api/client.ts
+++ b/apps/inno-agent/web/src/api/client.ts
@@ -108,7 +108,7 @@ export async function* streamSSE<T>(url: string, body: unknown, signal?: AbortSi
  * SSE stream via GET. Returns silently on 404 (no active stream).
  * Yields parsed JSON objects from `data:` lines.
  */
-export async function* streamSSEGet<T>(url: string, signal?: AbortSignal): AsyncGenerator<T> {
+export async function* streamSSEGet<T>(url: string, signal?: AbortSignal, options: { allowNotFound?: boolean } = {}): AsyncGenerator<T> {
 	let res: Response;
 	try {
 		res = await fetch(url, { method: "GET", signal });
@@ -121,7 +121,8 @@ export async function* streamSSEGet<T>(url: string, signal?: AbortSignal): Async
 		// rather than lingering until GC. A 404 here is expected (no active
 		// backend stream for this session) but the response still holds a socket.
 		void res.body?.cancel().catch(() => {});
-		return;
+		if (options.allowNotFound !== false) return;
+		throw new ApiError(404, "Stream not found");
 	}
 	if (!res.ok) {
 		const errBody = await res.json().catch(() => ({}));

--- a/apps/inno-agent/web/src/api/sessions.ts
+++ b/apps/inno-agent/web/src/api/sessions.ts
@@ -18,6 +18,8 @@ export interface SessionMeta {
 
 export interface SessionDetail extends SessionMeta {
 	messages: ChatMessage[];
+	messageCount: number;
+	sessionRevision: string;
 }
 
 export interface SessionActivationResult {

--- a/apps/inno-agent/web/src/react/App.tsx
+++ b/apps/inno-agent/web/src/react/App.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useRef } from "react";
 import { appStore, type RightPanelTab, type WorkspaceMode } from "../stores/app-store.js";
 import { settingsStore } from "../stores/settings-store.js";
 import { themeStore, type ThemeId } from "../stores/theme-store.js";
+import { sessionsStore } from "../stores/sessions-store.js";
+import { workspacesStore } from "../stores/workspaces-store.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { ChatCenter } from "./ChatCenter.js";
 import { SessionSidebar } from "./SessionSidebar.js";
@@ -11,6 +13,18 @@ import { WorkspacePanel } from "./WorkspacePanel.js";
 const SIDEBAR_COLLAPSE_BP = 960;
 const WORKSPACE_COLLAPSE_BP = 820;
 
+let initializationPromise: Promise<void> | null = null;
+
+function initializeApp(): Promise<void> {
+	if (initializationPromise) return initializationPromise;
+	initializationPromise = (async () => {
+		await Promise.all([sessionsStore.load(), workspacesStore.load()]);
+		const requestedSession = new URL(window.location.href).searchParams.get("session");
+		if (requestedSession) await sessionsStore.openSession(requestedSession, { historyMode: "none" });
+	})();
+	return initializationPromise;
+}
+
 export function App() {
 	const app = useStoreSnapshot(appStore, () => ({
 		rightPanelTab: appStore.rightPanelTab,
@@ -18,6 +32,17 @@ export function App() {
 		workspaceMode: appStore.workspaceMode,
 		workspaceWidth: appStore.workspaceWidth,
 	}));
+
+	useEffect(() => {
+		void initializeApp();
+		const onPopState = () => {
+			const sessionId = new URL(window.location.href).searchParams.get("session");
+			if (!sessionId) sessionsStore.showWelcomeFromHistory();
+			else if (sessionId !== sessionsStore.currentSessionId) void sessionsStore.openSession(sessionId, { historyMode: "none" });
+		};
+		window.addEventListener("popstate", onPopState);
+		return () => window.removeEventListener("popstate", onPopState);
+	}, []);
 
 	// Load settings once at boot so Simple Mode (tab hiding, preset cards) is
 	// available app-wide before the user ever opens the Settings panel.

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -456,6 +456,7 @@ export function ChatCenter() {
 		streamingActivity: chatStore.streamingActivity,
 		streamingActivityDetail: chatStore.streamingActivityDetail,
 		streamingError: chatStore.streamingError,
+		canReconnect: chatStore.canReconnect,
 		activeTools: chatStore.activeTools,
 		completedTools: chatStore.completedTools,
 		lastUserPrompt: chatStore.lastUserPrompt,
@@ -702,6 +703,10 @@ export function ChatCenter() {
 		chatStore.cancel();
 	}, []);
 
+	const handleReconnect = useCallback(() => {
+		void chatStore.reconnect();
+	}, []);
+
 	const handleRetry = useCallback(() => {
 		shouldStickToBottomRef.current = true;
 		void chatStore.retry();
@@ -889,13 +894,24 @@ export function ChatCenter() {
 				disabled={chat.isSending || isUploading}
 			/>
 			{chat.isSending ? (
-				<button
-					className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--inno-danger)] text-white transition-opacity hover:opacity-90 active:scale-[0.97]"
-					title={t("chat.stopGeneration")}
-					onClick={handleStop}
-				>
-					<Square size={16} />
-				</button>
+				<>
+					{chat.canReconnect ? (
+						<button
+							className="inno-icon-button flex h-9 w-9 shrink-0 rounded-md"
+							title={t("chat.reconnect", "重新连接")}
+							onClick={handleReconnect}
+						>
+							<RotateCcw size={16} />
+						</button>
+					) : null}
+					<button
+						className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-[var(--inno-danger)] text-white transition-opacity hover:opacity-90 active:scale-[0.97]"
+						title={t("chat.stopGeneration")}
+						onClick={handleStop}
+					>
+						<Square size={16} />
+					</button>
+				</>
 			) : (
 				<>
 					{chat.lastUserPrompt ? (

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -524,11 +524,6 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 	const workspaceFiltering = Boolean(state.searchQuery || state.channelFilter);
 
 	useEffect(() => {
-		void sessionsStore.load();
-		void workspacesStore.load();
-	}, []);
-
-	useEffect(() => {
 		if (!sortMenuOpen) return;
 		const closeOnEscape = (event: KeyboardEvent) => {
 			if (event.key === "Escape") setSortMenuOpen(false);

--- a/apps/inno-agent/web/src/stores/chat-store.test.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	streamChat: vi.fn(),
+	abortChat: vi.fn(),
+	getChatStatus: vi.fn(),
+	streamSessionEvents: vi.fn(),
+	submitChatQuestion: vi.fn(),
+	getSession: vi.fn(),
+	refresh: vi.fn(),
+}));
+
+vi.mock("../api/chat.js", () => ({
+	streamChat: mocks.streamChat,
+	abortChat: mocks.abortChat,
+	getChatStatus: mocks.getChatStatus,
+	streamSessionEvents: mocks.streamSessionEvents,
+	submitChatQuestion: mocks.submitChatQuestion,
+}));
+
+vi.mock("../api/sessions.js", () => ({ getSession: mocks.getSession }));
+vi.mock("./sessions-store.js", () => ({ sessionsStore: { currentSessionId: "session.jsonl", refresh: mocks.refresh } }));
+vi.mock("./notebook-store.js", () => ({ notebookStore: { loadAll: vi.fn() } }));
+vi.mock("./app-store.js", () => ({
+	appStore: {
+		workspaceWidth: 640,
+		workspaceMode: "half",
+		setRightPanelTab: vi.fn(),
+		setWorkspaceWidth: vi.fn(),
+		setWorkspaceMode: vi.fn(),
+	},
+}));
+vi.mock("./workspace-store.js", () => ({
+	workspaceStore: {
+		streamingPreview: null,
+		clearStreamingPreview: vi.fn(),
+		finishStreamingPreview: vi.fn(),
+		updateStreamingPreview: vi.fn(),
+		startStreamingPreview: vi.fn(),
+		loadTree: vi.fn(),
+		selectFile: vi.fn(),
+	},
+}));
+
+import { ChatStoreImpl } from "./chat-store.js";
+import type { ChatStreamEvent, StreamEventEnvelope } from "../types/chat.js";
+
+const CLIENT_REQUEST_ID = "00000000-0000-4000-8000-000000000001";
+
+function envelope(eventId: number, event: ChatStreamEvent): StreamEventEnvelope {
+	return {
+		eventId,
+		sessionId: "session.jsonl",
+		turnId: "turn-1",
+		clientRequestId: CLIENT_REQUEST_ID,
+		event,
+	};
+}
+
+function activeSnapshot() {
+	return {
+		found: true,
+		stream: {
+			sessionId: "session.jsonl",
+			turnId: "turn-1",
+			clientRequestId: CLIENT_REQUEST_ID,
+			workspaceId: "workspace-1",
+			status: "running" as const,
+			createdAt: new Date().toISOString(),
+			inputSnapshot: { prompt: "hello", submittedAt: new Date().toISOString(), images: [] },
+			activeTools: [],
+			lastEventId: 3,
+			cancelRequested: false,
+			baselineMessageCount: 0,
+			baselineSessionRevision: "0:0",
+			persisted: false,
+		},
+	};
+}
+
+describe("ChatStore stream ownership", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(CLIENT_REQUEST_ID);
+		mocks.abortChat.mockResolvedValue(undefined);
+		mocks.getChatStatus.mockResolvedValue(activeSnapshot());
+		mocks.getSession.mockResolvedValue({ messages: [], messageCount: 0, sessionRevision: "0:0" });
+	});
+
+	it("keeps the owner while a scoped cancellation waits for its terminal event", async () => {
+		let releaseTerminal!: () => void;
+		const terminalReady = new Promise<void>((resolve) => { releaseTerminal = resolve; });
+		mocks.streamChat.mockImplementation(async function* () {
+			yield envelope(1, { type: "stream_state", status: "queued" });
+			await terminalReady;
+			yield envelope(2, { type: "aborted", message: "Stopped", persisted: false });
+		});
+
+		const store = new ChatStoreImpl();
+		const sending = store.send("hello");
+		await vi.waitFor(() => expect(store.isSending).toBe(true));
+		store.cancel();
+		await vi.waitFor(() => expect(mocks.abortChat).toHaveBeenCalledWith("session.jsonl", "turn-1"));
+		expect(store.isSending).toBe(true);
+		releaseTerminal();
+		await sending;
+		expect(store.isSending).toBe(false);
+		expect(store.messages.at(-1)).toMatchObject({ role: "assistant", transient: true, complete: false });
+	});
+
+	it("uses the last cursor for transient reconnect without clearing accumulated text", async () => {
+		mocks.streamChat.mockImplementation(async function* () {
+			yield envelope(1, { type: "stream_state", status: "queued" });
+			yield envelope(2, { type: "stream_state", status: "running" });
+			yield envelope(3, { type: "text_delta", delta: "A" });
+			throw new Error("network lost");
+		});
+		mocks.streamSessionEvents.mockImplementation(async function* () {
+			yield envelope(4, { type: "text_delta", delta: "B" });
+			yield envelope(5, { type: "aborted", message: "Stopped", persisted: false });
+		});
+
+		const store = new ChatStoreImpl();
+		await store.send("hello");
+		expect(mocks.streamSessionEvents).toHaveBeenCalledWith("session.jsonl", "turn-1", 3, expect.any(AbortSignal));
+		expect(store.messages.at(-1)).toMatchObject({ role: "assistant", content: "AB", transient: true });
+	});
+
+	it("does not replace a transient turn with stale canonical history", async () => {
+		vi.useFakeTimers();
+		try {
+			mocks.streamChat.mockImplementation(async function* () {
+				yield envelope(1, { type: "stream_state", status: "queued" });
+				yield envelope(2, { type: "stream_state", status: "running" });
+				yield envelope(3, { type: "text_delta", delta: "new reply" });
+				yield envelope(4, { type: "done", fullText: "new reply", persisted: true, finalMessageCount: 4, finalSessionRevision: "4:4" });
+			});
+			mocks.getSession.mockResolvedValue({
+				messages: [{ role: "assistant", content: "old", timestamp: 1 }],
+				messageCount: 1,
+				sessionRevision: "1:1",
+			});
+
+			const store = new ChatStoreImpl();
+			const sending = store.send("hello");
+			await vi.waitFor(() => expect(mocks.getSession).toHaveBeenCalled());
+			await vi.runAllTimersAsync();
+			await sending;
+			expect(store.isSending).toBe(true);
+			expect(store.canReconnect).toBe(true);
+			expect(store.messages[0]).toMatchObject({ role: "user", content: "hello", transient: true });
+			expect(store.streamingText).toBe("new reply");
+			store.detach();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+});

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "./event-emitter.js";
-import { streamChat, abortChat, streamSessionEvents } from "../api/chat.js";
+import { streamChat, abortChat, getChatStatus, streamSessionEvents, submitChatQuestion } from "../api/chat.js";
 import type { InlineImage } from "../api/chat.js";
-import type { ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult, WorkspaceFileChange } from "../types/chat.js";
+import type { ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult, StreamEventEnvelope, StreamSnapshot, WorkspaceFileChange } from "../types/chat.js";
 import { notebookStore } from "./notebook-store.js";
 import { appStore } from "./app-store.js";
 import { workspaceStore, type StreamingWorkspacePreview } from "./workspace-store.js";
@@ -16,7 +16,23 @@ interface ChatStoreEvents {
 	change: void;
 }
 
-class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
+interface ActiveStreamOwner {
+	sessionId: string;
+	clientRequestId: string;
+	turnId: string | null;
+	generation: number;
+	controller: AbortController;
+	lastAppliedEventId: number;
+	cancellationRequested: boolean;
+	terminalEvent?: TerminalChatStreamEvent;
+	phase: "submitting" | "streaming" | "cancelling" | "reconnecting" | "reloading_history";
+}
+
+type TerminalChatStreamEvent = Extract<ChatStreamEvent, { type: "done" | "error" | "aborted" }>;
+
+const RECONNECT_DELAYS_MS = [250, 500, 1_000, 2_000] as const;
+
+export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	messages: ChatMessage[] = [];
 	isSending = false;
 	/** Set while fetching persisted history for a session. */
@@ -37,6 +53,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	lastImages: InlineImage[] | undefined = undefined;
 	/** Pending question from agent's ask_user_question tool */
 	pendingQuestion: PendingQuestion | null = null;
+	canReconnect = false;
 	private abortController: AbortController | null = null;
 	private detachMode = false;
 	private wikiInvalidated = false;
@@ -47,19 +64,20 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	private completedFileToolIds = new Set<string>();
 	private previewChangeTimer: ReturnType<typeof setTimeout> | null = null;
 	private pendingPreviewUpdate: { id: string; patch: StreamingPreviewPatch } | null = null;
+	private activeOwner: ActiveStreamOwner | null = null;
+	private ownerGeneration = 0;
+	private currentSessionContext: string | null = null;
+	private retryInputBySession = new Map<string, { prompt: string; images?: InlineImage[] }>();
 
 	async send(prompt: string, images?: InlineImage[]): Promise<void> {
 		if ((!prompt.trim() && !images?.length) || this.isSending) return;
-		this.detachMode = false;
-		this.resetStreamTimers();
-		this.streamingTarget = "chat";
-		this.resetWorkspaceStreamState();
-
-		// Capture the target session at send time to prevent misalignment
-		// if the user switches sessions while the request is queued.
 		const { sessionsStore } = await import("./sessions-store.js");
 		const targetSessionId = sessionsStore.currentSessionId;
+		if (!targetSessionId || this.isSending) return;
 
+		this.detachMode = false;
+		this.currentSessionContext = targetSessionId;
+		this.retryInputBySession.set(targetSessionId, { prompt, images });
 		this.lastUserPrompt = prompt;
 		this.lastImages = images;
 		this.messages = [...this.messages, {
@@ -70,124 +88,46 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				previewUrl: `data:${mimeType};base64,${data}`,
 				mimeType,
 			})),
+			transient: true,
+			complete: false,
 		}];
+		this.resetTransientStreamState();
 		this.isSending = true;
-		this.streamingText = "";
-		this.streamingThinking = "";
 		this.setStreamingActivity("正在分析请求");
-		this.streamingError = "";
-		this.activeTools = [];
-		this.completedTools = [];
 		this.wikiInvalidated = false;
 		const controller = new AbortController();
 		this.abortController = controller;
+		const owner: ActiveStreamOwner = {
+			sessionId: targetSessionId,
+			clientRequestId: crypto.randomUUID(),
+			turnId: null,
+			generation: ++this.ownerGeneration,
+			controller,
+			lastAppliedEventId: 0,
+			cancellationRequested: false,
+			phase: "submitting",
+		};
+		this.activeOwner = owner;
 		this.emit("change", undefined);
 
 		try {
-			for await (const event of streamChat(prompt, targetSessionId, controller.signal, images)) {
-				this._handleStreamEvent(event);
+			for await (const envelope of streamChat(prompt, targetSessionId, owner.clientRequestId, controller.signal, images)) {
+				await this._handleStreamEnvelope(owner, envelope);
 			}
-			this.flushStreamChange();
-			const aborted = controller.signal.aborted;
-
-			// Finalize: add accumulated text as assistant message. Also finalize
-			// when the turn produced only an error (no text), so the error is
-			// preserved in history instead of vanishing when streaming state resets.
-			if (this.detachMode) {
-				// skip — backend still running, loadHistory will show final result
-			} else if (this.streamingText || this.streamingError || aborted) {
-				this.messages = [
-					...this.messages,
-					{
-						role: "assistant",
-						content: aborted && !this.streamingText
-							? "[Stopped by user]"
-							: this.streamingText + (aborted ? "\n\n[Stopped by user]" : ""),
-						timestamp: Date.now(),
-						thinking: this.streamingThinking || undefined,
-						tools: this.completedTools.length > 0 ? this.completedTools : undefined,
-						error: this.streamingError || undefined,
-					},
-				];
+			if (this.owns(owner) && !owner.terminalEvent) {
+				await this.reconnectOwner(owner, new Error("实时连接提前结束"));
 			}
 		} catch (err) {
-			if (!controller.signal.aborted && !this.detachMode && targetSessionId) {
-				console.warn("[chat-store] SSE stream disconnected, attempting reconnect...");
-				this.setStreamingActivity("连接中断，正在重连");
-				this.emit("change", undefined);
-				try {
-					await new Promise((r) => setTimeout(r, 1000));
-					this.streamingText = "";
-					this.streamingThinking = "";
-					this.streamingError = "";
-					this.activeTools = [];
-					this.completedTools = [];
-					const reconnectController = new AbortController();
-					this.abortController = reconnectController;
-					for await (const event of streamSessionEvents(targetSessionId, reconnectController.signal)) {
-						this._handleStreamEvent(event);
-					}
-					this.flushStreamChange();
-					if (!this.detachMode && (this.streamingText || this.streamingError)) {
-						this.messages = [
-							...this.messages,
-							{
-								role: "assistant",
-								content: this.streamingText,
-								timestamp: Date.now(),
-								thinking: this.streamingThinking || undefined,
-								tools: this.completedTools.length > 0 ? this.completedTools : undefined,
-								error: this.streamingError || undefined,
-							},
-						];
-					}
-				} catch (reconnectErr) {
-					if (!this.abortController?.signal.aborted) {
-						const message = reconnectErr instanceof Error ? reconnectErr.message : "Unknown error";
-						this.messages = [
-							...this.messages,
-							{ role: "assistant", content: "", timestamp: Date.now(), error: `Reconnect failed: ${message}` },
-						];
-					}
-				}
-			} else if (!controller.signal.aborted) {
-				const message = err instanceof Error ? err.message : "Unknown error";
-				this.messages = [
-					...this.messages,
-					{ role: "assistant", content: "", timestamp: Date.now(), error: message },
-				];
+			if (!this.owns(owner) || owner.controller.signal.aborted || owner.terminalEvent) return;
+			const bound = await this.bindOwnerFromStatus(owner);
+			if (!this.owns(owner)) return;
+			if (!bound) {
+				const message = err instanceof Error ? err.message : "提交请求失败";
+				this.materializeTransientTurn(owner, message);
+				this.finalizeOwner(owner);
+				return;
 			}
-		} finally {
-			this.flushStreamChange();
-			this.isSending = false;
-			this.streamingText = "";
-			this.streamingThinking = "";
-			this.streamingTarget = "chat";
-			this.streamingActivity = "";
-			this.streamingActivityDetail = "";
-			this.streamingError = "";
-			this.activeTools = [];
-			this.completedTools = [];
-			this.abortController = null;
-			this.detachMode = false;
-			this.pendingQuestion = null;
-			this.resetStreamTimers();
-			this.resetWorkspaceStreamState({ flushPreview: true });
-			const shouldRefreshWiki = this.wikiInvalidated;
-			this.wikiInvalidated = false;
-			this.emit("change", undefined);
-			if (shouldRefreshWiki) {
-				// L2 tools mutated the wiki — refresh pages + graph so the
-				// Notebook tab reflects the new state without manual reload.
-				void notebookStore.loadAll();
-			}
-			// Refresh the sessions sidebar so the current conversation
-			// (especially a freshly-created one) appears with its updated
-			// preview / message count without a manual page reload.
-			//
-			// Dynamic import avoids a hard circular-import dependency with
-			// sessions-store (which already imports chat-store).
-			void import("./sessions-store.js").then((m) => m.sessionsStore.refresh());
+			await this.reconnectOwner(owner, err);
 		}
 	}
 
@@ -196,13 +136,14 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	 * the only path that actually stops the backend task.
 	 */
 	cancel(): void {
-		const wasSending = this.isSending;
-		this.abortController?.abort();
-		// Aborting the local fetch may not promptly close the upstream connection
-		// (dev proxy buffering), so explicitly tell the backend to stop the run.
-		// This releases the server's shared prompt queue immediately, preventing
-		// new-session / switch-session from blocking behind a still-running turn.
-		if (wasSending) void abortChat();
+		const owner = this.activeOwner;
+		if (!owner) return;
+		owner.cancellationRequested = true;
+		owner.phase = "cancelling";
+		this.canReconnect = false;
+		this.setStreamingActivity("正在取消");
+		this.emit("change", undefined);
+		void this.cancelOwnedTurn(owner);
 	}
 
 	/**
@@ -211,86 +152,264 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	 */
 	detach(): void {
 		this.detachMode = true;
-		this.abortController?.abort();
+		this.activeOwner?.controller.abort();
+		this.activeOwner = null;
+		this.ownerGeneration++;
 		this.abortController = null;
+		this.isSending = false;
+		this.canReconnect = false;
+		this.currentSessionContext = null;
+		this.lastUserPrompt = null;
+		this.lastImages = undefined;
+		this.resetTransientStreamState();
+		this.emit("change", undefined);
+	}
+
+	private async cancelOwnedTurn(owner: ActiveStreamOwner): Promise<void> {
+		try {
+			if (!owner.turnId) await this.bindOwnerFromStatus(owner);
+			if (!this.owns(owner)) return;
+			if (!owner.turnId) throw new Error("尚未确认服务端任务，请重试停止操作");
+			await abortChat(owner.sessionId, owner.turnId);
+			if (!this.owns(owner)) return;
+			this.setStreamingActivity("正在等待任务停止");
+			this.emit("change", undefined);
+		} catch (err) {
+			if (this.owns(owner)) {
+				this.canReconnect = true;
+				this.streamingError = err instanceof Error ? err.message : "无法停止该任务";
+				this.emit("change", undefined);
+			}
+		}
 	}
 
 	/**
 	 * Reconnect to an in-progress session's backend event stream.
 	 * Replays history and continues receiving live events.
 	 */
-	async resumeStream(sessionId: string): Promise<void> {
+	async resumeStream(sessionId: string, snapshot?: StreamSnapshot): Promise<void> {
 		if (this.isSending) return;
-		this.resetStreamTimers();
+		const stream = snapshot ?? (await getChatStatus(sessionId)).stream;
+		if (!stream || !["queued", "running"].includes(stream.status)) return;
+		if (!Number.isInteger(stream.baselineMessageCount) || stream.baselineMessageCount < 0) {
+			this.streamingError = "该任务缺少恢复基线，无法安全恢复实时内容";
+			this.emit("change", undefined);
+			return;
+		}
+		this.currentSessionContext = sessionId;
+		this.resetTransientStreamState();
 		this.isSending = true;
-		this.streamingText = "";
-		this.streamingThinking = "";
-		this.streamingTarget = "chat";
 		this.streamingActivity = "正在恢复生成";
-		this.streamingActivityDetail = "";
-		this.streamingError = "";
-		this.activeTools = [];
-		this.completedTools = [];
 		this.detachMode = false;
-		this.resetWorkspaceStreamState();
 		const controller = new AbortController();
 		this.abortController = controller;
+		const owner: ActiveStreamOwner = {
+			sessionId,
+			clientRequestId: stream.clientRequestId,
+			turnId: stream.turnId,
+			generation: ++this.ownerGeneration,
+			controller,
+			lastAppliedEventId: 0,
+			cancellationRequested: stream.cancelRequested,
+			phase: "reconnecting",
+		};
+		this.activeOwner = owner;
+		this.messages = [
+			...this.messages.slice(0, stream.baselineMessageCount),
+			{
+				role: "user",
+				content: stream.inputSnapshot.prompt,
+				timestamp: Date.parse(stream.inputSnapshot.submittedAt) || Date.now(),
+				images: stream.inputSnapshot.images
+					.filter((image) => image.previewUrl)
+					.map((image) => ({ previewUrl: image.previewUrl!, mimeType: image.mimeType })),
+				turnId: stream.turnId,
+				transient: true,
+				complete: false,
+			},
+		];
 		this.emit("change", undefined);
 
 		try {
-			for await (const event of streamSessionEvents(sessionId, controller.signal)) {
-				this._handleStreamEvent(event);
+			for await (const envelope of streamSessionEvents(sessionId, stream.turnId, 0, controller.signal)) {
+				await this._handleStreamEnvelope(owner, envelope);
 			}
-			this.flushStreamChange();
-			// Finalize assistant message from accumulated streaming text
-			if (this.detachMode) {
-				// detached again — skip finalize
-			} else if (this.streamingText || this.streamingError) {
-				this.messages = [
-					...this.messages,
-					{
-						role: "assistant",
-						content: this.streamingText,
-						timestamp: Date.now(),
-						thinking: this.streamingThinking || undefined,
-						tools: this.completedTools.length > 0 ? this.completedTools : undefined,
-						error: this.streamingError || undefined,
-					},
-				];
+			if (this.owns(owner) && !owner.terminalEvent) {
+				await this.reconnectOwner(owner, new Error("恢复连接提前结束"));
 			}
 		} catch (err) {
-			if (!controller.signal.aborted) {
-				console.warn("[chat-store] resumeStream error:", err);
+			if (this.owns(owner) && !controller.signal.aborted && !owner.terminalEvent) {
+				await this.reconnectOwner(owner, err);
 			}
-		} finally {
-			this.flushStreamChange();
-			this.isSending = false;
-			this.streamingText = "";
-			this.streamingThinking = "";
-			this.streamingTarget = "chat";
-			this.streamingActivity = "";
-			this.streamingActivityDetail = "";
-			this.streamingError = "";
-			this.activeTools = [];
-			this.completedTools = [];
-			this.abortController = null;
-			this.detachMode = false;
-			this.pendingQuestion = null;
-			this.resetStreamTimers();
-			this.resetWorkspaceStreamState({ flushPreview: true });
-			this.emit("change", undefined);
-			void import("./sessions-store.js").then((m) => m.sessionsStore.refresh());
 		}
 	}
 
 	/** Re-send the last user prompt. No-op while a send is in flight. */
 	async retry(): Promise<void> {
-		if (this.isSending || !this.lastUserPrompt) return;
-		await this.send(this.lastUserPrompt, this.lastImages);
+		if (this.isSending || !this.currentSessionContext) return;
+		const input = this.retryInputBySession.get(this.currentSessionContext);
+		if (!input) return;
+		await this.send(input.prompt, input.images);
 	}
 
-	private _handleStreamEvent(event: ChatStreamEvent) {
+	/** Retry a failed event reconnect or final-history confirmation. */
+	async reconnect(): Promise<void> {
+		const owner = this.activeOwner;
+		if (!owner || !this.canReconnect) return;
+		this.canReconnect = false;
+		this.streamingError = "";
+		if (owner.terminalEvent) {
+			await this.handleTerminal(owner, owner.terminalEvent);
+		} else {
+			await this.reconnectOwner(owner, new Error("用户请求重新连接"));
+		}
+	}
+
+	private owns(owner: ActiveStreamOwner): boolean {
+		return this.activeOwner === owner && this.activeOwner.generation === owner.generation;
+	}
+
+	private async bindOwnerFromStatus(owner: ActiveStreamOwner): Promise<boolean> {
+		for (let attempt = 0; attempt < RECONNECT_DELAYS_MS.length; attempt++) {
+			if (!this.owns(owner)) return false;
+			try {
+				const status = await getChatStatus(owner.sessionId);
+				if (status.stream?.clientRequestId === owner.clientRequestId) {
+					owner.turnId = status.stream.turnId;
+					return true;
+				}
+			} catch {
+				// A just-submitted request may not be visible yet; retry below.
+			}
+			if (attempt < RECONNECT_DELAYS_MS.length - 1) await delay(RECONNECT_DELAYS_MS[attempt]);
+		}
+		return false;
+	}
+
+	private async reconnectOwner(owner: ActiveStreamOwner, cause: unknown): Promise<void> {
+		if (!this.owns(owner) || owner.terminalEvent) return;
+		owner.phase = "reconnecting";
+		this.setStreamingActivity("连接中断，正在重连");
+		this.emit("change", undefined);
+		let lastError = cause;
+		for (let attempt = 0; attempt < RECONNECT_DELAYS_MS.length; attempt++) {
+			if (!this.owns(owner) || owner.terminalEvent) return;
+			if (attempt > 0) await delay(RECONNECT_DELAYS_MS[attempt - 1]);
+			try {
+				if (!owner.turnId && !(await this.bindOwnerFromStatus(owner))) continue;
+				if (!owner.turnId || !this.owns(owner)) return;
+				const status = await getChatStatus(owner.sessionId);
+				if (!status.stream || status.stream.turnId !== owner.turnId || status.stream.clientRequestId !== owner.clientRequestId) {
+					throw new Error("服务端任务状态已不可用");
+				}
+				const reconnectController = new AbortController();
+				owner.controller = reconnectController;
+				this.abortController = reconnectController;
+				for await (const envelope of streamSessionEvents(owner.sessionId, owner.turnId, owner.lastAppliedEventId, reconnectController.signal)) {
+					await this._handleStreamEnvelope(owner, envelope);
+				}
+				if (!this.owns(owner) || owner.terminalEvent) return;
+				lastError = new Error("重连后事件流提前结束");
+			} catch (error) {
+				if (!this.owns(owner) || owner.controller.signal.aborted) return;
+				lastError = error;
+			}
+		}
+		this.failRecovery(owner, lastError, "实时连接恢复失败，请重新连接");
+	}
+
+	private async _handleStreamEnvelope(owner: ActiveStreamOwner, envelope: StreamEventEnvelope): Promise<void> {
+		if (!this.owns(owner) || envelope.sessionId !== owner.sessionId || envelope.clientRequestId !== owner.clientRequestId) return;
+		if (owner.turnId === null) owner.turnId = envelope.turnId;
+		if (owner.turnId !== envelope.turnId || envelope.eventId <= owner.lastAppliedEventId) return;
+		owner.lastAppliedEventId = envelope.eventId;
+		if (envelope.event.type === "stream_state" && envelope.event.status === "running") owner.phase = "streaming";
+		this._handleStreamEvent(envelope.event, owner);
+		if (!["done", "error", "aborted"].includes(envelope.event.type)) return;
+		await this.handleTerminal(owner, envelope.event as TerminalChatStreamEvent);
+	}
+
+	private async handleTerminal(owner: ActiveStreamOwner, terminal: TerminalChatStreamEvent): Promise<void> {
+		if (!this.owns(owner)) return;
+		owner.terminalEvent = terminal;
+		owner.phase = "reloading_history";
+		if (!terminal.persisted) {
+			const message = terminal.type === "error" ? terminal.message : terminal.message ?? "最终记录尚未确认";
+			this.materializeTransientTurn(owner, message);
+			this.finalizeOwner(owner);
+			return;
+		}
+		const loaded = await this.reloadCanonicalHistory(owner, terminal.finalMessageCount, terminal.finalSessionRevision);
+		if (loaded) this.finalizeOwner(owner);
+		else this.failRecovery(owner, new Error("最终记录尚未确认"), "最终记录尚未确认，请重新加载");
+	}
+
+	private async reloadCanonicalHistory(owner: ActiveStreamOwner, finalMessageCount?: number, finalRevision?: string): Promise<boolean> {
+		const { getSession } = await import("../api/sessions.js");
+		for (let attempt = 0; attempt < RECONNECT_DELAYS_MS.length; attempt++) {
+			try {
+				const session = await getSession(owner.sessionId);
+				if (!this.owns(owner)) return false;
+				const countMatches = finalMessageCount !== undefined && session.messageCount >= finalMessageCount;
+				const revisionMatches = Boolean(finalRevision) && session.sessionRevision === finalRevision;
+				if (countMatches || revisionMatches) {
+					this.messages = session.messages.map((message) => ({ ...message, complete: true, transient: false }));
+					this.emit("change", undefined);
+					return true;
+				}
+			} catch {
+				// The JSONL write may not be visible to this request yet.
+			}
+			if (attempt < RECONNECT_DELAYS_MS.length - 1) await delay(RECONNECT_DELAYS_MS[attempt]);
+		}
+		return false;
+	}
+
+	private materializeTransientTurn(owner: ActiveStreamOwner, error: string): void {
+		if (!this.owns(owner)) return;
+		this.messages = [...this.messages, {
+			role: "assistant",
+			content: this.streamingText,
+			timestamp: Date.now(),
+			thinking: this.streamingThinking || undefined,
+			tools: this.completedTools.length ? this.completedTools : undefined,
+			error,
+			turnId: owner.turnId ?? undefined,
+			transient: true,
+			complete: false,
+		}];
+	}
+
+	private failRecovery(owner: ActiveStreamOwner, error: unknown, prefix: string): void {
+		if (!this.owns(owner)) return;
+		this.canReconnect = true;
+		const detail = error instanceof Error ? error.message : String(error);
+		this.streamingError = detail && detail !== prefix ? `${prefix}：${detail}` : prefix;
+		this.emit("change", undefined);
+	}
+
+	private finalizeOwner(owner: ActiveStreamOwner): void {
+		if (!this.owns(owner)) return;
+		this.flushStreamChange();
+		this.activeOwner = null;
+		this.abortController = null;
+		this.isSending = false;
+		this.canReconnect = false;
+		this.detachMode = false;
+		this.resetTransientStreamState();
+		const shouldRefreshWiki = this.wikiInvalidated;
+		this.wikiInvalidated = false;
+		this.emit("change", undefined);
+		if (shouldRefreshWiki) void notebookStore.loadAll();
+		void import("./sessions-store.js").then((module) => module.sessionsStore.refresh());
+	}
+
+	private _handleStreamEvent(event: ChatStreamEvent, owner: ActiveStreamOwner) {
 		switch (event.type) {
+			case "stream_state":
+				this.setStreamingActivity(event.status === "queued" ? "等待执行" : "正在分析请求");
+				this.emit("change", undefined);
+				break;
 			case "text_delta":
 				this.streamingText += event.delta;
 				if (!this.workspacePreviewId) this.setStreamingActivity("正在组织回复");
@@ -306,7 +425,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			case "tool_start":
 				this.flushStreamChange();
 				this.maybeStartFileToolPreview(event.toolCallId, event.toolName, event.args);
-				this.activeTools = [...this.activeTools, {
+				this.activeTools = [...this.activeTools.filter((tool) => tool.toolCallId !== event.toolCallId), {
 					toolCallId: event.toolCallId,
 					toolName: event.toolName,
 					args: compactToolPayload(event.args),
@@ -315,9 +434,9 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				break;
 			case "tool_end":
 				this.flushStreamChange();
-				this.maybeFinishFileToolPreview(event.toolCallId, event.toolName, event.result, event.isError);
+				this.maybeFinishFileToolPreview(event.toolCallId, event.toolName, event.result, event.isError, owner);
 				this.completedTools = [
-					...this.completedTools,
+					...this.completedTools.filter((tool) => tool.toolCallId !== event.toolCallId),
 					{
 						...(this.activeTools.find((t) => t.toolCallId === event.toolCallId) ?? {
 							toolCallId: event.toolCallId,
@@ -337,7 +456,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				this.emit("change", undefined);
 				break;
 			case "workspace_change":
-				this.handleWorkspaceChange(event);
+				this.handleWorkspaceChange(event, owner);
 				break;
 			case "error":
 				this.flushStreamChange();
@@ -358,12 +477,20 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				};
 				this.emit("change", undefined);
 				break;
+			case "question_resolved":
+				if (this.pendingQuestion?.questionId === event.questionId) this.pendingQuestion = null;
+				this.emit("change", undefined);
+				break;
 			case "done":
 				this.flushStreamChange();
 				// Final message set with full content
 				if (event.fullText) {
 					this.streamingText = event.fullText;
 				}
+				this.emit("change", undefined);
+				break;
+			case "aborted":
+				this.streamingError = event.message ?? "Stopped by user";
 				this.emit("change", undefined);
 				break;
 		}
@@ -385,6 +512,21 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	private resetStreamTimers(): void {
 		if (this.streamChangeTimer) clearTimeout(this.streamChangeTimer);
 		this.streamChangeTimer = null;
+	}
+
+	private resetTransientStreamState(): void {
+		this.resetStreamTimers();
+		this.streamingText = "";
+		this.streamingThinking = "";
+		this.streamingTarget = "chat";
+		this.streamingActivity = "";
+		this.streamingActivityDetail = "";
+		this.streamingError = "";
+		this.activeTools = [];
+		this.completedTools = [];
+		this.pendingQuestion = null;
+		if (this.workspacePreviewId) workspaceStore.clearStreamingPreview(this.workspacePreviewId);
+		this.resetWorkspaceStreamState();
 	}
 
 	private setStreamingActivity(label: string, detail = ""): void {
@@ -455,7 +597,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		}
 	}
 
-	private maybeFinishFileToolPreview(toolCallId: string, toolName: string, result: unknown, isError: boolean): void {
+	private maybeFinishFileToolPreview(toolCallId: string, toolName: string, result: unknown, isError: boolean, owner: ActiveStreamOwner): void {
 		if (!isFileWritingTool(toolName)) return;
 		this.flushPreviewChange();
 		const rawArgsText = this.fileToolArgText.get(toolCallId);
@@ -473,11 +615,11 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		if (!isError && filePath) {
 			this.completedFileToolIds.add(toolCallId);
 			this.setStreamingActivity("正在刷新文件预览", filePath);
-			void openChangedWorkspacePath(filePath, isActivePreview ? previewId : undefined);
+			void openChangedWorkspacePath(filePath, isActivePreview ? previewId : undefined, () => this.owns(owner));
 		}
 	}
 
-	private handleWorkspaceChange(event: Extract<ChatStreamEvent, { type: "workspace_change" }>): void {
+	private handleWorkspaceChange(event: Extract<ChatStreamEvent, { type: "workspace_change" }>, owner: ActiveStreamOwner): void {
 		if (!event.changes.length || (event.toolCallId && this.completedFileToolIds.has(event.toolCallId))) return;
 		const eventPreviewId = event.toolCallId ? `tool-${event.toolCallId}` : null;
 		const previewId = eventPreviewId && this.workspacePreviewId === eventPreviewId ? eventPreviewId : null;
@@ -488,7 +630,7 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			this.streamingTarget = "chat";
 			this.workspacePreviewId = null;
 		}
-		void openChangedWorkspacePath(target?.path, previewId ?? undefined);
+		void openChangedWorkspacePath(target?.path, previewId ?? undefined, () => this.owns(owner));
 	}
 
 	private updateToolArgText(toolCallId: string, argsDelta?: string): string {
@@ -530,16 +672,15 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	}
 
 	async submitQuestionResponse(questionId: string, result: QuestionnaireResult): Promise<void> {
-		this.pendingQuestion = null;
-		this.emit("change", undefined);
+		const owner = this.activeOwner;
+		if (!owner?.turnId || this.pendingQuestion?.questionId !== questionId) return;
 		try {
-			await fetch("/api/chat/question-response", {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({ questionId, result }),
-			});
-		} catch {
-			// best-effort — the agent will time out or get cancelled if this fails
+			await submitChatQuestion(owner.sessionId, owner.turnId, questionId, result);
+		} catch (err) {
+			if (this.owns(owner)) {
+				this.streamingError = err instanceof Error ? err.message : "提交回答失败";
+				this.emit("change", undefined);
+			}
 		}
 	}
 
@@ -548,41 +689,26 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	}
 
 	clear() {
-		// If a stream is still running, abort it so its finally{} can run and
-		// release isSending (otherwise the next .send / new-session attempt
-		// is locked behind a permanent isSending=true).
-		this.abortController?.abort();
-		this.abortController = null;
+		this.detach();
 		this.messages = [];
-		this.isSending = false;
-		this.streamingText = "";
-		this.streamingThinking = "";
-		this.streamingTarget = "chat";
-		this.streamingActivity = "";
-		this.streamingActivityDetail = "";
-		this.streamingError = "";
-		this.activeTools = [];
-		this.completedTools = [];
-		this.pendingQuestion = null;
-		this.resetStreamTimers();
-		this.resetWorkspaceStreamState();
 		this.emit("change", undefined);
 	}
 
-	loadHistory(messages: ChatMessage[]) {
+	loadHistory(messages: ChatMessage[], sessionId?: string) {
 		this.isLoadingHistory = false;
 		this.messages = messages;
 		this.isSending = false;
-		this.streamingText = "";
-		this.streamingThinking = "";
-		this.streamingTarget = "chat";
-		this.streamingActivity = "";
-		this.streamingActivityDetail = "";
-		this.streamingError = "";
-		this.activeTools = [];
-		this.completedTools = [];
-		this.resetStreamTimers();
-		this.resetWorkspaceStreamState();
+		this.canReconnect = false;
+		this.currentSessionContext = sessionId ?? null;
+		const retryInput = sessionId ? this.retryInputBySession.get(sessionId) : undefined;
+		this.lastUserPrompt = retryInput?.prompt ?? null;
+		this.lastImages = retryInput?.images;
+		this.resetTransientStreamState();
+		this.emit("change", undefined);
+	}
+
+	showError(message: string): void {
+		this.streamingError = message;
 		this.emit("change", undefined);
 	}
 
@@ -593,6 +719,10 @@ class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 }
 
 export const chatStore = new ChatStoreImpl();
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 /**
  * Tools that modify the L2 wiki/graph. When any of these complete during a
@@ -807,14 +937,16 @@ function pickOpenableWorkspaceChange(changes: WorkspaceFileChange[]): WorkspaceF
 		?? changes.find((change) => change.change !== "deleted");
 }
 
-async function openChangedWorkspacePath(filePath?: string, previewId?: string): Promise<void> {
+async function openChangedWorkspacePath(filePath?: string, previewId?: string, isCurrent: () => boolean = () => true): Promise<void> {
 	try {
+		if (!isCurrent()) return;
 		revealWorkspacePreview();
 		if (previewId) workspaceStore.clearStreamingPreview(previewId);
-		await workspaceStore.loadTree();
-		if (filePath) await workspaceStore.selectFile(filePath);
+		await workspaceStore.loadTree(isCurrent);
+		if (!isCurrent()) return;
+		if (filePath) await workspaceStore.selectFile(filePath, isCurrent);
 	} catch {
-		if (previewId) workspaceStore.finishStreamingPreview(previewId, "error");
+		if (previewId && isCurrent()) workspaceStore.finishStreamingPreview(previewId, "error");
 	}
 }
 

--- a/apps/inno-agent/web/src/stores/sessions-store.test.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	listSessions: vi.fn(),
+	getSession: vi.fn(),
+	createSession: vi.fn(),
+	activateSession: vi.fn(),
+	getChatStatus: vi.fn(),
+	chatDetach: vi.fn(),
+	chatClear: vi.fn(),
+	chatLoadHistory: vi.fn(),
+	chatSetLoadingHistory: vi.fn(),
+	chatShowError: vi.fn(),
+}));
+
+vi.mock("../api/sessions.js", () => ({
+	listSessions: mocks.listSessions,
+	getSession: mocks.getSession,
+	createSession: mocks.createSession,
+	activateSession: mocks.activateSession,
+	archiveSession: vi.fn(),
+	deleteSession: vi.fn(),
+	generateSessionName: vi.fn(),
+	unarchiveSession: vi.fn(),
+	updateSessionName: vi.fn(),
+}));
+vi.mock("../api/chat.js", () => ({ getChatStatus: mocks.getChatStatus }));
+vi.mock("../api/workspaces.js", () => ({ getSessionWorkspace: vi.fn().mockResolvedValue({ workspaceId: "workspace-1" }) }));
+vi.mock("./chat-store.js", () => ({
+	chatStore: {
+		messages: [],
+		isLoadingHistory: false,
+		isSending: false,
+		detach: mocks.chatDetach,
+		clear: mocks.chatClear,
+		loadHistory: mocks.chatLoadHistory,
+		setLoadingHistory: mocks.chatSetLoadingHistory,
+		showError: mocks.chatShowError,
+		resumeStream: vi.fn(),
+	},
+}));
+vi.mock("./workspace-store.js", () => ({ workspaceStore: { setActiveWorkspace: vi.fn() } }));
+vi.mock("./workspaces-store.js", () => ({ workspacesStore: { load: vi.fn() } }));
+vi.mock("./terminal-store.js", () => ({ terminalStore: { disconnect: vi.fn() } }));
+
+import { SessionsStoreImpl } from "./sessions-store.js";
+
+function session(id: string) {
+	return {
+		id,
+		name: id,
+		createdAt: "2026-01-01",
+		updatedAt: "2026-01-01",
+		messageCount: 0,
+		preview: "",
+		channels: [],
+		messages: [],
+		sessionRevision: "0:0",
+	};
+}
+
+describe("SessionsStore navigation", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		let href = "http://localhost/";
+		Object.defineProperty(globalThis, "window", {
+			configurable: true,
+			value: {
+				location: { get href() { return href; }, set href(value: string) { href = value; } },
+				history: {
+					pushState: vi.fn((_state, _title, url: URL) => { href = url.toString(); }),
+					replaceState: vi.fn((_state, _title, url: URL) => { href = url.toString(); }),
+				},
+			},
+		});
+		mocks.listSessions.mockResolvedValue([]);
+		mocks.activateSession.mockResolvedValue({ active: true });
+		mocks.getChatStatus.mockResolvedValue({ found: false });
+	});
+
+	it("writes the created session to the URL before the first send can continue", async () => {
+		mocks.createSession.mockResolvedValue({ id: "created.jsonl", active: true, workspaceId: "workspace-1" });
+		const store = new SessionsStoreImpl();
+		await store.createSessionWith({ workspaceId: "workspace-1" });
+		expect(store.currentSessionId).toBe("created.jsonl");
+		expect(new URL(window.location.href).searchParams.get("session")).toBe("created.jsonl");
+		expect(window.history.replaceState).toHaveBeenCalled();
+	});
+
+	it("returns to the welcome page on a popstate URL without a session", () => {
+		const store = new SessionsStoreImpl();
+		store.currentSessionId = "a.jsonl";
+		store.showWelcomeFromHistory();
+		expect(store.currentSessionId).toBeNull();
+		expect(store.pendingNewSession).toBe(true);
+		expect(mocks.chatDetach).toHaveBeenCalled();
+		expect(window.history.replaceState).not.toHaveBeenCalled();
+	});
+
+	it("does not let a stale open request overwrite a newer session", async () => {
+		let resolveA!: (value: ReturnType<typeof session>) => void;
+		const a = new Promise<ReturnType<typeof session>>((resolve) => { resolveA = resolve; });
+		mocks.getSession.mockImplementation((id: string) => id === "a.jsonl" ? a : Promise.resolve(session("b.jsonl")));
+		const store = new SessionsStoreImpl();
+		const openingA = store.openSession("a.jsonl", { historyMode: "none" });
+		await Promise.resolve();
+		await store.openSession("b.jsonl", { historyMode: "none" });
+		resolveA(session("a.jsonl"));
+		await openingA;
+		expect(store.currentSessionId).toBe("b.jsonl");
+		expect(mocks.chatLoadHistory).toHaveBeenLastCalledWith([], "b.jsonl");
+	});
+});

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -14,6 +14,7 @@ import {
 	type SessionMeta,
 } from "../api/sessions.js";
 import { getSessionWorkspace } from "../api/workspaces.js";
+import { getChatStatus } from "../api/chat.js";
 import { chatStore } from "./chat-store.js";
 import { workspaceStore } from "./workspace-store.js";
 import { workspacesStore } from "./workspaces-store.js";
@@ -23,7 +24,9 @@ interface SessionsStoreEvents {
 	change: void;
 }
 
-class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
+export type HistoryMode = "push" | "replace" | "none";
+
+export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	sessions: SessionMeta[] = [];
 	currentSessionId: string | null = null;
 	isLoading = false;
@@ -121,7 +124,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		this.emit("change", undefined);
 	}
 
-	async openSession(id: string): Promise<void> {
+	async openSession(id: string, options: { historyMode?: HistoryMode } = {}): Promise<void> {
 		const requestId = ++this._openRequestId;
 		const prevSessionId = this.currentSessionId;
 
@@ -139,6 +142,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		this.currentSessionId = id;
 		this.openingSessionId = id;
 		this.pendingNewSession = false;
+		this.syncSessionUrl(id, options.historyMode ?? "push");
 		this.emit("change", undefined);
 
 		// Detach from the current stream without stopping the backend task.
@@ -148,9 +152,9 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 
 		const cached = this._messageCache.get(id);
 		if (cached) {
-			chatStore.loadHistory(cached);
+			chatStore.loadHistory(cached, id);
 		} else {
-			chatStore.loadHistory([]);
+			chatStore.loadHistory([], id);
 			chatStore.setLoadingHistory(true);
 		}
 
@@ -167,26 +171,32 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 
 		try {
 			const session = await getSession(id);
+			const chatStatus = await getChatStatus(id).catch((error) => {
+				console.warn(`[sessions] failed to load chat status for ${id}:`, error instanceof Error ? error.message : error);
+				return { found: false } as Awaited<ReturnType<typeof getChatStatus>>;
+			});
 			if (requestId !== this._openRequestId) return;
 
-			const isBackground = this._backgroundRunningSessions.has(id);
-			const cachedMessages = this._messageCache.get(id);
-
-			if (isBackground && cachedMessages && cachedMessages.length > session.messages.length) {
-				chatStore.loadHistory(cachedMessages);
-			} else {
-				this._messageCache.set(id, session.messages);
-				chatStore.loadHistory(session.messages);
-			}
+			this._messageCache.set(id, session.messages);
+			chatStore.loadHistory(session.messages, id);
 
 			void activateSession(id).catch((err) => {
 				console.warn(`[sessions] failed to activate ${id}: ${err instanceof Error ? err.message : String(err)}`);
 			});
 
-			if (isBackground) {
-				this._backgroundRunningSessions.delete(id);
-				void chatStore.resumeStream(id);
+			this._backgroundRunningSessions.delete(id);
+			if (chatStatus.stream && ["queued", "running"].includes(chatStatus.stream.status)) {
+				void chatStore.resumeStream(id, chatStatus.stream);
 			}
+		} catch (error) {
+			if (requestId !== this._openRequestId) return;
+			this.currentSessionId = null;
+			this.pendingNewSession = true;
+			this._messageCache.delete(id);
+			chatStore.detach();
+			chatStore.loadHistory([]);
+			chatStore.showError(error instanceof Error ? `无法打开会话：${error.message}` : "无法打开会话");
+			this.syncSessionUrl(null, "replace");
 		} finally {
 			if (requestId === this._openRequestId) {
 				this.openingSessionId = null;
@@ -194,6 +204,30 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 				this.emit("change", undefined);
 			}
 		}
+	}
+
+	/** Apply a browser back/forward navigation to the welcome page. */
+	showWelcomeFromHistory(): void {
+		this._openRequestId++;
+		this.currentSessionId = null;
+		this.openingSessionId = null;
+		this.pendingNewSession = true;
+		this.preselectedWorkspaceId = null;
+		chatStore.detach();
+		chatStore.loadHistory([]);
+		void terminalStore.disconnect();
+		this.emit("change", undefined);
+	}
+
+	private syncSessionUrl(sessionId: string | null, mode: HistoryMode): void {
+		if (mode === "none" || typeof window === "undefined") return;
+		const nextUrl = new URL(window.location.href);
+		if (sessionId) nextUrl.searchParams.set("session", sessionId);
+		else nextUrl.searchParams.delete("session");
+		const current = new URL(window.location.href);
+		if (nextUrl.href === current.href) return;
+		if (mode === "push") window.history.pushState({}, "", nextUrl);
+		else window.history.replaceState({}, "", nextUrl);
 	}
 
 	/**
@@ -211,6 +245,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 			this._messageCache.delete(this.currentSessionId);
 		}
 		this.currentSessionId = null;
+		this.syncSessionUrl(null, "replace");
 		this.pendingNewSession = true;
 		this.preselectedWorkspaceId = null;
 		chatStore.detach();
@@ -259,6 +294,7 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 			void workspacesStore.load();
 			await this.load();
 			this.currentSessionId = created.id;
+			this.syncSessionUrl(created.id, "replace");
 			if (created.workspaceId) {
 				void workspaceStore.setActiveWorkspace(created.workspaceId);
 			}
@@ -304,8 +340,12 @@ class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		this._backgroundRunningSessions.delete(id);
 		this.sessions = this.sessions.filter((session) => session.id !== id);
 		if (this.currentSessionId === id) {
-			this.currentSessionId = result.newActiveId;
-			chatStore.clear();
+			if (result.newActiveId) {
+				await this.openSession(result.newActiveId, { historyMode: "replace" });
+			} else {
+				this.syncSessionUrl(null, "replace");
+				this.showWelcomeFromHistory();
+			}
 		}
 		this.emit("change", undefined);
 		if (result.newActiveId) {

--- a/apps/inno-agent/web/src/stores/workspace-store.ts
+++ b/apps/inno-agent/web/src/stores/workspace-store.ts
@@ -46,12 +46,18 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 	isEditing = false;
 	editBuffer = "";
 	isSaving = false;
+	private treeRequestId = 0;
+	private fileRequestId = 0;
 
 	/** Set the active workspace and reload the tree. */
 	async setActiveWorkspace(workspaceId: string | null): Promise<void> {
 		if (this.activeWorkspaceId === workspaceId) return;
+		this.treeRequestId++;
+		this.fileRequestId++;
 		this.activeWorkspaceId = workspaceId;
 		this.currentFile = null;
+		this.isLoadingTree = false;
+		this.isLoadingFile = false;
 		this.isEditing = false;
 		this.editBuffer = "";
 		this.emit("change", undefined);
@@ -62,26 +68,35 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 		return this.activeWorkspaceId ?? undefined;
 	}
 
-	async loadTree(): Promise<void> {
+	async loadTree(isCurrent: () => boolean = () => true): Promise<void> {
+		const requestId = ++this.treeRequestId;
+		const workspaceId = this.wsId;
 		this.isLoadingTree = true;
 		this.error = "";
 		this.emit("change", undefined);
 		try {
-			this.tree = await getWorkspaceTree(this.wsId);
+			const tree = await getWorkspaceTree(workspaceId);
+			if (requestId !== this.treeRequestId || workspaceId !== this.wsId || !isCurrent()) return;
+			this.tree = tree;
 			if (!this.currentFile) {
 				const first = this.findFirstPreviewable(this.tree.children);
-				if (first) await this.selectFile(first.path);
+				if (first) await this.selectFile(first.path, isCurrent);
 			}
 		} catch (err) {
+			if (requestId !== this.treeRequestId || workspaceId !== this.wsId || !isCurrent()) return;
 			this.error = err instanceof Error ? err.message : "Failed to load workspace";
 			this.tree = null;
 		} finally {
-			this.isLoadingTree = false;
-			this.emit("change", undefined);
+			if (requestId === this.treeRequestId && workspaceId === this.wsId && isCurrent()) {
+				this.isLoadingTree = false;
+				this.emit("change", undefined);
+			}
 		}
 	}
 
-	async selectFile(path: string): Promise<void> {
+	async selectFile(path: string, isCurrent: () => boolean = () => true): Promise<void> {
+		const requestId = ++this.fileRequestId;
+		const workspaceId = this.wsId;
 		// Discard any in-progress edit when switching files
 		if (this.isEditing) {
 			this.isEditing = false;
@@ -91,17 +106,22 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 		this.error = "";
 		this.emit("change", undefined);
 		try {
-			const file = await getWorkspaceFile(path, this.wsId);
+			const file = await getWorkspaceFile(path, workspaceId);
+			if (requestId !== this.fileRequestId || workspaceId !== this.wsId || !isCurrent()) return;
 			if (file && file.kind === "html" && file.content) {
-				file.content = await inlineWorkspaceHtml(file.content, file.path, this.wsId);
+				file.content = await inlineWorkspaceHtml(file.content, file.path, workspaceId);
+				if (requestId !== this.fileRequestId || workspaceId !== this.wsId || !isCurrent()) return;
 			}
 			this.currentFile = file;
 		} catch (err) {
+			if (requestId !== this.fileRequestId || workspaceId !== this.wsId || !isCurrent()) return;
 			this.error = err instanceof Error ? err.message : "Failed to load file";
 			this.currentFile = null;
 		} finally {
-			this.isLoadingFile = false;
-			this.emit("change", undefined);
+			if (requestId === this.fileRequestId && workspaceId === this.wsId && isCurrent()) {
+				this.isLoadingFile = false;
+				this.emit("change", undefined);
+			}
 		}
 	}
 

--- a/apps/inno-agent/web/src/types/chat.ts
+++ b/apps/inno-agent/web/src/types/chat.ts
@@ -8,6 +8,9 @@ export interface ChatMessage {
 	images?: Array<{ previewUrl: string; mimeType: string }>;
 	/** Backend/model error surfaced for this turn (e.g. HTTP 413 over-long context). */
 	error?: string;
+	turnId?: string;
+	transient?: boolean;
+	complete?: boolean;
 }
 
 export interface ChatToolRecord {
@@ -59,8 +62,46 @@ export interface QuestionnaireResult {
 	error?: string;
 }
 
-// Phase 2 SSE event types
+export type StreamStatus = "queued" | "running" | "completed" | "error" | "aborted";
+
+export interface StreamInputSnapshot {
+	prompt: string;
+	submittedAt: string;
+	images: Array<{ mimeType: string; workspacePath: string; previewUrl?: string }>;
+}
+
+export interface StreamSnapshot {
+	sessionId: string;
+	turnId: string;
+	clientRequestId: string;
+	workspaceId: string;
+	status: StreamStatus;
+	createdAt: string;
+	startedAt?: string;
+	finishedAt?: string;
+	inputSnapshot: StreamInputSnapshot;
+	activeTools: ChatToolRecord[];
+	pendingQuestion?: PendingQuestion;
+	lastEventId: number;
+	cancelRequested: boolean;
+	baselineMessageCount: number;
+	baselineSessionRevision: string;
+	persisted: boolean;
+	finalMessageCount?: number;
+	finalSessionRevision?: string;
+}
+
+export interface StreamEventEnvelope {
+	eventId: number;
+	sessionId: string;
+	turnId: string;
+	clientRequestId: string;
+	event: ChatStreamEvent;
+}
+
+// Turn-scoped SSE event types
 export type ChatStreamEvent =
+	| { type: "stream_state"; status: "queued" | "running" }
 	| { type: "text_delta"; delta: string }
 	| { type: "thinking_delta"; delta: string }
 	| { type: "tool_call_delta"; toolCallId: string; toolName: string; args?: unknown; argsDelta?: string }
@@ -68,5 +109,7 @@ export type ChatStreamEvent =
 	| { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
 	| { type: "workspace_change"; changes: WorkspaceFileChange[]; toolCallId?: string; toolName?: string; workspaceId?: string; truncated?: boolean }
 	| { type: "question"; questionId: string; params: { questions: QuestionData[] } }
-	| { type: "done"; fullText: string }
-	| { type: "error"; message: string };
+	| { type: "question_resolved"; questionId: string; cancelled?: boolean; error?: string }
+	| { type: "done"; fullText: string; persisted: true; finalMessageCount: number; finalSessionRevision: string }
+	| { type: "error"; message: string; code?: string; persisted: boolean; finalMessageCount?: number; finalSessionRevision?: string }
+	| { type: "aborted"; message?: string; persisted: boolean; finalMessageCount?: number; finalSessionRevision?: string };

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 	],
 	"main": "electron/main.js",
 	"scripts": {
+		"test": "vitest run",
 		"build": "npm --workspace inno-agent run build && npm --workspace inno-agent-web run build",
 		"start": "npm --workspace inno-agent run start --",
 		"sandbox": "npm --workspace inno-agent run start -- --sandbox",


### PR DESCRIPTION
## 背景

聊天任务在浏览器刷新、页面切换或 SSE 临时断开后，存在运行状态丢失、取消范围不准确、旧异步回调污染新会话，以及最终 JSONL 尚未确认就结束实时状态等问题。

本次修复按照 turn 级恢复协议重构聊天流生命周期，保证同一 Node Server 进程存活期间，活动任务能够被发现、重放、续接和精确取消。

## 主要改动

### 后端

- 新增 turn 级 Stream Registry：
  - `queued/running/completed/error/aborted` 状态机
  - 单调递增的 `eventId`
  - turn 历史重放与 subscriber 管理
  - terminal transition 幂等保护
  - active turn TTL 保护
- PI Runner 增加队列槽内生命周期：
  - 冻结 session path 和 workspace root
  - queued cancel
  - scoped active turn token
  - 持久化确认和终态发布均在同一 enqueue 槽内完成
- 新增和调整聊天协议：
  - `GET /api/chat/status/:sessionId`
  - turn-scoped SSE replay
  - scoped abort
  - scoped question response
- QuestionBridge 改为校验 `sessionId + turnId + questionId`
- SSE 断开仅取消订阅，不再取消后端任务或待回答问题
- 活动 turn 期间禁止删除或重绑相关 session/workspace
- terminal event 携带最终 JSONL 的 message count 和 revision

### 前端

- 引入 stream owner、generation 和 `clientRequestId`
- 使用 `eventId` 去重，防止重复文本和工具事件
- 冷启动恢复采用：
  - baseline 截断
  - transient 用户输入
  - `after=0` 全量重放
- 临时断线采用保留聚合状态的增量续接
- scoped cancel 在 terminal 到达前持续持有 owner
- terminal 后重新读取规范 JSONL
- history 未确认时保留 transient overlay，不接受过期历史
- 清理跨会话 pending question、工具和异步回调
- 新建会话、刷新和浏览器前进/后退与 `?session=` URL 同步
- 恢复安全的图片输入预览

## 行为变化

- `/api/chat/stream` 现在要求有效的 `sessionId` 和 `clientRequestId`
- 旧的无作用域 `/api/chat/abort` 不再执行全局中止
- SSE disconnect 不再等价于用户点击停止
- `done` 只在最终 JSONL 已确认后发布
- 同一 session 存在 queued/running turn 时，新请求返回 `409`
- queued cancel 返回 `202`，前端会等待最终 `aborted` 事件
- 本方案不支持 Server、Electron 主进程或机器重启后的任务续跑

## 测试

- [x] Stream Registry 状态转换、eventId、重放和 terminal 幂等
- [x] QuestionBridge 三 ID 校验、重复回答和超时
- [x] queued/running cancel
- [x] SSE 断线和全量恢复
- [x] terminal JSONL 重载与过期历史保护
- [x] A/B 会话快速切换和 owner generation 隔离
- [x] URL 冷启动、前进和后退
- [x] session/workspace active 约束
- [x] `npm test`
- [x] `npm run build`
- [x] chat recovery smoke tests

## 验收场景

- thinking、text delta、tool_start 和 question 阶段刷新
- 首轮用户输入尚未写入 JSONL 时刷新
- 多次连续刷新或重连不产生重复内容
- 取消 queued turn 不影响当前 running turn
- 切换会话只 detach，不取消后台任务
- A 的晚到回调、问题或历史重载不修改 B
- terminal 后 UI 最终由已确认的 JSONL 重建

## 风险与兼容性

该 PR 同时修改了前后端聊天流协议，必须作为同一版本发布，不能只部署其中一端。

运行状态仍保存在单个 Node Server 进程内；Server 重启后会安全降级为已持久化历史，不提供跨进程任务恢复。