### PR TITLE
fix(web): render LaTeX in question options

### DIFF
--- a/apps/inno-agent/web/src/custom-elements.d.ts
+++ b/apps/inno-agent/web/src/custom-elements.d.ts
@@ -5,6 +5,9 @@ type CustomElementProps = HTMLAttributes<HTMLElement>;
 declare module "react" {
 	namespace JSX {
 		interface IntrinsicElements {
+			"markdown-block": CustomElementProps & {
+				content: string;
+			};
 			"markdown-artifact": CustomElementProps & {
 				content: string;
 			};

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "motion/react";
 import type { PendingQuestion, QuestionAnswer, QuestionData, QuestionnaireResult } from "../types/chat.js";
 import { chatStore } from "../stores/chat-store.js";
+import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 
 function OptionRow({
 	label,
@@ -35,8 +36,8 @@ function OptionRow({
 				) : null}
 			</span>
 			<span className="min-w-0 flex-1">
-				<span className="font-medium">{label}</span>
-				{description ? <span className="mt-0.5 block text-xs text-[var(--inno-text-muted)]">{description}</span> : null}
+				<markdown-block className="font-medium" content={normalizeMarkdownMath(label)} />
+				{description ? <markdown-block className="mt-0.5 text-xs text-[var(--inno-text-muted)]" content={normalizeMarkdownMath(description)} /> : null}
 			</span>
 		</button>
 	);
@@ -121,7 +122,7 @@ function QuestionTab({
 
 	return (
 		<div className="space-y-3">
-			<p className="text-sm font-medium text-[var(--inno-text)]">{q.question}</p>
+			<markdown-block className="text-sm font-medium text-[var(--inno-text)]" content={normalizeMarkdownMath(q.question)} />
 
 			<div className={hasPreview ? "flex gap-3" : ""}>
 				<div className={`space-y-1.5 ${hasPreview ? "w-1/2" : ""}`}>


### PR DESCRIPTION
## Problem

Questionnaire prompts, option labels, and option descriptions were rendered as plain text. As a result, LaTeX expressions such as `$a_3=a_1q^2$` were displayed without mathematical formatting.

### Before

<img width="1100" alt="Questionnaire LaTeX expressions rendered as plain text" src="https://github.com/user-attachments/assets/389160a6-6f2c-4e6c-85a0-e3a5139330b7" />

## Solution

- Render questionnaire prompts with the existing `markdown-block` component.
- Render option labels and descriptions through the same component.
- Reuse `normalizeMarkdownMath` so questionnaire content follows the same LaTeX normalization pipeline as chat messages.
- Add the existing `markdown-block` custom element to the React JSX type declarations.

This is a frontend-only change and does not modify the questionnaire data structure, submission behavior, or backend APIs.

### After

<img width="1100" alt="Questionnaire LaTeX expressions rendered with KaTeX" src="https://github.com/user-attachments/assets/b109bddf-4451-400b-9940-1a013f808f1d" />

## Verification

- `npm --workspace inno-agent-web run build`
- Manually verified LaTeX rendering in:
  - questionnaire prompts
  - option labels
  - option descriptions