### PR TITLE
feat: persist pending question cards across restart

### DIFF
--- a/apps/inno-agent/src/agent/question-bridge.test.ts
+++ b/apps/inno-agent/src/agent/question-bridge.test.ts
@@ -39,4 +39,37 @@ describe("QuestionBridge", () => {
 		await expect(firstAnswer).resolves.toMatchObject({ cancelled: true, error: "superseded" });
 		expect(bridge.respond({ sessionId: "s2", turnId: "t2", questionId: oldQuestionId, result: { answers: [], cancelled: false } })).toBe("not_found");
 	});
+
+	it("persists a pending question on ask and removes it on any resolution", async () => {
+		const bridge = new QuestionBridge();
+		const saved = new Map<string, unknown>();
+		bridge.setPersistence({
+			save: (sessionId, question) => saved.set(sessionId, question),
+			remove: (sessionId) => saved.delete(sessionId),
+		});
+		bridge.bindTurn({ sessionId: "s1", turnId: "t1", emit: () => {}, timeoutMs: 10_000 });
+		const answerPromise = bridge.ask({ questions: [{ question: "q?" }] });
+		expect(saved.has("s1")).toBe(true);
+		expect(saved.get("s1")).toMatchObject({ turnId: "t1", params: { questions: [{ question: "q?" }] } });
+
+		bridge.respond({ sessionId: "s1", turnId: "t1", questionId: (saved.get("s1") as { questionId: string }).questionId, result: { answers: [], cancelled: false } });
+		await answerPromise;
+		expect(saved.has("s1")).toBe(false);
+	});
+
+	it("removes the persisted record when the turn is unbound (abort)", async () => {
+		const bridge = new QuestionBridge();
+		const saved = new Map<string, unknown>();
+		bridge.setPersistence({
+			save: (sessionId, question) => saved.set(sessionId, question),
+			remove: (sessionId) => saved.delete(sessionId),
+		});
+		bridge.bindTurn({ sessionId: "s1", turnId: "t1", emit: () => {}, timeoutMs: 10_000 });
+		const answerPromise = bridge.ask({ questions: [] });
+		expect(saved.has("s1")).toBe(true);
+
+		bridge.unbindTurn({ sessionId: "s1", turnId: "t1", reason: "cancelled" });
+		await expect(answerPromise).resolves.toMatchObject({ cancelled: true, error: "cancelled" });
+		expect(saved.has("s1")).toBe(false);
+	});
 });

--- a/apps/inno-agent/src/agent/question-bridge.ts
+++ b/apps/inno-agent/src/agent/question-bridge.ts
@@ -27,8 +27,26 @@ interface PendingQuestion {
 	questionId: string;
 	sessionId: string;
 	turnId: string;
+	params: unknown;
 	resolve: (result: QuestionBridgeResult) => void;
 	timer: ReturnType<typeof setTimeout>;
+}
+
+/** A persistable pending question (no resolve callback), so the card can be
+ *  restored after a full process restart. */
+export interface PersistedQuestion {
+	questionId: string;
+	sessionId: string;
+	turnId: string;
+	params: unknown;
+	createdAt: string;
+}
+
+/** Callbacks injected by the server to persist/restore pending questions
+ *  across process restarts. */
+export interface QuestionBridgePersistence {
+	save: (sessionId: string, question: PersistedQuestion) => void;
+	remove: (sessionId: string) => void;
 }
 
 export type QuestionResponseStatus = "accepted" | "not_found" | "scope_mismatch" | "already_resolved";
