### PR TITLE
feat(settings): guided add-provider wizard with presets and model probing

### DIFF
--- a/apps/inno-agent/src/agent/model-probe.ts
+++ b/apps/inno-agent/src/agent/model-probe.ts
@@ -1,0 +1,109 @@
+import { logger } from "../logger.js";
+
+/**
+ * Server-side model list probing for the settings UI.
+ *
+ * The browser cannot call provider APIs directly (CORS + API key exposure),
+ * so the "fetch model list" button in the add-provider wizard goes through
+ * this helper. Supports OpenAI-compatible `GET {baseUrl}/models` (Bearer
+ * auth) and Anthropic `GET {baseUrl}/models` (x-api-key auth).
+ */
+
+export interface ProbeModelsInput {
+	baseUrl: string;
+	apiKey?: string;
+	api?: string;
+}
+
+export interface ProbeModelsResult {
+	models: string[];
+}
+
+const PROBE_TIMEOUT_MS = 10_000;
+const MAX_MODELS = 500;
+
+function normalizeModelsUrl(baseUrl: string): string {
+	const trimmed = baseUrl.trim().replace(/\/+$/, "");
+	// Users often paste the full chat endpoint; strip it back to the API root.
+	return trimmed
+		.replace(/\/chat\/completions$/i, "")
+		.replace(/\/messages$/i, "") + "/models";
+}
+
+function buildHeaders(api: string | undefined, apiKey: string): Record<string, string> {
+	if (api === "anthropic-messages") {
+		return {
+			"x-api-key": apiKey,
+			"anthropic-version": "2023-06-01",
+			accept: "application/json",
+		};
+	}
+	return {
+		authorization: `Bearer ${apiKey}`,
+		accept: "application/json",
+	};
+}
+
+/**
+ * Fetch the list of model ids a provider exposes. Throws an Error with a
+ * human-readable message on failure; callers turn that into a 4xx response.
+ */
+export async function probeProviderModels(input: ProbeModelsInput): Promise<ProbeModelsResult> {
+	const baseUrl = input.baseUrl?.trim();
+	if (!baseUrl) throw new Error("缺少 Base URL");
+	if (!/^https?:\/\//i.test(baseUrl)) throw new Error("Base URL 必须以 http(s):// 开头");
+
+	const apiKey = input.apiKey?.trim() ?? "";
+	if (!apiKey) throw new Error("缺少 API Key");
+
+	const url = normalizeModelsUrl(baseUrl);
+	let res: Response;
+	try {
+		res = await fetch(url, {
+			headers: buildHeaders(input.api, apiKey),
+			signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+		});
+	} catch (err) {
+		logger.warn({ url, err }, "model probe: request failed");
+		throw new Error("无法连接到服务商，请检查 Base URL 与网络");
+	}
+
+	if (res.status === 401 || res.status === 403) {
+		throw new Error("API Key 无效或没有权限（401/403）");
+	}
+	if (res.status === 404) {
+		throw new Error("该服务商不支持列出模型，请手动填写模型 ID");
+	}
+	if (!res.ok) {
+		throw new Error(`服务商返回错误（HTTP ${res.status}）`);
+	}
+
+	let body: unknown;
+	try {
+		body = await res.json();
+	} catch {
+		throw new Error("服务商返回的不是有效的模型列表");
+	}
+
+	const ids = extractModelIds(body);
+	if (ids.length === 0) {
+		throw new Error("未获取到任何模型，请手动填写模型 ID");
+	}
+	return { models: ids.slice(0, MAX_MODELS) };
+}
+
+function extractModelIds(body: unknown): string[] {
+	// OpenAI-compatible: { data: [{ id: string }, ...] }
+	if (body && typeof body === "object" && Array.isArray((body as { data?: unknown }).data)) {
+		return (body as { data: unknown[] }).data
+			.map((entry) => (entry && typeof entry === "object" ? (entry as { id?: unknown }).id : undefined))
+			.filter((id): id is string => typeof id === "string" && id.length > 0);
+	}
+	// Some gateways return a bare array of ids or objects.
+	if (Array.isArray(body)) {
+		return body
+			.map((entry) => (typeof entry === "string" ? entry : entry && typeof entry === "object" ? (entry as { id?: unknown }).id : undefined))
+			.filter((id): id is string => typeof id === "string" && id.length > 0);
+	}
+	return [];
+}

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -15,6 +15,7 @@ import { buildWikiGraph } from "./memory/l2/wiki-graph.js";
 import { loadConfig, saveConfig, setDefaultModel, upsertProvider, deleteProvider, deleteModel, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig, type InnoModelConfig, type InnoProviderConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
 import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
+import { probeProviderModels } from "./agent/model-probe.js";
 import { ensureDir, readJson, readText, writeJson, writeText } from "./storage/file-store.js";
 import {
 	createNewSession,
@@ -4135,6 +4136,27 @@ const server = createServer(async (req, res) => {
 				config = saveConfig(paths.configPath, setDefaultModel(config, config.defaultProvider, config.defaultModel));
 			}
 			json(res, 200, buildSafeSettings());
+			return;
+		}
+
+		// Probe a provider's model list server-side (the browser can't call
+		// provider APIs directly due to CORS + API key exposure). If apiKey is
+		// omitted, fall back to the stored key of an existing provider.
+		if (method === "POST" && url === "/api/settings/providers/probe-models") {
+			const body = (await readBody(req)) as Record<string, unknown>;
+			const baseUrl = typeof body.baseUrl === "string" ? body.baseUrl.trim() : "";
+			const api = typeof body.api === "string" ? body.api : undefined;
+			let apiKey = typeof body.apiKey === "string" ? body.apiKey.trim() : "";
+			const providerId = typeof body.providerId === "string" ? body.providerId.trim() : "";
+			if ((!apiKey || apiKey.startsWith("****")) && providerId) {
+				apiKey = config.providers?.[providerId]?.apiKey ?? "";
+			}
+			try {
+				const result = await probeProviderModels({ baseUrl, apiKey, api });
+				json(res, 200, result);
+			} catch (err) {
+				json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+			}
 			return;
 		}
 

--- a/apps/inno-agent/web/src/api/settings.ts
+++ b/apps/inno-agent/web/src/api/settings.ts
@@ -32,6 +32,20 @@ export async function deleteModelApi(providerId: string, modelId: string): Promi
 	);
 }
 
+export interface ProbeModelsRequest {
+	baseUrl: string;
+	apiKey?: string;
+	providerId?: string;
+	api?: string;
+}
+
+export async function probeProviderModels(payload: ProbeModelsRequest): Promise<{ models: string[] }> {
+	return apiFetch<{ models: string[] }>("/api/settings/providers/probe-models", {
+		method: "POST",
+		body: JSON.stringify(payload),
+	});
+}
+
 export async function saveChannelsSettings(payload: ChannelsSettingsPayload): Promise<InnoSettings> {
 	return apiFetch<InnoSettings>("/api/settings/channels", {
 		method: "PUT",

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -551,7 +551,20 @@
 			"about": {
 				"desc": "Server status and storage stats"
 			}
-		}
+		},
+		"wizard": {
+			"docs": "Docs",
+			"changePreset": "Change provider",
+			"getApiKey": "Get API key",
+			"fetchModels": "Fetch model list",
+			"fetching": "Fetching…",
+			"fetchedCount": "{{count}} models fetched",
+			"modelPlaceholder": "Type or pick from the fetched list",
+			"vision": "Vision",
+			"autoFilled": "Parameters auto-filled",
+			"advanced": "Advanced options"
+		},
+		"editModel": "Edit model"
 	},
 	"chat": {
 		"welcomePlaceholder": "What would you like to learn or build? Send a message to start…",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -551,7 +551,20 @@
 			"about": {
 				"desc": "服务状态与存储统计"
 			}
-		}
+		},
+		"wizard": {
+			"docs": "文档",
+			"changePreset": "更换提供方",
+			"getApiKey": "获取 API Key",
+			"fetchModels": "拉取模型列表",
+			"fetching": "拉取中…",
+			"fetchedCount": "已拉取 {{count}} 个模型",
+			"modelPlaceholder": "输入或从拉取的列表中选择",
+			"vision": "视觉",
+			"autoFilled": "参数已自动填充",
+			"advanced": "高级选项"
+		},
+		"editModel": "编辑模型"
 	},
 	"chat": {
 		"welcomePlaceholder": "有什么想学习或实践的?发送消息开始…",

--- a/apps/inno-agent/web/src/react/settings/AddProviderWizard.tsx
+++ b/apps/inno-agent/web/src/react/settings/AddProviderWizard.tsx
@@ -1,0 +1,365 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ChevronDown, ChevronRight, Plus, ExternalLink, RefreshCw, Check } from "lucide-react";
+import { settingsStore } from "../../stores/settings-store.js";
+import { probeProviderModels } from "../../api/settings.js";
+import type { InnoProviderModel as ProviderModel, InnoProviderSettings } from "../../types/settings.js";
+import { checkboxCls } from "../ui/checkbox.js";
+import { formatTokens } from "./shared.js";
+import { PROVIDER_PRESETS, findPreset, type ProviderPreset } from "./provider-presets.js";
+import { inferModelMetadata } from "./model-metadata.js";
+
+const apiOptions = ["openai-completions", "openai-responses", "anthropic-messages"];
+
+/** Brand-colored letter-tile icon for a provider (preset or existing). */
+export function ProviderIcon({ providerId, size = 28 }: { providerId: string; size?: number }) {
+	const preset = findPreset(providerId);
+	const color = preset?.brandColor ?? "#8A8F98";
+	const glyph = preset?.glyph ?? providerId.trim().charAt(0).toUpperCase() ?? "?";
+	return (
+		<span
+			className="flex shrink-0 items-center justify-center rounded-md font-semibold text-white"
+			style={{ width: size, height: size, backgroundColor: color, fontSize: Math.round(size * 0.38) }}
+		>
+			{glyph}
+		</span>
+	);
+}
+
+interface WizardFormState {
+	providerId: string;
+	baseUrl: string;
+	apiKey: string;
+	api: string;
+	modelId: string;
+	contextWindow: string;
+	maxTokens: string;
+	reasoning: boolean;
+	supportsImages: boolean;
+	authHeader: boolean;
+	bypassProxy: boolean;
+	makeDefault: boolean;
+}
+
+function formFromPreset(preset: ProviderPreset, existingProviders: Record<string, InnoProviderSettings>): WizardFormState {
+	return {
+		providerId: preset.id === "custom" ? "" : preset.id,
+		baseUrl: preset.baseUrl,
+		apiKey: "",
+		api: preset.api,
+		modelId: "",
+		contextWindow: "128000",
+		maxTokens: "8192",
+		reasoning: false,
+		supportsImages: false,
+		authHeader: false,
+		bypassProxy: false,
+		// First configured model becomes the default automatically.
+		makeDefault: Object.keys(existingProviders).length === 0,
+	};
+}
+
+const inputCls = "w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1.5 text-xs text-[var(--inno-text)] focus:border-[var(--inno-accent)] focus:outline-none";
+const labelCls = "mb-0.5 block text-[10px] text-[var(--inno-text-muted)]";
+
+/**
+ * Guided add-provider wizard (cc-switch style): pick a preset, paste an API
+ * key, pull the model list from the provider, pick a model — context and
+ * capability fields are auto-filled and tucked into an advanced section.
+ */
+export function AddProviderWizard({ providers }: { providers: Record<string, InnoProviderSettings> }) {
+	const { t } = useTranslation();
+	const [expanded, setExpanded] = useState(false);
+	const [preset, setPreset] = useState<ProviderPreset | null>(null);
+	const [form, setForm] = useState<WizardFormState | null>(null);
+	const [showAdvanced, setShowAdvanced] = useState(false);
+	const [fetchedModels, setFetchedModels] = useState<string[] | null>(null);
+	const [probing, setProbing] = useState(false);
+	const [probeError, setProbeError] = useState<string | null>(null);
+	const [formError, setFormError] = useState<string | null>(null);
+	const [saving, setSaving] = useState(false);
+
+	const existingProviders = providers;
+
+	function reset() {
+		setPreset(null);
+		setForm(null);
+		setShowAdvanced(false);
+		setFetchedModels(null);
+		setProbeError(null);
+		setFormError(null);
+	}
+
+	function selectPreset(p: ProviderPreset) {
+		setPreset(p);
+		setForm(formFromPreset(p, existingProviders));
+		setFetchedModels(null);
+		setProbeError(null);
+		setFormError(null);
+	}
+
+	function applyModel(modelId: string) {
+		if (!form) return;
+		const meta = inferModelMetadata(modelId);
+		setForm({
+			...form,
+			modelId,
+			contextWindow: String(meta.contextWindow),
+			maxTokens: String(meta.maxTokens),
+			reasoning: meta.reasoning,
+			supportsImages: meta.supportsImages,
+		});
+	}
+
+	async function handleProbe() {
+		if (!form) return;
+		setProbing(true);
+		setProbeError(null);
+		try {
+			const existing = existingProviders[form.providerId];
+			const result = await probeProviderModels({
+				baseUrl: form.baseUrl,
+				apiKey: form.apiKey,
+				providerId: existing?.apiKey ? form.providerId : undefined,
+				api: form.api,
+			});
+			setFetchedModels(result.models);
+			if (result.models.length > 0 && !form.modelId) applyModel(result.models[0]);
+		} catch (err) {
+			setFetchedModels(null);
+			setProbeError(err instanceof Error ? err.message : String(err));
+		} finally {
+			setProbing(false);
+		}
+	}
+
+	async function handleSave() {
+		if (!form) return;
+		const contextWindow = Number(form.contextWindow);
+		const maxTokens = Number(form.maxTokens);
+		if (!form.providerId.trim()) return setFormError(t("settings.errors.providerRequired"));
+		if (!form.baseUrl.trim()) return setFormError(t("settings.errors.baseUrlRequired"));
+		if (!form.modelId.trim()) return setFormError(t("settings.errors.modelRequired"));
+		if (!Number.isFinite(contextWindow) || contextWindow <= 0 || !Number.isFinite(maxTokens) || maxTokens <= 0) {
+			return setFormError(t("settings.errors.tokensInvalid"));
+		}
+		setSaving(true);
+		setFormError(null);
+		try {
+			const providerId = form.providerId.trim();
+			const existing = existingProviders[providerId];
+			const model: ProviderModel = {
+				id: form.modelId.trim(),
+				name: form.modelId.trim(),
+				reasoning: form.reasoning,
+				input: form.supportsImages ? ["text", "image"] : ["text"],
+				contextWindow: Math.trunc(contextWindow),
+				maxTokens: Math.trunc(maxTokens),
+			};
+			// Adding to an existing provider merges with its models instead of
+			// replacing them; the new model goes first so makeDefault targets it
+			// (the backend takes models[0] as the default). Leaving the key
+			// blank keeps the stored one.
+			const models = [model, ...(existing?.models ?? []).filter((m) => m.id !== model.id)];
+			await settingsStore.saveProvider({
+				providerId,
+				baseUrl: form.baseUrl.trim(),
+				apiKey: form.apiKey,
+				api: form.api,
+				authHeader: form.authHeader,
+				bypassProxy: form.bypassProxy,
+				models,
+				makeDefault: form.makeDefault,
+				preserveApiKey: true,
+			});
+			setExpanded(false);
+			reset();
+		} catch (err) {
+			setFormError(err instanceof Error ? err.message : "Save failed");
+		} finally {
+			setSaving(false);
+		}
+	}
+
+	return (
+		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
+			<button
+				className="flex w-full items-center justify-between px-4 py-3 text-left"
+				onClick={() => { setExpanded((v) => !v); reset(); }}
+			>
+				<div className="flex items-center gap-2">
+					{expanded ? <ChevronDown size={14} className="text-[var(--inno-text-subtle)]" /> : <ChevronRight size={14} className="text-[var(--inno-text-subtle)]" />}
+					<span className="text-sm font-medium text-[var(--inno-text)]">{t("settings.newProvider")}</span>
+				</div>
+				<Plus size={14} className="text-[var(--inno-text-subtle)]" />
+			</button>
+
+			{expanded && (
+				<div className="border-t border-[var(--inno-border)] px-4 pb-4 pt-3">
+					{/* Step 1: preset picker */}
+					{!form && (
+						<div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+							{PROVIDER_PRESETS.map((p) => (
+								<button
+									key={p.id}
+									className="flex items-center gap-2.5 rounded-lg border border-[var(--inno-border)] p-2.5 text-left transition-colors hover:border-[var(--inno-accent)] hover:bg-[var(--inno-surface-muted)]"
+									onClick={() => selectPreset(p)}
+								>
+									<ProviderIcon providerId={p.id} size={30} />
+									<span className="min-w-0">
+										<span className="block truncate text-xs font-medium text-[var(--inno-text)]">{p.name}</span>
+										<span className="block truncate text-[10px] text-[var(--inno-text-subtle)]">{p.description}</span>
+									</span>
+								</button>
+							))}
+						</div>
+					)}
+
+					{/* Step 2: guided form */}
+					{form && preset && (
+						<div>
+							<div className="mb-3 flex items-center justify-between">
+								<div className="flex items-center gap-2.5">
+									<ProviderIcon providerId={preset.id} size={26} />
+									<span className="text-sm font-medium text-[var(--inno-text)]">{preset.name}</span>
+									{preset.docsUrl && (
+										<a className="flex items-center gap-0.5 text-[10px] text-[var(--inno-text-subtle)] hover:text-[var(--inno-accent)]" href={preset.docsUrl} target="_blank" rel="noreferrer">
+											{t("settings.wizard.docs", "文档")} <ExternalLink size={10} />
+										</a>
+									)}
+								</div>
+								<button className="text-[10px] text-[var(--inno-text-subtle)] hover:text-[var(--inno-text)]" onClick={reset}>
+									{t("settings.wizard.changePreset", "更换提供方")}
+								</button>
+							</div>
+
+							<div className="grid gap-2">
+								{/* API key + console link */}
+								<div>
+									<div className="mb-0.5 flex items-center justify-between">
+										<label className="text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiKey")}</label>
+										{preset.consoleUrl && (
+											<a className="flex items-center gap-0.5 text-[10px] text-[var(--inno-accent)] hover:underline" href={preset.consoleUrl} target="_blank" rel="noreferrer">
+												{t("settings.wizard.getApiKey", "获取 API Key")} <ExternalLink size={10} />
+											</a>
+										)}
+									</div>
+									<input
+										className={inputCls}
+										type="password"
+										placeholder={existingProviders[form.providerId] ? t("settings.form.apiKeyPreserved") ?? "" : "sk-..."}
+										value={form.apiKey}
+										onChange={(e) => setForm({ ...form, apiKey: e.target.value })}
+									/>
+								</div>
+
+								{/* Model fetch + pick */}
+								<div>
+									<div className="mb-0.5 flex items-center justify-between">
+										<label className="text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelId")}</label>
+										<button
+											className="flex items-center gap-1 text-[10px] text-[var(--inno-accent)] hover:underline disabled:opacity-50"
+											disabled={probing || !form.baseUrl.trim()}
+											onClick={() => void handleProbe()}
+										>
+											<RefreshCw size={10} className={probing ? "animate-spin" : ""} />
+											{probing
+												? t("settings.wizard.fetching", "拉取中…")
+												: fetchedModels
+													? t("settings.wizard.fetchedCount", { count: fetchedModels.length })
+													: t("settings.wizard.fetchModels", "拉取模型列表")}
+										</button>
+									</div>
+									<input
+										className={inputCls}
+										list="inno-probed-models"
+										placeholder={t("settings.wizard.modelPlaceholder", "输入或从拉取的列表中选择") ?? ""}
+										value={form.modelId}
+										onChange={(e) => applyModel(e.target.value)}
+									/>
+									{datalist(fetchedModels)}
+									{preset.modelHint && <p className="mt-1 text-[10px] text-[var(--inno-text-subtle)]">{preset.modelHint}</p>}
+									{probeError && <p className="mt-1 text-[10px] text-[var(--inno-danger)]">{probeError}</p>}
+									{form.modelId && (
+										<div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+											<span className="rounded bg-[var(--inno-surface-muted)] px-1.5 py-0.5 text-[10px] text-[var(--inno-text-muted)]">{formatTokens(Number(form.contextWindow) || 0)} context</span>
+											<span className="rounded bg-[var(--inno-surface-muted)] px-1.5 py-0.5 text-[10px] text-[var(--inno-text-muted)]">{formatTokens(Number(form.maxTokens) || 0)} max</span>
+											{form.reasoning && <span className="rounded bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-[10px] text-[var(--inno-accent)]">{t("settings.form.reasoning")}</span>}
+											{form.supportsImages && <span className="rounded bg-[var(--inno-accent-soft)] px-1.5 py-0.5 text-[10px] text-[var(--inno-accent)]">{t("settings.wizard.vision", "视觉")}</span>}
+											<span className="flex items-center gap-0.5 text-[10px] text-[var(--inno-success)]"><Check size={10} />{t("settings.wizard.autoFilled", "参数已自动填充")}</span>
+										</div>
+									)}
+								</div>
+
+								{/* Advanced */}
+								<button
+									className="mt-1 flex items-center gap-1 text-[10px] text-[var(--inno-text-subtle)] hover:text-[var(--inno-text)]"
+									onClick={() => setShowAdvanced((v) => !v)}
+								>
+									{showAdvanced ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+									{t("settings.wizard.advanced", "高级选项")}
+								</button>
+								{showAdvanced && (
+									<div className="grid grid-cols-2 gap-2 rounded-md bg-[var(--inno-surface-muted)] p-2.5">
+										<div>
+											<label className={labelCls}>{t("settings.form.providerId")}</label>
+											<input className={inputCls} value={form.providerId} onChange={(e) => setForm({ ...form, providerId: e.target.value })} />
+										</div>
+										<div>
+											<label className={labelCls}>{t("settings.form.apiType", "API Type")}</label>
+											<select className={inputCls} value={form.api} onChange={(e) => setForm({ ...form, api: e.target.value })}>
+												{apiOptions.map((api) => <option key={api} value={api}>{api}</option>)}
+											</select>
+										</div>
+										<div className="col-span-2">
+											<label className={labelCls}>{t("settings.form.baseUrl")}</label>
+											<input className={inputCls} value={form.baseUrl} onChange={(e) => setForm({ ...form, baseUrl: e.target.value })} />
+										</div>
+										<div>
+											<label className={labelCls}>{t("settings.form.contextWindow")}</label>
+											<input className={inputCls} value={form.contextWindow} onChange={(e) => setForm({ ...form, contextWindow: e.target.value })} />
+										</div>
+										<div>
+											<label className={labelCls}>{t("settings.form.maxTokens")}</label>
+											<input className={inputCls} value={form.maxTokens} onChange={(e) => setForm({ ...form, maxTokens: e.target.value })} />
+										</div>
+										<div className="col-span-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
+											<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
+											<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.supportsImages} onChange={(e) => setForm({ ...form, supportsImages: e.target.checked })} /> {t("settings.form.supportsImages")}</label>
+											<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.authHeader} onChange={(e) => setForm({ ...form, authHeader: e.target.checked })} /> {t("settings.form.authHeader")}</label>
+											<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.bypassProxy} onChange={(e) => setForm({ ...form, bypassProxy: e.target.checked })} /> {t("settings.form.bypassProxy")}</label>
+										</div>
+									</div>
+								)}
+
+								<label className="mt-1 flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
+									<input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} />
+									{t("settings.form.makeDefault")}
+								</label>
+							</div>
+
+							{formError ? <div className="mt-2 rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-xs text-[var(--inno-danger)]">{formError}</div> : null}
+							<div className="mt-3 flex gap-2">
+								<button className="rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
+									{saving ? t("settings.savingProvider") : t("settings.saveProvider")}
+								</button>
+								<button className="rounded-md border border-[var(--inno-border)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)]" onClick={() => { setExpanded(false); reset(); }}>
+									{t("common.cancel", "Cancel")}
+								</button>
+							</div>
+						</div>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+function datalist(models: string[] | null) {
+	if (!models || models.length === 0) return null;
+	return (
+		<datalist id="inno-probed-models">
+			{models.map((id) => <option key={id} value={id} />)}
+		</datalist>
+	);
+}

