### PR TITLE
feat(search): add Tavily web_search tool with configurable API key

### DIFF
--- a/apps/inno-agent/package.json
+++ b/apps/inno-agent/package.json
@@ -21,9 +21,12 @@
 		"@juicesharp/rpiv-ask-user-question": "^1.12.0",
 		"@larksuiteoapi/node-sdk": "^1.63.1",
 		"@llamaindex/liteparse": "^1.3.0",
+		"@tavily/core": "^0.7.6",
 		"@types/ws": "^8.18.1",
 		"axios": "^1.16.1",
 		"cron-parser": "^5.5.0",
+		"graphology": "^0.26.0",
+		"graphology-communities-louvain": "^2.0.2",
 		"node-pty": "^1.0.0",
 		"pi-sandbox": "^0.4.3",
 		"pi-subagents": "^0.28.0",
@@ -33,8 +36,6 @@
 		"typebox": "^1.1.24",
 		"undici": "^7.19.1",
 		"ws": "^8.21.0",
-		"graphology": "^0.26.0",
-		"graphology-communities-louvain": "^2.0.2",
 		"yaml": "^2.6.1"
 	},
 	"engines": {

--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -19,6 +19,7 @@ import { L3Memory, createL3Tools, formatRecallForPrompt } from "../memory/l3/l3-
 import { createPracticeTools } from "./practice-tools.js";
 import { createDocumentTools } from "./document-tools.js";
 import { createOcrTools } from "./ocr-tools.js";
+import { createTavilyTools } from "./tavily-tools.js";
 import { checkWorkspaceMutationPath } from "./workspace-path-guard.js";
 import { INNO_SYSTEM_PROMPT, ONBOARDING_GUIDE } from "./system-prompt.js";
 import { syncProvidersForSubagents } from "./provider-sync.js";
@@ -258,6 +259,13 @@ export function createInnoExtension(
 		// from configHolder so settings changes take effect without restart.
 		const ocrTools = createOcrTools(configHolder);
 		for (const tool of ocrTools) {
+			pi.registerTool(tool);
+		}
+
+		// 4d. Register web search tool (Tavily). Default internet search
+		// capability; reads the API key live from configHolder.
+		const tavilyTools = createTavilyTools(configHolder);
+		for (const tool of tavilyTools) {
 			pi.registerTool(tool);
 		}
 

--- a/apps/inno-agent/src/agent/system-prompt.ts
+++ b/apps/inno-agent/src/agent/system-prompt.ts
@@ -70,7 +70,13 @@ L2 目录边界（重要，违反会破坏知识库引用）：
 - filePath 也可以是工作区相对路径或 http(s) URL。
 - 工具调用百度 vl-ocr（PaddleOCR-VL）API，返回 markdown 文本。
 - 如果当前模型原生支持图片识别且能正常读取图片，直接处理即可，无需调用此工具。
-- 若未配置 OCR API token，工具会返回提示——此时直接告诉用户「尚未配置 OCR API，请在设置里填入 token 后重试」。`;
+- 若未配置 OCR API token，工具会返回提示——此时直接告诉用户「尚未配置 OCR API，请在设置里填入 token 后重试」。
+
+联网搜索（web_search）：
+- 当问题涉及时事、最新资讯、价格波动、软件版本等超出你知识截止日期的信息，或用户明确要求「查一下」「搜一下」「联网」时，调用 web_search 工具（Tavily）。
+- 优先用用户的语言构造 query；需要更全面的结果时把 searchDepth 设为 advanced，查新闻可把 topic 设为 news。
+- 回答时基于搜索结果作答，并标注关键信息的来源（标题/链接）。
+- 若未配置 Tavily API Key，工具会返回提示——此时直接告诉用户「尚未配置 Tavily API Key，请在设置里填入后重试」，不要编造搜索结果。`;
 
 export const ONBOARDING_GUIDE = `
 ## 新手引导（仅在用户画像为空时生效）

--- a/apps/inno-agent/src/agent/tavily-tools.ts
+++ b/apps/inno-agent/src/agent/tavily-tools.ts
@@ -1,0 +1,135 @@
+/**
+ * Web search tool — wraps the Tavily Search API (@tavily/core) as the agent's
+ * default internet search capability. Reads the API key live from configHolder
+ * (`config.tavily.apiKey`) so settings changes take effect without a restart.
+ * Unconfigured → the tool returns a "not configured" hint.
+ */
+
+import { tavily, type TavilySearchResponse } from "@tavily/core";
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+import type { ConfigHolder } from "./inno-extension.js";
+import { logger } from "../logger.js";
+
+/** Upper bound for a single search request (seconds, Tavily API timeout). */
+const REQUEST_TIMEOUT_S = 60;
+const DEFAULT_MAX_RESULTS = 5;
+const MAX_RESULTS_LIMIT = 10;
+
+function resolveApiKey(holder: ConfigHolder): string | undefined {
+	const key = holder.current.tavily?.apiKey?.trim();
+	return key || undefined;
+}
+
+/** Format a Tavily search response into agent-readable markdown text. */
+function formatResults(resp: TavilySearchResponse): string {
+	const parts: string[] = [];
+	if (resp.answer?.trim()) {
+		parts.push(`## 摘要\n\n${resp.answer.trim()}`);
+	}
+	const results = resp.results ?? [];
+	if (results.length > 0) {
+		const lines = results.map((r, i) => {
+			const published = r.publishedDate ? ` (${r.publishedDate})` : "";
+			return `${i + 1}. [${r.title}](${r.url})${published}\n   ${r.content}`;
+		});
+		parts.push(`## 搜索结果\n\n${lines.join("\n\n")}`);
+	}
+	return parts.join("\n\n") || "未找到相关结果。";
+}
+
+export function createTavilyTools(configHolder: ConfigHolder): ToolDefinition[] {
+	const tool = defineTool({
+		name: "web_search",
+		label: "联网搜索 (Tavily)",
+		description:
+			"通过 Tavily 搜索引擎联网检索最新信息，返回结果标题、URL、内容摘要和可选的综合答案。" +
+			"当用户的问题涉及时事、最新资讯、超出知识截止日期的事实，或明确要求联网查询时使用。" +
+			"优先用用户的语言构造 query；复杂或时效性强的查询可将 searchDepth 设为 advanced。",
+		parameters: Type.Object({
+			query: Type.String({ description: "搜索查询词" }),
+			searchDepth: Type.Optional(
+				Type.Union([Type.Literal("basic"), Type.Literal("advanced")], {
+					description: "检索深度：basic 快速（默认），advanced 更全但更慢更贵",
+				}),
+			),
+			maxResults: Type.Optional(
+				Type.Number({ description: `返回结果条数（1-${MAX_RESULTS_LIMIT}，默认 ${DEFAULT_MAX_RESULTS}）` }),
+			),
+			topic: Type.Optional(
+				Type.Union([Type.Literal("general"), Type.Literal("news"), Type.Literal("finance")], {
+					description: "搜索主题：general（默认）/ news / finance",
+				}),
+			),
+			includeAnswer: Type.Optional(
+				Type.Boolean({ description: "是否返回 Tavily 综合摘要答案（默认 true）" }),
+			),
+		}),
+		async execute(_toolCallId, params) {
+			const typed = params as {
+				query: string;
+				searchDepth?: "basic" | "advanced";
+				maxResults?: number;
+				topic?: "general" | "news" | "finance";
+				includeAnswer?: boolean;
+			};
+			const query = String(typed.query ?? "").trim();
+			if (!query) {
+				return {
+					content: [{ type: "text" as const, text: "请提供 query（搜索查询词）。" }],
+					details: { error: "missing_query" } as Record<string, unknown>,
+				};
+			}
+
+			const apiKey = resolveApiKey(configHolder);
+			if (!apiKey) {
+				return {
+					content: [{
+						type: "text" as const,
+						text: "尚未配置 Tavily API Key。请在设置面板的「联网搜索 (Tavily)」卡片填入 API Key 后重试。",
+					}],
+					details: { error: "tavily_not_configured" } as Record<string, unknown>,
+				};
+			}
+
+			const maxResults = Math.min(
+				Math.max(Math.floor(typed.maxResults ?? DEFAULT_MAX_RESULTS), 1),
+				MAX_RESULTS_LIMIT,
+			);
+
+			try {
+				const client = tavily({ apiKey });
+				const resp = await client.search(query, {
+					searchDepth: typed.searchDepth ?? "basic",
+					topic: typed.topic ?? "general",
+					maxResults,
+					includeAnswer: typed.includeAnswer ?? true,
+					timeout: REQUEST_TIMEOUT_S,
+				});
+
+				return {
+					content: [{ type: "text" as const, text: formatResults(resp) }],
+					details: {
+						query: resp.query,
+						responseTime: resp.responseTime,
+						resultCount: resp.results?.length ?? 0,
+						results: (resp.results ?? []).map((r) => ({
+							title: r.title,
+							url: r.url,
+							score: r.score,
+						})),
+					} as Record<string, unknown>,
+				};
+			} catch (err) {
+				logger.warn({ err, query }, "web_search: tavily search failed");
+				const msg = err instanceof Error ? err.message : String(err);
+				return {
+					content: [{ type: "text" as const, text: `联网搜索失败：${msg}` }],
+					details: { error: "search_failed", query, message: msg } as Record<string, unknown>,
+				};
+			}
+		},
+	});
+
+	return [tool];
+}

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -166,6 +166,13 @@ export interface InnoConfig {
 		model?: string;
 		baseUrl?: string;
 	};
