### PR TITLE
feat(electron): auto-update via electron-updater + GitHub Releases

### DIFF
--- a/.github/workflows/release-mac.yml
+++ b/.github/workflows/release-mac.yml
@@ -50,24 +50,29 @@ jobs:
       - name: Build frontend (vite)
         run: npm --workspace inno-agent-web run build
 
-      # ── 7. 打包 Electron DMG ─────────────────────────────────────────────────
+      # ── 7. 打包 Electron DMG + ZIP ────────────────────────────────────────────
       #   未签名版：不需要 Apple 证书，用户首次打开需右键→打开
-      - name: Package Electron (unsigned DMG)
-        # --publish never：只打包，不让 electron-builder 自动发布（发布交给后面的步骤）
-        run: npx electron-builder --mac dmg --arm64 --publish never
+      #   tag 触发时 --publish always：electron-builder 自动创建/复用 GitHub Release
+      #   并上传 dmg/zip/latest-mac.yml（自动更新的更新源）；手动触发只打包不发布
+      - name: Package Electron (unsigned DMG + ZIP)
+        run: npx electron-builder --mac --arm64 --publish ${{ startsWith(github.ref, 'refs/tags/') && 'always' || 'never' }}
         env:
           # 跳过代码签名（无证书时必须）
           CSC_IDENTITY_AUTO_DISCOVERY: false
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ── 7b. [可选] 签名 + 公证版（取消注释并配置 Secrets 后生效） ────────────
+      #   签名后 macOS 自动更新即可启用（electron-updater 要求 app 已签名，
+      #   未签名构建只能「检测新版本 + 引导手动下载」）
       # - name: Package Electron (signed + notarized DMG)
-      #   run: npx electron-builder --mac dmg --arm64
+      #   run: npx electron-builder --mac --arm64 --publish ${{ startsWith(github.ref, 'refs/tags/') && 'always' || 'never' }}
       #   env:
       #     CSC_LINK: ${{ secrets.CSC_LINK }}                          # base64 编码的 .p12 证书
       #     CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}          # .p12 密码
       #     APPLE_ID: ${{ secrets.APPLE_ID }}                          # Apple ID 邮箱
       #     APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
       #     APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ── 8. 读取实际版本号 ────────────────────────────────────────────────────
       - name: Read version
