### PR TITLE
perf(chat): smoother streaming rendering for chat view

### DIFF
--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -423,6 +423,15 @@ inno-workspace-panel textarea {
 	display: block;
 }
 
+/* The streaming bubble splits the reply into a memoized stable region and a
+   live tail, each rendered as its own markdown-artifact. Each artifact carries
+   p-4 padding, so without correction the junction would show 2rem of vertical
+   space where a single artifact would show a 1rem paragraph margin. Pull the
+   second artifact up by 1rem to make the split seam invisible. */
+.inno-streaming-blocks markdown-artifact + markdown-artifact {
+	margin-top: -1rem;
+}
+
 .inno-composer {
 	border: 1px solid var(--inno-border);
 	background: var(--inno-surface);

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
@@ -19,6 +19,7 @@ import type { PresetMeta } from "../types/presets.js";
 import { arrayBufferToBase64 } from "../api/uploads.js";
 import { uploadWorkspaceFiles } from "../api/workspace.js";
 import { normalizeMarkdownMath } from "../utils/markdown-math.js";
+import { splitStreamingMarkdown } from "../utils/markdown-blocks.js";
 import { groupByCategory, matchesQuery } from "../utils/category-grouping.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { QuestionDialog } from "./QuestionDialog.js";
@@ -216,9 +217,12 @@ function AssistantContent({ content }: { content: string }) {
 	const { t } = useTranslation();
 	const [expanded, setExpanded] = useState(false);
 	const trimmed = content.trim();
+	// normalizeMarkdownMath is a multi-regex full-text scan — cache it so
+	// unrelated re-renders (e.g. streaming emits) don't re-scan old messages.
+	const normalized = useMemo(() => normalizeMarkdownMath(trimmed), [trimmed]);
 	if (!trimmed) return null;
 	if (!shouldCollapseAssistantContent(trimmed)) {
-		return <markdown-artifact content={normalizeMarkdownMath(trimmed)} />;
+		return <markdown-artifact content={normalized} />;
 	}
 	const lineCount = trimmed.split(/\r\n|\r|\n/).length;
 	const preview = trimmed.slice(0, 900);
@@ -231,7 +235,7 @@ function AssistantContent({ content }: { content: string }) {
 			</div>
 			{expanded ? (
 				<div className="max-h-[60vh] overflow-auto rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] p-2">
-					<markdown-artifact content={normalizeMarkdownMath(trimmed)} />
+					<markdown-artifact content={normalized} />
 				</div>
 			) : (
 				<pre className="max-h-36 overflow-hidden whitespace-pre-wrap break-words font-mono text-[11px] leading-relaxed text-[var(--inno-text-muted)] [overflow-wrap:anywhere]">
@@ -271,7 +275,7 @@ function ToolRecordDetails({ tool, className }: { tool: ChatToolRecord; classNam
 	);
 }
 
-function MessageBubble({ message, showChannel }: { message: ChatMessage; showChannel?: boolean }) {
+const MessageBubble = memo(function MessageBubble({ message, showChannel }: { message: ChatMessage; showChannel?: boolean }) {
 	const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
 
 	if (message.role === "user") {
@@ -341,6 +345,108 @@ function MessageBubble({ message, showChannel }: { message: ChatMessage; showCha
 				) : null}
 			</div>
 		</motion.div>
+	);
+});
+
+/**
+ * Memoized artifact for one closed block of a streaming reply. Closed blocks
+ * never change, so they are parsed by marked/KaTeX exactly once and never
+ * re-render — which also keeps the bubble's height monotonically growing
+ * (no re-parse shrink that could yank the scroll position upwards).
+ */
+const StableStreamingMarkdown = memo(function StableStreamingMarkdown({ content }: { content: string }) {
+	return <markdown-artifact content={content} />;
+});
+
+/**
+ * Live-stream bubbles (thinking + reply text). Subscribes to the chat store
+ * independently so the high-frequency text flushes re-render only this small
+ * subtree, not the whole message list.
+ */
+function StreamingBubbles() {
+	const { t } = useTranslation();
+	const stream = useStoreSnapshot(chatStore, () => ({
+		text: chatStore.streamingText,
+		thinking: chatStore.streamingThinking,
+		target: chatStore.streamingTarget,
+		// Low-frequency fields for the "waiting" dots — included here (rather
+		// than read off ChatCenter's snapshot) so the dots live in the same
+		// subtree that knows whether reply text has started.
+		isSending: chatStore.isSending,
+		hasError: chatStore.streamingError !== "",
+		hasPendingQuestion: chatStore.pendingQuestion !== null,
+		activeToolCount: chatStore.activeTools.length,
+	}));
+
+	const normalized = useMemo(() => normalizeMarkdownMath(stream.text), [stream.text]);
+	const { blocks, tail } = useMemo(() => splitStreamingMarkdown(normalized), [normalized]);
+
+	return (
+		<>
+			{stream.thinking ? (
+				<motion.div
+					className="flex justify-start"
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ duration: 0.2, ease: "easeOut" }}
+				>
+					<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
+						<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Thinking...</summary>
+						<pre className="mt-1 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono [overflow-wrap:anywhere]">{stream.thinking}</pre>
+					</details>
+				</motion.div>
+			) : null}
+
+			{stream.text && stream.target === "workspace" ? (
+				<motion.div
+					className="flex justify-start"
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ duration: 0.2, ease: "easeOut" }}
+				>
+					<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] text-[var(--inno-text-muted)]">
+						<div className="flex min-w-0 items-center gap-2">
+							<span className="inno-stream-status-dot is-streaming shrink-0" />
+							<span className="min-w-0 break-words [overflow-wrap:anywhere]">{t("chat.streamingInWorkspace", "长内容正在右侧文件区生成")}</span>
+						</div>
+					</div>
+				</motion.div>
+			) : stream.text ? (
+				<motion.div
+					className="flex justify-start"
+					initial={{ opacity: 0, y: 8 }}
+					animate={{ opacity: 1, y: 0 }}
+					transition={{ duration: 0.2, ease: "easeOut" }}
+				>
+					<div className="inno-message inno-streaming-blocks max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
+						{blocks.map((block, index) => (
+							<StableStreamingMarkdown key={index} content={block} />
+						))}
+						{/* Always mounted while text streams (even when the tail is
+						    momentarily empty) so the DOM node — and the height below the
+						    stable blocks — never churns mid-stream. */}
+						<markdown-artifact content={tail} />
+					</div>
+				</motion.div>
+			) : null}
+
+			{stream.isSending && !stream.hasPendingQuestion && !stream.text && !stream.hasError && stream.activeToolCount === 0 ? (
+				<motion.div
+					className="flex justify-start"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					transition={{ duration: 0.15 }}
+				>
+					<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3 py-2 text-sm text-[var(--inno-text-muted)]">
+						<span className="inline-flex gap-1">
+							<span className="animate-bounce">·</span>
+							<span className="animate-bounce" style={{ animationDelay: "150ms" }}>·</span>
+							<span className="animate-bounce" style={{ animationDelay: "300ms" }}>·</span>
+						</span>
+					</div>
+				</motion.div>
+			) : null}
+		</>
 	);
 }
 
@@ -545,13 +651,15 @@ export function ChatCenter() {
 		void settingsStore.saveSimpleMode(next).finally(() => setTogglingMode(false));
 	}, [togglingMode]);
 
