### PR TITLE
fix(web): preserve answered questionnaires in place

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1839,6 +1839,7 @@ interface SessionMessageSummary {
 		toolCallId: string;
 		toolName: string;
 		args: unknown;
+		contentOffset?: number;
 		result?: unknown;
 		isError?: boolean;
 	}>;
@@ -2080,7 +2081,12 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 							const toolName = typeof block.name === "string" ? block.name : "tool";
 							const args = block.arguments;
 							pending.tools = pending.tools ?? [];
-							pending.tools.push({ toolCallId, toolName, args });
+							pending.tools.push({
+								toolCallId,
+								toolName,
+								args,
+								contentOffset: pending.content.length,
+							});
 						}
 					}
 				} else if (typeof content === "string" && content) {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -2098,7 +2098,12 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 				const pending = ensureAssistant(ts);
 				const toolCallId = typeof message.toolCallId === "string" ? message.toolCallId : "";
 				const toolName = typeof message.toolName === "string" ? message.toolName : "tool";
-				const result = textFromContent(message.content) || message.content;
+				// PI keeps a tool's structured details alongside its text content. Keep
+				// those details in session history so completed questionnaires can be
+				// rendered with the selected options after the session is reopened.
+				const result = toolName === "ask_user_question" && message.details !== undefined
+					? message.details
+					: textFromContent(message.content) || message.content;
 				const isError = Boolean(message.isError);
 				pending.tools = pending.tools ?? [];
 				const existing = pending.tools.find((t) => t.toolCallId === toolCallId);

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -609,7 +609,8 @@
 		"chatAboutThis": "Chat about this",
 		"submit": "Submit",
 		"submitNext": "Next",
-		"optionSelectedHint": "Option selected; deselect to enter custom text"
+		"optionSelectedHint": "Option selected; deselect to enter custom text",
+		"answered": "Selected"
 	},
 	"sidebar": {
 		"expand": "Expand",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -609,7 +609,8 @@
 		"chatAboutThis": "直接聊聊",
 		"submit": "提交",
 		"submitNext": "下一题",
-		"optionSelectedHint": "已选择选项，如需自定义请先取消选择"
+		"optionSelectedHint": "已选择选项，如需自定义请先取消选择",
+		"answered": "已选择"
 	},
 	"sidebar": {
 		"expand": "展开",

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -21,8 +21,9 @@ import { uploadWorkspaceFiles } from "../api/workspace.js";
 import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 import { splitStreamingMarkdown } from "../utils/markdown-blocks.js";
 import { groupByCategory, matchesQuery } from "../utils/category-grouping.js";
+import { answeredQuestionnaireFromTool } from "../utils/questionnaire.js";
 import { useStoreSnapshot } from "./hooks.js";
-import { QuestionDialog } from "./QuestionDialog.js";
+import { AnsweredQuestionCard, QuestionDialog } from "./QuestionDialog.js";
 import { buildConversationTurns, ConversationMinimap } from "./ConversationMinimap.js";
 import { MarkdownArtifact } from "./MarkdownArtifact.js";
 
@@ -277,6 +278,12 @@ function ToolRecordDetails({ tool, className }: { tool: ChatToolRecord; classNam
 
 const MessageBubble = memo(function MessageBubble({ message, showChannel }: { message: ChatMessage; showChannel?: boolean }) {
 	const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+	const toolViews = (message.tools ?? []).map((tool) => ({
+		tool,
+		questionnaire: answeredQuestionnaireFromTool(tool),
+	}));
+	const answeredQuestionnaires = toolViews.filter((item) => item.questionnaire !== null);
+	const regularTools = toolViews.filter((item) => item.questionnaire === null).map((item) => item.tool);
 
 	if (message.role === "user") {
 		return (
@@ -321,21 +328,28 @@ const MessageBubble = memo(function MessageBubble({ message, showChannel }: { me
 				{showChannel && message.channel ? (
 					<div className="mb-1"><ChannelBadge channel={message.channel} /></div>
 				) : null}
-				{message.thinking || message.tools?.length ? (
+				{message.thinking || regularTools.length ? (
 					<details className="mb-2 min-w-0 max-w-full overflow-hidden rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1.5 text-xs text-[var(--inno-text-muted)]">
 						<summary className="cursor-pointer select-none break-words font-medium text-[var(--inno-text-muted)] [overflow-wrap:anywhere]">
 							Thinking & tool calls
-							{message.tools?.length ? ` · ${message.tools.length}` : ""}
+							{regularTools.length ? ` · ${regularTools.length}` : ""}
 						</summary>
 						{message.thinking ? <pre className="mt-2 max-h-44 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono [overflow-wrap:anywhere]">{message.thinking}</pre> : null}
-						{message.tools?.length ? (
+						{regularTools.length ? (
 							<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
-								{message.tools.map((tool) => (
+								{regularTools.map((tool) => (
 									<ToolRecordDetails key={tool.toolCallId} tool={tool} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1" />
 								))}
 							</div>
 						) : null}
 					</details>
+				) : null}
+				{answeredQuestionnaires.length ? (
+					<div className="mb-2 space-y-2">
+						{answeredQuestionnaires.map(({ tool, questionnaire }) => (
+							<AnsweredQuestionCard key={tool.toolCallId} questionnaire={questionnaire!} />
+						))}
+					</div>
 				) : null}
 				<AssistantContent content={message.content} />
 				{message.error ? (
@@ -347,6 +361,45 @@ const MessageBubble = memo(function MessageBubble({ message, showChannel }: { me
 		</motion.div>
 	);
 });
+
+function CompletedToolRecords({ tools }: { tools: ChatToolRecord[] }) {
+	const views = tools.map((tool) => ({ tool, questionnaire: answeredQuestionnaireFromTool(tool) }));
+	const questionnaires = views.filter((item) => item.questionnaire !== null);
+	const regularTools = views.filter((item) => item.questionnaire === null).map((item) => item.tool);
+
+	return (
+		<>
+			{questionnaires.map(({ tool, questionnaire }) => (
+				<motion.div
+					key={tool.toolCallId}
+					className="flex max-w-[76%] justify-start"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					transition={{ duration: 0.2 }}
+				>
+					<AnsweredQuestionCard questionnaire={questionnaire!} />
+				</motion.div>
+			))}
+			{regularTools.length ? (
+				<motion.div
+					className="flex justify-start"
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					transition={{ duration: 0.2 }}
+				>
+					<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
+						<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Completed tool calls · {regularTools.length}</summary>
+						<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
+							{regularTools.map((tool) => (
+								<ToolRecordDetails key={tool.toolCallId} tool={tool} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1" />
+							))}
+						</div>
+					</details>
+				</motion.div>
+			) : null}
+		</>
+	);
+}
 
 /**
  * Memoized artifact for one closed block of a streaming reply. Closed blocks
@@ -1427,23 +1480,7 @@ export function ChatCenter() {
 						</motion.div>
 					) : null}
 
-					{chat.completedTools.length > 0 ? (
-						<motion.div
-							className="flex justify-start"
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							transition={{ duration: 0.2 }}
-						>
-							<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
-								<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Completed tool calls · {chat.completedTools.length}</summary>
-								<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
-									{chat.completedTools.map((tool) => (
-										<ToolRecordDetails key={tool.toolCallId} tool={tool} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1" />
-									))}
-								</div>
-							</details>
-						</motion.div>
-					) : null}
+					{chat.completedTools.length > 0 ? <CompletedToolRecords tools={chat.completedTools} /> : null}
 
 					{/* Thinking + reply text bubbles — own store subscription, see above */}
 					<StreamingBubbles />

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
@@ -21,7 +21,8 @@ import { uploadWorkspaceFiles } from "../api/workspace.js";
 import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 import { splitStreamingMarkdown } from "../utils/markdown-blocks.js";
 import { groupByCategory, matchesQuery } from "../utils/category-grouping.js";
-import { answeredQuestionnaireFromTool } from "../utils/questionnaire.js";
+import { answeredQuestionnaireFromTool, buildAnsweredQuestionnaireTimeline } from "../utils/questionnaire.js";
+import type { AnsweredQuestionnaireView } from "../utils/questionnaire.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { AnsweredQuestionCard, QuestionDialog } from "./QuestionDialog.js";
 import { buildConversationTurns, ConversationMinimap } from "./ConversationMinimap.js";
@@ -254,6 +255,27 @@ function AssistantContent({ content }: { content: string }) {
 	);
 }
 
+/** Keep a completed questionnaire anchored where its tool call interrupted the
+ * assistant text. Session history merges the text before and after a tool call
+ * into one message, so rendering every tool above the message moves the card
+ * away from the point at which the learner originally answered it. */
+function AssistantTimelineContent({ content, questionnaires }: { content: string; questionnaires: AnsweredQuestionnaireView[] }) {
+	const timeline = buildAnsweredQuestionnaireTimeline(content, questionnaires);
+	return (
+		<>
+			{timeline.entries.map(({ tool, questionnaire, before }) => (
+				<Fragment key={tool.toolCallId}>
+					<AssistantContent content={before} />
+					<div className="my-2">
+						<AnsweredQuestionCard questionnaire={questionnaire} />
+					</div>
+				</Fragment>
+			))}
+			<AssistantContent content={timeline.tail} />
+		</>
+	);
+}
+
 function ToolRecordDetails({ tool, className }: { tool: ChatToolRecord; className: string }) {
 	const [open, setOpen] = useState(false);
 	const detail = useMemo(() => {
@@ -344,14 +366,10 @@ const MessageBubble = memo(function MessageBubble({ message, showChannel }: { me
 						) : null}
 					</details>
 				) : null}
-				{answeredQuestionnaires.length ? (
-					<div className="mb-2 space-y-2">
-						{answeredQuestionnaires.map(({ tool, questionnaire }) => (
-							<AnsweredQuestionCard key={tool.toolCallId} questionnaire={questionnaire!} />
-						))}
-					</div>
-				) : null}
-				<AssistantContent content={message.content} />
+				<AssistantTimelineContent
+					content={message.content}
+					questionnaires={answeredQuestionnaires as AnsweredQuestionnaireView[]}
+				/>
 				{message.error ? (
 					<div className={message.content.trim() ? "mt-2" : ""}>
 						<ErrorBlock error={message.error} />
@@ -364,23 +382,9 @@ const MessageBubble = memo(function MessageBubble({ message, showChannel }: { me
 
 function CompletedToolRecords({ tools }: { tools: ChatToolRecord[] }) {
 	const views = tools.map((tool) => ({ tool, questionnaire: answeredQuestionnaireFromTool(tool) }));
-	const questionnaires = views.filter((item) => item.questionnaire !== null);
 	const regularTools = views.filter((item) => item.questionnaire === null).map((item) => item.tool);
 
-	return (
-		<>
-			{questionnaires.map(({ tool, questionnaire }) => (
-				<motion.div
-					key={tool.toolCallId}
-					className="flex max-w-[76%] justify-start"
-					initial={{ opacity: 0 }}
-					animate={{ opacity: 1 }}
-					transition={{ duration: 0.2 }}
-				>
-					<AnsweredQuestionCard questionnaire={questionnaire!} />
-				</motion.div>
-			))}
-			{regularTools.length ? (
+	return regularTools.length ? (
 				<motion.div
 					className="flex justify-start"
 					initial={{ opacity: 0 }}
@@ -396,9 +400,7 @@ function CompletedToolRecords({ tools }: { tools: ChatToolRecord[] }) {
 						</div>
 					</details>
 				</motion.div>
-			) : null}
-		</>
-	);
+	) : null;
 }
 
 /**
@@ -429,9 +431,18 @@ function StreamingBubbles() {
 		hasError: chatStore.streamingError !== "",
 		hasPendingQuestion: chatStore.pendingQuestion !== null,
 		activeToolCount: chatStore.activeTools.length,
+		completedTools: chatStore.completedTools,
 	}));
 
-	const normalized = useMemo(() => normalizeMarkdownMath(stream.text), [stream.text]);
+	const questionnaires = useMemo(() => stream.completedTools.flatMap((tool): AnsweredQuestionnaireView[] => {
+		const questionnaire = answeredQuestionnaireFromTool(tool);
+		return questionnaire ? [{ tool, questionnaire }] : [];
+	}), [stream.completedTools]);
+	const timeline = useMemo(
+		() => buildAnsweredQuestionnaireTimeline(stream.text, questionnaires),
+		[stream.text, questionnaires],
+	);
+	const normalized = useMemo(() => normalizeMarkdownMath(timeline.tail), [timeline.tail]);
 	const { blocks, tail } = useMemo(() => splitStreamingMarkdown(normalized), [normalized]);
 
 	// Shrink guard: while a reply streams, the tail <markdown-artifact> re-parses
@@ -490,7 +501,7 @@ function StreamingBubbles() {
 						</div>
 					</div>
 				</motion.div>
-			) : stream.text ? (
+			) : stream.text || questionnaires.length ? (
 				<motion.div
 					className="flex justify-start"
 					initial={{ opacity: 0, y: 8 }}
@@ -498,6 +509,14 @@ function StreamingBubbles() {
 					transition={{ duration: 0.2, ease: "easeOut" }}
 				>
 					<div ref={streamingBubbleRef} className="inno-message inno-streaming-blocks max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
+						{timeline.entries.map(({ tool, questionnaire, before }) => (
+							<Fragment key={tool.toolCallId}>
+								{before.trim() ? <StableStreamingMarkdown content={normalizeMarkdownMath(before.trim())} /> : null}
+								<div className="my-2">
+									<AnsweredQuestionCard questionnaire={questionnaire} />
+								</div>
+							</Fragment>
+						))}
 						{blocks.map((block, index) => (
 							<StableStreamingMarkdown key={index} content={block} />
 						))}
@@ -509,7 +528,7 @@ function StreamingBubbles() {
 				</motion.div>
 			) : null}
 
-			{stream.isSending && !stream.hasPendingQuestion && !stream.text && !stream.hasError && stream.activeToolCount === 0 ? (
+			{stream.isSending && !stream.hasPendingQuestion && !stream.text && questionnaires.length === 0 && !stream.hasError && stream.activeToolCount === 0 ? (
 				<motion.div
 					className="flex justify-start"
 					initial={{ opacity: 0 }}

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { motion } from "motion/react";
 import type { PendingQuestion, QuestionAnswer, QuestionData, QuestionnaireResult } from "../types/chat.js";
+import type { AnsweredQuestionnaire } from "../utils/questionnaire.js";
 import { chatStore } from "../stores/chat-store.js";
 import { normalizeMarkdownMath } from "../utils/markdown-math.js";
 
@@ -12,21 +13,25 @@ function OptionRow({
 	multi,
 	onSelect,
 	onFocus,
+	readOnly = false,
 }: {
 	label: string;
 	description: string;
 	selected: boolean;
 	multi: boolean;
-	onSelect: () => void;
-	onFocus: () => void;
+	onSelect?: () => void;
+	onFocus?: () => void;
+	readOnly?: boolean;
 }) {
 	return (
 		<button
+			aria-pressed={selected}
 			className={`flex w-full items-start gap-2.5 rounded-md border px-3 py-2 text-left text-[13px] transition-colors ${
 				selected
 					? "border-[var(--inno-accent)] bg-[var(--inno-accent-soft)] text-[var(--inno-text)]"
-					: "border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text)] hover:border-[var(--inno-border-strong)] hover:bg-[var(--inno-surface-muted)]"
+					: `border-[var(--inno-border)] bg-[var(--inno-surface)] text-[var(--inno-text)] ${readOnly ? "opacity-60" : "hover:border-[var(--inno-border-strong)] hover:bg-[var(--inno-surface-muted)]"}`
 			}`}
+			disabled={readOnly}
 			onClick={onSelect}
 			onMouseEnter={onFocus}
 		>
@@ -40,6 +45,51 @@ function OptionRow({
 				{description ? <markdown-block className="mt-0.5 text-xs text-[var(--inno-text-muted)]" content={normalizeMarkdownMath(description)} /> : null}
 			</span>
 		</button>
+	);
+}
+
+/** Read-only counterpart to the pending questionnaire. It deliberately keeps
+ * the original options visible so the selected state remains part of the
+ * conversation instead of disappearing into generic tool-call details. */
+export function AnsweredQuestionCard({ questionnaire }: { questionnaire: AnsweredQuestionnaire }) {
+	const { t } = useTranslation();
+
+	return (
+		<div className="w-full rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-surface)] px-4 py-3 shadow-sm">
+			<div className="mb-3 text-xs font-medium text-[var(--inno-accent)]">{t("question.answered")}</div>
+			<div className="space-y-4">
+				{questionnaire.questions.map((question, questionIndex) => {
+					const answer = questionnaire.result.answers.find((item) => item.questionIndex === questionIndex);
+					if (!answer) return null;
+					const selectedLabels = new Set(answer.selected ?? (answer.kind === "option" && answer.answer ? [answer.answer] : []));
+					return (
+						<div key={`${question.question}-${questionIndex}`} className="space-y-2">
+							{questionnaire.questions.length > 1 ? (
+								<div className="text-xs font-medium text-[var(--inno-text-muted)]">{question.header}</div>
+							) : null}
+							<markdown-block className="text-sm font-medium text-[var(--inno-text)]" content={normalizeMarkdownMath(question.question)} />
+							<div className="space-y-1.5">
+								{question.options.map((option) => (
+									<OptionRow
+										key={option.label}
+										label={option.label}
+										description={option.description}
+										selected={selectedLabels.has(option.label)}
+										multi={question.multiSelect === true}
+										readOnly
+									/>
+								))}
+								{answer.kind === "custom" && answer.answer ? (
+									<div className="rounded-md border border-[var(--inno-accent)] bg-[var(--inno-accent-soft)] px-3 py-2 text-[13px] text-[var(--inno-text)]">
+										{answer.answer}
+									</div>
+								) : null}
+							</div>
+						</div>
+					);
+				})}
+			</div>
+		</div>
 	);
 }
 

--- a/apps/inno-agent/web/src/stores/chat-store.test.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.test.ts
@@ -44,7 +44,8 @@ vi.mock("./workspace-store.js", () => ({
 }));
 
 import { ChatStoreImpl } from "./chat-store.js";
-import type { ChatStreamEvent, StreamEventEnvelope } from "../types/chat.js";
+import type { ChatStreamEvent, QuestionnaireResult, StreamEventEnvelope } from "../types/chat.js";
+import { answeredQuestionnaireFromTool } from "../utils/questionnaire.js";
 
 const CLIENT_REQUEST_ID = "00000000-0000-4000-8000-000000000001";
 
@@ -84,6 +85,7 @@ describe("ChatStore stream ownership", () => {
 		vi.clearAllMocks();
 		vi.spyOn(globalThis.crypto, "randomUUID").mockReturnValue(CLIENT_REQUEST_ID);
 		mocks.abortChat.mockResolvedValue(undefined);
+		mocks.submitChatQuestion.mockResolvedValue({ accepted: true });
 		mocks.getChatStatus.mockResolvedValue(activeSnapshot());
 		mocks.getSession.mockResolvedValue({ messages: [], messageCount: 0, sessionRevision: "0:0" });
 	});
@@ -125,6 +127,68 @@ describe("ChatStore stream ownership", () => {
 		await store.send("hello");
 		expect(mocks.streamSessionEvents).toHaveBeenCalledWith("session.jsonl", "turn-1", 3, expect.any(AbortSignal));
 		expect(store.messages.at(-1)).toMatchObject({ role: "assistant", content: "AB", transient: true });
+	});
+
+	it("records where a tool call interrupted the assistant text", async () => {
+		mocks.streamChat.mockImplementation(async function* () {
+			yield envelope(1, { type: "stream_state", status: "running" });
+			yield envelope(2, { type: "text_delta", delta: "before" });
+			yield envelope(3, { type: "tool_start", toolCallId: "question-1", toolName: "ask_user_question", args: { questions: [] } });
+			yield envelope(4, { type: "tool_end", toolCallId: "question-1", toolName: "ask_user_question", result: {}, isError: false });
+			yield envelope(5, { type: "aborted", message: "Stopped", persisted: false });
+		});
+
+		const store = new ChatStoreImpl();
+		await store.send("hello");
+
+		expect(store.messages.at(-1)?.tools?.[0]).toMatchObject({
+			toolCallId: "question-1",
+			contentOffset: 6,
+		});
+	});
+
+	it("materializes the full answered questionnaire as soon as it is submitted", async () => {
+		let releaseTool!: () => void;
+		const toolFinished = new Promise<void>((resolve) => { releaseTool = resolve; });
+		const params = {
+			questions: [{
+				question: "Choose one",
+				header: "Choice",
+				options: [
+					{ label: "A", description: "First" },
+					{ label: "B", description: "Second" },
+				],
+			}],
+		};
+		const result: QuestionnaireResult = {
+			answers: [{ questionIndex: 0, question: "Choose one", kind: "option", answer: "B" }],
+			cancelled: false,
+		};
+		mocks.streamChat.mockImplementation(async function* () {
+			yield envelope(1, { type: "stream_state", status: "running" });
+			yield envelope(2, { type: "text_delta", delta: "before" });
+			yield envelope(3, { type: "tool_start", toolCallId: "question-tool", toolName: "ask_user_question", args: params });
+			yield envelope(4, { type: "question", questionId: "question-card", params });
+			await toolFinished;
+			yield envelope(5, { type: "tool_end", toolCallId: "question-tool", toolName: "ask_user_question", result, isError: false });
+			yield envelope(6, { type: "aborted", message: "Stopped", persisted: false });
+		});
+
+		const store = new ChatStoreImpl();
+		const sending = store.send("hello");
+		await vi.waitFor(() => expect(store.pendingQuestion?.questionId).toBe("question-card"));
+		await store.submitQuestionResponse("question-card", result);
+
+		expect(store.pendingQuestion).toBeNull();
+		expect(store.activeTools).toHaveLength(0);
+		expect(store.completedTools).toHaveLength(1);
+		expect(answeredQuestionnaireFromTool(store.completedTools[0]!)).toEqual({
+			questions: params.questions,
+			result,
+		});
+
+		releaseTool();
+		await sending;
 	});
 
 	it("does not replace a transient turn with stale canonical history", async () => {

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -438,22 +438,28 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				this.activeTools = [...this.activeTools.filter((tool) => tool.toolCallId !== event.toolCallId), {
 					toolCallId: event.toolCallId,
 					toolName: event.toolName,
-					args: compactToolPayload(event.args),
+					// Questionnaire options sit one level deeper than the generic tool
+					// payload compactor keeps. Preserve this small, bounded payload so
+					// the completed card can render every option immediately.
+					args: event.toolName === "ask_user_question" ? event.args : compactToolPayload(event.args),
+					contentOffset: this.streamingText.length,
 				}];
 				this.emit("change", undefined);
 				break;
 			case "tool_end":
 				this.flushStreamChange();
 				this.maybeFinishFileToolPreview(event.toolCallId, event.toolName, event.result, event.isError, owner);
+				const existingTool = this.completedTools.find((tool) => tool.toolCallId === event.toolCallId)
+					?? this.activeTools.find((tool) => tool.toolCallId === event.toolCallId);
 				this.completedTools = [
 					...this.completedTools.filter((tool) => tool.toolCallId !== event.toolCallId),
 					{
-						...(this.activeTools.find((t) => t.toolCallId === event.toolCallId) ?? {
+						...(existingTool ?? {
 							toolCallId: event.toolCallId,
-							toolName: "tool",
+							toolName: event.toolName,
 							args: undefined,
 						}),
-						result: compactToolPayload(event.result),
+						result: event.toolName === "ask_user_question" ? event.result : compactToolPayload(event.result),
 						isError: event.isError,
 					},
 				];
@@ -696,6 +702,25 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		const turnId = this.activeOwner?.turnId ?? pending.turnId;
 		if (!sessionId || !turnId) return;
 		this.answeredQuestionIds.add(questionId);
+		const activeQuestionTool = this.activeTools.find((tool) => tool.toolName === "ask_user_question");
+		const optimisticToolCallId = !result.cancelled ? activeQuestionTool?.toolCallId : undefined;
+		// Swap the editable card for a complete read-only card immediately. The
+		// eventual tool_end event reuses this record and replaces only its result,
+		// so subsequent streamed text grows below it without changing the card.
+		this.pendingQuestion = null;
+		if (activeQuestionTool && !result.cancelled) {
+			this.activeTools = this.activeTools.filter((tool) => tool.toolCallId !== activeQuestionTool.toolCallId);
+			this.completedTools = [
+				...this.completedTools.filter((tool) => tool.toolCallId !== activeQuestionTool.toolCallId),
+				{
+					...activeQuestionTool,
+					args: pending.params,
+					result,
+					isError: false,
+				},
+			];
+		}
+		this.emit("change", undefined);
 		try {
 			const response = await submitChatQuestion(sessionId, turnId, questionId, result);
 			if (response.expired) {
@@ -708,6 +733,12 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			}
 		} catch (err) {
 			if (!this.activeOwner || this.owns(this.activeOwner)) {
+				if (optimisticToolCallId) {
+					this.completedTools = this.completedTools.filter((tool) => tool.toolCallId !== optimisticToolCallId);
+					if (activeQuestionTool) this.activeTools = [...this.activeTools, activeQuestionTool];
+				}
+				this.pendingQuestion = pending;
+				this.answeredQuestionIds.delete(questionId);
 				this.streamingError = err instanceof Error ? err.message : "提交回答失败";
 				this.emit("change", undefined);
 			}

--- a/apps/inno-agent/web/src/types/chat.ts
+++ b/apps/inno-agent/web/src/types/chat.ts
@@ -17,6 +17,8 @@ export interface ChatToolRecord {
 	toolCallId: string;
 	toolName: string;
 	args: unknown;
+	/** Character offset in the assistant text at which the tool was called. */
+	contentOffset?: number;
 	result?: unknown;
 	isError?: boolean;
 }

--- a/apps/inno-agent/web/src/utils/questionnaire.test.ts
+++ b/apps/inno-agent/web/src/utils/questionnaire.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import type { ChatToolRecord } from "../types/chat.js";
+import {
+	buildAnsweredQuestionnaireTimeline,
+	type AnsweredQuestionnaire,
+	type AnsweredQuestionnaireView,
+} from "./questionnaire.js";
+
+const questionnaire: AnsweredQuestionnaire = {
+	questions: [{
+		question: "Choose one",
+		header: "Choice",
+		options: [{ label: "A", description: "" }],
+	}],
+	result: {
+		answers: [{ questionIndex: 0, question: "Choose one", kind: "option", answer: "A" }],
+		cancelled: false,
+	},
+};
+
+function view(toolCallId: string, contentOffset?: number): AnsweredQuestionnaireView {
+	const tool: ChatToolRecord = {
+		toolCallId,
+		toolName: "ask_user_question",
+		args: {},
+		...(contentOffset === undefined ? {} : { contentOffset }),
+	};
+	return { tool, questionnaire };
+}
+
+describe("buildAnsweredQuestionnaireTimeline", () => {
+	it("keeps a questionnaire between the text produced before and after its tool call", () => {
+		const timeline = buildAnsweredQuestionnaireTimeline("beforeafter", [view("question-1", 6)]);
+
+		expect(timeline.entries).toHaveLength(1);
+		expect(timeline.entries[0]?.before).toBe("before");
+		expect(timeline.tail).toBe("after");
+	});
+
+	it("orders multiple questionnaires by their original content offsets", () => {
+		const timeline = buildAnsweredQuestionnaireTimeline("one-two-three", [
+			view("question-2", 7),
+			view("question-1", 3),
+		]);
+
+		expect(timeline.entries.map((entry) => [entry.tool.toolCallId, entry.before])).toEqual([
+			["question-1", "one"],
+			["question-2", "-two"],
+		]);
+		expect(timeline.tail).toBe("-three");
+	});
+
+	it("places legacy questionnaires without an offset after the existing text", () => {
+		const timeline = buildAnsweredQuestionnaireTimeline("already shown", [view("legacy")]);
+
+		expect(timeline.entries[0]?.before).toBe("already shown");
+		expect(timeline.tail).toBe("");
+	});
+});

--- a/apps/inno-agent/web/src/utils/questionnaire.ts
+++ b/apps/inno-agent/web/src/utils/questionnaire.ts
@@ -5,6 +5,31 @@ export interface AnsweredQuestionnaire {
 	result: QuestionnaireResult;
 }
 
+export interface AnsweredQuestionnaireView {
+	tool: ChatToolRecord;
+	questionnaire: AnsweredQuestionnaire;
+}
+
+/** Split merged assistant text at the original positions of completed
+ * questionnaires. Older API responses did not expose an offset, so those
+ * cards safely fall back to the end of the message instead of jumping above
+ * text that was already visible when the question was asked. */
+export function buildAnsweredQuestionnaireTimeline(content: string, views: AnsweredQuestionnaireView[]) {
+	let cursor = 0;
+	const ordered = [...views].sort((left, right) => {
+		const leftOffset = left.tool.contentOffset ?? content.length;
+		const rightOffset = right.tool.contentOffset ?? content.length;
+		return leftOffset - rightOffset;
+	});
+	const entries = ordered.map((view) => {
+		const offset = Math.max(cursor, Math.min(content.length, view.tool.contentOffset ?? content.length));
+		const before = content.slice(cursor, offset);
+		cursor = offset;
+		return { ...view, before };
+	});
+	return { entries, tail: content.slice(cursor) };
+}
+
 /**
  * Recover a completed ask_user_question interaction from either a live tool
  * result ({ content, details }) or the human-readable result stored by older

--- a/apps/inno-agent/web/src/utils/questionnaire.ts
+++ b/apps/inno-agent/web/src/utils/questionnaire.ts
@@ -1,0 +1,122 @@
+import type { ChatToolRecord, QuestionAnswer, QuestionData, QuestionnaireResult } from "../types/chat.js";
+
+export interface AnsweredQuestionnaire {
+	questions: QuestionData[];
+	result: QuestionnaireResult;
+}
+
+/**
+ * Recover a completed ask_user_question interaction from either a live tool
+ * result ({ content, details }) or the human-readable result stored by older
+ * session files. Keeping this conversion outside React makes the history and
+ * live-stream render paths behave identically.
+ */
+export function answeredQuestionnaireFromTool(tool: ChatToolRecord): AnsweredQuestionnaire | null {
+	if (tool.toolName !== "ask_user_question") return null;
+	const questions = readQuestions(tool.args);
+	if (!questions.length) return null;
+
+	const structured = readQuestionnaireResult(tool.result);
+	if (structured && !structured.cancelled && structured.answers.length) {
+		return { questions, result: structured };
+	}
+
+	const text = readResultText(tool.result);
+	const answers = text ? readAnswersFromEnvelope(text, questions) : [];
+	return answers.length
+		? { questions, result: { answers, cancelled: false } }
+		: null;
+}
+
+function readQuestions(value: unknown): QuestionData[] {
+	if (!isRecord(value) || !Array.isArray(value.questions)) return [];
+	return value.questions.flatMap((question) => {
+		if (!isRecord(question) || typeof question.question !== "string" || !Array.isArray(question.options)) return [];
+		const options = question.options.flatMap((option) => {
+			if (!isRecord(option) || typeof option.label !== "string") return [];
+			return [{
+				label: option.label,
+				description: typeof option.description === "string" ? option.description : "",
+				...(typeof option.preview === "string" ? { preview: option.preview } : {}),
+			}];
+		});
+		return [{
+			question: question.question,
+			header: typeof question.header === "string" ? question.header : question.question,
+			options,
+			...(question.multiSelect === true ? { multiSelect: true } : {}),
+		}];
+	});
+}
+
+function readQuestionnaireResult(value: unknown): QuestionnaireResult | null {
+	const candidate = isRecord(value) && isRecord(value.details) ? value.details : value;
+	if (!isRecord(candidate) || !Array.isArray(candidate.answers)) return null;
+	const answers = candidate.answers.flatMap(readAnswer);
+	return {
+		answers,
+		cancelled: candidate.cancelled === true,
+		...(typeof candidate.error === "string" ? { error: candidate.error } : {}),
+	};
+}
+
+function readAnswer(value: unknown): QuestionAnswer[] {
+	if (!isRecord(value)
+		|| typeof value.questionIndex !== "number"
+		|| typeof value.question !== "string"
+		|| !["option", "custom", "chat", "multi"].includes(String(value.kind))) return [];
+	return [{
+		questionIndex: value.questionIndex,
+		question: value.question,
+		kind: value.kind as QuestionAnswer["kind"],
+		answer: typeof value.answer === "string" ? value.answer : null,
+		...(Array.isArray(value.selected) ? { selected: value.selected.filter((item): item is string => typeof item === "string") } : {}),
+		...(typeof value.notes === "string" ? { notes: value.notes } : {}),
+		...(typeof value.preview === "string" ? { preview: value.preview } : {}),
+	}];
+}
+
+function readResultText(value: unknown): string {
+	if (typeof value === "string") return value;
+	if (!isRecord(value) || !Array.isArray(value.content)) return "";
+	return value.content
+		.filter((item): item is Record<string, unknown> => isRecord(item))
+		.map((item) => typeof item.text === "string" ? item.text : "")
+		.filter(Boolean)
+		.join("\n");
+}
+
+function readAnswersFromEnvelope(text: string, questions: QuestionData[]): QuestionAnswer[] {
+	const answers: QuestionAnswer[] = [];
+	questions.forEach((question, questionIndex) => {
+		const marker = `"${question.question}"="`;
+		const start = text.indexOf(marker);
+		if (start < 0) return;
+		const valueStart = start + marker.length;
+		const valueEnd = text.indexOf('".', valueStart);
+		if (valueEnd < 0) return;
+		const answer = text.slice(valueStart, valueEnd);
+		if (question.multiSelect) {
+			answers.push({
+				questionIndex,
+				question: question.question,
+				kind: "multi",
+				answer: null,
+				selected: answer.split(", ").filter(Boolean),
+			});
+			return;
+		}
+		const isKnownOption = question.options.some((option) => option.label === answer);
+		answers.push({
+			questionIndex,
+			question: question.question,
+			kind: isKnownOption ? "option" : "custom",
+			answer,
+		});
+	});
+	return answers;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
+}


### PR DESCRIPTION
**Problem**

Two related issues made completed `ask_user_question` interactions difficult to follow in the Web UI:

**The selected options disappeared after submission.** Completed questionnaires were reduced to generic tool-call details. During live streaming, the generic payload compactor also collapsed the nested option objects, while restored session history kept only the human-readable tool text and discarded the structured answer details.

**Answered cards moved away from where the question was asked.** PI session history merges assistant text before and after a tool call into one message. Rendering completed tools above that merged message placed the questionnaire before text that had already appeared when the question was originally shown.

**Fix**

**Structured answered-question cards:**

- preserve the complete `ask_user_question` arguments and structured result instead of applying the generic tool payload compactor
- retain questionnaire `details` when restoring session history
- recover completed questionnaires from live results, restored structured details, and legacy human-readable envelopes
- render the original question, all available options, and the selected single-choice, multi-choice, or custom answer
- keep Markdown/LaTeX rendering for restored question text

**Conversation-position anchoring:**

- record the assistant-text offset when the questionnaire tool starts, both during live streaming and while rebuilding session history
- split merged assistant text at those offsets and render each answered card where the tool call originally interrupted the response
- place legacy questionnaires without an offset at the end of the existing message instead of moving them above previously visible text

**Immediate submission feedback:**

- replace the editable questionnaire with its read-only answered card immediately after submission
- reuse the optimistic card when the eventual `tool_end` event arrives
- restore the pending questionnaire and active tool state if submission fails

**Before**

<img width="1190" height="623" alt="image" src="https://github.com/user-attachments/assets/0ce7b5c8-257f-491e-bd17-f733794504b5" />

**After**

<img width="1262" height="690" alt="image" src="https://github.com/user-attachments/assets/3d0b0269-902f-4def-b5e1-b885a3c1eadd" />

**Verification**

- questionnaire timeline and ChatStore regression tests: 10/10 passed ✓
- immediate answered-card materialization ✓
- tool-call position preservation ✓
- legacy questionnaire fallback ✓
- `npm run build` ✓