@@ -81,16 +86,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: InnoAgent-${{ steps.pkg.outputs.version }}-arm64
-          path: dist-electron/*.dmg
+          path: |
+            dist-electron/*.dmg
+            dist-electron/*.zip
           retention-days: 30
-
-      # ── 10. 创建 GitHub Release（仅 tag 触发时） ────────────────────────────
-      - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          name: "Inno Agent v${{ steps.pkg.outputs.version }}"
-          files: dist-electron/*.dmg
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}

--- a/.github/workflows/release-win.yml
+++ b/.github/workflows/release-win.yml
@@ -51,8 +51,12 @@ jobs:
         run: npm --workspace inno-agent-web run build
 
       # ── 7. 打包 Electron（NSIS exe + MSI）───────────────────────────────────
+      #   tag 触发时 --publish always：electron-builder 自动创建/复用 GitHub Release
+      #   并上传 exe/msi/latest.yml（自动更新的更新源）；手动触发只打包不发布
       - name: Package Electron (Windows)
-        run: npx electron-builder --win --x64 --publish never
+        run: npx electron-builder --win --x64 --publish ${{ startsWith(github.ref, 'refs/tags/') && 'always' || 'never' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # ── 8. 读取实际版本号 ────────────────────────────────────────────────────
       - name: Read version
@@ -70,16 +74,3 @@ jobs:
             dist-electron/*.exe
             dist-electron/*.msi
           retention-days: 30
-
-      # ── 10. 创建 / 更新 GitHub Release（仅 tag 触发时） ─────────────────────
-      - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
-        with:
-          name: "Inno Agent v${{ steps.pkg.outputs.version }}"
-          files: |
-            dist-electron/*.exe
-            dist-electron/*.msi
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}

--- a/ELECTRON_BUILD.md
+++ b/ELECTRON_BUILD.md
@@ -9,6 +9,8 @@
 | 文件 | 用途 |
 |------|------|
 | `main.js` | Electron 主进程：启动后端、托盘、窗口 |
+| `updater.js` | 自动更新（electron-updater 封装 + IPC） |
+| `preload.cjs` | contextBridge 注入 `window.innoDesktop`（web UI 感知桌面端） |
 | `loading.html` | 服务启动期间的 loading 页 |
 
 首次启动会在 `~/.inno-agent/config/config.json` 写入默认配置（API Key 为空）；用户在应用内设置页填写即可。
@@ -18,3 +20,10 @@
 - `use-mock-keychain`：未签名 app 避免 macOS 钥匙串弹窗
 - `ELECTRON_RUN_AS_NODE=1` + `spawn(process.execPath, [server.js])`：用 Electron 内置 Node 跑后端，正确解析 asar 内 `node_modules`
 - 轮询 `http://localhost:3000/health`，就绪后关闭 loading 窗口并打开主界面
+
+## 自动更新
+
+- **更新源**:`hhyqhh/inno-agent` 的 GitHub Releases（根 `package.json` 的 `build.publish`)。tag 触发发版工作流时 `electron-builder --publish always` 自动创建/复用 Release 并上传安装包与 `latest.yml` / `latest-mac.yml` 清单（客户端检查更新拉取的就是这些 yml)。
+- **客户端**:`electron/updater.js` 在打包环境中启动 10s 后首次检查、之后每 4 小时轮询；状态经 IPC 推送给 web UI，「设置 → 关于 → 版本与更新」展示版本、检查按钮与下载进度。浏览器访问 web UI 时 `window.innoDesktop` 为 undefined，更新区块自动隐藏。
+- **Windows(NSIS)**：完整自动更新 —— 后台自动下载，下载完成后用户点「重启安装」。
+- **macOS**：当前构建未签名，electron-updater 拒绝安装未签名更新，因此 mac 只做**新版本提示 + 跳转 Release 页手动下载**(`autoDownload=false`)。配置签名 secrets(`CSC_LINK` 等，见 release-mac.yml 注释块）后，把 `updater.js` 中 `canAutoInstall` 放开到 darwin 即可启用 mac 自动安装；mac target 中的 `zip` 产物即为此预留（electron-updater 的 mac 更新使用 zip，不用 dmg)。

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -551,6 +551,21 @@
 			"about": {
 				"desc": "Server status and storage stats"
 			}
+		},
+		"update": {
+			"title": "Version & Updates",
+			"currentVersion": "Current version",
+			"check": "Check for updates",
+			"checking": "Checking for updates…",
+			"available": "New version v{{version}} available",
+			"downloading": "Downloading update v{{version}}…",
+			"downloaded": "Update v{{version}} is ready",
+			"notAvailable": "You're on the latest version",
+			"error": "Update check failed: {{message}}",
+			"install": "Restart & install",
+			"goDownload": "Download",
+			"devDisabled": "Auto-update is disabled in development",
+			"macHint": "In-app installation is not supported on macOS yet. Please download the latest installer and reinstall."
 		}
 	},
 	"chat": {

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -551,6 +551,21 @@
 			"about": {
 				"desc": "服务状态与存储统计"
 			}
+		},
+		"update": {
+			"title": "版本与更新",
+			"currentVersion": "当前版本",
+			"check": "检查更新",
+			"checking": "正在检查更新…",
+			"available": "发现新版本 v{{version}}",
+			"downloading": "正在下载更新 v{{version}}…",
+			"downloaded": "更新 v{{version}} 已就绪",
+			"notAvailable": "已是最新版本",
+			"error": "检查更新失败：{{message}}",
+			"install": "重启安装",
+			"goDownload": "前往下载",
+			"devDisabled": "开发环境不启用自动更新",
+			"macHint": "macOS 版本暂不支持应用内安装，请下载最新安装包覆盖安装。"
 		}
 	},
 	"chat": {

--- a/apps/inno-agent/web/src/react/settings/AboutSettings.tsx
+++ b/apps/inno-agent/web/src/react/settings/AboutSettings.tsx
@@ -2,10 +2,94 @@ import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { getWikiStats } from "../../api/wiki.js";
 import { settingsStore } from "../../stores/settings-store.js";
+import { updaterStore } from "../../stores/updater-store.js";
 import type { WikiStats } from "../../types/wiki.js";
 import { useStoreSnapshot } from "../hooks.js";
 import { SettingsSection, SettingsCard } from "./primitives.js";
 import { formatBytes } from "./shared.js";
+
+/** 桌面端（Electron）版本与更新卡片；浏览器环境不渲染。 */
+function UpdateCard() {
+	const { t } = useTranslation();
+	const state = useStoreSnapshot(updaterStore, () => ({
+		info: updaterStore.info,
+		status: updaterStore.status,
+	}));
+
+	useEffect(() => {
+		updaterStore.init();
+	}, []);
+
+	if (!updaterStore.isDesktop) return null;
+
+	const { info, status } = state;
+	const version = "version" in status ? status.version : undefined;
+
+	let statusText = "";
+	if (!info?.enabled) statusText = t("settings.update.devDisabled");
+	else if (status.status === "checking") statusText = t("settings.update.checking");
+	else if (status.status === "available") statusText = t("settings.update.available", { version });
+	else if (status.status === "downloading") statusText = t("settings.update.downloading", { version });
+	else if (status.status === "downloaded") statusText = t("settings.update.downloaded", { version });
+	else if (status.status === "not-available") statusText = t("settings.update.notAvailable");
+	else if (status.status === "error") statusText = t("settings.update.error", { message: status.error });
+
+	const checking = status.status === "checking";
+	const downloading = status.status === "downloading";
+
+	return (
+		<SettingsCard className="mt-3">
+			<div className="mb-3 flex items-center justify-between">
+				<h4 className="text-sm font-medium text-[var(--inno-text)]">{t("settings.update.title")}</h4>
+				<button
+					className="shrink-0 rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-1.5 text-sm text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-50"
+					disabled={!info?.enabled || checking || downloading}
+					onClick={() => void updaterStore.check()}
+				>
+					{t("settings.update.check")}
+				</button>
+			</div>
+			<div className="flex items-center justify-between gap-3 text-sm">
+				<div className="min-w-0">
+					<span className="text-[var(--inno-text-muted)]">{t("settings.update.currentVersion")}</span>{" "}
+					<span className="font-medium text-[var(--inno-text)]">{info?.version ?? "-"}</span>
+					{statusText ? (
+						<div className={`mt-1 text-xs ${status.status === "error" ? "text-[var(--inno-danger)]" : "text-[var(--inno-text-muted)]"}`}>
+							{statusText}
+						</div>
+					) : null}
+					{downloading ? (
+						<div className="mt-2 h-1.5 w-48 overflow-hidden rounded-full bg-[var(--inno-surface-muted)]">
+							<div
+								className="h-full rounded-full bg-[var(--inno-accent)] transition-[width]"
+								style={{ width: `${Math.round(status.progress.percent)}%` }}
+							/>
+						</div>
+					) : null}
+				</div>
+				{info?.canAutoInstall && status.status === "downloaded" ? (
+					<button
+						className="shrink-0 rounded-md bg-[var(--inno-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+						onClick={() => void updaterStore.install()}
+					>
+						{t("settings.update.install")}
+					</button>
+				) : null}
+				{info?.enabled && !info.canAutoInstall && (status.status === "available" || status.status === "downloaded") ? (
+					<button
+						className="shrink-0 rounded-md bg-[var(--inno-accent)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
+						onClick={() => void updaterStore.openDownloadPage()}
+					>
+						{t("settings.update.goDownload")}
+					</button>
+				) : null}
+			</div>
+			{info?.enabled && !info.canAutoInstall ? (
+				<p className="mt-2 text-xs text-[var(--inno-text-muted)]">{t("settings.update.macHint")}</p>
+			) : null}
+		</SettingsCard>
+	);
+}
 
 export function AboutSettings() {
 	const { t } = useTranslation();
@@ -52,6 +136,7 @@ export function AboutSettings() {
 					</div>
 				</div>
 			</SettingsCard>
+			<UpdateCard />
 		</SettingsSection>
 	);
 }

