### PR TITLE
fix: resilient native-vision image turns with tiered 413 retry

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.test.ts
+++ b/apps/inno-agent/src/agent/pi-runner.test.ts
@@ -3,6 +3,7 @@ import {
 	finalizePromptRun,
 	isNativeImageCapabilityError,
 	isNativeImagePayloadError,
+	isOversizedPayloadError,
 	nativeImageModelKey,
 	type PromptRunLifecycle,
 	type PromptRunOutcome,
@@ -74,5 +75,27 @@ describe("native image fallback classification", () => {
 			model: { provider: "custom", baseUrl: "https://two.example/v1", id: "vision" },
 		} as never);
 		expect(first).not.toBe(second);
+	});
+});
+
+describe("oversized payload classification", () => {
+	it.each([
+		"413 <html><head><title>413 Request Entity Too Large</title></head></html>",
+		"413 Request Entity Too Large",
+		"request entity too large",
+		"Payload Too Large",
+	])("recognizes a proxy-level oversized rejection: %s", (message) => {
+		expect(isOversizedPayloadError(message)).toBe(true);
+		// Never a capability rejection: the model may still accept smaller images.
+		expect(isNativeImageCapabilityError(message)).toBe(false);
+	});
+
+	it.each([
+		"401 unauthorized",
+		"rate limit exceeded",
+		"unknown variant 'image_url', expected 'text'",
+		undefined,
+	])("ignores unrelated errors: %s", (message) => {
+		expect(isOversizedPayloadError(message)).toBe(false);
 	});
 });