--- a/apps/inno-agent/web/src/react/settings/ModelsSettings.tsx
+++ b/apps/inno-agent/web/src/react/settings/ModelsSettings.tsx
@@ -1,17 +1,21 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Trash2, Pencil, X, ChevronDown, ChevronRight, Plus } from "lucide-react";
+import { Trash2, Pencil, X, ChevronDown, ChevronRight } from "lucide-react";
 import { settingsStore } from "../../stores/settings-store.js";
 import type { InnoModelInfo, InnoProviderModel as ProviderModel, InnoSettings } from "../../types/settings.js";
 import { useStoreSnapshot } from "../hooks.js";
 import { checkboxCls } from "../ui/checkbox.js";
 import { SettingsSection, SettingsCard } from "./primitives.js";
 import { formatTokens, modelKey } from "./shared.js";
+import { AddProviderWizard, ProviderIcon } from "./AddProviderWizard.js";
+import { findPreset } from "./provider-presets.js";
 
 const apiOptions = ["openai-completions", "openai-responses", "anthropic-messages"];
 
-interface ProviderFormState {
-	providerId: string;
+const inputCls = "w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1.5 text-xs text-[var(--inno-text)] focus:border-[var(--inno-accent)] focus:outline-none";
+const labelCls = "mb-0.5 block text-[10px] text-[var(--inno-text-muted)]";
+
+interface ModelEditFormState {
 	baseUrl: string;
 	apiKey: string;
 	api: string;
@@ -24,25 +28,7 @@ interface ProviderFormState {
 	authHeader: boolean;
 	bypassProxy: boolean;
 	makeDefault: boolean;
-	preserveApiKey: boolean;
 }
-
-const emptyForm: ProviderFormState = {
-	providerId: "",
-	baseUrl: "",
-	apiKey: "",
-	api: "openai-completions",
-	modelId: "",
-	modelName: "",
-	contextWindow: "128000",
-	maxTokens: "8192",
-	reasoning: false,
-	supportsImages: false,
-	authHeader: false,
-	bypassProxy: false,
-	makeDefault: true,
-	preserveApiKey: false,
-};
 
 /* ---------- Model Edit Form (inline) ---------- */
 
@@ -53,8 +39,7 @@ function ModelEditForm({ model, settings, onClose }: {
 }) {
 	const { t } = useTranslation();
 	const provider = settings.providers[model.provider];
-	const [form, setForm] = useState<ProviderFormState>({
-		providerId: model.provider,
+	const [form, setForm] = useState<ModelEditFormState>({
 		baseUrl: provider?.baseUrl ?? "",
 		apiKey: "",
 		api: provider?.api ?? "openai-completions",
@@ -67,15 +52,14 @@ function ModelEditForm({ model, settings, onClose }: {
 		authHeader: provider?.authHeader === true,
 		bypassProxy: provider?.bypassProxy === true,
 		makeDefault: settings.defaultProvider === model.provider && settings.defaultModel === model.id,
-		preserveApiKey: Boolean(provider?.apiKey),
 	});
+	const [showAdvanced, setShowAdvanced] = useState(false);
 	const [formError, setFormError] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
 
 	async function handleSave() {
 		const contextWindow = Number(form.contextWindow);
 		const maxTokens = Number(form.maxTokens);
-		if (!form.providerId.trim()) return setFormError(t("settings.errors.providerRequired"));
 		if (!form.baseUrl.trim()) return setFormError(t("settings.errors.baseUrlRequired"));
 		if (!form.modelId.trim()) return setFormError(t("settings.errors.modelRequired"));
 		if (!Number.isFinite(contextWindow) || contextWindow <= 0 || !Number.isFinite(maxTokens) || maxTokens <= 0) {
@@ -91,16 +75,20 @@ function ModelEditForm({ model, settings, onClose }: {
 				contextWindow: Math.trunc(contextWindow),
 				maxTokens: Math.trunc(maxTokens),
 			};
+			// Merge with the provider's other models (upsert replaces the whole
+			// list); the edited model goes first so makeDefault targets it.
+			const models = [providerModel, ...(provider?.models ?? []).filter((m) => m.id !== model.id)];
 			await settingsStore.saveProvider({
-				providerId: form.providerId.trim(),
+				providerId: model.provider,
 				baseUrl: form.baseUrl.trim(),
 				apiKey: form.apiKey,
 				api: form.api,
 				authHeader: form.authHeader,
 				bypassProxy: form.bypassProxy,
-				models: [providerModel],
+				models,
 				makeDefault: form.makeDefault,
-				preserveApiKey: form.preserveApiKey,
+				// Empty key field means "keep the stored key".
+				preserveApiKey: true,
 			});
 			onClose();
 		} catch (err) {
@@ -110,59 +98,70 @@ function ModelEditForm({ model, settings, onClose }: {
 		}
 	}
 
-	const maskedKey = provider?.apiKey ? "••••••••" : "";
-
 	return (
 		<div className="rounded-lg bg-[var(--inno-surface)] p-3">
 			<div className="mb-2 flex items-center justify-between">
-				<span className="text-xs font-medium text-[var(--inno-text)]">{t("settings.editModel", "Edit Model")}</span>
+				<div className="flex items-center gap-2">
+					<ProviderIcon providerId={model.provider} size={22} />
+					<span className="text-xs font-medium text-[var(--inno-text)]">{t("settings.editModel", "Edit Model")}</span>
+				</div>
 				<button className="flex h-6 w-6 items-center justify-center rounded text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]" onClick={onClose}><X size={14} /></button>
 			</div>
 			<div className="grid grid-cols-2 gap-2">
 				<div>
-					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.providerId")}</label>
-					<input className="w-full rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2.5 py-1.5 text-xs text-[var(--inno-text-muted)]" value={form.providerId} readOnly />
+					<label className={labelCls}>{t("settings.form.modelId")}</label>
+					<input className={inputCls} value={form.modelId} onChange={(e) => setForm({ ...form, modelId: e.target.value })} />
 				</div>
 				<div>
-					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiType", "API Type")}</label>
-					<select className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.api} onChange={(e) => setForm({ ...form, api: e.target.value })}>
-						{apiOptions.map((api) => <option key={api} value={api}>{api}</option>)}
-					</select>
+					<label className={labelCls}>{t("settings.form.modelName")}</label>
+					<input className={inputCls} value={form.modelName} onChange={(e) => setForm({ ...form, modelName: e.target.value })} />
 				</div>
 				<div className="col-span-2">
-					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.baseUrl")}</label>
-					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.baseUrl} onChange={(e) => setForm({ ...form, baseUrl: e.target.value })} />
+					<label className={labelCls}>
+						{t("settings.form.apiKey")} {provider?.apiKey ? <span className="text-[var(--inno-text-subtle)]">(••••••••)</span> : null}
+					</label>
+					<input className={inputCls} type="password" placeholder={provider?.apiKey ? t("settings.form.apiKeyPreserved") ?? "" : ""} value={form.apiKey} onChange={(e) => setForm({ ...form, apiKey: e.target.value })} />
 				</div>
 				<div className="col-span-2">
-					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiKey")} {maskedKey && <span className="text-[var(--inno-text-subtle)]">({maskedKey})</span>}</label>
-					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" type="password" placeholder={form.preserveApiKey ? t("settings.form.apiKeyPreserved", "Leave empty to keep current key") ?? "" : ""} value={form.apiKey} onChange={(e) => setForm({ ...form, apiKey: e.target.value })} />
+					<label className={labelCls}>{t("settings.form.baseUrl")}</label>
+					<input className={inputCls} value={form.baseUrl} onChange={(e) => setForm({ ...form, baseUrl: e.target.value })} />
 				</div>
 				<div>
-					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelId")}</label>
-					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.modelId} onChange={(e) => setForm({ ...form, modelId: e.target.value })} />
+					<label className={labelCls}>{t("settings.form.contextWindow")}</label>
+					<input className={inputCls} value={form.contextWindow} onChange={(e) => setForm({ ...form, contextWindow: e.target.value })} />
 				</div>
 				<div>
-					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelName")}</label>
-					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.modelName} onChange={(e) => setForm({ ...form, modelName: e.target.value })} />
-				</div>
-				<div>
-					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.contextWindow")}</label>
-					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.contextWindow} onChange={(e) => setForm({ ...form, contextWindow: e.target.value })} />
-				</div>
-				<div>
-					<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.maxTokens")}</label>
-					<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.maxTokens} onChange={(e) => setForm({ ...form, maxTokens: e.target.value })} />
+					<label className={labelCls}>{t("settings.form.maxTokens")}</label>
+					<input className={inputCls} value={form.maxTokens} onChange={(e) => setForm({ ...form, maxTokens: e.target.value })} />
 				</div>
 			</div>
-			<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
-				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
-				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.supportsImages} onChange={(e) => setForm({ ...form, supportsImages: e.target.checked })} /> {t("settings.form.supportsImages")}</label>
-				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.authHeader} onChange={(e) => setForm({ ...form, authHeader: e.target.checked })} /> {t("settings.form.authHeader")}</label>
-				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.bypassProxy} onChange={(e) => setForm({ ...form, bypassProxy: e.target.checked })} /> {t("settings.form.bypassProxy")}</label>
-				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
-				<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.preserveApiKey} onChange={(e) => setForm({ ...form, preserveApiKey: e.target.checked })} /> {t("settings.form.preserveApiKey")}</label>
-			</div>
-			<p className="mt-1 text-[10px] text-[var(--inno-text-subtle)]">{t("settings.form.supportsImagesHint")}</p>
+
+			<button className="mt-2 flex items-center gap-1 text-[10px] text-[var(--inno-text-subtle)] hover:text-[var(--inno-text)]" onClick={() => setShowAdvanced((v) => !v)}>
+				{showAdvanced ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+				{t("settings.wizard.advanced", "高级选项")}
+			</button>
+			{showAdvanced && (
+				<div className="mt-1.5 grid gap-2 rounded-md bg-[var(--inno-surface-muted)] p-2.5">
+					<div>
+						<label className={labelCls}>{t("settings.form.apiType", "API Type")}</label>
+						<select className={inputCls} value={form.api} onChange={(e) => setForm({ ...form, api: e.target.value })}>
+							{apiOptions.map((api) => <option key={api} value={api}>{api}</option>)}
+						</select>
+					</div>
+					<div className="flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
+						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
+						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.supportsImages} onChange={(e) => setForm({ ...form, supportsImages: e.target.checked })} /> {t("settings.form.supportsImages")}</label>
+						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.authHeader} onChange={(e) => setForm({ ...form, authHeader: e.target.checked })} /> {t("settings.form.authHeader")}</label>
+						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.bypassProxy} onChange={(e) => setForm({ ...form, bypassProxy: e.target.checked })} /> {t("settings.form.bypassProxy")}</label>
+					</div>
+					<p className="text-[10px] text-[var(--inno-text-subtle)]">{t("settings.form.supportsImagesHint")}</p>
+				</div>
+			)}
+
+			<label className="mt-2 flex items-center gap-1.5 text-xs text-[var(--inno-text-muted)]">
+				<input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} />
+				{t("settings.form.makeDefault")}
+			</label>
 			{formError ? <div className="mt-2 rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-xs text-[var(--inno-danger)]">{formError}</div> : null}
 			<div className="mt-2 flex gap-2">
 				<button className="rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