+	/**
+	 * Optional Tavily config. The `web_search` tool uses this API key for
+	 * internet search. Unconfigured → the tool returns a "not configured" hint.
+	 */
+	tavily?: {
+		apiKey: string;
+	};
 }
 
 interface LegacyInnoConfig extends Partial<InnoConfig> {
@@ -313,6 +320,7 @@ export function normalizeConfig(config: LegacyInnoConfig): InnoConfig {
 		simpleMode: normalizeSimpleModeConfig(config.simpleMode),
 		ui: config.ui,
 		ocrApi: config.ocrApi,
+		tavily: config.tavily,
 	} as InnoConfig;
 }
 

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -600,6 +600,9 @@ function buildSafeSettings() {
 				baseUrl: config.ocrApi.baseUrl,
 			}
 			: undefined,
+		tavily: config.tavily
+			? { apiKey: maskSecret(config.tavily.apiKey) }
+			: undefined,
 		contentHub: config.contentHub
 			? { ...config.contentHub, token: maskSecret(config.contentHub.token) }
 			: undefined,
@@ -4230,6 +4233,27 @@ const server = createServer(async (req, res) => {
 					model: model || undefined,
 					baseUrl: baseUrl || undefined,
 				};
+			}
+			config = saveConfig(paths.configPath, config);
+			syncConfig(config);
+			json(res, 200, buildSafeSettings());
+			return;
+		}
+
+		// --- Tavily settings (web_search tool API key) ---
+		if (method === "PUT" && url === "/api/settings/tavily") {
+			const body = (await readBody(req)) as Record<string, unknown>;
+			if (typeof body.apiKey !== "string") {
+				json(res, 400, { error: "Missing apiKey (string)" });
+				return;
+			}
+			const incoming = body.apiKey.trim();
+			// A masked value (e.g. "****abcd") means "keep the existing key".
+			const apiKey = incoming.startsWith("****") ? (config.tavily?.apiKey ?? "") : incoming;
+			if (!apiKey) {
+				config.tavily = undefined;
+			} else {
+				config.tavily = { apiKey };
 			}
 			config = saveConfig(paths.configPath, config);
 			syncConfig(config);

--- a/apps/inno-agent/web/src/api/settings.ts
+++ b/apps/inno-agent/web/src/api/settings.ts
@@ -79,6 +79,13 @@ export async function saveOcrSettings(payload: OcrSettingsPayload): Promise<Inno
 	});
 }
 