--- a/apps/inno-agent/web/src/stores/updater-store.ts
+++ b/apps/inno-agent/web/src/stores/updater-store.ts
@@ -1,0 +1,52 @@
+import { EventEmitter } from "./event-emitter.js";
+import type { DesktopInfo, UpdateStatus } from "../types/desktop.js";
+
+interface UpdaterStoreEvents {
+	change: void;
+}
+
+/**
+ * 桌面端自动更新状态。浏览器环境下 isDesktop=false，UI 应整体隐藏更新区块。
+ */
+class UpdaterStoreImpl extends EventEmitter<UpdaterStoreEvents> {
+	readonly isDesktop = typeof window !== "undefined" && !!window.innoDesktop;
+	info: DesktopInfo | null = null;
+	status: UpdateStatus = { status: "idle" };
+	private initialized = false;
+
+	/** 懒初始化：首次进入关于页时拉取 info/status 并订阅推送。 */
+	init(): void {
+		if (!this.isDesktop || this.initialized) return;
+		this.initialized = true;
+		const bridge = window.innoDesktop!;
+		void bridge.updater.getInfo().then((info) => {
+			this.info = info;
+			this.emit("change", undefined);
+		}).catch(() => undefined);
+		void bridge.updater.getStatus().then((status) => {
+			this.status = status;
+			this.emit("change", undefined);
+		}).catch(() => undefined);
+		bridge.updater.onStatusChanged((status) => {
+			this.status = status;
+			this.emit("change", undefined);
+		});
+	}
+
+	async check(): Promise<void> {
+		if (!this.isDesktop) return;
+		await window.innoDesktop!.updater.checkForUpdates().catch(() => undefined);
+	}
+
+	async install(): Promise<void> {
+		if (!this.isDesktop) return;
+		await window.innoDesktop!.updater.quitAndInstall().catch(() => undefined);
+	}
+
+	async openDownloadPage(): Promise<void> {
+		if (!this.isDesktop) return;
+		await window.innoDesktop!.updater.openDownloadPage().catch(() => undefined);
+	}
+}
+
+export const updaterStore = new UpdaterStoreImpl();

