### PR TITLE
fix(chat): release parked ask_user_question on scoped abort

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -4355,6 +4355,12 @@ const server = createServer(async (req, res) => {
 				return;
 			}
 			streamRegistry.requestCancel(state);
+			// Resolve a parked ask_user_question before aborting: session.abort()
+			// alone cannot wake the agent loop while it awaits the question
+			// promise, so the turn (and its queue slot) would stay stuck until
+			// the 30-minute question timeout. unbindTurn is idempotent — the
+			// onFinish unbind becomes a no-op once the binding is cleared here.
+			questionBridge.unbindTurn({ sessionId: state.sessionId, turnId: state.turnId, reason: "cancelled" });
 			if (state.status === "running") await abortPromptForTurnToken(state.turnId);
 			json(res, 202, { status: state.status, cancelRequested: true });
 			return;


### PR DESCRIPTION
## Summary

- Follow-up to #101 (reported in [this comment](https://github.com/hhyqhh/inno-agent/pull/101#issuecomment-5105757625)): aborting a turn while `ask_user_question` is parked blocked the abort HTTP response and the turn until the 30-minute question timeout, because `session.abort()` cannot wake an agent loop that is awaiting the question promise.
- The scoped abort route now resolves the parked question via `questionBridge.unbindTurn({ sessionId, turnId, reason: "cancelled" })` before calling `abortPromptForTurnToken`, so the tool call resolves as cancelled and the loop observes the abort immediately. The unbind is idempotent — the `onFinish` unbind becomes a no-op.

## Test plan

- [x] `npm run build` (backend + web)
- [x] `npm test` (18 tests pass)
- [x] Live reproduction: prompt the agent to call `ask_user_question`, wait for the parked question, then `POST /api/chat/:sessionId/:turnId/abort`
  - Before: abort HTTP timed out after 60s, turn stuck in `running` for 100s+ (only released by answering the question or the 30-min timeout)
  - After: abort returns immediately (`0s`), turn reaches `aborted` with `persisted: true` and the terminal event is published