+export async function saveTavilySettings(apiKey: string): Promise<InnoSettings> {
+	return apiFetch<InnoSettings>("/api/settings/tavily", {
+		method: "PUT",
+		body: JSON.stringify({ apiKey }),
+	});
+}
+
 export interface ContentHubPayload {
 	type: "github" | "bundle";
 	owner?: string;

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -412,6 +412,13 @@
 			"saved": "Saved",
 			"clear": "Clear"
 		},
+		"tavily": {
+			"title": "Web Search (Tavily)",
+			"desc": "Gives the agent internet search capability. Get an API key from tavily.com (starts with tvly-). The web_search tool is unavailable until configured.",
+			"placeholder": "tvly-…",
+			"saved": "Saved",
+			"clear": "Clear"
+		},
 		"form": {
 			"providerId": "Provider id",
 			"baseUrl": "Base URL",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -412,6 +412,13 @@
 			"saved": "已保存",
 			"clear": "清除"
 		},
+		"tavily": {
+			"title": "联网搜索 (Tavily)",
+			"desc": "为 agent 提供联网检索能力。需在 tavily.com 获取 API Key（形如 tvly-…）。未配置时 web_search 工具不可用。",
+			"placeholder": "tvly-…",
+			"saved": "已保存",
+			"clear": "清除"
+		},
 		"form": {
 			"providerId": "提供方 ID",
 			"baseUrl": "Base URL",

--- a/apps/inno-agent/web/src/react/SettingsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SettingsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef, useCallback } from "react";
 import { useTranslation } from "react-i18next";