--- a/apps/inno-agent/web/src/types/desktop.ts
+++ b/apps/inno-agent/web/src/types/desktop.ts
@@ -1,0 +1,41 @@
+/**
+ * 桌面端（Electron）能力桥的类型声明。
+ *
+ * electron/preload.cjs 通过 contextBridge 注入 window.innoDesktop；
+ * 浏览器访问时为 undefined，所有桌面 UI 必须先做存在性判断。
+ */
+
+export type UpdateStatus =
+	| { status: "idle" }
+	| { status: "checking" }
+	| { status: "available"; version: string; releaseNotes?: string }
+	| { status: "downloading"; version: string; progress: { percent: number; transferred: number; total: number; bytesPerSecond: number } }
+	| { status: "downloaded"; version: string }
+	| { status: "not-available" }
+	| { status: "error"; error: string };
+
+export interface DesktopInfo {
+	version: string;
+	platform: string;
+	/** 打包环境才为 true（开发环境不启用自动更新） */
+	enabled: boolean;
+	/** Windows 自动下载安装路径；mac 未签名仅提示 */
+	canAutoInstall: boolean;
+}
+
+export interface InnoDesktopBridge {
+	updater: {
+		getInfo: () => Promise<DesktopInfo>;
+		getStatus: () => Promise<UpdateStatus>;
+		checkForUpdates: () => Promise<void>;
+		quitAndInstall: () => Promise<void>;
+		openDownloadPage: () => Promise<void>;
+		onStatusChanged: (callback: (status: UpdateStatus) => void) => () => void;
+	};
+}
+
+declare global {
+	interface Window {
+		innoDesktop?: InnoDesktopBridge;
+	}
+}

