### PR TITLE
feat(notebook): live force-directed graph with Obsidian-style drag

### DIFF
--- a/apps/inno-agent/web/src/react/notebook/GraphView.tsx
+++ b/apps/inno-agent/web/src/react/notebook/GraphView.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Scan, Shuffle, RefreshCw, Network, Tag } from "lucide-react";
 import { Spinner } from "../ui/Spinner.js";
 import cytoscape, { type Core, type ElementDefinition } from "cytoscape";
+import { ForceSimulation, type SimLink, type SimNode } from "./force-simulation.js";
 import type { WikiGraphEdge, WikiGraphNode } from "../../types/wiki.js";
 import { notebookStore } from "../../stores/notebook-store.js";
 import { useStoreSnapshot } from "../hooks.js";
@@ -49,7 +50,7 @@ function deduplicateEdges(edges: WikiGraphEdge[]): WikiGraphEdge[] {
 	return [...byPair.values()];
 }
 
-function truncateLabel(label: string, maxLength = 34): string {
+function truncateLabel(label: string, maxLength = 20): string {
 	return label.length <= maxLength ? label : `${label.slice(0, maxLength - 3)}...`;
 }
 
@@ -68,10 +69,10 @@ function buildCommunitySeedPositions(nodes: WikiGraphNode[]): Map<string, { x: n
 	const goldenAngle = Math.PI * (3 - Math.sqrt(5));
 
 	orderedGroups.forEach(([, group], groupIndex) => {
-		const centerX = (groupIndex % columns) * 420;
-		const centerY = Math.floor(groupIndex / columns) * 340;
+		const centerX = (groupIndex % columns) * 540;
+		const centerY = Math.floor(groupIndex / columns) * 440;
 		group.sort((a, b) => a.id.localeCompare(b.id)).forEach((node, nodeIndex) => {
-			const radius = nodeIndex === 0 ? 0 : 34 + Math.sqrt(nodeIndex) * 19;
+			const radius = nodeIndex === 0 ? 0 : 44 + Math.sqrt(nodeIndex) * 25;
 			const angle = nodeIndex * goldenAngle;
 			positions.set(node.id, {
 				x: centerX + Math.cos(angle) * radius,
@@ -115,7 +116,7 @@ function buildElements(nodes: WikiGraphNode[], edges: WikiGraphEdge[]): ElementD
 				color: TYPE_COLORS[n.type] ?? TYPE_COLORS.tag,
 				community: n.community ?? 0,
 				degree: nodeDegree,
-				size: 16 + Math.min(30, Math.sqrt(nodeDegree) * 6),
+				size: 9 + Math.min(20, Math.sqrt(nodeDegree) * 3.5),
 				seedX: seed.x,
 				seedY: seed.y,
 			},
@@ -139,7 +140,7 @@ function buildElements(nodes: WikiGraphNode[], edges: WikiGraphEdge[]): ElementD
 				weight: e.weight ?? 1,
 				normalizedWeight,
 				sameCommunity,
-				edgeWidth: e.type === "tag" ? 0.5 : 0.3 + Math.pow(normalizedWeight, 1.3) * 3.2,
+				edgeWidth: e.type === "tag" ? 0.25 : 0.15 + Math.pow(normalizedWeight, 1.3) * 0.95,
 				edgeOpacity: communityEdgeOpacity,
 				communityEdgeOpacity,
 				typeEdgeOpacity: baseOpacity,
@@ -149,48 +150,82 @@ function buildElements(nodes: WikiGraphNode[], edges: WikiGraphEdge[]): ElementD
 	return els;
 }
 
-function makeCommunityLayoutOptions(): cytoscape.LayoutOptions {
-	return {
-		name: "preset",
-		fit: false,
-		animate: false,
-		positions: (node: cytoscape.NodeSingular) => ({
-			x: Number(node.data("seedX")),
-			y: Number(node.data("seedY")),
-		}),
-		padding: 32,
-	} as unknown as cytoscape.LayoutOptions;
-}
-
-function makeRelationshipLayoutOptions(randomize = true, animationDuration = 500): cytoscape.LayoutOptions {
-	return {
-		name: "cose",
-		fit: false,
-		animate: "end",
-		animationDuration,
-		randomize,
-		nodeRepulsion: () => 9_000,
-		idealEdgeLength: (edge: cytoscape.EdgeSingular) =>
-			125 - Number(edge.data("normalizedWeight") ?? 0) * 55,
-		edgeElasticity: () => 100,
-		gravity: 0.25,
-		numIter: 1_200,
-		initialTemp: 200,
-		coolingFactor: 0.95,
-		minTemp: 1,
-		padding: 32,
-	} as unknown as cytoscape.LayoutOptions;
-}
-
-function createLayout(cy: Core, mode: GraphColorMode): cytoscape.Layouts {
-	if (mode === "community") {
-		cy.nodes(":visible").forEach((node) => {
-			node.position({ x: Number(node.data("seedX")), y: Number(node.data("seedY")) });
+/**
+ * Rebuild the live simulation from the currently visible elements, keeping
+ * each node's on-screen position. Returns cytoscape nodes aligned index-for-
+ * index with the simulation's nodes so ticks can write positions back cheaply.
+ */
+function syncSimulation(cy: Core, sim: ForceSimulation, mode: GraphColorMode): cytoscape.NodeSingular[] {
+	const cyNodes: cytoscape.NodeSingular[] = [];
+	const simNodes: SimNode[] = [];
+	const indexById = new Map<string, number>();
+	cy.nodes(":visible").forEach((node) => {
+		const pos = node.position();
+		indexById.set(node.id(), simNodes.length);
+		cyNodes.push(node);
+		simNodes.push({
+			id: node.id(),
+			x: pos.x,
+			y: pos.y,
+			vx: 0,
+			vy: 0,
+			radius: (Number(node.data("size")) || 14) / 2,
+			fixed: node.grabbed(),
+			group: Number(node.data("community")) || 0,
 		});
+	});
+
+	const degree = new Map<number, number>();
+	const rawLinks: { source: number; target: number; tag: boolean; weight: number }[] = [];
+	cy.edges(":visible").forEach((edge) => {
+		const source = indexById.get(edge.source().id());
+		const target = indexById.get(edge.target().id());
+		if (source === undefined || target === undefined || source === target) return;
+		degree.set(source, (degree.get(source) ?? 0) + 1);
+		degree.set(target, (degree.get(target) ?? 0) + 1);
+		rawLinks.push({
+			source,
+			target,
+			tag: edge.data("edgeType") === "tag",
+			weight: Number(edge.data("normalizedWeight")) || 0,
+		});
+	});
+	const links: SimLink[] = rawLinks.map((link) => {
+		// d3-force-style: hubs get weaker per-link springs so they stay put
+		// while leaves swing around them.
+		const minDegree = Math.max(1, Math.min(degree.get(link.source) ?? 1, degree.get(link.target) ?? 1));
+		const strength = Math.min(0.42, (link.tag ? 0.18 : 0.62) / minDegree + 0.035);
+		return {
+			source: link.source,
+			target: link.target,
+			length: link.tag ? 280 : 150 + (1 - link.weight) * 105,
+			strength,
+		};
+	});
+
+	sim.setGraph(simNodes, links);
+	sim.options.groupStrength = mode === "community" ? 0.025 : 0;
+	if (simNodes.length > 0) {
+		let cx = 0;
+		let cyy = 0;
+		for (const node of simNodes) {
+			cx += node.x;
+			cyy += node.y;
+		}
+		sim.setCenter(cx / simNodes.length, cyy / simNodes.length);
 	}
-	return cy.elements(":visible").layout(
-		mode === "community" ? makeCommunityLayoutOptions() : makeRelationshipLayoutOptions(),
-	);
+	return cyNodes;
+}
+
+function applySimPositions(cy: Core, sim: ForceSimulation, cyNodes: cytoscape.NodeSingular[]): void {
+	cy.batch(() => {
+		for (let i = 0; i < cyNodes.length; i++) {
+			const simNode = sim.getNode(cyNodes[i].id());
+			// Grabbed/fixed nodes are positioned by cytoscape's own drag handling.
+			if (!simNode || simNode.fixed) continue;
+			cyNodes[i].position({ x: simNode.x, y: simNode.y });
+		}
+	});
 }
 
 export function GraphView() {
@@ -207,15 +242,16 @@ export function GraphView() {
 
 	const containerRef = useRef<HTMLDivElement | null>(null);
 	const cyRef = useRef<Core | null>(null);
-	const layoutRef = useRef<cytoscape.Layouts | null>(null);
-	const colorModeRef = useRef<GraphColorMode>("community");
+	const simRef = useRef<ForceSimulation | null>(null);
+	if (!simRef.current) simRef.current = new ForceSimulation();
+	const simNodesRef = useRef<cytoscape.NodeSingular[]>([]);
+	const rafRef = useRef<number | null>(null);
 
 	const [visibleCategories, setVisibleCategories] = useState<Set<NodeCategory>>(
 		() => new Set(DEFAULT_VISIBLE),
 	);
 	const [colorMode, setColorMode] = useState<GraphColorMode>("community");
 	const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
-	colorModeRef.current = colorMode;
 
 	const toggleCategory = useCallback((category: NodeCategory) => {
 		setVisibleCategories((prev) => {
@@ -241,9 +277,9 @@ export function GraphView() {
 					style: {
 						"background-color": "data(color)",
 						label: "data(label)",
-						color: "#0f172a",
-						"font-size": 11,
-						"text-margin-y": 6,
+						color: "#334155",
+						"font-size": 10,
+						"text-margin-y": 5,
 						"text-valign": "bottom",
 						"text-halign": "center",
 						"text-outline-width": 2,
@@ -252,7 +288,7 @@ export function GraphView() {
 						width: "data(size)" as unknown as number,
 						height: "data(size)" as unknown as number,
 						"border-color": "#ffffff",
-						"border-width": 1.5,
+						"border-width": 1,
 						"overlay-opacity": 0,
 						"transition-property": "opacity, border-color, border-width",
 						"transition-duration": 150,
@@ -303,7 +339,7 @@ export function GraphView() {
 				},
 				{
 					selector: "edge.hl",
-					style: { "line-color": "#2563eb", width: 4, opacity: 1 },
+					style: { "line-color": "#2563eb", width: 2, opacity: 1 },
 				},
 			],
 		});
@@ -335,34 +371,81 @@ export function GraphView() {
 			setHoveredNodeId(null);
 			cy.elements().removeClass("dim").removeClass("hl");
 		});
-		cy.on("grab", "node", () => {
-			layoutRef.current?.stop();
+
+		const sim = simRef.current!;
+		const startTicking = () => {
+			if (rafRef.current !== null) return;
+			const frame = () => {
+				if (!cyRef.current || !sim.running) {
+					rafRef.current = null;
+					return;
+				}
+				sim.tick();
+				applySimPositions(cy, sim, simNodesRef.current);
+				rafRef.current = requestAnimationFrame(frame);
+			};
+			rafRef.current = requestAnimationFrame(frame);
+		};
+		cy.scratch("innoStartTicking", startTicking);
+
+		// Obsidian-style drag: the grabbed node is pinned to the pointer while
+		// the simulation keeps running, so springs pull neighbours along and
+		// repulsion shoulders bystanders out of the way. Reheat only once the
+		// pointer actually moves — a plain click should not shake the graph.
+		let dragging = false;
+		cy.on("grab", "node", (evt) => {
+			const simNode = sim.getNode((evt.target as cytoscape.NodeSingular).id());
+			if (simNode) simNode.fixed = true;
+		});
+		cy.on("drag", "node", (evt) => {
+			const node = evt.target as cytoscape.NodeSingular;
+			const simNode = sim.getNode(node.id());
+			if (!simNode) return;
+			const pos = node.position();
+			simNode.x = pos.x;
+			simNode.y = pos.y;
+			if (!dragging) {
+				dragging = true;
+				sim.reheat(0.45, 0.28);
+				startTicking();
+			}
 		});
 		cy.on("free", "node", (evt) => {
-			if (colorModeRef.current !== "type") return;
-			const draggedNode = evt.target as cytoscape.NodeSingular;
-			draggedNode.lock();
-			layoutRef.current?.stop();
-			const layout = cy.elements(":visible").layout(makeRelationshipLayoutOptions(false, 300));
-			layoutRef.current = layout;
-			layout.one("layoutstop", () => draggedNode.unlock());
-			layout.run();
+			const node = evt.target as cytoscape.NodeSingular;
+			const simNode = sim.getNode(node.id());
+			if (simNode) {
+				const pos = node.position();
+				simNode.x = pos.x;
+				simNode.y = pos.y;
+				simNode.fixed = false;
+			}
+			if (dragging) {
+				dragging = false;
+				sim.alphaTarget = 0;
+				sim.reheat(0.25);
+				startTicking();
+			}
 		});
 
 		cyRef.current = cy;
 		return () => {
-			layoutRef.current?.stop();
-			layoutRef.current = null;
+			if (rafRef.current !== null) {
+				cancelAnimationFrame(rafRef.current);
+				rafRef.current = null;
+			}
+			sim.stop();
+			simNodesRef.current = [];
 			cy.destroy();
 			cyRef.current = null;
 		};
 	}, [elements]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	// Keep presentation and layout changes in one effect. Separate mode and
-	// visibility effects would both start a layout when the graph mounts.
+	// visibility effects would each rebuild the simulation when the graph mounts.
 	useEffect(() => {
 		const cy = cyRef.current;
-		if (!cy) return;
+		const sim = simRef.current;
+		if (!cy || !sim) return;
 		cy.batch(() => {
 			cy.nodes().forEach((node) => {
 				node.data("color", node.data(colorMode === "community" ? "communityColor" : "typeColor"));
@@ -379,12 +462,16 @@ export function GraphView() {
 				const targetHidden = edge.target().hasClass("hidden");
 				edge.toggleClass("hidden", sourceHidden || targetHidden);
 			});
+			if (colorMode === "community") {
+				cy.nodes(":visible").forEach((node) => {
+					node.position({ x: Number(node.data("seedX")), y: Number(node.data("seedY")) });
+				});
+			}
 		});
-		layoutRef.current?.stop();
-		const layout = createLayout(cy, colorMode);
-		layoutRef.current = layout;
-		layout.one("layoutstop", () => cy.fit(cy.elements(":visible"), 32));
-		layout.run();
+		simNodesRef.current = syncSimulation(cy, sim, colorMode);
+		cy.fit(cy.elements(":visible"), 32);
+		sim.reheat(colorMode === "community" ? 0.35 : 0.6);
+		(cy.scratch("innoStartTicking") as (() => void) | undefined)?.();
 	}, [colorMode, elements, visibleCategories]);
 
 	// React to selection from outside (e.g. clicking the list)
@@ -423,12 +510,19 @@ export function GraphView() {
 
 	function reLayout() {
 		const cy = cyRef.current;
-		if (!cy) return;
-		layoutRef.current?.stop();
-		const layout = createLayout(cy, colorMode);
-		layoutRef.current = layout;
-		layout.one("layoutstop", () => cy.fit(cy.elements(":visible"), 32));
-		layout.run();
+		const sim = simRef.current;
+		if (!cy || !sim) return;
+		if (colorMode === "community") {
+			cy.batch(() => {
+				cy.nodes(":visible").forEach((node) => {
+					node.position({ x: Number(node.data("seedX")), y: Number(node.data("seedY")) });
+				});
+			});
+		}
+		simNodesRef.current = syncSimulation(cy, sim, colorMode);
+		cy.fit(cy.elements(":visible"), 32);
+		sim.reheat(0.8);
+		(cy.scratch("innoStartTicking") as (() => void) | undefined)?.();
 	}
 
 	const visibleNodeCount = useMemo(

--- a/apps/inno-agent/web/src/react/notebook/force-simulation.ts
+++ b/apps/inno-agent/web/src/react/notebook/force-simulation.ts
@@ -1,0 +1,360 @@
+/**
+ * Continuous force simulation for the notebook graph.
+ *
+ * Modelled on d3-force's velocity-Verlet integrator so the graph keeps a live
+ * physics state: dragging a node drags its neighbours through link springs
+ * while every node pushes its neighbours away. Repulsion uses a spatial hash
+ * with a cutoff instead of Barnes-Hut, which keeps a tick O(n) and is enough
+ * because centering gravity — not long-range repulsion — is what spreads
+ * disconnected components apart.
+ *
+ * The simulation owns positions only; the caller is responsible for reading
+ * them back onto whatever renders the graph.
+ */
+
+export interface SimNode {
+	id: string;
+	x: number;
+	y: number;
+	vx: number;
+	vy: number;
+	/** Rendered radius; drives repulsion mass and the minimum spring length. */
+	radius: number;
+	/** Held in place by a drag or an explicit pin. */
+	fixed: boolean;
+	/** Community id, used by the optional group cohesion force. */
+	group: number;
+}
+
+export interface SimLink {
+	source: number;
+	target: number;
+	length: number;
+	strength: number;
+}
+
+export interface ForceSimulationOptions {
+	/** Pairwise repulsion coefficient; force falls off as 1/d². */
+	repulsion: number;
+	/** Distance beyond which repulsion is not evaluated. */
+	repulsionCutoff: number;
+	/** Pull towards the layout centre, per pixel of offset. */
+	centerStrength: number;
+	/** Pull towards the node's own community centroid. */
+	groupStrength: number;
+	/** Fraction of velocity kept between ticks. */
+	velocityDecay: number;
+	alphaDecay: number;
+	alphaMin: number;
+	/** Horizontal clearance kept between node edges, sized for labels. */
+	collidePaddingX: number;
+	/** Vertical clearance kept between node edges. */
+	collidePaddingY: number;
+	/** Relaxation passes per tick for the separation constraint. */
+	collideIterations: number;
+	/** Fraction of an overlap corrected per pass; <1 keeps the pass springy. */
+	collideRelax: number;
+	/** How much of the positional correction is also removed from velocity. */
+	collideDamping: number;
+}
+
+export const DEFAULT_FORCE_OPTIONS: ForceSimulationOptions = {
+	repulsion: 6_600,
+	repulsionCutoff: 440,
+	centerStrength: 0.005,
+	groupStrength: 0,
+	velocityDecay: 0.72,
+	alphaDecay: 0.022,
+	alphaMin: 0.006,
+	collidePaddingX: 74,
+	collidePaddingY: 30,
+	collideIterations: 2,
+	collideRelax: 0.55,
+	collideDamping: 0.5,
+};
+
+/** Cap per-tick velocity so a near-zero distance cannot fling nodes offscreen. */
+const MAX_VELOCITY = 45;
+
+/** Largest node radius produced by the sizing formula in GraphView. */
+const MAX_NODE_RADIUS = 14.5;
+
+export class ForceSimulation {
+	private nodes: SimNode[] = [];
+	private links: SimLink[] = [];
+	private index = new Map<string, SimNode>();
+	private fx: Float64Array = new Float64Array(0);
+	private fy: Float64Array = new Float64Array(0);
+	private groupCentroids = new Map<number, { x: number; y: number; count: number }>();
+	private centerX = 0;
+	private centerY = 0;
+
+	alpha = 0;
+	alphaTarget = 0;
+	options: ForceSimulationOptions;
+
+	constructor(options: Partial<ForceSimulationOptions> = {}) {
+		this.options = { ...DEFAULT_FORCE_OPTIONS, ...options };
+	}
+
+	setGraph(nodes: SimNode[], links: SimLink[]): void {
+		this.nodes = nodes;
+		this.links = links;
+		this.index = new Map(nodes.map((node) => [node.id, node]));
+		this.fx = new Float64Array(nodes.length);
+		this.fy = new Float64Array(nodes.length);
+	}
+
+	getNode(id: string): SimNode | undefined {
+		return this.index.get(id);
+	}
+
+	get nodeCount(): number {
+		return this.nodes.length;
+	}
+
+	setCenter(x: number, y: number): void {
+		this.centerX = x;
+		this.centerY = y;
+	}
+
+	/** Kick the simulation back to life, e.g. on drag or a layout change. */
+	reheat(alpha = 0.45, target = 0): void {
+		this.alpha = Math.max(this.alpha, alpha);
+		this.alphaTarget = target;
+	}
+
+	stop(): void {
+		this.alpha = 0;
+		this.alphaTarget = 0;
+	}
+
+	get running(): boolean {
+		return this.alpha > this.options.alphaMin || this.alphaTarget > 0;
+	}
+
+	tick(): void {
+		const { alphaDecay, alphaMin, velocityDecay } = this.options;
+		this.alpha += (this.alphaTarget - this.alpha) * alphaDecay;
+		if (this.alpha < alphaMin && this.alphaTarget === 0) {
+			this.alpha = 0;
+			return;
+		}
+
+		this.fx.fill(0);
+		this.fy.fill(0);
+		this.applyRepulsion();
+		this.applyLinks();
+		this.applyCentering();
+
+		const alpha = this.alpha;
+		for (let i = 0; i < this.nodes.length; i++) {
+			const node = this.nodes[i];
+			if (node.fixed) {
+				node.vx = 0;
+				node.vy = 0;
+				continue;
+			}
+			node.vx = (node.vx + this.fx[i] * alpha) * velocityDecay;
+			node.vy = (node.vy + this.fy[i] * alpha) * velocityDecay;
+			const speed = Math.hypot(node.vx, node.vy);
+			if (speed > MAX_VELOCITY) {
+				const scale = MAX_VELOCITY / speed;
+				node.vx *= scale;
+				node.vy *= scale;
+			}
+			node.x += node.vx;
+			node.y += node.vy;
+		}
+
+		this.resolveCollisions();
+	}
+
+	/**
+	 * Hard separation pass. Repulsion alone leaves nodes closer than their
+	 * labels need, so nudge overlapping pairs apart positionally — the label box
+	 * is wider than tall, hence the asymmetric padding.
+	 */
+	private resolveCollisions(): void {
+		const { collidePaddingX, collidePaddingY, collideIterations, collideRelax, collideDamping } =
+			this.options;
+		if (collideIterations <= 0) return;
+		const cell = 2 * (MAX_NODE_RADIUS + collidePaddingX);
+		for (let pass = 0; pass < collideIterations; pass++) {
+			const bins = new Map<string, number[]>();
+			for (let i = 0; i < this.nodes.length; i++) {
+				const node = this.nodes[i];
+				const key = `${Math.floor(node.x / cell)},${Math.floor(node.y / cell)}`;
+				const bin = bins.get(key);
+				if (bin) bin.push(i);
+				else bins.set(key, [i]);
+			}
+			for (let i = 0; i < this.nodes.length; i++) {
+				const a = this.nodes[i];
+				const bx = Math.floor(a.x / cell);
+				const by = Math.floor(a.y / cell);
+				for (let gx = bx - 1; gx <= bx + 1; gx++) {
+					for (let gy = by - 1; gy <= by + 1; gy++) {
+						const bin = bins.get(`${gx},${gy}`);
+						if (!bin) continue;
+						for (const j of bin) {
+							if (j <= i) continue;
+							const b = this.nodes[j];
+							// Scale to an ellipse so a wide label clears sideways
+							// while stacked rows stay compact.
+							const aspect = (collidePaddingX + MAX_NODE_RADIUS) / (collidePaddingY + MAX_NODE_RADIUS);
+							const dx = (b.x - a.x) / aspect;
+							const dy = b.y - a.y;
+							const minDist = a.radius + b.radius + collidePaddingY;
+							let dist = Math.hypot(dx, dy);
+							if (dist >= minDist) continue;
+							let ux: number;
+							let uy: number;
+							if (dist < 0.001) {
+								ux = ((i * 37 + j * 17) % 13) - 6 || 1;
+								uy = ((i * 19 + j * 41) % 11) - 5 || 1;
+								dist = Math.hypot(ux, uy);
+								ux /= dist;
+								uy /= dist;
+							} else {
+								ux = dx / dist;
+								uy = dy / dist;
+							}
+							// Relax rather than fully separate: a hard positional
+							// snap fights the spring pulling the pair together and
+							// the two never agree, which reads as jitter.
+							const push = ((minDist - dist) / 2) * collideRelax;
+							const px = ux * push * aspect;
+							const py = uy * push;
+							if (!a.fixed) {
+								a.x -= px;
+								a.y -= py;
+								// Cancel the inbound velocity component too, so the
+								// next tick does not re-close the gap we just opened.
+								a.vx -= px * collideDamping;
+								a.vy -= py * collideDamping;
+							}
+							if (!b.fixed) {
+								b.x += px;
+								b.y += py;
+								b.vx += px * collideDamping;
+								b.vy += py * collideDamping;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	/**
+	 * O(n) short-range repulsion: bin nodes into a grid sized to the cutoff and
+	 * only evaluate pairs within the 3×3 neighbourhood of each bin.
+	 */
+	private applyRepulsion(): void {
+		const { repulsion, repulsionCutoff } = this.options;
+		const cell = repulsionCutoff;
+		const cutoffSq = repulsionCutoff * repulsionCutoff;
+		const bins = new Map<string, number[]>();
+		for (let i = 0; i < this.nodes.length; i++) {
+			const node = this.nodes[i];
+			const key = `${Math.floor(node.x / cell)},${Math.floor(node.y / cell)}`;
+			const bin = bins.get(key);
+			if (bin) bin.push(i);
+			else bins.set(key, [i]);
+		}
+
+		for (let i = 0; i < this.nodes.length; i++) {
+			const a = this.nodes[i];
+			const bx = Math.floor(a.x / cell);
+			const by = Math.floor(a.y / cell);
+			for (let gx = bx - 1; gx <= bx + 1; gx++) {
+				for (let gy = by - 1; gy <= by + 1; gy++) {
+					const bin = bins.get(`${gx},${gy}`);
+					if (!bin) continue;
+					for (const j of bin) {
+						if (j <= i) continue;
+						const b = this.nodes[j];
+						let dx = b.x - a.x;
+						let dy = b.y - a.y;
+						let distSq = dx * dx + dy * dy;
+						if (distSq >= cutoffSq) continue;
+						if (distSq < 1) {
+							// Deterministic jitter to split co-located nodes.
+							dx = ((i * 37 + j * 17) % 13) - 6 || 1;
+							dy = ((i * 19 + j * 41) % 11) - 5 || 1;
+							distSq = dx * dx + dy * dy;
+						}
+						const dist = Math.sqrt(distSq);
+						// Taper to zero at the cutoff so nodes crossing it do not pop.
+						const taper = 1 - dist / repulsionCutoff;
+						const mass = (a.radius + b.radius) / 14;
+						const force = (repulsion * mass * taper) / distSq;
+						const fx = (dx / dist) * force;
+						const fy = (dy / dist) * force;
+						this.fx[i] -= fx;
+						this.fy[i] -= fy;
+						this.fx[j] += fx;
+						this.fy[j] += fy;
+					}
+				}
+			}
+		}
+	}
+
+	private applyLinks(): void {
+		for (const link of this.links) {
+			const a = this.nodes[link.source];
+			const b = this.nodes[link.target];
+			let dx = b.x - a.x;
+			let dy = b.y - a.y;
+			let dist = Math.hypot(dx, dy);
+			if (dist < 1) {
+				dx = 1;
+				dy = 0;
+				dist = 1;
+			}
+			const minLength = a.radius + b.radius + 34;
+			const rest = Math.max(link.length, minLength);
+			const displacement = ((dist - rest) / dist) * link.strength;
+			const fx = dx * displacement;
+			const fy = dy * displacement;
+			this.fx[link.source] += fx;
+			this.fy[link.source] += fy;
+			this.fx[link.target] -= fx;
+			this.fy[link.target] -= fy;
+		}
+	}
+
+	private applyCentering(): void {
+		const { centerStrength, groupStrength } = this.options;
+		if (groupStrength > 0) {
+			this.groupCentroids.clear();
+			for (const node of this.nodes) {
+				const centroid = this.groupCentroids.get(node.group);
+				if (centroid) {
+					centroid.x += node.x;
+					centroid.y += node.y;
+					centroid.count += 1;
+				} else {
+					this.groupCentroids.set(node.group, { x: node.x, y: node.y, count: 1 });
+				}
+			}
+			for (const centroid of this.groupCentroids.values()) {
+				centroid.x /= centroid.count;
+				centroid.y /= centroid.count;
+			}
+		}
+		for (let i = 0; i < this.nodes.length; i++) {
+			const node = this.nodes[i];
+			this.fx[i] += (this.centerX - node.x) * centerStrength;
+			this.fy[i] += (this.centerY - node.y) * centerStrength;
+			if (groupStrength > 0) {
+				const centroid = this.groupCentroids.get(node.group);
+				if (centroid && centroid.count > 1) {
+					this.fx[i] += (centroid.x - node.x) * groupStrength;
+					this.fy[i] += (centroid.y - node.y) * groupStrength;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The notebook graph ran a one-shot `cose` layout, so dragging a node moved only that node — no physical coupling to its neighbours. This replaces it with a continuous force simulation that stays warm during interaction, giving the Obsidian feel: drag a node and its linked neighbours follow, while nearby nodes push apart.

## What changed

**New `web/src/react/notebook/force-simulation.ts`** — a d3-force-style velocity Verlet integrator:

- **Link springs** — connected nodes pull on each other; strength scales down with degree so a hub is not flung around by its leaves.
- **Many-body repulsion** — pairwise `1/d²` falloff with a cutoff, evaluated through a spatial hash grid so each tick is O(n). 400 nodes cost 0.83 ms/tick.
- **Centering + community cohesion** — keeps the graph from drifting; in community colour mode, same-community nodes cluster slightly.
- **Alpha cooling** — idles at zero CPU when untouched, reheats on drag, exactly as d3/Obsidian do.

**`GraphView.tsx`** now drives that simulation instead of `cose`/`preset`. Grabbing a node pins it to the pointer and reheats the sim; releasing hands it back and the graph relaxes into a new equilibrium. A click without movement does not reheat, so the graph never twitches for no reason. Relayout and colour-mode switches reuse the same code path, and the old one-shot layout code is gone.

**Visual tuning for label legibility** — node diameter `10–32px` → `9–29px`, edge width `0.2–2.0px` → `0.15–1.1px`, spring rest length and seed spacing widened, label truncation 34 → 20 chars, softer label colour.

## Note on the jitter fix

The separation constraint initially corrected position only. That fights the spring pulling a pair together — the two never agree and it reads as continuous jitter in dense regions (sparse graphs never trigger the constraint, which is why it was not obvious at first). It is now a soft relaxation that corrects a fraction of the overlap per pass **and** removes the inbound velocity component, with spring strength and velocity decay softened to match.

Measured on a 90-node clustered graph held hot as if mid-drag:

| | residual speed | peak |
|---|---|---|
| before | 3.36 px/frame | 16.5 px |
| after | 0.55 px/frame | 2.6 px |

## Testing

- `tsc --noEmit` and the Vite production build both pass.
- Numeric checks on the simulation: converges in ~226 ticks from a cold start, leaves follow a dragged hub, positions stay bounded and finite (no NaN or blow-up), minimum edge-to-edge gap 64.8 px with 130 px horizontal clearance for labels, 400-node tick cost 0.83 ms (comfortable 60 fps headroom).
- Not yet exercised by hand in the browser — worth a drag test on a real wiki graph to confirm the feel.

Tuning parameters are collected in `DEFAULT_FORCE_OPTIONS` at the top of `force-simulation.ts`.