@@ -172,126 +171,6 @@ function ModelEditForm({ model, settings, onClose }: {
 					{t("common.cancel", "Cancel")}
 				</button>
 			</div>
-		</div>
-	);
-}
-
-/* ---------- New Provider Form (collapsible) ---------- */
-
-function NewProviderForm() {
-	const { t } = useTranslation();
-	const [expanded, setExpanded] = useState(false);
-	const [form, setForm] = useState<ProviderFormState>(emptyForm);
-	const [formError, setFormError] = useState<string | null>(null);
-	const [saveMessage, setSaveMessage] = useState<string | null>(null);
-	const [saving, setSaving] = useState(false);
-
-	async function handleSave() {
-		const contextWindow = Number(form.contextWindow);
-		const maxTokens = Number(form.maxTokens);
-		if (!form.providerId.trim()) return setFormError(t("settings.errors.providerRequired"));
-		if (!form.baseUrl.trim()) return setFormError(t("settings.errors.baseUrlRequired"));
-		if (!form.modelId.trim()) return setFormError(t("settings.errors.modelRequired"));
-		if (!Number.isFinite(contextWindow) || contextWindow <= 0 || !Number.isFinite(maxTokens) || maxTokens <= 0) {
-			return setFormError(t("settings.errors.tokensInvalid"));
-		}
-		setSaving(true);
-		try {
-			const model: ProviderModel = {
-				id: form.modelId.trim(),
-				name: form.modelName.trim() || form.modelId.trim(),
-				reasoning: form.reasoning,
-				input: form.supportsImages ? ["text", "image"] : ["text"],
-				contextWindow: Math.trunc(contextWindow),
-				maxTokens: Math.trunc(maxTokens),
-			};
-			await settingsStore.saveProvider({
-				providerId: form.providerId.trim(),
-				baseUrl: form.baseUrl.trim(),
-				apiKey: form.apiKey,
-				api: form.api,
-				authHeader: form.authHeader,
-				bypassProxy: form.bypassProxy,
-				models: [model],
-				makeDefault: form.makeDefault,
-				preserveApiKey: false,
-			});
-			setSaveMessage(t("settings.saved"));
-			setForm(emptyForm);
-			setFormError(null);
-			setExpanded(false);
-		} catch (err) {
-			setFormError(err instanceof Error ? err.message : "Save failed");
-		} finally {
-			setSaving(false);
-		}
-	}
-
-	return (
-		<div className="rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)]">
-			<button
-				className="flex w-full items-center justify-between px-4 py-3 text-left"
-				onClick={() => { setExpanded((v) => !v); setFormError(null); setSaveMessage(null); }}
-			>
-				<div className="flex items-center gap-2">
-					{expanded ? <ChevronDown size={14} className="text-[var(--inno-text-subtle)]" /> : <ChevronRight size={14} className="text-[var(--inno-text-subtle)]" />}
-					<span className="text-sm font-medium text-[var(--inno-text)]">{t("settings.newProvider")}</span>
-				</div>
-				<Plus size={14} className="text-[var(--inno-text-subtle)]" />
-			</button>
-			{expanded && (
-				<div className="border-t border-[var(--inno-border)] px-4 pb-4 pt-3">
-					<div className="grid grid-cols-2 gap-2">
-						<div>
-							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.providerId")}</label>
-							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" placeholder={t("settings.form.providerId") ?? ""} value={form.providerId} onChange={(e) => setForm({ ...form, providerId: e.target.value })} />
-						</div>
-						<div>
-							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiType", "API Type")}</label>
-							<select className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.api} onChange={(e) => setForm({ ...form, api: e.target.value })}>
-								{apiOptions.map((api) => <option key={api} value={api}>{api}</option>)}
-							</select>
-						</div>
-						<div className="col-span-2">
-							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.baseUrl")}</label>
-							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" placeholder={t("settings.form.baseUrl") ?? ""} value={form.baseUrl} onChange={(e) => setForm({ ...form, baseUrl: e.target.value })} />
-						</div>
-						<div className="col-span-2">
-							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.apiKey")}</label>
-							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" type="password" placeholder={t("settings.form.apiKey") ?? ""} value={form.apiKey} onChange={(e) => setForm({ ...form, apiKey: e.target.value })} />
-						</div>
-						<div>
-							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelId")}</label>
-							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" placeholder={t("settings.form.modelId") ?? ""} value={form.modelId} onChange={(e) => setForm({ ...form, modelId: e.target.value })} />
-						</div>
-						<div>
-							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.modelName")}</label>
-							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" placeholder={t("settings.form.modelName") ?? ""} value={form.modelName} onChange={(e) => setForm({ ...form, modelName: e.target.value })} />
-						</div>
-						<div>
-							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.contextWindow")}</label>
-							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.contextWindow} onChange={(e) => setForm({ ...form, contextWindow: e.target.value })} />
-						</div>
-						<div>
-							<label className="mb-0.5 block text-[10px] text-[var(--inno-text-muted)]">{t("settings.form.maxTokens")}</label>
-							<input className="w-full rounded-md border border-[var(--inno-border)] px-2.5 py-1.5 text-xs" value={form.maxTokens} onChange={(e) => setForm({ ...form, maxTokens: e.target.value })} />
-						</div>
-					</div>
-					<div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-[var(--inno-text-muted)]">
-						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.reasoning} onChange={(e) => setForm({ ...form, reasoning: e.target.checked })} /> {t("settings.form.reasoning")}</label>
-						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.supportsImages} onChange={(e) => setForm({ ...form, supportsImages: e.target.checked })} /> {t("settings.form.supportsImages")}</label>
-						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.authHeader} onChange={(e) => setForm({ ...form, authHeader: e.target.checked })} /> {t("settings.form.authHeader")}</label>
-						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.bypassProxy} onChange={(e) => setForm({ ...form, bypassProxy: e.target.checked })} /> {t("settings.form.bypassProxy")}</label>
-						<label className="flex items-center gap-1.5"><input type="checkbox" className={checkboxCls} checked={form.makeDefault} onChange={(e) => setForm({ ...form, makeDefault: e.target.checked })} /> {t("settings.form.makeDefault")}</label>
-					</div>
-					<p className="mt-1 text-[10px] text-[var(--inno-text-subtle)]">{t("settings.form.supportsImagesHint")}</p>
-					{formError ? <div className="mt-2 rounded bg-[var(--inno-danger-bg)] px-2 py-1 text-xs text-[var(--inno-danger)]">{formError}</div> : null}
-					{saveMessage ? <div className="mt-2 rounded bg-[var(--inno-success-bg)] px-2 py-1 text-xs text-[var(--inno-success)]">{saveMessage}</div> : null}
-					<button className="mt-3 rounded-md inno-primary-button px-3 py-1.5 text-xs text-white disabled:opacity-50" disabled={saving} onClick={() => void handleSave()}>
-						{saving ? t("settings.savingProvider") : t("settings.saveProvider")}
-					</button>
-				</div>
-			)}
 		</div>
 	);
 }