--- a/electron/main.js
+++ b/electron/main.js
@@ -4,6 +4,7 @@ import { spawn } from "node:child_process";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
+import { initAutoUpdater, registerUpdaterIpc } from "./updater.js";
 
 // macOS 上避免未签名 app 触发钥匙串权限弹窗
 app.commandLine.appendSwitch("use-mock-keychain");
@@ -87,13 +88,20 @@ function openMainWindow() {
     minHeight: 600,
     title: "Inno Agent",
     backgroundColor: "#0f1117",
-    webPreferences: { contextIsolation: true, nodeIntegration: false },
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      preload: join(__dirname, "preload.cjs"),
+    },
   });
 
   mainWindow.loadURL(`http://localhost:${PORT}`);
 
   // 关闭 loading 窗口
   loadingWindow?.close();
+
+  // 自动更新（仅打包环境启用，开发环境跳过）
+  if (app.isPackaged) initAutoUpdater(mainWindow);
 
   mainWindow.on("closed", () => { mainWindow = null; });
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
@@ -161,6 +169,7 @@ app.whenReady().then(async () => {
   tray.on("click", () => { if (mainWindow) mainWindow.show(); else openMainWindow(); });
 
   ensureConfig();
+  registerUpdaterIpc();
   openLoadingWindow();
   startServer(() => openMainWindow());
 });

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -1,0 +1,31 @@
+/**
+ * Preload 脚本：以 contextBridge 向 web UI 暴露桌面端能力。
+ *
+ * web UI 通过 window.innoDesktop 感知自己运行在 Electron 中；
+ * 浏览器访问时该对象为 undefined，所有桌面能力按不可用降级。
+ */
+
+const { contextBridge, ipcRenderer } = require("electron");
+
+contextBridge.exposeInMainWorld("innoDesktop", {
+  updater: {
+    /** 获取版本/平台/更新器可用性信息 */
+    getInfo: () => ipcRenderer.invoke("inno:updater:get-info"),
+    /** 获取当前更新状态 */
+    getStatus: () => ipcRenderer.invoke("inno:updater:get-status"),
+    /** 手动触发检查更新 */
+    checkForUpdates: () => ipcRenderer.invoke("inno:updater:check"),
+    /** 重启并安装已下载的更新 */
+    quitAndInstall: () => ipcRenderer.invoke("inno:updater:quit-and-install"),
+    /** 打开 Release 下载页（mac 手动下载路径） */
+    openDownloadPage: () => ipcRenderer.invoke("inno:updater:open-download-page"),
+    /** 订阅更新状态推送，返回取消订阅函数 */
+    onStatusChanged: (callback) => {
+      const listener = (_event, status) => callback(status);
+      ipcRenderer.on("inno:updater:status", listener);
+      return () => {
+        ipcRenderer.removeListener("inno:updater:status", listener);
+      };
+    },
+  },
+});