--- a/apps/inno-agent/src/agent/pi-runner.test.ts
+++ b/apps/inno-agent/src/agent/pi-runner.test.ts
@@ -44,6 +44,7 @@ describe("native image fallback classification", () => {
 		"unknown variant 'image_url', expected 'text'",
 		"This model does not support image input",
 		"Vision content is unsupported by this endpoint",
+		"400 Model only support text input Request id: 0217855120827721",
 	])("recognizes provider capability rejection: %s", (message) => {
 		expect(isNativeImagePayloadError(message)).toBe(true);
 		expect(isNativeImageCapabilityError(message)).toBe(true);

--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -438,6 +438,18 @@ export function isNativeImageCapabilityError(message: string | undefined): boole
 		!/format|mime|base64|decode|dimension|resolution|too large|file size/.test(normalized);
 }
 
+/**
+ * HTTP 413-style rejections. Reverse proxies (e.g. nginx in front of a
+ * provider) answer an oversized base64 image request with a bare
+ * "413 Request Entity Too Large" page that never mentions images, so
+ * isNativeImagePayloadError cannot catch it. Only treat this as an image
+ * payload error when the turn actually carried native images.
+ */
+export function isOversizedPayloadError(message: string | undefined): boolean {
+	if (!message) return false;
+	return /^\s*413\b|\brequest entity too large\b|\bpayload too large\b|\bcontent too large\b/i.test(message);
+}
+
 function eventErrorMessage(event: AgentSessionEvent): string | undefined {
 	if (event.type === "message_update" && event.assistantMessageEvent.type === "error") {
 		return event.assistantMessageEvent.error.errorMessage;
@@ -492,7 +504,9 @@ async function promptWithNativeImageFallback(
 	const errorMessage = thrownError instanceof Error
 		? thrownError.message
 		: lastAssistantError(session);
-	if (!isNativeImagePayloadError(errorMessage)) {
+	const payloadRejected = isNativeImagePayloadError(errorMessage) ||
+		(nativeImages?.length ? isOversizedPayloadError(errorMessage) : false);
+	if (!payloadRejected) {
 		if (thrownError) throw thrownError;
 		return;
 	}
@@ -803,6 +817,9 @@ export async function runPrompt(prompt: string, images?: ImageContent[]): Promis
 				streamError = ev.error.errorMessage || `LLM API error (stopReason: ${ev.error.stopReason})`;
 				logger.error({ errorMessage: streamError, stopReason: ev.error.stopReason, elapsedMs: Date.now() - promptStartTime }, "LLM API stream error in runPrompt");
 			}
+		} else if (event.type === "message_end") {
+			const terminalError = eventErrorMessage(event);
+			if (terminalError) streamError = terminalError;
 		} else if (event.type === "auto_retry_start") {
 			obsLogger.warn({
 				event: "auto_retry_start",
@@ -975,6 +992,14 @@ export function runPromptStreaming(
 			if (!nativeAttemptRejected || retryingWithoutNativeImages) {
 				onEvent(event);
 			}
+			// The PI SDK converts provider failures into a terminal assistant
+			// message (message_end, stopReason "error") instead of throwing —
+			// capture it so the outcome reflects the failure. A rejected native
+			// attempt also lands here but is cleared by the fallback callback.
+			if (event.type === "message_end") {
+				const terminalError = eventErrorMessage(event);
+				if (terminalError) streamError = terminalError;
+			}
 			if (event.type === "message_update") {
 				const ev = event.assistantMessageEvent;
 				if (ev.type === "text_delta") {
@@ -1070,6 +1095,12 @@ export function runPromptStreamingInSession(
 					}
 					if (!nativeAttemptRejected || retryingWithoutNativeImages) {
 						onEvent(event);
+					}
+					// See runPromptStreaming: terminal provider failures arrive as
+					// message_end with stopReason "error", not as thrown errors.
+					if (event.type === "message_end") {
+						const terminalError = eventErrorMessage(event);
+						if (terminalError) streamError = terminalError;
 					}
 					if (event.type === "message_update") {
 						const ev = event.assistantMessageEvent;

--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -376,6 +376,36 @@ function modelAllowsNativeImages(session: AgentSession): boolean {
 
 type AgentMessages = AgentSession["agent"]["state"]["messages"];
 
+function isImageBlock(item: unknown): boolean {
+	return Boolean(
+		item && typeof item === "object" &&
+		["image", "image_url"].includes(String((item as { type?: unknown }).type)),
+	);
+}
+
+function messageHasImageBlock(message: unknown): boolean {
+	const content = (message as { content?: unknown }).content;
+	return Array.isArray(content) && content.some(isImageBlock);
+}
+
+/** Index of the last user message (the current turn), or -1. */
+function lastUserMessageIndex(messages: AgentMessages): number {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		if (messages[index].role === "user") return index;
+	}
+	return -1;
+}
+
+/**
+ * Image blocks anywhere in the context except the current turn's user
+ * message. History images are re-sent with every request, so they are what
+ * makes follow-up turns 413 even when the current turn carries no image.
+ */
+function hasHistoryImageBlocks(messages: AgentMessages): boolean {
+	const currentTurn = lastUserMessageIndex(messages);
+	return messages.some((message, index) => index !== currentTurn && messageHasImageBlock(message));
+}
+
 const NATIVE_IMAGE_OMITTED_NOTICE = [
 	"[当前 Provider 无法接收图片内容，因此这张图片没有发送给模型。",
 	"你并没有看到图片；不要猜测或声称已经看到。",
@@ -384,19 +414,44 @@ const NATIVE_IMAGE_OMITTED_NOTICE = [
 	"如果 OCR 无法提供足够信息，请明确说明限制。]",
 ].join("");
 
+const HISTORY_IMAGE_OMITTED_NOTICE = [
+	"[较早轮次的图片已从本次请求的上下文中移除（请求体过大）。",
+	"你当前只能看到本轮新发送的图片；不要声称看到了被移除的历史图片。]",
+].join("");
+
 function withoutNativeImageBlocks(messages: AgentMessages): AgentMessages {
 	return messages.map((message) => {
 		const content = (message as { content?: unknown }).content;
 		if (!Array.isArray(content)) return message;
-		const filtered = content.filter((item) =>
-			!(item && typeof item === "object" &&
-				["image", "image_url"].includes(String((item as { type?: unknown }).type))));
+		const filtered = content.filter((item) => !isImageBlock(item));
 		if (filtered.length === content.length) return message;
 		return {
 			...message,
 			content: filtered.length > 0
 				? [...filtered, { type: "text", text: NATIVE_IMAGE_OMITTED_NOTICE }]
 				: [{ type: "text", text: NATIVE_IMAGE_OMITTED_NOTICE }],
+		};
+	}) as AgentMessages;
+}
+
+/**
+ * Strip image blocks from history only, keeping the current turn's images.
+ * Used for the first retry after an oversized-body (413) rejection so a
+ * vision turn keeps its own images while the accumulated history shrinks.
+ */
+function withoutHistoryImageBlocks(messages: AgentMessages): AgentMessages {
+	const currentTurn = lastUserMessageIndex(messages);
+	return messages.map((message, index) => {
+		if (index === currentTurn) return message;
+		const content = (message as { content?: unknown }).content;
+		if (!Array.isArray(content)) return message;
+		const filtered = content.filter((item) => !isImageBlock(item));
+		if (filtered.length === content.length) return message;
+		return {
+			...message,
+			content: filtered.length > 0
+				? [...filtered, { type: "text", text: HISTORY_IMAGE_OMITTED_NOTICE }]
+				: [{ type: "text", text: HISTORY_IMAGE_OMITTED_NOTICE }],
 		};
 	}) as AgentMessages;
 }
@@ -419,9 +474,35 @@ async function promptWithoutNativeImages(
 	}
 }
 
+/**
+ * Send the prompt with the current turn's images but history image blocks
+ * stripped — the first retry after an oversized-body (413) rejection.
+ */
+async function promptWithTrimmedHistoryImages(
+	session: AgentSession,
+	prompt: string,
+	nativeImages: ImageContent[] | undefined,
+): Promise<void> {
+	const originalTransform = session.agent.transformContext;
+	session.agent.transformContext = async (messages, signal) => {
+		const transformed = originalTransform
+			? await originalTransform(messages, signal)
+			: messages;
+		return withoutHistoryImageBlocks(transformed);
+	};
+	try {
+		await session.prompt(prompt, nativeImages?.length ? { images: nativeImages } : undefined);
+	} finally {
+		session.agent.transformContext = originalTransform;
+	}
+}
+
 export function isNativeImagePayloadError(message: string | undefined): boolean {
 	if (!message) return false;
 	const normalized = message.toLowerCase();
+	// Text-only deployments that answer image requests with a plain
+	// "model only support(s) text input" 400 — no image keyword at all.
+	if (/only supports? text( |-)?input/.test(normalized)) return true;
 	const mentionsImagePayload = /image_url|image message|image input|image content|vision/.test(normalized);
 	const rejectsPayload = /unknown variant|expected [`'"]?text|unsupported|not support|does not support|invalid|malformed|decode failed|too large/.test(normalized);
 	return mentionsImagePayload && rejectsPayload;
@@ -430,6 +511,7 @@ export function isNativeImagePayloadError(message: string | undefined): boolean 
 export function isNativeImageCapabilityError(message: string | undefined): boolean {
 	if (!message) return false;
 	const normalized = message.toLowerCase();
+	if (/only supports? text( |-)?input/.test(normalized)) return true;
 	if (/unknown variant.{0,80}image_url|image_url.{0,80}unknown variant/.test(normalized)) return true;
 	if (/expected [`'"]?text.{0,80}(?:image|vision)|(?:image|vision).{0,80}expected [`'"]?text/.test(normalized)) {
 		return true;
@@ -482,15 +564,42 @@ function restoreSessionBeforeFailedPrompt(session: AgentSession, previousLeafId:
 	session.agent.state.messages = session.sessionManager.buildSessionContext().messages;
 }
 
+/**
+ * Callbacks for the tiered native-image retry. `onRetry` fires before the
+ * history-trimming retry (the turn keeps its images, so it is NOT a fallback
+ * to OCR); `onFallback` fires before the final OCR-friendly retry.
+ */
+export interface NativeImageRetryCallbacks {
+	onRetry?: () => void;
+	onFallback: (errorMessage: string) => void;
+}
+
+/**
+ * Run a prompt with native images, degrading gracefully when the
+ * model/provider cannot accept them:
+ *
+ *  1. Native attempt (current turn's images + full history).
+ *  2. On an oversized-body rejection (413) with images anywhere in the
+ *     context: retry with history image blocks stripped but the current
+ *     turn's images kept. History images are re-sent with every request, so
+ *     they are what 413s follow-up turns even when the current turn is
+ *     small or carries no image at all.
+ *  3. On a payload rejection (or a second 413): restore the session and
+ *     retry with all image blocks stripped, using `fallbackPrompt` — the
+ *     variant of `prompt` carrying the saved-image path hint for
+ *     `ocr_image`. Vision-capable turns never see that hint, so they are not
+ *     steered toward `ocr_image`.
+ */
 async function promptWithNativeImageFallback(
 	session: AgentSession,
 	prompt: string,
 	nativeImages: ImageContent[] | undefined,
-	onFallback: (errorMessage: string) => void,
+	callbacks: NativeImageRetryCallbacks,
+	fallbackPrompt?: string,
 ): Promise<void> {
 	const allowsNativeImages = modelAllowsNativeImages(session);
 	if (!allowsNativeImages) {
-		await promptWithoutNativeImages(session, prompt);
+		await promptWithoutNativeImages(session, fallbackPrompt ?? prompt);
 		return;
 	}
 
@@ -501,11 +610,42 @@ async function promptWithNativeImageFallback(
 	} catch (error) {
 		thrownError = error;
 	}
-	const errorMessage = thrownError instanceof Error
+	let errorMessage = thrownError instanceof Error
 		? thrownError.message
 		: lastAssistantError(session);
+
+	// Tier 2: oversized body with images in history — trim history images and
+	// retry while keeping the current turn's images.
+	if (
+		errorMessage &&
+		isOversizedPayloadError(errorMessage) &&
+		hasHistoryImageBlocks(session.messages)
+	) {
+		logger.warn(
+			{
+				provider: session.model?.provider,
+				model: session.model?.id,
+				errorMessage,
+			},
+			"request body too large; retrying the turn with history images stripped from context",
+		);
+		restoreSessionBeforeFailedPrompt(session, previousLeafId);
+		callbacks.onRetry?.();
+		thrownError = undefined;
+		try {
+			await promptWithTrimmedHistoryImages(session, prompt, nativeImages);
+		} catch (error) {
+			thrownError = error;
+		}
+		errorMessage = thrownError instanceof Error
+			? thrownError.message
+			: lastAssistantError(session);
+		if (!errorMessage) return;
+	}
+
+	const contextHasImages = Boolean(nativeImages?.length) || hasHistoryImageBlocks(session.messages);
 	const payloadRejected = isNativeImagePayloadError(errorMessage) ||
-		(nativeImages?.length ? isOversizedPayloadError(errorMessage) : false);
+		(contextHasImages && isOversizedPayloadError(errorMessage));
 	if (!payloadRejected) {
 		if (thrownError) throw thrownError;
 		return;
@@ -523,8 +663,8 @@ async function promptWithNativeImageFallback(
 		"provider rejected native image payload; retrying the turn with workspace OCR fallback",
 	);
 	restoreSessionBeforeFailedPrompt(session, previousLeafId);
-	onFallback(errorMessage ?? "Provider rejected the native image payload.");
-	await promptWithoutNativeImages(session, prompt);
+	callbacks.onFallback(errorMessage ?? "Provider rejected the native image payload.");
+	await promptWithoutNativeImages(session, fallbackPrompt ?? prompt);
 }
 
 /**
@@ -796,8 +936,10 @@ export function getLoadedSkills() {
 /**
  * Run a prompt through the session and collect the full text response.
  * Optionally pass images (base64 encoded) for multimodal input.
+ * `imageFallbackPrompt` is sent instead of `prompt` when the images cannot go
+ * to the model natively (text-only model or provider rejection).
  */
-export async function runPrompt(prompt: string, images?: ImageContent[]): Promise<string> {
+export async function runPrompt(prompt: string, images?: ImageContent[], imageFallbackPrompt?: string): Promise<string> {
 	const session = getSession();
 
 	let output = "";
@@ -849,10 +991,14 @@ export async function runPrompt(prompt: string, images?: ImageContent[]): Promis
 
 	try {
 		const nativeImages = nativeImagesForSession(session, images);
-		await promptWithNativeImageFallback(session, prompt, nativeImages, () => {
+		const resetAttempt = () => {
 			output = "";
 			streamError = undefined;
-		});
+		};
+		await promptWithNativeImageFallback(session, prompt, nativeImages, {
+			onRetry: resetAttempt,
+			onFallback: resetAttempt,
+		}, imageFallbackPrompt);
 	} finally {
 		unsubscribe();
 		obsUnsub();
@@ -873,8 +1019,8 @@ export async function runPrompt(prompt: string, images?: ImageContent[]): Promis
  * Run a prompt with serialized access (only one prompt at a time).
  * All concurrent calls are queued and executed sequentially.
  */
-export function runPromptSerialized(prompt: string, images?: ImageContent[]): Promise<string> {
-	return enqueue(() => runPrompt(prompt, images));
+export function runPromptSerialized(prompt: string, images?: ImageContent[], imageFallbackPrompt?: string): Promise<string> {
+	return enqueue(() => runPrompt(prompt, images, imageFallbackPrompt));
 }
 
 /**
@@ -886,10 +1032,11 @@ export function runPromptInSession(
 	sessionPath: string,
 	prompt: string,
 	images?: ImageContent[],
+	imageFallbackPrompt?: string,
 ): Promise<string> {
 	return enqueue(async () => {
 		await switchToSession(sessionPath);
-		return runPrompt(prompt, images);
+		return runPrompt(prompt, images, imageFallbackPrompt);
 	});
 }
 
@@ -968,6 +1115,7 @@ export function runPromptStreaming(
 	prompt: string,
 	onEvent: StreamEventCallback,
 	images?: ImageContent[],
+	imageFallbackPrompt?: string,
 ): Promise<string> {
 	return enqueue(async () => {
 		const session = getSession();
@@ -1035,11 +1183,18 @@ export function runPromptStreaming(
 			}
 		});
 		try {
-			await promptWithNativeImageFallback(session, prompt, nativeImages, () => {
-				retryingWithoutNativeImages = true;
-				output = "";
-				streamError = undefined;
-			});
+			await promptWithNativeImageFallback(session, prompt, nativeImages, {
+				onRetry: () => {
+					nativeAttemptRejected = false;
+					output = "";
+					streamError = undefined;
+				},
+				onFallback: () => {
+					retryingWithoutNativeImages = true;
+					output = "";
+					streamError = undefined;
+				},
+			}, imageFallbackPrompt);
 		} finally {
 			unsubscribe();
 			obsUnsub();
@@ -1067,6 +1222,7 @@ export function runPromptStreamingInSession(
 	images?: ImageContent[],
 	lifecycle?: PromptRunLifecycle,
 	cwdOverride?: string,
+	imageFallbackPrompt?: string,
 ): Promise<string> {
 	return enqueue(async () => {
 		let output = "";
@@ -1112,11 +1268,18 @@ export function runPromptStreamingInSession(
 					}
 				});
 				try {
-					await promptWithNativeImageFallback(session, prompt, nativeImages, () => {
-						retryingWithoutNativeImages = true;
-						output = "";
-						streamError = undefined;
-					});
+					await promptWithNativeImageFallback(session, prompt, nativeImages, {
+						onRetry: () => {
+							nativeAttemptRejected = false;
+							output = "";
+							streamError = undefined;
+						},
+						onFallback: () => {
+							retryingWithoutNativeImages = true;
+							output = "";
+							streamError = undefined;
+						},
+					}, imageFallbackPrompt);
 				} finally {
 					unsubscribe();
 					obsUnsub();

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -525,9 +525,11 @@ function mimeTypeToExtension(mimeType: string): string {
 }
 
 /**
- * Prepend a path-hint block to the user prompt when inline images were
- * persisted, so the agent knows which files to pass to `ocr_image` /
- * `parse_document` when the model can't natively see images.
+ * Build the fallback prompt variant carrying the saved-image path hint, so
+ * the agent knows which files to pass to `ocr_image` / `parse_document`.
+ * Only sent when the model can't natively see images (text-only model or a
+ * rejected native payload) — vision-capable turns receive the raw prompt so
+ * they aren't steered toward `ocr_image`.
  */
 function prependImagePathsHint(prompt: string, imagePaths: string[]): string {
 	if (imagePaths.length === 0) return prompt;
@@ -4410,19 +4412,22 @@ const server = createServer(async (req, res) => {
 			const imageWorkspaceId = workspaceRegistry.getSessionWorkspaceId(imageSessionId);
 			const imageWorkspaceRoot = workspaceRegistry.resolveWorkspaceDir(imageWorkspaceId) ?? paths.workspaceDir;
 			const imagePaths = persistInlineImages(images, imageWorkspaceRoot);
-			const promptWithHint = prependImagePathsHint(prompt, imagePaths);
+			// Sent only when the images can't reach the model natively (text-only
+			// model or provider rejection); vision turns get the raw prompt so
+			// they aren't steered toward ocr_image.
+			const imageFallbackPrompt = prependImagePathsHint(prompt, imagePaths);
 			// Use atomic switch+prompt when a specific session is requested.
 			let output: string;
 			try {
 				if (requestedSessionId) {
 					const sessionPath = sessionFileFromId(join(dataDir, "sessions"), requestedSessionId);
 					if (sessionPath && existsSync(sessionPath)) {
-						output = await runPromptInSession(sessionPath, promptWithHint, images.length ? images : undefined);
+						output = await runPromptInSession(sessionPath, prompt, images.length ? images : undefined, imageFallbackPrompt);
 					} else {
-						output = await runPromptSerialized(promptWithHint, images.length ? images : undefined);
+						output = await runPromptSerialized(prompt, images.length ? images : undefined, imageFallbackPrompt);
 					}
 				} else {
-					output = await runPromptSerialized(promptWithHint, images.length ? images : undefined);
+					output = await runPromptSerialized(prompt, images.length ? images : undefined, imageFallbackPrompt);
 				}
 			} catch (err) {
 				logger.error({ err, sessionId: requestedSessionId }, "Non-streaming chat LLM call failed");
@@ -4585,7 +4590,10 @@ const server = createServer(async (req, res) => {
 			// Persist inline images to the workspace so file-path tools (ocr_image,
 			// parse_document) can read them when the chat model can't see images.
 			const imagePaths = persistInlineImages(images, streamWorkspaceRoot);
-			const promptWithHint = prependImagePathsHint(prompt, imagePaths);
+			// Sent only when the images can't reach the model natively (text-only
+			// model or provider rejection); vision turns get the raw prompt so
+			// they aren't steered toward ocr_image.
+			const imageFallbackPrompt = prependImagePathsHint(prompt, imagePaths);
 			const imageArgs = images.length ? images : undefined;
 			const baseline = readSessionBaseline(targetSessionPath);
 			let state: SessionStreamState;
@@ -4725,7 +4733,7 @@ const server = createServer(async (req, res) => {
 
 			promptStartTime = Date.now();
 			try {
-				await runPromptStreamingInSession(targetSessionPath, promptWithHint, onEvent, imageArgs, {
+				await runPromptStreamingInSession(targetSessionPath, prompt, onEvent, imageArgs, {
 					token: state.turnId,
 					shouldStart: () => !state.cancelRequested,
 					isCancellationRequested: () => state.cancelRequested,
@@ -4794,7 +4802,7 @@ const server = createServer(async (req, res) => {
 							}
 						}
 					},
-				}, streamWorkspaceRoot);
+				}, streamWorkspaceRoot, imageFallbackPrompt);
 			} catch (err) {
 				logger.error({ err, sessionId: state.sessionId, turnId: state.turnId }, "SSE chat turn failed");
 			} finally {

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -33,6 +33,99 @@ const PASTE_COLLAPSE_CHARS = 2000;
 const LONG_ASSISTANT_CHARS = 6000;
 const LONG_ASSISTANT_LINES = 140;
 
+// Inline chat images are sent to the provider as base64 inside the JSON body.
+// Full-resolution photos (3–10 MB, +33% once base64-encoded) blow past the
+// body-size limit of reverse proxies in front of providers (nginx defaults to
+// 1 MB) and come back as HTTP 413, silently demoting the turn to the OCR
+// fallback. Downscale/re-encode before sending so native vision turns
+// actually reach the model. The target is deliberately well under 1 MB:
+// base64 inflates ~4/3 and the body also carries the system prompt and
+// conversation history.
+const INLINE_IMAGE_MAX_DIMENSION = 1280;
+const INLINE_IMAGE_TARGET_BYTES = 380 * 1024;
+const INLINE_IMAGE_MAX_BYTES = 500 * 1024;
+
+type PreparedInlineImage = InlineImage & { name: string; previewUrl: string };
+
+function rawInlineImage(file: File, dataUrl: string): PreparedInlineImage {
+	const commaIdx = dataUrl.indexOf(",");
+	const header = dataUrl.slice(0, commaIdx);
+	return {
+		data: dataUrl.slice(commaIdx + 1),
+		mimeType: header.match(/:(.*?);/)?.[1] ?? file.type,
+		name: file.name || "image",
+		previewUrl: dataUrl,
+	};
+}
+
+/** Binary size estimate of a base64 data URL payload. */
+function dataUrlBytes(dataUrl: string): number {
+	return Math.floor((dataUrl.length - dataUrl.indexOf(",") - 1) * 3 / 4);
+}
+
+/**
+ * Re-encode as JPEG, shrinking quality first and then dimensions until the
+ * payload fits INLINE_IMAGE_TARGET_BYTES. Returns the smallest result even
+ * when the target can't be reached.
+ */
+function downscaleToFit(img: HTMLImageElement): string | undefined {
+	const canvas = document.createElement("canvas");
+	const ctx = canvas.getContext("2d");
+	if (!ctx) return undefined;
+	let scale = Math.min(1, INLINE_IMAGE_MAX_DIMENSION / Math.max(img.naturalWidth, img.naturalHeight));
+	let quality = 0.8;
+	let best: string | undefined;
+	for (let attempt = 0; attempt < 5; attempt++) {
+		canvas.width = Math.max(1, Math.round(img.naturalWidth * scale));
+		canvas.height = Math.max(1, Math.round(img.naturalHeight * scale));
+		// Flatten alpha onto white — JPEG has no transparency.
+		ctx.fillStyle = "#ffffff";
+		ctx.fillRect(0, 0, canvas.width, canvas.height);
+		ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+		const outUrl = canvas.toDataURL("image/jpeg", quality);
+		if (!best || outUrl.length < best.length) best = outUrl;
+		if (dataUrlBytes(outUrl) <= INLINE_IMAGE_TARGET_BYTES) break;
+		if (quality > 0.5) {
+			quality -= 0.15;
+		} else {
+			scale *= 0.75;
+			quality = 0.7;
+		}
+	}
+	return best;
+}
+
+async function prepareInlineImage(file: File): Promise<PreparedInlineImage> {
+	const dataUrl = await new Promise<string>((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve(reader.result as string);
+		reader.onerror = () => reject(reader.error);
+		reader.readAsDataURL(file);
+	});
+	const passthrough = () => rawInlineImage(file, dataUrl);
+	if (file.size <= INLINE_IMAGE_MAX_BYTES) return passthrough();
+	try {
+		const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+			// `Image` the DOM constructor is shadowed by the lucide icon import.
+			const el = document.createElement("img");
+			el.onload = () => resolve(el);
+			el.onerror = () => reject(new Error("image decode failed"));
+			el.src = dataUrl;
+		});
+		const outUrl = downscaleToFit(img);
+		// Keep the original if re-encoding failed or produced a larger payload.
+		if (!outUrl || outUrl.length >= dataUrl.length) return passthrough();
+		return {
+			data: outUrl.slice(outUrl.indexOf(",") + 1),
+			mimeType: "image/jpeg",
+			name: file.name || "image",
+			previewUrl: outUrl,
+		};
+	} catch {
+		return passthrough();
+	}
+}
+
 interface PendingUpload {
 	fileName: string;
 	path: string;
@@ -764,16 +857,9 @@ export function ChatCenter() {
 
 	const addImageFiles = useCallback((files: File[]) => {
 		files.forEach((file) => {
-			const reader = new FileReader();
-			reader.onload = () => {
-				const dataUrl = reader.result as string;
-				const commaIdx = dataUrl.indexOf(",");
-				const header = dataUrl.slice(0, commaIdx);
-				const data = dataUrl.slice(commaIdx + 1);
-				const mimeType = header.match(/:(.*?);/)?.[1] ?? file.type;
-				setInlineImages((prev) => [...prev, { data, mimeType, name: file.name || "image", previewUrl: dataUrl }]);
-			};
-			reader.readAsDataURL(file);
+			void prepareInlineImage(file).then((prepared) => {
+				setInlineImages((prev) => [...prev, prepared]);
+			});
 		});
 	}, []);
 


### PR DESCRIPTION
## Problem

Image attachments on vision-capable models were unreliable in three ways:

1. **Every image turn was steered toward OCR.** The `.chat-images/` path hint (\"call `ocr_image`\") was prepended unconditionally, so even models that could see images natively were pushed to the OCR tool.
2. **Follow-up turns hard-failed with 413.** History image blocks are re-sent with every request. Once a session accumulated images over the reverse proxy's 1 MB body limit (nginx in front of the provider), every subsequent turn — even text-only ones — got a bare nginx `413 Request Entity Too Large` page and failed outright. The existing 413 retry only looked at the *current* turn's images.
3. **Full-resolution uploads blew the body limit on their own.** The web UI sent photos as-is (3–10 MB, +33% base64), so a single image could exceed the proxy limit.

Also, text-only deployments that answer image requests with a plain `400 Model only support text input` (no image keyword) were not recognized as capability rejections and surfaced as hard 500s.

## Changes

**Backend — `promptWithNativeImageFallback` (pi-runner.ts)**
- Chat routes now pass the raw prompt plus an `imageFallbackPrompt` variant carrying the OCR-hint. The runner decides at execution time (authoritative session model): vision turns get the raw prompt and are never steered toward `ocr_image`; text-only models and rejected native payloads get the hint variant.
- Tiered retry on oversized-body rejections: (1) native attempt with full history → (2) on 413 with images in context, retry with **history image blocks stripped but the current turn's kept** (`withoutHistoryImageBlocks`) → (3) on a second 413 or a capability rejection, restore and retry fully stripped with the OCR-hint prompt. Callbacks are now `{ onRetry, onFallback }` so streaming output/error state resets between attempts.
- Recognize `only support(s) text input` in `isNativeImagePayloadError` / `isNativeImageCapabilityError`, so text-only deployments degrade gracefully to OCR and skip native attempts thereafter (unit test added).

**Frontend — ChatCenter.tsx**
- `prepareInlineImage`: files > 500 KB are re-encoded as JPEG (alpha flattened onto white) in an iterative loop — reduce quality first (0.8 → 0.5), then dimensions (×0.75, cap 1280px) — targeting ≤ 380 KB per image, well under the 1 MB proxy limit once base64 and the system prompt are accounted for. Small files pass through unchanged; re-encode falls back to the original on failure.

## Verification

- `npm run build` clean; `npm test` 45/45 passing (new case for the text-input 400).
- Live against the real providers:
  - Vision model (`gpt-5.2`): image described natively (colors, layout, text); persisted turn has no OCR hint and carries the native image block; no `ocr_image` call.
  - Text-only model (`deepseek-v4-pro`): hint delivered, `ocr_image` called, `.chat-images/` file resolved.
  - A previously \"poisoned\" session (2 × ~980k-char images in history) that hard-failed every follow-up now succeeds via the history-trimming retry.
  - Text-only deployment (`Qwen3.6-35B-inno`, rejects with `400 Model only support text input`): graceful OCR fallback instead of a hard 500.