### PR TITLE
fix(chat): keep stick-to-bottom engaged during streaming

### DIFF
--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -275,6 +275,10 @@ inno-workspace-panel textarea {
 .chat-scroll {
 	scrollbar-width: thin;
 	scrollbar-color: var(--inno-scrollbar-thumb) transparent;
+	/* Stick-to-bottom is managed explicitly by the ResizeObserver in
+	   ChatCenter. Browser scroll anchoring would otherwise shift scrollTop
+	   during streaming markdown re-renders and fight that pinning. */
+	overflow-anchor: none;
 }
 
 .chat-scroll::-webkit-scrollbar,

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -607,7 +607,6 @@ export function ChatCenter() {
 	const imageInputRef = useRef<HTMLInputElement | null>(null);
 	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const shouldStickToBottomRef = useRef(true);
-	const lastProgrammaticPinTopRef = useRef<number | null>(null);
 	const [uploads, setUploads] = useState<PendingUpload[]>([]);
 	const [isUploading, setIsUploading] = useState(false);
 	const [inlineImages, setInlineImages] = useState<(InlineImage & { name: string; previewUrl: string })[]>([]);
@@ -773,6 +772,14 @@ export function ChatCenter() {
 	// between flushes left the view behind; combined with transient height
 	// shrink during re-parses, the pinned scrollTop got clamped and the view
 	// jumped back up towards the question.)
+	//
+	// The sticky flag is updated ONLY in response to genuine user gestures
+	// (wheel / touch / scrollbar drag / keyboard). Scroll-position changes also
+	// come from our own pins, from browser clamping after transient content
+	// shrink, and from CSS scroll anchoring during markdown re-renders — all of
+	// which fire scroll events whose distance-from-bottom says nothing about
+	// user intent. Treating those as "user scrolled away" wrongly disengaged
+	// sticking, and the view ended up back near the question at turn end.
 	useEffect(() => {
 		const el = scrollRef.current;
 		const content = el?.querySelector<HTMLElement>("[data-conversation-content]");
@@ -780,9 +787,6 @@ export function ChatCenter() {
 		const observer = new ResizeObserver(() => {
 			if (!shouldStickToBottomRef.current) return;
 			el.scrollTop = el.scrollHeight;
-			// Record the position we pinned to (read back after clamping) so the
-			// scroll handler can recognise this pin's echo event.
-			lastProgrammaticPinTopRef.current = el.scrollTop;
 		});
 		observer.observe(content);
 		return () => observer.disconnect();
@@ -790,22 +794,38 @@ export function ChatCenter() {
 
 	useEffect(() => {
 		shouldStickToBottomRef.current = true;
-		lastProgrammaticPinTopRef.current = null;
 	}, [sessions.currentSessionId]);
+
+	const userScrollGestureRef = useRef(false);
+	const markUserScrollGesture = useCallback(() => {
+		userScrollGestureRef.current = true;
+	}, []);
+	// Only presses on the scrollbar track (right edge) count as scroll gestures —
+	// plain content clicks (text selection, links, buttons) must not, or the next
+	// programmatic/anchoring scroll event would be mistaken for user intent.
+	const handleScrollerPointerDown = useCallback((event: React.PointerEvent<HTMLDivElement>) => {
+		const el = scrollRef.current;
+		if (!el) return;
+		if (event.clientX >= el.getBoundingClientRect().right - 24) markUserScrollGesture();
+	}, [markUserScrollGesture]);
 
 	const handleChatScroll = useCallback(() => {
 		const el = scrollRef.current;
 		if (!el) return;
-		// Scroll events are dispatched asynchronously, so the echo of our own
-		// stick-to-bottom pin can fire *after* the next streaming flush has
-		// already grown scrollHeight. Reading the distance-from-bottom at that
-		// point sees the stale pinned scrollTop against the new scrollHeight and
-		// wrongly clears the sticky flag — the view then stops following the
-		// stream and ends up back near the question. A scroll position that is
-		// exactly where our last pin put it is such an echo, not a user scroll.
-		if (lastProgrammaticPinTopRef.current !== null && el.scrollTop === lastProgrammaticPinTopRef.current) return;
-		shouldStickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 96;
-		if (!shouldStickToBottomRef.current) lastProgrammaticPinTopRef.current = null;
+		const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+		// Reaching the bottom always re-engages sticking, no matter how the
+		// scroll was initiated (user gesture, smooth-scroll button, or a pin).
+		if (distanceFromBottom < 96) {
+			shouldStickToBottomRef.current = true;
+			userScrollGestureRef.current = false;
+			return;
+		}
+		// Away from the bottom: only a real user gesture may disengage sticking.
+		// Echoes of programmatic pins, clamping, and scroll-anchoring shifts are
+		// ignored — see the comment above the observer.
+		if (!userScrollGestureRef.current) return;
+		userScrollGestureRef.current = false;
+		shouldStickToBottomRef.current = false;
 	}, []);
 
 	const pauseAutoScroll = useCallback(() => {
@@ -1304,6 +1324,9 @@ export function ChatCenter() {
 				<div
 					ref={scrollRef}
 					onScroll={handleChatScroll}
+					onWheel={markUserScrollGesture}
+					onTouchStart={markUserScrollGesture}
+					onPointerDown={handleScrollerPointerDown}
 					className="chat-scroll inno-chat-grid h-full min-h-0 overflow-y-auto px-4 py-4"
 				>
 					<div data-conversation-content className="mx-auto flex min-w-0 max-w-3xl flex-col gap-3">

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -381,6 +381,32 @@ function StreamingBubbles() {
 	const normalized = useMemo(() => normalizeMarkdownMath(stream.text), [stream.text]);
 	const { blocks, tail } = useMemo(() => splitStreamingMarkdown(normalized), [normalized]);
 
+	// Shrink guard: while a reply streams, the tail <markdown-artifact> re-parses
+	// on every flush — code fences open and close as characters arrive, tables
+	// snap into being when their separator row lands — and its height briefly
+	// shrinks before settling taller. The stick-to-bottom pin faithfully
+	// amplifies each transient shrink into a visible yank. Hold the bubble at
+	// the tallest height seen so far (via min-height) so re-parse shrinks are
+	// absorbed as blank space inside the bubble instead of moving the layout.
+	// The callback ref re-arms per bubble mount, so each turn starts fresh.
+	const heightWatermarkRef = useRef(0);
+	const bubbleObserverRef = useRef<ResizeObserver | null>(null);
+	const streamingBubbleRef = useCallback((el: HTMLDivElement | null) => {
+		bubbleObserverRef.current?.disconnect();
+		bubbleObserverRef.current = null;
+		if (!el) return;
+		heightWatermarkRef.current = 0;
+		el.style.minHeight = "";
+		const observer = new ResizeObserver(() => {
+			const height = el.offsetHeight;
+			if (height > heightWatermarkRef.current) heightWatermarkRef.current = height;
+			const minHeight = `${heightWatermarkRef.current}px`;
+			if (el.style.minHeight !== minHeight) el.style.minHeight = minHeight;
+		});
+		observer.observe(el);
+		bubbleObserverRef.current = observer;
+	}, []);
+
 	return (
 		<>
 			{stream.thinking ? (
@@ -418,7 +444,7 @@ function StreamingBubbles() {
 					animate={{ opacity: 1, y: 0 }}
 					transition={{ duration: 0.2, ease: "easeOut" }}
 				>
-					<div className="inno-message inno-streaming-blocks max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
+					<div ref={streamingBubbleRef} className="inno-message inno-streaming-blocks max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
 						{blocks.map((block, index) => (
 							<StableStreamingMarkdown key={index} content={block} />
 						))}

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -607,6 +607,7 @@ export function ChatCenter() {
 	const imageInputRef = useRef<HTMLInputElement | null>(null);
 	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const shouldStickToBottomRef = useRef(true);
+	const lastProgrammaticPinTopRef = useRef<number | null>(null);
 	const [uploads, setUploads] = useState<PendingUpload[]>([]);
 	const [isUploading, setIsUploading] = useState(false);
 	const [inlineImages, setInlineImages] = useState<(InlineImage & { name: string; previewUrl: string })[]>([]);
@@ -777,7 +778,11 @@ export function ChatCenter() {
 		const content = el?.querySelector<HTMLElement>("[data-conversation-content]");
 		if (!el || !content) return;
 		const observer = new ResizeObserver(() => {
-			if (shouldStickToBottomRef.current) el.scrollTop = el.scrollHeight;
+			if (!shouldStickToBottomRef.current) return;
+			el.scrollTop = el.scrollHeight;
+			// Record the position we pinned to (read back after clamping) so the
+			// scroll handler can recognise this pin's echo event.
+			lastProgrammaticPinTopRef.current = el.scrollTop;
 		});
 		observer.observe(content);
 		return () => observer.disconnect();
@@ -785,12 +790,22 @@ export function ChatCenter() {
 
 	useEffect(() => {
 		shouldStickToBottomRef.current = true;
+		lastProgrammaticPinTopRef.current = null;
 	}, [sessions.currentSessionId]);
 
 	const handleChatScroll = useCallback(() => {
 		const el = scrollRef.current;
 		if (!el) return;
+		// Scroll events are dispatched asynchronously, so the echo of our own
+		// stick-to-bottom pin can fire *after* the next streaming flush has
+		// already grown scrollHeight. Reading the distance-from-bottom at that
+		// point sees the stale pinned scrollTop against the new scrollHeight and
+		// wrongly clears the sticky flag — the view then stops following the
+		// stream and ends up back near the question. A scroll position that is
+		// exactly where our last pin put it is such an echo, not a user scroll.
+		if (lastProgrammaticPinTopRef.current !== null && el.scrollTop === lastProgrammaticPinTopRef.current) return;
 		shouldStickToBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 96;
+		if (!shouldStickToBottomRef.current) lastProgrammaticPinTopRef.current = null;
 	}, []);
 
 	const pauseAutoScroll = useCallback(() => {


### PR DESCRIPTION
## Problem

Two related streaming-scroll issues on current main:

1. **Turn ends near the user's question instead of the bottom.** The stick-to-bottom flag was updated from *every* scroll event by measuring distance-from-bottom — but scroll positions also change without user intent (echoes of the ResizeObserver's own pins, browser clamping after transient content shrink, CSS scroll anchoring). Any of these landing while >96px from the bottom wrongly disengaged pinning.

2. **Page jitter while streaming code/text fragments.** The tail `<markdown-artifact>` re-parses on every flush (code fences open/close as characters arrive, tables snap into existence), briefly shrinking before settling taller. The pin amplified each transient shrink into a visible yank.

(Note: on builds before 2026-08-03 the same "jump back to question" symptom was the already-fixed cf90425 issue, still unreleased.)

## Fix

**Gesture-driven sticky flag** (`ChatCenter.tsx`):
- `wheel` / `touchstart` on the scroller and pointer presses on the scrollbar track (right edge — plain content clicks excluded) mark a scroll gesture; only then may a scroll event away from the bottom disengage sticking
- reaching the bottom always re-engages sticking, however the scroll was initiated
- sending a message re-engages sticking (existing behavior)
- `overflow-anchor: none` on the chat scroller so scroll anchoring stops fighting the pinning

**Height watermark for the streaming bubble** (`ChatCenter.tsx`):
- a ResizeObserver tracks the tallest height the streaming bubble has reached and holds it via `min-height` (re-armed per bubble mount), so re-parse shrinks are absorbed as blank space inside the bubble instead of moving the layout

## Verification (CDP-driven Chromium)

- Normal turn → ends pinned at bottom ✓
- Real wheel-up mid-stream → disengages, view stays put ✓
- Next send → re-engages, ends at bottom ✓
- rAF-level jitter sampling over a code+table-heavy stream: bubble height drops 1 → 0, mid-stream scrollTop drops eliminated ✓
- `npm --workspace inno-agent-web run build` ✓, `npx vitest run` 73/73 ✓

Known remaining minor item: a single ~150px drop at the completion swap (streaming bubble unmounts before the canonical message's artifact finishes its first render) — left for a follow-up if it proves noticeable.