### PR TITLE
fix(web): register markdown-block element explicitly in main.tsx

### DIFF
--- a/apps/inno-agent/web/src/main.tsx
+++ b/apps/inno-agent/web/src/main.tsx
@@ -1,6 +1,9 @@
 import "./app.css";
 import "./i18n/index.js";
 import "./stores/theme-store.js";
+// Register <markdown-block> explicitly — QuestionDialog depends on it and must not
+// rely on pi-web-ui's side-effect import chain (ChatCenter → MarkdownArtifact → mini-lit).
+import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";


### PR DESCRIPTION
## Problem

PR #112 made `QuestionDialog` render question text and option labels with the `<markdown-block>` custom element. That element is registered by `@mariozechner/mini-lit/dist/MarkdownBlock.js`, which the app only pulls in as a side effect of pi-web-ui's import chain:

`ChatCenter.tsx → @earendil-works/pi-web-ui → MarkdownArtifact.js → mini-lit MarkdownBlock.js`

If ChatCenter (or pi-web-ui's internals) is ever refactored to drop that chain, `<markdown-block>` would silently render nothing in the question dialog — no build error, no runtime warning.

## Fix

Import `@mariozechner/mini-lit/dist/MarkdownBlock.js` explicitly in `main.tsx` (the app entry) so the element is always registered regardless of which components import pi-web-ui.

## Verification

- `npm --workspace inno-agent-web run build` passes (tsc + vite)
- `./dist/*` subpath is covered by mini-lit's package `exports`, so the deep import resolves cleanly