### PR TITLE
fix(web): keep pi-web-ui chunk out of the entry module graph

### DIFF
--- a/apps/inno-agent/web/vite.config.ts
+++ b/apps/inno-agent/web/vite.config.ts
@@ -227,6 +227,13 @@ export default defineConfig({
 		},
 		rollupOptions: {
 			output: {
+				// Only assign modules that explicitly match manualChunks below.
+				// Without this, Rollup merges each matched module's whole dependency
+				// subtree into the manual chunk — which dragged mini-lit's
+				// MarkdownBlock.js (statically imported by main.tsx for QuestionDialog)
+				// into the pi-web-ui chunk, making that 2MB chunk a static dependency
+				// of the entry and defeating the lazy loading entirely.
+				onlyExplicitManualChunks: true,
 				manualChunks(id) {
 					if (id.includes("vite/preload-helper")) {
 						return "vite-preload-helper";
@@ -248,10 +255,16 @@ export default defineConfig({
 					) {
 						return "markdown-editor";
 					}
+					// NOTE: @mariozechner/mini-lit is deliberately NOT assigned here.
+					// main.tsx statically imports mini-lit/dist/MarkdownBlock.js (needed by
+					// QuestionDialog), so forcing all of mini-lit into the pi-web-ui chunk
+					// would make that chunk a static dependency of the entry and defeat the
+					// lazy loading of pi-web-ui (and its katex/docx-preview/xlsx deps).
+					// Leaving mini-lit unassigned lets Rollup put only MarkdownBlock's
+					// closure into the entry graph; the rest stays inside the lazy chunk.
 					if (
 						id.includes("/node_modules/@earendil-works/pi-web-ui/") ||
-						id.includes("/node_modules/@juicesharp/") ||
-						id.includes("/node_modules/@mariozechner/mini-lit/")
+						id.includes("/node_modules/@juicesharp/")
 					) {
 						return "pi-web-ui";
 					}


### PR DESCRIPTION
## Problem

Follow-up to #116. Verification of that PR showed the lazy loading was silently defeated: the 2.1MB `pi-web-ui` chunk (plus its static `katex`/`docx-preview`/`xlsx` deps) was still fetched on first load.

**Root cause:** Rollup's `manualChunks` merges each matched module's *entire dependency subtree* into the manual chunk by default. Since pi-web-ui depends on mini-lit, `MarkdownBlock.js` — statically imported by `main.tsx` to register `<markdown-block>` for QuestionDialog — was dragged into the `pi-web-ui` chunk. That made the chunk a static dependency of the entry, pulling ~830KB (gzip) back into the first load. Confirmed by bisect (commenting out the `main.tsx` import removes the static imports) and by headless-Chromium netlog capture.

## Fix

- Enable `output.onlyExplicitManualChunks` so only explicitly matched modules are assigned to manual chunks (no dependency-subtree merging).
- Stop assigning `@mariozechner/mini-lit` to the `pi-web-ui` chunk — with `onlyExplicitManualChunks` this would re-introduce the same problem.

Both changes are required; either alone is insufficient.

## First-load transfer (gzip)

| | before #116 | #116 alone | this PR |
|---|---|---|---|
| first load JS+CSS | ~2.05 MB | ~1.07 MB | **~0.33 MB** |

Measured via headless Chromium netlog on the welcome screen. pi-web-ui / PromptDialog / codemirror / markdown-editor / cytoscape / docx-preview / xlsx now all load on demand. katex (78KB gz) stays on the critical path because `MarkdownBlock.js` genuinely imports it.

## Verification

- Headless Chromium netlog: first load fetches only `index + react-vendor + katex + preload-helper + CSS`; app boots and issues `/api/sessions` etc.
- `npx vitest run`: 73/73 passed.
- gzip/brotli precompression artifacts regenerated and served correctly.