+	// NOTE: high-frequency streaming fields (streamingText / streamingThinking
+	// / streamingTarget) are deliberately excluded — they flush every 40ms and
+	// are subscribed to by StreamingBubbles instead, so token growth re-renders
+	// only that subtree. Combined with the shallow-equal guard in
+	// useStoreSnapshot, streaming emits no longer re-render ChatCenter at all.
 	const chat = useStoreSnapshot(chatStore, () => ({
 		messages: chatStore.messages,
 		isSending: chatStore.isSending,
 		isLoadingHistory: chatStore.isLoadingHistory,
-		streamingText: chatStore.streamingText,
-		streamingThinking: chatStore.streamingThinking,
-		streamingTarget: chatStore.streamingTarget,
 		streamingActivity: chatStore.streamingActivity,
 		streamingActivityDetail: chatStore.streamingActivityDetail,
 		streamingError: chatStore.streamingError,
@@ -656,18 +764,28 @@ export function ChatCenter() {
 		}
 	}, [isWelcome, wsMode, wsExistingId, sessions.preselectedWorkspaceId]);
 
-	const scrollTextKey = chat.streamingTarget === "workspace" ? chat.streamingTarget : chat.streamingText;
+	// Stick-to-bottom scrolling, driven by a ResizeObserver on the content
+	// column: any height change — streaming flushes, Lit's async markdown
+	// renders, KaTeX, code highlighting, images — re-pins the scroll position
+	// in the same frame the growth happens. (The previous effect-based rAF
+	// scroll only fired when specific React state changed, so async renders
+	// between flushes left the view behind; combined with transient height
+	// shrink during re-parses, the pinned scrollTop got clamped and the view
+	// jumped back up towards the question.)
+	useEffect(() => {
+		const el = scrollRef.current;
+		const content = el?.querySelector<HTMLElement>("[data-conversation-content]");
+		if (!el || !content) return;
+		const observer = new ResizeObserver(() => {
+			if (shouldStickToBottomRef.current) el.scrollTop = el.scrollHeight;
+		});
+		observer.observe(content);
+		return () => observer.disconnect();
+	}, [sessions.currentSessionId]);
 
 	useEffect(() => {
 		shouldStickToBottomRef.current = true;
 	}, [sessions.currentSessionId]);
-
-	useEffect(() => {
-		requestAnimationFrame(() => {
-			const el = scrollRef.current;
-			if (el && shouldStickToBottomRef.current) el.scrollTop = el.scrollHeight;
-		});
-	}, [chat.messages, scrollTextKey, chat.streamingThinking, chat.activeTools.length, chat.completedTools.length, chat.pendingQuestion]);
 
 	const handleChatScroll = useCallback(() => {
 		const el = scrollRef.current;
@@ -1245,20 +1363,6 @@ export function ChatCenter() {
 						</motion.div>
 					) : null}
 
-					{chat.streamingThinking ? (
-						<motion.div
-							className="flex justify-start"
-							initial={{ opacity: 0, y: 8 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.2, ease: "easeOut" }}
-						>
-							<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
-								<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Thinking...</summary>
-								<pre className="mt-1 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono [overflow-wrap:anywhere]">{chat.streamingThinking}</pre>
-							</details>
-						</motion.div>
-					) : null}
-
 					{chat.completedTools.length > 0 ? (
 						<motion.div
 							className="flex justify-start"
@@ -1277,32 +1381,8 @@ export function ChatCenter() {
 						</motion.div>
 					) : null}
 
-					{chat.streamingText && chat.streamingTarget === "workspace" ? (
-						<motion.div
-							className="flex justify-start"
-							initial={{ opacity: 0, y: 8 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.2, ease: "easeOut" }}
-						>
-							<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] text-[var(--inno-text-muted)]">
-								<div className="flex min-w-0 items-center gap-2">
-									<span className="inno-stream-status-dot is-streaming shrink-0" />
-									<span className="min-w-0 break-words [overflow-wrap:anywhere]">{t("chat.streamingInWorkspace", "长内容正在右侧文件区生成")}</span>
-								</div>
-							</div>
-						</motion.div>
-					) : chat.streamingText ? (
-						<motion.div
-							className="flex justify-start"
-							initial={{ opacity: 0, y: 8 }}
-							animate={{ opacity: 1, y: 0 }}
-							transition={{ duration: 0.2, ease: "easeOut" }}
-						>
-							<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
-								<markdown-artifact content={normalizeMarkdownMath(chat.streamingText)} />
-							</div>
-						</motion.div>
-					) : null}
+					{/* Thinking + reply text bubbles — own store subscription, see above */}
+					<StreamingBubbles />
 
 					{chat.streamingError ? (
 						<motion.div
@@ -1313,23 +1393,6 @@ export function ChatCenter() {
 						>
 							<div className="inno-message max-w-[78%]">
 								<ErrorBlock error={chat.streamingError} />
-							</div>
-						</motion.div>
-					) : null}
-
-					{chat.isSending && !chat.pendingQuestion && !chat.streamingText && !chat.streamingError && chat.activeTools.length === 0 ? (
-						<motion.div
-							className="flex justify-start"
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							transition={{ duration: 0.15 }}
-						>
-							<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3 py-2 text-sm text-[var(--inno-text-muted)]">
-								<span className="inline-flex gap-1">
-									<span className="animate-bounce">·</span>
-									<span className="animate-bounce" style={{ animationDelay: "150ms" }}>·</span>
-									<span className="animate-bounce" style={{ animationDelay: "300ms" }}>·</span>
-								</span>
 							</div>
 						</motion.div>
 					) : null}

--- a/apps/inno-agent/web/src/react/ConversationMinimap.tsx
+++ b/apps/inno-agent/web/src/react/ConversationMinimap.tsx
@@ -224,8 +224,12 @@ export function ConversationMinimap({
 		const resizeObserver = new ResizeObserver(scheduleMeasure);
 		resizeObserver.observe(scrollElement);
 		resizeObserver.observe(trackElement);
-		const contentElement = scrollElement.querySelector<HTMLElement>("[data-conversation-content]");
-		if (contentElement) resizeObserver.observe(contentElement);
+		// Observe each turn anchor, NOT the whole content container: while a
+		// reply streams, the container grows every frame (forcing a full
+		// getBoundingClientRect pass over all turns each time), but the anchors
+		// themselves don't move — the streaming bubble isn't a turn. Turn
+		// additions re-run this effect via `turns.length`, and content edits
+		// (expand/collapse, image loads) resize the affected anchor directly.
 		for (const anchor of scrollElement.querySelectorAll<HTMLElement>("[data-conversation-turn]")) {
 			resizeObserver.observe(anchor);
 		}

--- a/apps/inno-agent/web/src/react/hooks.ts
+++ b/apps/inno-agent/web/src/react/hooks.ts
@@ -4,6 +4,23 @@ type ChangeStore = {
 	on(event: "change", fn: () => void): () => void;
 };
 
+/**
+ * Shallow equality for store snapshots. Stores emit "change" for any field
+ * update, but a component's snapshot often picks fields that didn't change —
+ * returning the previous state in that case lets React skip the re-render
+ * entirely (this is what keeps high-frequency streaming emits from
+ * re-rendering the whole chat view 25 times a second).
+ */
+function snapshotEqual(a: unknown, b: unknown): boolean {
+	if (Object.is(a, b)) return true;
+	if (typeof a !== "object" || a === null || typeof b !== "object" || b === null) return false;
+	const aRecord = a as Record<string, unknown>;
+	const bRecord = b as Record<string, unknown>;
+	const aKeys = Object.keys(aRecord);
+	if (aKeys.length !== Object.keys(bRecord).length) return false;
+	return aKeys.every((key) => Object.is(aRecord[key], bRecord[key]));
+}
+
 export function useStoreSnapshot<TStore extends ChangeStore, TSnapshot>(
 	store: TStore,
 	getSnapshot: () => TSnapshot,
@@ -13,9 +30,15 @@ export function useStoreSnapshot<TStore extends ChangeStore, TSnapshot>(
 	getSnapshotRef.current = getSnapshot;
 
 	useEffect(() => {
-		setSnapshot(getSnapshotRef.current());
+		setSnapshot((prev) => {
+			const next = getSnapshotRef.current();
+			return snapshotEqual(prev, next) ? prev : next;
+		});
 		return store.on("change", () => {
-			setSnapshot(getSnapshotRef.current());
+			setSnapshot((prev) => {
+				const next = getSnapshotRef.current();
+				return snapshotEqual(prev, next) ? prev : next;
+			});
 		});
 	}, [store]);
 

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -8,7 +8,11 @@ import { workspaceStore, type StreamingWorkspacePreview } from "./workspace-stor
 
 type StreamingTarget = "chat" | "workspace";
 
-const STREAM_CHANGE_INTERVAL_MS = 80;
+// Flush interval for streaming text/thinking updates. 40ms (~25fps) is the
+// floor for motion to read as continuous rather than stepped; rendering cost
+// per flush is bounded by the block-split in StreamingBubbles (only the
+// incomplete tail re-parses), so a faster cadence is affordable.
+const STREAM_CHANGE_INTERVAL_MS = 40;
 
 type StreamingPreviewPatch = Partial<Pick<StreamingWorkspacePreview, "title" | "path" | "language" | "content" | "status" | "stage">>;
 

--- a/apps/inno-agent/web/src/utils/markdown-blocks.ts
+++ b/apps/inno-agent/web/src/utils/markdown-blocks.ts
@@ -1,0 +1,65 @@
+/**
+ * Split streaming markdown into a stable prefix and an active tail.
+ *
+ * Cut points are blank lines — once a blank line arrives, everything before
+ * it is final (markdown never reaches backwards across a paragraph break),
+ * so the prefix can be rendered by a memoized component and never parsed
+ * again. Two constructs may legitimately contain blank lines and therefore
+ * suppress cutting while open:
+ *
+ * - fenced code blocks (``` / ~~~)
+ * - display math ($$...$$)
+ *
+ * The result is used to keep per-tick re-rendering cost proportional to the
+ * tail (the still-growing paragraph) instead of the whole message.
+ */
+export interface StreamingMarkdownSplit {
+	/** Closed blocks, oldest first; each is final and safe to cache forever. */
+	blocks: string[];
+	/** The trailing, still-incomplete block ("" when text just ended on a blank line). */
+	tail: string;
+}
+
+export function splitStreamingMarkdown(text: string): StreamingMarkdownSplit {
+	const blocks: string[] = [];
+	let blockStart = 0;
+	let inFence = false;
+	let fenceChar = "";
+	let inMath = false;
+
+	let lineStart = 0;
+	const n = text.length;
+	while (lineStart < n) {
+		let lineEnd = text.indexOf("\n", lineStart);
+		if (lineEnd === -1) lineEnd = n;
+		const trimmed = text.slice(lineStart, lineEnd).trim();
+
+		const fence = /^(`{3,}|~{3,})/.exec(trimmed);
+		if (fence) {
+			if (!inFence) {
+				inFence = true;
+				fenceChar = fence[1][0];
+			} else if (fence[1][0] === fenceChar) {
+				inFence = false;
+			}
+		}
+		if (!inFence) {
+			// Naive parity tracking: inline $$...$$ toggles twice on one line and
+			// nets out; a lone $$ opens/closes a display block.
+			let pos = lineStart;
+			while ((pos = text.indexOf("$$", pos)) !== -1 && pos < lineEnd) {
+				inMath = !inMath;
+				pos += 2;
+			}
+		}
+
+		if (!inFence && !inMath && trimmed === "" && lineStart > blockStart) {
+			const block = text.slice(blockStart, lineStart).trim();
+			if (block) blocks.push(block);
+			blockStart = lineEnd + 1;
+		}
+		lineStart = lineEnd + 1;
+	}
+
+	return { blocks, tail: text.slice(blockStart).trim() };
+}

--- a/apps/inno-agent/web/vite.config.ts
+++ b/apps/inno-agent/web/vite.config.ts
@@ -42,9 +42,43 @@ const stubLmStudioPlugin = {
 	},
 };
 
+// @mariozechner/mini-lit's MarkdownBlock calls marked.use() inside render(),
+// re-registering the same four KaTeX math extensions on the global marked
+// instance on every render. The tokenizer chain grows without bound, so every
+// markdown parse gets slower the longer the page lives (only a reload resets
+// it). Route the call through a once-per-page-load guard, applied as a source
+// transform so node_modules stays untouched. Requires the package to be
+// excluded from optimizeDeps so dev-mode prebundling doesn't bypass this hook.
+const MINILIT_MARKED_GUARD = "__innoRegisterMarkedExtensionsOnce";
+const patchMiniLitMarkedPlugin = {
+	name: "inno-patch-minilit-marked",
+	enforce: "pre" as const,
+	transform(code: string, id: string) {
+		// Dev-mode ids carry a version query ("MarkdownBlock.js?v=3ef4b778").
+		const path = id.split("?", 1)[0];
+		if (!path.includes("@mariozechner/mini-lit") || !path.endsWith("MarkdownBlock.js")) return null;
+		if (code.includes(MINILIT_MARKED_GUARD)) return null;
+		if (code.split("marked.use({").length !== 2) {
+			console.warn("[inno-patch-minilit-marked] unexpected marked.use() count in MarkdownBlock.js — leaving upstream code untouched");
+			return null;
+		}
+		const prelude = `function ${MINILIT_MARKED_GUARD}(markedInstance, options) {\n\tif (globalThis.__innoMarkedExtensionsDone) return;\n\tglobalThis.__innoMarkedExtensionsDone = true;\n\tmarkedInstance.use(options);\n}\n`;
+		return {
+			code: prelude + code.replace("marked.use({", `${MINILIT_MARKED_GUARD}(marked, {`),
+			map: null,
+		};
+	},
+};
+
 export default defineConfig({
+	optimizeDeps: {
+		// Serve mini-lit as plain ESM so patchMiniLitMarkedPlugin's transform
+		// hook sees MarkdownBlock.js in dev mode (prebundled deps skip transforms).
+		exclude: ["@mariozechner/mini-lit"],
+	},
 	plugins: [
 		stubLmStudioPlugin,
+		patchMiniLitMarkedPlugin,
 		react(),
 		{
 			name: "link-katex-fonts",


### PR DESCRIPTION
## Why

Streaming replies felt choppy compared to other chat clients. Profiling the render path showed several compounding issues:

- Every 80ms flush re-rendered the **entire chat view** (no memoization anywhere) and **re-parsed the full reply markdown** (marked + KaTeX + full `innerHTML` swap) — O(n²) over a turn, with a hard 12.5fps ceiling from the flush throttle.
- mini-lit's `MarkdownBlock` calls `marked.use()` **inside `render()`**, re-registering the same four KaTeX math extensions on the global marked instance every render — the tokenizer chain grows without bound, so all markdown parsing degrades the longer the page lives (only a reload resets it).
- The minimap observed the whole content container, forcing a full `getBoundingClientRect` pass over all turns on every streaming frame.
- Stick-to-bottom scroll ran once per flush via rAF, but Lit/KaTeX/highlighting render asynchronously *after* the flush, so the view always lagged; worse, transient height shrink during full re-parses clamped the pinned `scrollTop` and **yanked the viewport back up to the question** on long replies.

## What changed

- **Render isolation**: high-frequency streaming fields moved out of `ChatCenter`'s snapshot into a dedicated `StreamingBubbles` component; `useStoreSnapshot` now shallow-compares snapshots and skips no-op re-renders; `MessageBubble` is memoized; `normalizeMarkdownMath` cached via `useMemo`. Token growth now re-renders only the streaming bubble.
- **Incremental block rendering** (`utils/markdown-blocks.ts`): streaming text is split at blank-line boundaries (never inside code fences or `$$` math). Closed blocks render via per-block memoized artifacts and are never re-parsed — per-flush cost is proportional to the incomplete tail, and bubble height grows monotonically (no shrink-induced scroll jumps). A CSS rule collapses the double `p-4` padding at artifact junctions so the split is invisible.
- **ResizeObserver-driven stick-to-bottom**: any content growth (streaming flush, async Lit render, KaTeX, images) re-pins scroll in the same frame. Replaces both the rAF effect and the streaming scroll effect.
- **Flush interval 80ms → 40ms** (~25fps), affordable now that per-flush rendering is cheap.
- **Vite plugin** patches mini-lit's `marked.use()` at transform time with a once-per-page-load guard (no `node_modules` writes; dev + build both verified). The package is excluded from `optimizeDeps` so the dev transform applies.
- **Minimap** observes turn anchors only, not the whole content container.

## Verification

- `npm run build` (backend tsc + web tsc + vite) passes; all 73 vitest tests pass.
- Patch marker confirmed present in the built bundle and in dev-mode served module.
- 7 edge-case checks for the block splitter (fences, display math, inline math, multi-block) pass.
- Manual: long replies with code blocks / math should now stream at a steady cadence with the viewport following output to the bottom.