@@ -306,62 +185,92 @@ export function ModelsSettings({ settings }: { settings: InnoSettings }) {
 
 	const models = settings.availableModels ?? settings.configuredModels ?? [];
 
+	// Group models by provider, preserving first-seen order.
+	const groups = new Map<string, InnoModelInfo[]>();
+	for (const model of models) {
+		const list = groups.get(model.provider) ?? [];
+		list.push(model);
+		groups.set(model.provider, list);
+	}
+
 	return (
 		<SettingsSection title={t("settings.tabs.models")} description={t("settings.sections.models.desc", "配置模型提供商与默认模型")}>
 			<SettingsCard>
 				<h4 className="mb-3 text-sm font-medium text-[var(--inno-text)]">{t("settings.models")}</h4>
-				<div className="grid gap-2">
-					{models.map((model) => {
-						const key = modelKey(model);
-						const current = settings.defaultProvider === model.provider && settings.defaultModel === model.id;
-						const isEditing = editingModel === key;
-
-						if (isEditing) {
-							return (
-								<ModelEditForm
-									key={key}
-									model={model}
-									settings={settings}
-									onClose={() => setEditingModel(null)}
-								/>
-							);
-						}
-
+				<div className="grid gap-4">
+					{[...groups.entries()].map(([providerId, providerModels]) => {
+						const preset = findPreset(providerId);
 						return (
-							<div key={key} className={`group flex items-center justify-between rounded border p-3 ${current ? "border-[var(--inno-accent-soft)] bg-[var(--inno-accent-soft)]" : "border-[var(--inno-border)] bg-[var(--inno-surface)]"}`}>
-								<div className="min-w-0 flex-1">
-									<div className="text-sm font-medium text-[var(--inno-text)]">{model.name || model.id}</div>
-									<div className="text-xs text-[var(--inno-text-muted)]">{model.provider} · {formatTokens(model.contextWindow)} context · {formatTokens(model.maxTokens)} max</div>
-								</div>
-								<div className="flex items-center gap-1.5">
-									<button
-										className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] group-hover:opacity-100"
-										title={t("common.edit", "Edit")}
-										onClick={() => setEditingModel(key)}
-									>
-										<Pencil size={14} />
-									</button>
-									<button
-										className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)] group-hover:opacity-100"
-										title={t("common.delete", "Delete")}
-										onClick={() => {
-											if (window.confirm(t("settings.confirmDelete", { id: `${model.provider}/${model.id}` }) ?? "")) {
-												void settingsStore.deleteModel(model.provider, model.id);
-											}
-										}}
-									>
-										<Trash2 size={14} />
-									</button>
-									{!current && (
-										<button
-											className="rounded-md border border-[var(--inno-border)] px-2.5 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
-											disabled={isSavingModel}
-											onClick={() => void settingsStore.switchModel(model.provider, model.id)}
-										>
-											{t("settings.use")}
-										</button>
+							<div key={providerId}>
+								<div className="mb-1.5 flex items-center gap-2">
+									<ProviderIcon providerId={providerId} size={20} />
+									<span className="text-xs font-medium text-[var(--inno-text)]">{preset?.name ?? providerId}</span>
+									{preset?.docsUrl && (
+										<a className="text-[10px] text-[var(--inno-text-subtle)] hover:text-[var(--inno-accent)]" href={preset.docsUrl} target="_blank" rel="noreferrer">
+											{t("settings.wizard.docs", "文档")}
+										</a>
 									)}
-									{current && <span className="rounded-md bg-[var(--inno-accent-soft)] px-2.5 py-1 text-xs font-medium text-[var(--inno-accent)]">{t("settings.current")}</span>}
+								</div>
+								<div className="grid gap-2">
+									{providerModels.map((model) => {
+										const key = modelKey(model);
+										const current = settings.defaultProvider === model.provider && settings.defaultModel === model.id;
+										const isEditing = editingModel === key;
+
+										if (isEditing) {
+											return (
+												<ModelEditForm
+													key={key}
+													model={model}
+													settings={settings}
+													onClose={() => setEditingModel(null)}
+												/>
+											);
+										}
+
+										return (
+											<div key={key} className={`group flex items-center justify-between rounded border p-3 ${current ? "border-[var(--inno-accent-soft)] bg-[var(--inno-accent-soft)]" : "border-[var(--inno-border)] bg-[var(--inno-surface)]"}`}>
+												<div className="min-w-0 flex-1">
+													<div className="flex items-center gap-1.5 text-sm font-medium text-[var(--inno-text)]">
+														{model.name || model.id}
+														{model.reasoning && <span className="rounded bg-[var(--inno-surface-muted)] px-1 py-px text-[9px] font-normal text-[var(--inno-text-muted)]">{t("settings.form.reasoning")}</span>}
+														{model.input.includes("image") && <span className="rounded bg-[var(--inno-surface-muted)] px-1 py-px text-[9px] font-normal text-[var(--inno-text-muted)]">{t("settings.wizard.vision", "视觉")}</span>}
+													</div>
+													<div className="text-xs text-[var(--inno-text-muted)]">{formatTokens(model.contextWindow)} context · {formatTokens(model.maxTokens)} max</div>
+												</div>
+												<div className="flex items-center gap-1.5">
+													<button
+														className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] group-hover:opacity-100"
+														title={t("common.edit", "Edit")}
+														onClick={() => setEditingModel(key)}
+													>
+														<Pencil size={14} />
+													</button>
+													<button
+														className="flex h-7 w-7 items-center justify-center rounded text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)] group-hover:opacity-100"
+														title={t("common.delete", "Delete")}
+														onClick={() => {
+															if (window.confirm(t("settings.confirmDelete", { id: `${model.provider}/${model.id}` }) ?? "")) {
+																void settingsStore.deleteModel(model.provider, model.id);
+															}
+														}}
+													>
+														<Trash2 size={14} />
+													</button>
+													{!current && (
+														<button
+															className="rounded-md border border-[var(--inno-border)] px-2.5 py-1 text-xs text-[var(--inno-text-muted)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+															disabled={isSavingModel}
+															onClick={() => void settingsStore.switchModel(model.provider, model.id)}
+														>
+															{t("settings.use")}
+														</button>
+													)}
+													{current && <span className="rounded-md bg-[var(--inno-accent-soft)] px-2.5 py-1 text-xs font-medium text-[var(--inno-accent)]">{t("settings.current")}</span>}
+												</div>
+											</div>
+										);
+									})}
 								</div>
 							</div>
 						);
@@ -370,7 +279,7 @@ export function ModelsSettings({ settings }: { settings: InnoSettings }) {
 			</SettingsCard>
 
 			{/* New Provider — hidden in Simple Mode */}
-			{!simpleMode && <NewProviderForm />}
+			{!simpleMode && <AddProviderWizard providers={settings.providers} />}
 		</SettingsSection>
 	);
 }

--- a/apps/inno-agent/web/src/react/settings/model-metadata.ts
+++ b/apps/inno-agent/web/src/react/settings/model-metadata.ts
@@ -1,0 +1,76 @@
+/**
+ * Static model metadata rules used to auto-fill context window / max output
+ * tokens / capability flags when a user picks a model in the add-provider
+ * wizard. Provider `/models` endpoints only return ids, so we infer the rest
+ * from well-known model families. First matching rule wins; everything stays
+ * editable in the advanced section afterwards.
+ */
+
+export interface ModelMetadata {
+	contextWindow: number;
+	maxTokens: number;
+	reasoning: boolean;
+	supportsImages: boolean;
+}
+
+interface ModelMetaRule {
+	pattern: RegExp;
+	contextWindow: number;
+	maxTokens: number;
+	reasoning?: boolean;
+	supportsImages?: boolean;
+}
+
+const RULES: ModelMetaRule[] = [
+	// DeepSeek
+	{ pattern: /deepseek-reasoner/i, contextWindow: 128000, maxTokens: 8192, reasoning: true },
+	{ pattern: /deepseek/i, contextWindow: 128000, maxTokens: 8192 },
+	// Moonshot / Kimi
+	{ pattern: /kimi-k2/i, contextWindow: 262144, maxTokens: 16384 },
+	{ pattern: /moonshot-v1-8k/i, contextWindow: 8192, maxTokens: 8192 },
+	{ pattern: /moonshot-v1-32k/i, contextWindow: 32768, maxTokens: 8192 },
+	{ pattern: /moonshot-v1-128k/i, contextWindow: 131072, maxTokens: 8192 },
+	{ pattern: /kimi|moonshot/i, contextWindow: 131072, maxTokens: 8192 },
+	// MiniMax
+	{ pattern: /minimax-m2/i, contextWindow: 204800, maxTokens: 8192 },
+	{ pattern: /minimax/i, contextWindow: 1000000, maxTokens: 8192 },
+	// Volcengine Doubao
+	{ pattern: /doubao.*256k/i, contextWindow: 262144, maxTokens: 8192 },
+	{ pattern: /doubao.*128k/i, contextWindow: 131072, maxTokens: 8192 },
+	{ pattern: /doubao.*32k/i, contextWindow: 32768, maxTokens: 4096 },
+	{ pattern: /doubao-seed/i, contextWindow: 262144, maxTokens: 16384 },
+	{ pattern: /doubao/i, contextWindow: 131072, maxTokens: 8192 },
+	// Xiaomi MiMo
+	{ pattern: /mimo/i, contextWindow: 262144, maxTokens: 8192 },
+	// Alibaba Qwen
+	{ pattern: /qwq/i, contextWindow: 131072, maxTokens: 8192, reasoning: true },
+	{ pattern: /qwen[0-9.]*-?vl|-vl-/i, contextWindow: 131072, maxTokens: 8192, supportsImages: true },
+	{ pattern: /qwen3/i, contextWindow: 262144, maxTokens: 16384 },
+	{ pattern: /qwen-max/i, contextWindow: 32768, maxTokens: 8192 },
+	{ pattern: /qwen-plus/i, contextWindow: 131072, maxTokens: 8192 },
+	{ pattern: /qwen-turbo/i, contextWindow: 1000000, maxTokens: 8192 },
+	{ pattern: /qwen-long/i, contextWindow: 10000000, maxTokens: 8192 },
+	{ pattern: /qwen/i, contextWindow: 131072, maxTokens: 8192 },
+	// Common western families (for custom gateways)
+	{ pattern: /claude/i, contextWindow: 200000, maxTokens: 64000, supportsImages: true },
+	{ pattern: /gpt-5|gpt-4\.1|gpt-4o/i, contextWindow: 128000, maxTokens: 16384, supportsImages: true },
+	{ pattern: /gemini/i, contextWindow: 1000000, maxTokens: 65536, supportsImages: true },
+];
+
+export const DEFAULT_MODEL_METADATA: ModelMetadata = {
+	contextWindow: 128000,
+	maxTokens: 8192,
+	reasoning: false,
+	supportsImages: false,
+};
+
+export function inferModelMetadata(modelId: string): ModelMetadata {
+	const rule = RULES.find((r) => r.pattern.test(modelId));
+	if (!rule) return { ...DEFAULT_MODEL_METADATA };
+	return {
+		contextWindow: rule.contextWindow,
+		maxTokens: rule.maxTokens,
+		reasoning: rule.reasoning === true,
+		supportsImages: rule.supportsImages === true,
+	};
+}

--- a/apps/inno-agent/web/src/react/settings/provider-presets.ts
+++ b/apps/inno-agent/web/src/react/settings/provider-presets.ts
@@ -1,0 +1,115 @@
+/**
+ * Guided provider presets for the "add model" wizard, in the spirit of
+ * cc-switch's preset catalog. Each preset pre-fills the OpenAI-compatible
+ * endpoint, links to the console where the user gets an API key, and carries
+ * brand metadata (icon glyph + color) used across the settings UI.
+ */
+
+export interface ProviderPreset {
+	/** Default provider id written into config.json */
+	id: string;
+	/** Display name */
+	name: string;
+	/** One-line description shown on the picker card */
+	description: string;
+	/** Brand color used for the icon tile */
+	brandColor: string;
+	/** Short glyph rendered inside the icon tile (letter mark) */
+	glyph: string;
+	/** Pre-filled API base URL (OpenAI-compatible unless api says otherwise) */
+	baseUrl: string;
+	api: string;
+	/** Console page where the user creates/copies an API key */
+	consoleUrl: string;
+	/** API documentation page */
+	docsUrl: string;
+	/** Optional hint shown under the model field (e.g. endpoint-id note) */
+	modelHint?: string;
+}
+
+export const PROVIDER_PRESETS: ProviderPreset[] = [
+	{
+		id: "deepseek",
+		name: "DeepSeek",
+		description: "深度求索 · deepseek-chat / reasoner",
+		brandColor: "#4D6BFE",
+		glyph: "DS",
+		baseUrl: "https://api.deepseek.com/v1",
+		api: "openai-completions",
+		consoleUrl: "https://platform.deepseek.com/api_keys",
+		docsUrl: "https://api-docs.deepseek.com/zh-cn/",
+	},
+	{
+		id: "kimi",
+		name: "Kimi",
+		description: "月之暗面 · kimi-k2 系列",
+		brandColor: "#6366F1",
+		glyph: "K",
+		baseUrl: "https://api.moonshot.cn/v1",
+		api: "openai-completions",
+		consoleUrl: "https://platform.moonshot.cn/console/api-keys",
+		docsUrl: "https://platform.moonshot.cn/docs",
+	},
+	{
+		id: "minimax",
+		name: "MiniMax",
+		description: "MiniMax-M2 系列",
+		brandColor: "#FF6B6B",
+		glyph: "MM",
+		baseUrl: "https://api.minimaxi.com/v1",
+		api: "openai-completions",
+		consoleUrl: "https://platform.minimaxi.com/user-center/basic-information/interface-key",
+		docsUrl: "https://platform.minimaxi.com/document",
+	},
+	{
+		id: "volcengine",
+		name: "火山引擎",
+		description: "字节跳动 · 豆包 Doubao",
+		brandColor: "#F5582E",
+		glyph: "火",
+		baseUrl: "https://ark.cn-beijing.volces.com/api/v3",
+		api: "openai-completions",
+		consoleUrl: "https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey",
+		docsUrl: "https://www.volcengine.com/docs/82379",
+		modelHint: "模型 ID 填推理接入点 ID（ep-xxx）或模型名称",
+	},
+	{
+		id: "xiaomimimo",
+		name: "小米 MiMo",
+		description: "小米 · mimo 系列",
+		brandColor: "#FF6900",
+		glyph: "Mi",
+		baseUrl: "https://api.xiaomimimo.com/v1",
+		api: "openai-completions",
+		consoleUrl: "https://platform.xiaomimimo.com",
+		docsUrl: "https://platform.xiaomimimo.com",
+	},
+	{
+		id: "bailian",
+		name: "阿里百炼",
+		description: "阿里云 · 通义千问 Qwen",
+		brandColor: "#624AFF",
+		glyph: "百",
+		baseUrl: "https://dashscope.aliyuncs.com/compatible-mode/v1",
+		api: "openai-completions",
+		consoleUrl: "https://bailian.console.aliyun.com/#/api-key",
+		docsUrl: "https://help.aliyun.com/zh/model-studio/",
+	},
+	{
+		id: "custom",
+		name: "自定义",
+		description: "任意 OpenAI / Anthropic 兼容端点",
+		brandColor: "#8A8F98",
+		glyph: "+",
+		baseUrl: "",
+		api: "openai-completions",
+		consoleUrl: "",
+		docsUrl: "",
+	},
+];
+
+/** Look up a preset by provider id (used to brand existing providers). */
+export function findPreset(providerId: string): ProviderPreset | undefined {
+	const lower = providerId.toLowerCase();
+	return PROVIDER_PRESETS.find((p) => p.id !== "custom" && (p.id === lower || lower.includes(p.id)));
+}


### PR DESCRIPTION
## Summary

Redesigns **Settings → Models → Add provider** into a cc-switch-style guided flow.

- **Preset picker**: DeepSeek, Kimi (Moonshot), MiniMax, Volcengine (Doubao), Xiaomi MiMo, Alibaba Bailian, and custom — each with a brand icon, pre-filled OpenAI-compatible base URL, and links to the console (get API key) and docs
- **Model auto-fetch**: new `POST /api/settings/providers/probe-models` endpoint proxies the provider's `GET /models` server-side (avoids CORS, keeps keys off the browser); falls back to the stored key when the field is left blank, with graded Chinese error messages (401/403, 404 → manual entry, network)
- **Parameter auto-fill**: picking a model infers context window / max tokens / reasoning / vision from a built-in metadata table (deepseek, kimi-k2, moonshot, MiniMax-M2, doubao, mimo, qwen families + claude/gpt/gemini)
- **Form cleanup**: rarely used params (provider id, API type, base URL, token limits, authHeader, bypassProxy) move into a collapsible "advanced options" section; the `preserveApiKey` checkbox is gone — an empty key field now always means "keep stored key"
- **Model list**: grouped by provider with brand icons and reasoning/vision badges
- i18n strings for zh-CN and en

## Bug fix included

Editing a model previously submitted only that model to `upsertProvider`, which replaces the provider's entire model list — silently deleting its other models. Both the edit form and the wizard now merge with existing models and put the target model first so `makeDefault` (which takes `models[0]`) points at the right model.

## Verification

- `npm run build` passes (backend tsc + web tsc & vite)
- probe helper smoke-tested against a local mock (success, URL normalization, 401, 404)
- route verified end-to-end against the real DeepSeek endpoint (invalid key → 401 with localized message)