@@ -37,6 +55,11 @@ export class QuestionBridge {
 	private binding: TurnBinding | null = null;
 	private pending: PendingQuestion | null = null;
 	private lastResolved: Pick<PendingQuestion, "questionId" | "sessionId" | "turnId"> | null = null;
+	private persistence: QuestionBridgePersistence | null = null;
+
+	setPersistence(p: QuestionBridgePersistence | null): void {
+		this.persistence = p;
+	}
 
 	bindTurn(binding: TurnBinding): void {
 		if (this.binding && (this.binding.sessionId !== binding.sessionId || this.binding.turnId !== binding.turnId)) {
@@ -51,12 +74,19 @@ export class QuestionBridge {
 		if (this.pending) this.resolvePending({ answers: [], cancelled: true, error: "superseded" }, false);
 
 		const questionId = randomUUID();
+		this.persistence?.save(binding.sessionId, {
+			questionId,
+			sessionId: binding.sessionId,
+			turnId: binding.turnId,
+			params,
+			createdAt: new Date().toISOString(),
+		});
 		return new Promise<QuestionBridgeResult>((resolve) => {
 			const timer = setTimeout(() => {
 				if (this.pending?.questionId !== questionId) return;
 				this.resolvePending({ answers: [], cancelled: true, error: "timeout" }, true);
 			}, binding.timeoutMs);
-			this.pending = { questionId, sessionId: binding.sessionId, turnId: binding.turnId, resolve, timer };
+			this.pending = { questionId, sessionId: binding.sessionId, turnId: binding.turnId, params, resolve, timer };
 			binding.emit({ type: "question", questionId, params });
 		});
 	}
@@ -89,6 +119,9 @@ export class QuestionBridge {
 		clearTimeout(pending.timer);
 		this.pending = null;
 		this.lastResolved = { questionId: pending.questionId, sessionId: pending.sessionId, turnId: pending.turnId };
+		// Any resolution (answer, timeout, abort, turn end) ends the card's
+		// lifecycle — drop the restart-safe record with it.
+		this.persistence?.remove(pending.sessionId);
 		if (emitResolved && this.binding?.sessionId === pending.sessionId && this.binding.turnId === pending.turnId) {
 			this.binding.emit({ type: "question_resolved", questionId: pending.questionId, cancelled: result.cancelled, error: result.error });
 		}

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -53,7 +53,7 @@ import type { LearnerProfile, LearningGoal, KnowledgeState, Misconception, Learn
 import { randomUUID } from "node:crypto";
 import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
-import { questionBridge, type QuestionBridgeResult } from "./agent/question-bridge.js";
+import { questionBridge, type PersistedQuestion, type QuestionBridgeResult } from "./agent/question-bridge.js";
 import { streamRegistry, type SessionStreamState, type StreamPersistence } from "./chat/stream-registry.js";
 import { DEFAULT_WORKSPACE_ID, TEMP_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
 import { listPresets, listRemotePresets, ensurePresetCached, instantiatePreset } from "./presets/preset-store.js";
@@ -2089,6 +2089,29 @@ function sessionArchiveMetadataPath(): string {
 	return join(dataDir, "sessions", "archives.json");
 }
 
+// --- Pending question persistence (survives process restart) ---
+function sessionQuestionMetadataPath(): string {
+	return join(dataDir, "sessions", "questions.json");
+}
+
+type SessionQuestionMetadata = Record<string, PersistedQuestion>;
+
+/** In-memory cache of questions.json — read once, updated on every write.
+ *  Avoids a synchronous readFileSync on every session-detail request. */
+let _questionMetadataCache: SessionQuestionMetadata | null = null;
+
+function readSessionQuestionMetadata(): SessionQuestionMetadata {
+	if (_questionMetadataCache === null) {
+		_questionMetadataCache = readJson<SessionQuestionMetadata>(sessionQuestionMetadataPath(), {});
+	}
+	return _questionMetadataCache;
+}
+
+function writeSessionQuestionMetadata(meta: SessionQuestionMetadata): void {
+	_questionMetadataCache = meta;
+	writeJson(sessionQuestionMetadataPath(), meta);
+}
+
 function readSessionChannelMetadata(): SessionChannelMetadata {
 	return readJson<SessionChannelMetadata>(sessionChannelMetadataPath(), {});
 }
@@ -2906,6 +2929,10 @@ const server = createServer(async (req, res) => {
 				messages: parsed.messages,
 				messageCount: parsed.messages.length,
 				sessionRevision: sessionRevision(sessionPath),
+				// Attach any persisted pending question so the frontend can restore
+				// the card after a full process restart (the in-memory turn and its
+				// event replay are gone by then).
+				pendingQuestion: readSessionQuestionMetadata()[basename(sessionPath)] ?? undefined,
 			});
 			return;
 		}
@@ -3064,6 +3091,11 @@ const server = createServer(async (req, res) => {
 				if (archiveMeta[sessionId]) {
 					delete archiveMeta[sessionId];
 					writeJson(sessionArchiveMetadataPath(), archiveMeta);
+				}
+				const questionMeta = readSessionQuestionMetadata();
+				if (questionMeta[sessionId]) {
+					delete questionMeta[sessionId];
+					writeSessionQuestionMetadata(questionMeta);
 				}
 				workspaceRegistry.unbindSession(sessionId);
 				if (shouldDropTempWorkspace) {
@@ -4358,6 +4390,20 @@ const server = createServer(async (req, res) => {
 				return;
 			}
 			const status = questionBridge.respond({ sessionId, turnId, questionId, result });
+			if (status === "not_found") {
+				// The live turn is gone (process restarted, or the turn ended while
+				// the card was parked). If a persisted card matches, consume it and
+				// tell the client to resubmit the answer as a fresh chat turn — the
+				// agent then picks the answer up from the session history.
+				const questionMeta = readSessionQuestionMetadata();
+				const persistedEntry = Object.entries(questionMeta).find(([, q]) => q.questionId === questionId);
+				if (persistedEntry) {
+					delete questionMeta[persistedEntry[0]];
+					writeSessionQuestionMetadata(questionMeta);
+					json(res, 200, { accepted: true, expired: true, sessionId: persistedEntry[0] });
+					return;
+				}
+			}
 			json(res, status === "accepted" ? 200 : status === "scope_mismatch" || status === "already_resolved" ? 409 : 404, { accepted: status === "accepted" });
 			return;
 		}
@@ -4826,6 +4872,23 @@ function bindTerminalWs(ws: WebSocket, terminalId: string): void {
 // Start listening immediately — /health and static files work right away.
 // All other endpoints call ensureBootstrapped() lazily on first request.
 // ---------------------------------------------------------------------------
+
+// Inject persistence callbacks into questionBridge so pending question cards
+// survive a full process restart.
+questionBridge.setPersistence({
+	save: (sessionId, question) => {
+		const meta = readSessionQuestionMetadata();
+		meta[sessionId] = question;
+		writeSessionQuestionMetadata(meta);
+	},
+	remove: (sessionId) => {
+		const meta = readSessionQuestionMetadata();
+		if (sessionId in meta) {
+			delete meta[sessionId];
+			writeSessionQuestionMetadata(meta);
+		}
+	},
+});
 
 server.listen(port, () => {
 	console.log(`[inno-server] listening on http://localhost:${port}`);

--- a/apps/inno-agent/web/src/api/chat.ts
+++ b/apps/inno-agent/web/src/api/chat.ts
@@ -39,9 +39,28 @@ export async function getChatStatus(sessionId: string): Promise<{ found: boolean
 	return apiFetch(`/api/chat/status/${encodeURIComponent(sessionId)}`);
 }
 
-export async function submitChatQuestion(sessionId: string, turnId: string, questionId: string, result: QuestionnaireResult): Promise<void> {
-	await apiFetch("/api/chat/question-response", {
+export interface SubmitChatQuestionResponse {
+	accepted: boolean;
+	/** The owning turn is gone (server restarted). The persisted card was
+	 *  consumed; the client should resend the answer as a fresh chat turn. */
+	expired?: boolean;
+	sessionId?: string;
+}
+
+export async function submitChatQuestion(sessionId: string, turnId: string, questionId: string, result: QuestionnaireResult): Promise<SubmitChatQuestionResponse> {
+	return apiFetch<SubmitChatQuestionResponse>("/api/chat/question-response", {
 		method: "POST",
 		body: JSON.stringify({ sessionId, turnId, questionId, result }),
 	});
+}
+
+/** Render a questionnaire result as a plain user message. Used when the
+ *  original turn no longer exists and the answer must start a fresh turn. */
+export function formatQuestionnaireAsPrompt(result: QuestionnaireResult): string {
+	return result.answers
+		.map((a) => {
+			if (a.kind === "multi" && a.selected?.length) return `${a.question}: ${a.selected.join(", ")}`;
+			return `${a.question}: ${a.answer ?? a.selected?.join(", ") ?? ""}`;
+		})
+		.join("\n");
 }

--- a/apps/inno-agent/web/src/api/sessions.ts
+++ b/apps/inno-agent/web/src/api/sessions.ts
@@ -16,10 +16,21 @@ export interface SessionMeta {
 	archived?: boolean;
 }
 
+export interface PendingQuestionData {
+	questionId: string;
+	sessionId: string;
+	turnId: string;
+	params: unknown;
+	createdAt: string;
+}
+
 export interface SessionDetail extends SessionMeta {
 	messages: ChatMessage[];
 	messageCount: number;
 	sessionRevision: string;
+	/** A pending question card restored from server-side persistence (e.g.
+	 *  after a process restart killed the in-memory turn). */
+	pendingQuestion?: PendingQuestionData;
 }
 
 export interface SessionActivationResult {

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -891,7 +891,7 @@ export function ChatCenter() {
 				onKeyDown={handleKeyDown}
 				onInput={handleInput}
 				onPaste={handlePaste}
-				disabled={chat.isSending || isUploading}
+				disabled={chat.isSending || isUploading || !!chat.pendingQuestion}
 			/>
 			{chat.isSending ? (
 				<>

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "./event-emitter.js";
-import { streamChat, abortChat, getChatStatus, streamSessionEvents, submitChatQuestion } from "../api/chat.js";
+import { streamChat, abortChat, getChatStatus, streamSessionEvents, submitChatQuestion, formatQuestionnaireAsPrompt } from "../api/chat.js";
 import type { InlineImage } from "../api/chat.js";
 import type { ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult, StreamEventEnvelope, StreamSnapshot, WorkspaceFileChange } from "../types/chat.js";
 import { notebookStore } from "./notebook-store.js";
@@ -53,6 +53,10 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	lastImages: InlineImage[] | undefined = undefined;
 	/** Pending question from agent's ask_user_question tool */
 	pendingQuestion: PendingQuestion | null = null;
+	/** Question IDs the user has already answered. Suppresses stale replays
+	 *  (backend may re-push a question event before the answer POST lands) and
+	 *  guards restored cards against reappearing from a stale cache. */
+	private answeredQuestionIds = new Set<string>();
 	canReconnect = false;
 	private abortController: AbortController | null = null;
 	private detachMode = false;
@@ -470,10 +474,15 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				if (this.workspacePreviewId) workspaceStore.finishStreamingPreview(this.workspacePreviewId, "error");
 				break;
 			case "question":
+				// Skip replays of questions the user already answered (the backend
+				// may still hold the pending question briefly after the answer POST).
+				if (this.answeredQuestionIds.has(event.questionId)) break;
 				this.flushStreamChange();
 				this.pendingQuestion = {
 					questionId: event.questionId,
 					params: event.params,
+					sessionId: owner.sessionId,
+					turnId: owner.turnId ?? undefined,
 				};
 				this.emit("change", undefined);
 				break;
@@ -672,12 +681,27 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	}
 
 	async submitQuestionResponse(questionId: string, result: QuestionnaireResult): Promise<void> {
-		const owner = this.activeOwner;
-		if (!owner?.turnId || this.pendingQuestion?.questionId !== questionId) return;
+		const pending = this.pendingQuestion;
+		if (pending?.questionId !== questionId) return;
+		// Live cards take the scope from the active stream owner; restored cards
+		// (persisted across a restart) carry their own stale scope — the backend
+		// detects the dead turn and asks us to resend the answer as a new turn.
+		const sessionId = this.activeOwner?.sessionId ?? pending.sessionId;
+		const turnId = this.activeOwner?.turnId ?? pending.turnId;
+		if (!sessionId || !turnId) return;
+		this.answeredQuestionIds.add(questionId);
 		try {
-			await submitChatQuestion(owner.sessionId, owner.turnId, questionId, result);
+			const response = await submitChatQuestion(sessionId, turnId, questionId, result);
+			if (response.expired) {
+				// The original turn is gone: consume the card and resubmit the
+				// answer as a normal user prompt so the agent resumes from the
+				// session history.
+				this.pendingQuestion = null;
+				this.emit("change", undefined);
+				await this.send(formatQuestionnaireAsPrompt(result));
+			}
 		} catch (err) {
-			if (this.owns(owner)) {
+			if (!this.activeOwner || this.owns(this.activeOwner)) {
 				this.streamingError = err instanceof Error ? err.message : "提交回答失败";
 				this.emit("change", undefined);
 			}
@@ -691,6 +715,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	clear() {
 		this.detach();
 		this.messages = [];
+		this.answeredQuestionIds.clear();
 		this.emit("change", undefined);
 	}
 
@@ -714,6 +739,17 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 
 	setLoadingHistory(loading: boolean) {
 		this.isLoadingHistory = loading;
+		this.emit("change", undefined);
+	}
+
+	/** Restore a previously-shown question card after switching back to a
+	 *  session (from the local per-session cache or the server-persisted
+	 *  record). No-op if a newer question is already shown — the live stream
+	 *  replay wins. Skips cards the user already answered. */
+	restorePendingQuestion(question: PendingQuestion | null): void {
+		if (this.pendingQuestion) return;
+		if (!question || this.answeredQuestionIds.has(question.questionId)) return;
+		this.pendingQuestion = question;
 		this.emit("change", undefined);
 	}
 }

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -16,6 +16,7 @@ import {
 import { getSessionWorkspace } from "../api/workspaces.js";
 import { getChatStatus } from "../api/chat.js";
 import { chatStore } from "./chat-store.js";
+import type { PendingQuestion } from "../types/chat.js";
 import { workspaceStore } from "./workspace-store.js";
 import { workspacesStore } from "./workspaces-store.js";
 import { terminalStore } from "./terminal-store.js";
@@ -39,6 +40,10 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	preselectedWorkspaceId: string | null = null;
 	private _openRequestId = 0;
 	private _messageCache = new Map<string, Awaited<ReturnType<typeof getSession>>["messages"]>();
+	/** Caches an unanswered question card across session switches so it can be
+	 *  restored instantly when switching back (the backend replay/persistence
+	 *  reconciles it afterwards). Keyed by session id. */
+	private _pendingQuestionCache = new Map<string, PendingQuestion>();
 	private _backgroundRunningSessions = new Set<string>();
 
 	/**
@@ -137,6 +142,14 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 			} else {
 				this._messageCache.delete(prevSessionId);
 			}
+			// Preserve an unanswered question card so it can be restored on
+			// return. This applies to streaming sessions (live card) and to
+			// restored-but-unanswered cards alike.
+			if (chatStore.pendingQuestion) {
+				this._pendingQuestionCache.set(prevSessionId, chatStore.pendingQuestion);
+			} else {
+				this._pendingQuestionCache.delete(prevSessionId);
+			}
 		}
 
 		this.currentSessionId = id;
@@ -186,7 +199,25 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 
 			this._backgroundRunningSessions.delete(id);
 			if (chatStatus.stream && ["queued", "running"].includes(chatStatus.stream.status)) {
+				// The turn is live: its question event (if any) replays through the
+				// resumed stream, so no manual card restore is needed here.
 				void chatStore.resumeStream(id, chatStatus.stream);
+			} else {
+				// No live turn (e.g. after a full restart): restore the card from
+				// the local switch cache first, falling back to the server-persisted
+				// record.
+				const cached = this._pendingQuestionCache.get(id);
+				if (cached) {
+					chatStore.restorePendingQuestion(cached);
+				} else if (session.pendingQuestion) {
+					chatStore.restorePendingQuestion({
+						questionId: session.pendingQuestion.questionId,
+						params: session.pendingQuestion.params as PendingQuestion["params"],
+						sessionId: session.pendingQuestion.sessionId,
+						turnId: session.pendingQuestion.turnId,
+						restored: true,
+					});
+				}
 			}
 		} catch (error) {
 			if (requestId !== this._openRequestId) return;
@@ -337,6 +368,7 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	async deleteSession(id: string): Promise<void> {
 		const result = await deleteSession(id);
 		this._messageCache.delete(id);
+		this._pendingQuestionCache.delete(id);
 		this._backgroundRunningSessions.delete(id);
 		this.sessions = this.sessions.filter((session) => session.id !== id);
 		if (this.currentSessionId === id) {

--- a/apps/inno-agent/web/src/types/chat.ts
+++ b/apps/inno-agent/web/src/types/chat.ts
@@ -44,6 +44,14 @@ export interface QuestionData {
 export interface PendingQuestion {
 	questionId: string;
 	params: { questions: QuestionData[] };
+	/** Scope of the turn that asked the question. Present on restored cards so
+	 *  the answer can still be submitted after a restart (the backend consumes
+	 *  the persisted card and asks the client to resend it as a fresh turn). */
+	sessionId?: string;
+	turnId?: string;
+	/** True when the card was restored from server-side persistence rather
+	 *  than received from a live stream. */
+	restored?: boolean;
 }
 
 export interface QuestionAnswer {


### PR DESCRIPTION
## Summary

Reimplements the still-relevant parts of #87 on top of the turn-level chat protocol introduced by #101/#102 (with which the original PR now conflicts):

- **questions.json persistence** — `QuestionBridge.ask()` persists each pending question to `sessions/questions.json` (keyed by session, including `turnId`); any resolution (answer, timeout, abort, turn end) removes it. Cards survive a full process restart.
- **Restore path** — `GET /api/sessions/:id` returns the persisted `pendingQuestion`; the frontend restores the card when reopening a session with no live turn. `DELETE /api/sessions/:id` cleans up the record.
- **Expired-answer resend** — when the owning turn is gone, `POST /api/chat/question-response` consumes the persisted card and replies `expired: true`; the client resubmits the answer as a normal new chat turn through the standard stream pipeline. (Differs from #87's server-side resend, which bypassed the stream registry.)
- **Replay dedup** — the frontend tracks `answeredQuestionIds` to suppress stale question replays, caches unanswered cards across session switches, and disables the chat input while a card awaits an answer.

Supersedes #87 (its suspend/cancel dual semantics and broadcaster-retention concerns are already covered by the #101/#102 turn protocol and scoped abort).

## Test plan

- [x] `npm run build` (backend + web)
- [x] `npm test` — 20 vitest tests pass, incl. 2 new persistence tests (save on ask, remove on resolve/unbind)
- [x] curl smoke: session detail returns `pendingQuestion`; stale-turn answer returns `{accepted, expired: true}` and consumes the record; unknown id → 404; session delete removes the record
- [x] Browser: live question card → restart server → reopen session → card restored → answer resumes the conversation as a new turn