### PR TITLE
feat(web): refresh sidebar until auto-generated topic lands

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1799,6 +1799,8 @@ interface SessionSummary {
 	channels: SessionChannel[];
 	/** Immutable birthplace of the session (web/cli/feishu/wechat/scheduler). */
 	origin?: SessionChannel;
+	/** True once a topic (manual or auto-generated) has been recorded. */
+	hasTopic?: boolean;
 }
 
 type SessionTopicMetadata = Record<string, { topic: string; updatedAt: string; generated?: boolean }>;
@@ -2173,7 +2175,9 @@ function withRecordedChannels(summary: SessionSummary, metadata: SessionChannelM
 
 function withRecordedTopic(summary: SessionSummary, metadata: SessionTopicMetadata): SessionSummary {
 	const topic = metadata[summary.id]?.topic?.trim();
-	return topic ? { ...summary, name: topic } : summary;
+	// hasTopic lets clients distinguish "no topic recorded yet" (auto-topic may
+	// still be generating) from a fallback preview name, without guessing.
+	return topic ? { ...summary, name: topic, hasTopic: true } : { ...summary, hasTopic: false };
 }
 
 /**

--- a/apps/inno-agent/web/src/api/sessions.ts
+++ b/apps/inno-agent/web/src/api/sessions.ts
@@ -14,6 +14,8 @@ export interface SessionMeta {
 	/** Immutable birthplace of the session (web/cli/feishu/wechat/scheduler). */
 	origin?: SessionChannel;
 	archived?: boolean;
+	/** True once a topic (manual or auto-generated) has been recorded server-side. */
+	hasTopic?: boolean;
 }
 
 export interface PendingQuestionData {

--- a/apps/inno-agent/web/src/stores/chat-store.test.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
 	submitChatQuestion: vi.fn(),
 	getSession: vi.fn(),
 	refresh: vi.fn(),
+	refreshUntilTopic: vi.fn(),
 }));
 
 vi.mock("../api/chat.js", () => ({
@@ -19,7 +20,7 @@ vi.mock("../api/chat.js", () => ({
 }));
 
 vi.mock("../api/sessions.js", () => ({ getSession: mocks.getSession }));
-vi.mock("./sessions-store.js", () => ({ sessionsStore: { currentSessionId: "session.jsonl", refresh: mocks.refresh } }));
+vi.mock("./sessions-store.js", () => ({ sessionsStore: { currentSessionId: "session.jsonl", refresh: mocks.refresh, refreshUntilTopic: mocks.refreshUntilTopic } }));
 vi.mock("./notebook-store.js", () => ({ notebookStore: { loadAll: vi.fn() } }));
 vi.mock("./app-store.js", () => ({
 	appStore: {

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -405,7 +405,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.wikiInvalidated = false;
 		this.emit("change", undefined);
 		if (shouldRefreshWiki) void notebookStore.loadAll();
-		void import("./sessions-store.js").then((module) => module.sessionsStore.refresh());
+		void import("./sessions-store.js").then((module) => module.sessionsStore.refreshUntilTopic(owner.sessionId));
 	}
 
 	private _handleStreamEvent(event: ChatStreamEvent, owner: ActiveStreamOwner) {

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -27,6 +27,9 @@ interface SessionsStoreEvents {
 
 export type HistoryMode = "push" | "replace" | "none";
 
+/** Backoff for refreshUntilTopic (~62s total, covering slow topic models). */
+const TOPIC_REFRESH_DELAYS_MS = [2_000, 4_000, 8_000, 16_000, 32_000] as const;
+
 export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	sessions: SessionMeta[] = [];
 	currentSessionId: string | null = null;
@@ -121,6 +124,24 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 			this.emit("change", undefined);
 		} catch {
 			// ignore — keep previous list
+		}
+	}
+
+	/**
+	 * Refresh the sidebar until the session's auto-generated topic lands.
+	 *
+	 * Topic generation is fire-and-forget on the server (an extra LLM call
+	 * after the turn's `done` event), so the refresh that runs at turn end
+	 * usually sees the untitled fallback name. Poll with bounded backoff and
+	 * stop as soon as `hasTopic` flips (or the session disappears).
+	 */
+	async refreshUntilTopic(sessionId: string): Promise<void> {
+		await this.refresh();
+		for (const delayMs of TOPIC_REFRESH_DELAYS_MS) {
+			const entry = this.sessions.find((session) => session.id === sessionId);
+			if (!entry || entry.hasTopic) return;
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+			await this.refresh();
 		}
 	}
 


### PR DESCRIPTION
## Summary

Ports the one idea from #88 not already covered by #101/#102: prompt sidebar title updates once auto-topic generation finishes.

- **Backend**: session summaries now expose `hasTopic`, letting clients distinguish a recorded topic from the fallback preview name.
- **Frontend**: `sessionsStore.refreshUntilTopic(sessionId)` polls the session list with bounded backoff (2s/4s/8s/16s/32s) at turn end, stopping as soon as the topic lands or the session disappears. Replaces the single best-effort refresh in chat finalization.

**Why polling instead of #88's `session_topic` SSE push**: under the turn protocol the stream registry forbids publishing after the terminal event (`done`), and the SSE response closes at `done` — there is no live channel to the client when the topic arrives seconds later. Bounded polling is the reliable mechanism here.

The blocking-`done` problem #88 originally fixed is already gone on main: `done` is published first and `maybeAutoGenerateTopic` runs fire-and-forget with concurrent dedup.

## Test plan

- [x] `npm run build` (backend + web)
- [x] `npm test` — 20 tests pass (chat-store mock updated)
- [x] `GET /api/sessions` returns `hasTopic: true/false` correctly
- [ ] Browser: send first message in a new session → sidebar shows generated topic within a few seconds without navigation