-import { Trash2, Pencil, X, ChevronDown, ChevronRight, Plus, QrCode as QrCodeIcon, CheckCircle, Wifi, WifiOff, Database, KeyRound } from "lucide-react";
+import { Trash2, Pencil, X, ChevronDown, ChevronRight, Plus, QrCode as QrCodeIcon, CheckCircle, Wifi, WifiOff, Database, KeyRound, Globe } from "lucide-react";
 import { QRCodeSVG } from "qrcode.react";
 import { getWikiStats } from "../api/wiki.js";
 import { settingsStore } from "../stores/settings-store.js";
@@ -1036,6 +1036,111 @@ function OcrSettings({ settings }: { settings: InnoSettings }) {
 	);
 }
 
+/* ---------- Tavily Settings (web_search tool API key) ---------- */
+
+function TavilySettings({ settings }: { settings: InnoSettings }) {
+	const { t } = useTranslation();
+	const tavily = settings.tavily;
+	const [open, setOpen] = useState(false);
+	const [apiKey, setApiKey] = useState("");
+	const [saving, setSaving] = useState(false);
+	const [saved, setSaved] = useState(false);
+
+	const maskedKey = tavily?.apiKey ?? "";
+	const hasExistingKey = Boolean(maskedKey);
+	const [keyDirty, setKeyDirty] = useState(false);
+
+	useEffect(() => {
+		setApiKey("");
+		setKeyDirty(false);
+		setSaved(false);
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [maskedKey]);
+
+	const dirty = keyDirty;
+
+	async function handleSave() {
+		setSaving(true);
+		setSaved(false);
+		try {
+			await settingsStore.saveTavily(keyDirty ? apiKey.trim() : maskedKey);
+			setSaved(true);
+			setApiKey("");
+			setKeyDirty(false);
+		} catch {
+			// error surfaced via store
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	async function handleClear() {
+		setSaving(true);
+		setSaved(false);
+		try {
+			await settingsStore.saveTavily("");
+			setSaved(true);
+			setApiKey("");
+			setKeyDirty(false);
+		} catch {
+			// error surfaced via store
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div className="min-w-0 rounded-lg bg-[var(--inno-surface)] p-4">
+			<button className="inno-settings-card-toggle flex w-full min-w-0 items-start gap-2 text-left" onClick={() => setOpen((v) => !v)}>
+				<Globe size={16} className="mt-0.5 shrink-0 text-[var(--inno-text)]" />
+				<div className="min-w-0 flex-1">
+					<h4 className="break-words text-sm font-medium text-[var(--inno-text)]">{t("settings.tavily.title", "联网搜索 (Tavily)")}</h4>
+					<p className="mt-1 max-w-full break-words text-xs leading-relaxed text-[var(--inno-text-muted)]">
+						{t("settings.tavily.desc", "为 agent 提供联网检索能力。需在 tavily.com 获取 API Key。")}
+					</p>
+					{!open && (
+						<p className="mt-1 break-all text-[11px] leading-relaxed text-[var(--inno-text-subtle)]">
+							{hasExistingKey ? `apiKey: ${maskedKey}` : t("settings.tavily.placeholder", "tvly-…")}
+						</p>
+					)}
+				</div>
+				<ChevronDown size={14} className={`mt-1 shrink-0 text-[var(--inno-text-subtle)] transition-transform ${open ? "rotate-180" : ""}`} />
+			</button>
+
+			{open ? (
+				<div className="mt-3 grid gap-2.5">
+					<input
+						className={inputCls}
+						type="password"
+						value={apiKey}
+						onChange={(e) => { setApiKey(e.target.value); setKeyDirty(true); setSaved(false); }}
+						placeholder={hasExistingKey ? maskedKey : (t("settings.tavily.placeholder", "tvly-…") ?? "")}
+						autoComplete="off"
+					/>
+					<div className="flex min-w-0 flex-wrap items-center gap-2">
+						<button
+							disabled={saving || !dirty}
+							onClick={() => void handleSave()}
+							className="flex h-8 shrink-0 items-center rounded-md inno-primary-button px-3 text-xs text-white disabled:opacity-50"
+						>
+							{saving ? t("common.loading") : saved ? t("settings.tavily.saved", "已保存") : t("common.save")}
+						</button>
+						{hasExistingKey && (
+							<button
+								disabled={saving}
+								onClick={() => void handleClear()}
+								className="flex h-8 shrink-0 items-center rounded-md border border-[var(--inno-border)] px-3 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+							>
+								{t("settings.tavily.clear", "清除")}
+							</button>
+						)}
+					</div>
+				</div>
+			) : null}
+		</div>
+	);
+}
+
 /* ---------- Memory Settings (L1/L2/L3 layer toggles) ---------- */
 
 type MemoryLayer = "l1Enabled" | "l2Enabled" | "l3Enabled";
@@ -1318,6 +1423,9 @@ export function SettingsPanel() {
 
 						{/* OCR API (Baidu PaddleOCR-VL token for image text extraction) */}
 						{state.settings && <OcrSettings settings={state.settings} />}
+
+					{/* Tavily (web_search tool API key) */}
+					{state.settings && <TavilySettings settings={state.settings} />}
 
 						{/* Channels Settings */}
 						{state.settings && <ChannelsSettings settings={state.settings} />}

--- a/apps/inno-agent/web/src/stores/settings-store.ts
+++ b/apps/inno-agent/web/src/stores/settings-store.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "./event-emitter.js";
-import { getSettings, switchBackendModel, upsertProvider, deleteProviderApi, deleteModelApi, saveChannelsSettings, saveMemorySettings, saveSimpleModeSettings, saveGithubSettings, saveOcrSettings, saveContentHubSettings, type MemorySettingsPatch, type ContentHubPayload, type OcrSettingsPayload } from "../api/settings.js";
+import { getSettings, switchBackendModel, upsertProvider, deleteProviderApi, deleteModelApi, saveChannelsSettings, saveMemorySettings, saveSimpleModeSettings, saveGithubSettings, saveOcrSettings, saveTavilySettings, saveContentHubSettings, type MemorySettingsPatch, type ContentHubPayload, type OcrSettingsPayload } from "../api/settings.js";
 import type { InnoSettings, UpsertProviderRequest, ChannelsSettingsPayload } from "../types/settings.js";
 
 interface SettingsStoreEvents {
@@ -15,6 +15,7 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 	isSavingMemory = false;
 	isSavingGithub = false;
 	isSavingOcr = false;
+	isSavingTavily = false;
 	isSavingContentHub = false;
 	isSavingSimpleMode = false;
 	error: string | null = null;
@@ -183,6 +184,22 @@ class SettingsStoreImpl extends EventEmitter<SettingsStoreEvents> {
 			throw err;
 		} finally {
 			this.isSavingOcr = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async saveTavily(apiKey: string): Promise<void> {
+		this.isSavingTavily = true;
+		this.error = null;
+		this.emit("change", undefined);
+		try {
+			this.settings = await saveTavilySettings(apiKey);
+		} catch (err) {
+			this.error = err instanceof Error ? err.message : "Failed to save Tavily settings";
+			this.emit("change", undefined);
+			throw err;
+		} finally {
+			this.isSavingTavily = false;
 			this.emit("change", undefined);
 		}
 	}

--- a/apps/inno-agent/web/src/types/settings.ts
+++ b/apps/inno-agent/web/src/types/settings.ts
@@ -92,6 +92,9 @@ export interface InnoSettings {
 		model?: string;
 		baseUrl?: string;
 	};
+	tavily?: {
+		apiKey: string; // masked
+	};
 	contentHub?: {
 		type: "github" | "bundle";
 		owner: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
 				"@juicesharp/rpiv-ask-user-question": "^1.12.0",
 				"@larksuiteoapi/node-sdk": "^1.63.1",
 				"@llamaindex/liteparse": "^1.3.0",
+				"@tavily/core": "^0.7.6",
 				"@types/ws": "^8.18.1",
 				"axios": "^1.16.1",
 				"cron-parser": "^5.5.0",
@@ -1863,7 +1864,7 @@
 				"typebox": "1.1.38"
 			},
 			"bin": {
-				"pi-ai": "./dist/cli.js"
+				"pi-ai": "dist/cli.js"
 			},
 			"engines": {
 				"node": ">=22.19.0"
@@ -1979,9 +1980,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1997,9 +1995,6 @@
 			"integrity": "sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -2017,9 +2012,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2036,9 +2028,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2054,9 +2043,6 @@
 			"integrity": "sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -6524,6 +6510,17 @@
 				"vite": "^5.2.0 || ^6 || ^7 || ^8"
 			}
 		},
+		"node_modules/@tavily/core": {
+			"version": "0.7.6",
+			"resolved": "https://registry.npmjs.org/@tavily/core/-/core-0.7.6.tgz",
+			"integrity": "sha512-swNz2RaietpfXWrA+y/ERSQ9H3bq0mNu0hcp2OcVKqTrUUcdygEXIXr67o6qQ1XSjgBbB3FNQtAkrPPB8bYkaA==",
+			"license": "MIT",
+			"dependencies": {
+				"axios": "^1.7.7",
+				"https-proxy-agent": "^7.0.6",
+				"js-tiktoken": "^1.0.14"
+			}
+		},
 		"node_modules/@tokenizer/inflate": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmmirror.com/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -10651,6 +10648,15 @@
 			"license": "MIT",
 			"bin": {
 				"jiti": "lib/jiti-cli.mjs"
+			}
+		},
+		"node_modules/js-tiktoken": {
+			"version": "1.0.21",
+			"resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
+			"integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.5.1"
 			}
 		},
 		"node_modules/js-tokens": {


### PR DESCRIPTION
## Summary
- Wrap `@tavily/core` as the agent's default internet search tool (`web_search`): `query`, `searchDepth` (basic/advanced), `maxResults` (1–10), `topic` (general/news/finance), `includeAnswer`; returns a synthesized answer plus a numbered result list with titles/URLs.
- API key lives in `config.json` (`tavily.apiKey`), editable from a new "Web Search (Tavily)" card in the settings panel (`PUT /api/settings/tavily`, masked-value semantics same as OCR/GitHub); the tool reads the key live via `configHolder` so changes apply without restart.
- System prompt gains a web-search section: when to search, how to phrase queries, cite sources, and never fabricate results when unconfigured.

## Test plan
- [x] `npm run build` (backend tsc + frontend vite) passes
- [x] `npm test` — 18/18 vitest pass
- [x] Smoke: PUT real key → persisted + masked in API; PUT masked → old key kept; PUT empty → cleared
- [x] Live Tavily search call with a real key returns answer + results