--- a/electron/updater.js
+++ b/electron/updater.js
@@ -1,0 +1,185 @@
+/**
+ * 自动更新模块
+ *
+ * 检测新版本 → (Windows) 后台自动下载 → 用户点击「重启安装」。
+ * macOS 构建当前未签名，electron-updater 拒绝安装未签名更新，
+ * 因此 mac 只检测并提示，由 UI 引导用户去 Release 页手动下载。
+ * 仅在打包后的生产环境启用。
+ */
+
+import { autoUpdater } from "electron-updater";
+import { app, ipcMain, shell } from "electron";
+
+const DOWNLOAD_PAGE_URL = "https://github.com/hhyqhh/inno-agent/releases/latest";
+
+/** Windows 上由 electron-updater 自动下载安装；macOS 仅提示（未签名无法安装） */
+const canAutoInstall = process.platform === "win32";
+
+/** 当前更新状态 */
+let currentStatus = { status: "idle" };
+
+/** 主窗口引用（用于推送状态） */
+let win = null;
+
+/** 定时检查定时器 */
+let checkInterval = null;
+
+/** 更新状态并推送给渲染进程 */
+function setStatus(status) {
+  currentStatus = status;
+  win?.webContents?.send("inno:updater:status", status);
+}
+
+/** 归一化 releaseNotes（可能是 string 或数组） */
+function normalizeReleaseNotes(releaseNotes) {
+  if (typeof releaseNotes === "string") return releaseNotes;
+  if (Array.isArray(releaseNotes)) {
+    return releaseNotes.map((n) => n?.note).filter(Boolean).join("\n");
+  }
+  return undefined;
+}
+
+/** 手动触发检查更新 */
+export async function checkForUpdates() {
+  if (!app.isPackaged) {
+    console.log("[更新] 开发环境，跳过检查");
+    return;
+  }
+  // 已在下载中或已下载完成，不重复检查
+  if (currentStatus.status === "downloading" || currentStatus.status === "downloaded") {
+    console.log("[更新] 跳过检查：已在下载中或已下载完成");
+    return;
+  }
+
+  try {
+    setStatus({ status: "checking" });
+    await autoUpdater.checkForUpdates();
+  } catch (err) {
+    console.error("[更新] 检查更新失败:", err);
+    setStatus({ status: "error", error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+/** 退出并安装已下载的更新（仅 Windows 自动更新路径可达） */
+export function quitAndInstall() {
+  if (!app.isPackaged) {
+    console.warn("[更新] 开发环境不支持安装更新");
+    return;
+  }
+  if (currentStatus.status !== "downloaded") {
+    console.warn("[更新] 跳过安装：当前没有已下载的更新");
+    return;
+  }
+  // before-quit 已负责 kill 后端子进程
+  autoUpdater.quitAndInstall(true, true);
+}
+
+/**
+ * 初始化自动更新
+ *
+ * @param mainWindow - 主窗口实例，用于推送更新状态
+ */
+export function initAutoUpdater(mainWindow) {
+  win = mainWindow;
+
+  autoUpdater.logger = {
+    info: (...args) => console.log("[更新-updater]", ...args),
+    warn: (...args) => console.warn("[更新-updater]", ...args),
+    error: (...args) => console.error("[更新-updater]", ...args),
+    debug: (...args) => console.log("[更新-updater:debug]", ...args),
+  };
+
+  // mac 不自动下载（未签名装不上，避免浪费带宽）；下载后也不在退出时自动安装，
+  // 由用户在设置页明确点击「重启安装」。
+  autoUpdater.autoDownload = canAutoInstall;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  autoUpdater.on("checking-for-update", () => {
+    console.log("[更新] 正在检查更新...");
+    setStatus({ status: "checking" });
+  });
+
+  autoUpdater.on("update-available", (info) => {
+    console.log("[更新] 发现新版本:", info.version);
+    setStatus({
+      status: "available",
+      version: info.version,
+      releaseNotes: normalizeReleaseNotes(info.releaseNotes),
+    });
+  });
+
+  autoUpdater.on("download-progress", (progress) => {
+    setStatus({
+      status: "downloading",
+      version: currentStatus.version || "",
+      progress: {
+        percent: progress.percent,
+        transferred: progress.transferred,
+        total: progress.total,
+        bytesPerSecond: progress.bytesPerSecond,
+      },
+    });
+  });
+
+  autoUpdater.on("update-downloaded", (info) => {
+    console.log("[更新] 下载完成:", info.version);
+    setStatus({ status: "downloaded", version: info.version });
+  });
+
+  autoUpdater.on("update-not-available", () => {
+    console.log("[更新] 已是最新版本");
+    setStatus({ status: "not-available" });
+  });
+
+  autoUpdater.on("error", (err) => {
+    console.error("[更新] 更新出错:", err);
+    setStatus({ status: "error", error: err.message });
+  });
+
+  // 启动后延迟 10 秒首次检查
+  setTimeout(() => {
+    console.log("[更新] 首次自动检查更新");
+    checkForUpdates();
+  }, 10_000);
+
+  // 每 4 小时自动检查一次
+  checkInterval = setInterval(() => {
+    console.log("[更新] 定时自动检查更新");
+    checkForUpdates();
+  }, 4 * 60 * 60 * 1000);
+
+  // 窗口关闭时清理定时器
+  mainWindow.on("closed", () => {
+    if (checkInterval) {
+      clearInterval(checkInterval);
+      checkInterval = null;
+    }
+    win = null;
+  });
+
+  console.log(`[更新] 自动更新模块已初始化（${canAutoInstall ? "自动下载" : "仅检测提示"}）`);
+}
+
+/** 注册更新相关 IPC 处理器（供 preload 调用） */
+export function registerUpdaterIpc() {
+  ipcMain.handle("inno:updater:get-info", () => ({
+    version: app.getVersion(),
+    platform: process.platform,
+    enabled: app.isPackaged,
+    canAutoInstall: app.isPackaged && canAutoInstall,
+  }));
+
+  ipcMain.handle("inno:updater:get-status", () => currentStatus);
+
+  ipcMain.handle("inno:updater:check", async () => {
+    await checkForUpdates();
+  });
+
+  ipcMain.handle("inno:updater:quit-and-install", () => {
+    quitAndInstall();
+  });
+
+  ipcMain.handle("inno:updater:open-download-page", () => {
+    shell.openExternal(DOWNLOAD_PAGE_URL);
+  });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
 				"apps/inno-agent",
 				"apps/inno-agent/web"
 			],
+			"dependencies": {
+				"electron-updater": "^6.6.2"
+			},
 			"devDependencies": {
 				"@tailwindcss/cli": "^4.0.0-beta.14",
 				"@tailwindcss/vite": "^4.1.7",
@@ -7361,7 +7364,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmmirror.com/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true,
 			"license": "Python-2.0"
 		},
 		"node_modules/assert-plus": {
@@ -8779,6 +8781,47 @@
 			"dev": true,
 			"license": "ISC"
 		},
+		"node_modules/electron-updater": {
+			"version": "6.8.9",
+			"resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+			"integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+			"license": "MIT",
+			"dependencies": {
+				"builder-util-runtime": "9.7.0",
+				"fs-extra": "^10.1.0",
+				"js-yaml": "^4.1.0",
+				"lazy-val": "^1.0.5",
+				"lodash.escaperegexp": "^4.1.2",
+				"lodash.isequal": "^4.5.0",
+				"semver": "~7.7.3",
+				"tiny-typed-emitter": "^2.1.0"
+			}
+		},
+		"node_modules/electron-updater/node_modules/builder-util-runtime": {
+			"version": "9.7.0",
+			"resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+			"integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.3.4",
+				"sax": "^1.2.4"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/electron-updater/node_modules/semver": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"license": "ISC",
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/electron-winstaller": {
 			"version": "5.4.0",
 			"resolved": "https://registry.npmmirror.com/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -9502,7 +9545,6 @@
 			"version": "10.1.0",
 			"resolved": "https://registry.npmmirror.com/fs-extra/-/fs-extra-10.1.0.tgz",
 			"integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
@@ -9834,7 +9876,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/graphology": {
@@ -10670,7 +10711,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.1.tgz",
 			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -10753,7 +10793,6 @@
 			"version": "6.2.1",
 			"resolved": "https://registry.npmmirror.com/jsonfile/-/jsonfile-6.2.1.tgz",
 			"integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"universalify": "^2.0.0"
@@ -10860,7 +10899,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmmirror.com/lazy-val/-/lazy-val-1.0.5.tgz",
 			"integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lie": {
@@ -11171,10 +11209,23 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/lodash.escaperegexp": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+			"license": "MIT"
+		},
 		"node_modules/lodash.identity": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmmirror.com/lodash.identity/-/lodash.identity-3.0.0.tgz",
 			"integrity": "sha512-AupTIzdLQxJS5wIYUQlgGyk2XRTfGXA+MCghDHqZk0pzUNYvd3EESS6dkChNauNYVIutcb0dfHw1ri9Q1yPV8Q==",
+			"license": "MIT"
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -14100,7 +14151,6 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmmirror.com/sax/-/sax-1.6.0.tgz",
 			"integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=11.0.0"
@@ -14844,6 +14894,12 @@
 				"semver": "bin/semver"
 			}
 		},
+		"node_modules/tiny-typed-emitter": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+			"integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+			"license": "MIT"
+		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",
 			"resolved": "https://registry.npmmirror.com/tinybench/-/tinybench-2.9.0.tgz",
@@ -15206,7 +15262,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmmirror.com/universalify/-/universalify-2.0.1.tgz",
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
 		"directories": {
 			"output": "dist-electron"
 		},
+		"publish": {
+			"provider": "github",
+			"owner": "hhyqhh",
+			"repo": "inno-agent"
+		},
 		"files": [
 			"electron/**/*",
 			"apps/inno-agent/dist/**/*",
@@ -56,6 +61,12 @@
 			"target": [
 				{
 					"target": "dmg",
+					"arch": [
+						"arm64"
+					]
+				},
+				{
+					"target": "zip",
 					"arch": [
 						"arm64"
 					]
@@ -107,6 +118,9 @@
 			"oneClick": false,
 			"perMachine": false
 		}
+	},
+	"dependencies": {
+		"electron-updater": "^6.6.2"
 	},
 	"devDependencies": {
 		"@tailwindcss/cli": "^4.0.0-beta.14",


### PR DESCRIPTION
## Summary

Port the auto-update mechanism (inspired by proma-ai/Proma) to the Inno Agent desktop client.

- **electron/updater.js** — update state machine: first check 10s after launch, then every 4h; status pushed to the renderer over IPC. Windows (NSIS) downloads automatically in the background and offers "restart & install"; unsigned macOS builds only notify and link to the release page, since electron-updater refuses to install unsigned updates. `quitAndInstall` is guarded by `isPackaged` + downloaded state.
- **electron/preload.cjs** — contextBridge exposing `window.innoDesktop.updater`, so the web UI can detect the desktop shell. Browser access degrades gracefully (update UI hidden).
- **Web UI** — `updater-store` + a "Version & Updates" card in About settings: current version, check button, download progress bar, "Restart & install" (Windows) / "Download" (mac); zh-CN/en i18n.
- **Build** — `electron-updater` dependency, `build.publish` → `hhyqhh/inno-agent`, mac `zip` target added (prerequisite for future signed mac auto-update).
- **CI** — tag builds now publish via `electron-builder --publish always` (creates/reuses the GitHub Release and uploads artifacts + `latest*.yml` manifests); manual dispatch still builds without publishing. Dropped `softprops/action-gh-release`.

## Notes

- Release names will now default to the version string and auto-generated release notes are gone (electron-builder manages the release); semver prerelease tags are marked automatically.
- Enabling macOS in-app updates later only requires signing secrets (`CSC_LINK` etc., see the commented block in `release-mac.yml`) plus flipping `canAutoInstall` in `electron/updater.js`.

## Verification

- `npm run build` (tsc + vite typecheck) passes.
- Local `electron-builder --mac --arm64` package succeeds; `dist-electron/latest-mac.yml` generated with the zip as the update path — publish config confirmed working.
- End-to-end check happens on the next `v*` tag: CI uploads `latest*.yml`, older Windows clients pick up the update.