### PR TITLE
fix(web): load HTML preview assets safely and enable printing

### DIFF
--- a/apps/inno-agent/web/src/api/workspace.test.ts
+++ b/apps/inno-agent/web/src/api/workspace.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { inlineWorkspaceHtml } from "./workspace.js";
+
+describe("inlineWorkspaceHtml", () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	it("inlines relative CSS and JavaScript while rebasing CSS asset URLs", async () => {
+		const files = new Map<string, string>([
+			[
+				"reports/assets/site.css",
+				[
+					'.logo { background: url("../images/logo.svg#mark"); }',
+					'.remote { background: url("https://cdn.example.com/bg.png"); }',
+					'.embedded { background: url(data:image/png;base64,abc); }',
+				].join("\n"),
+			],
+			["reports/summary/scripts/app.js", 'const marker = "$&"; console.log(marker);'],
+		]);
+
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(String(input), "http://localhost");
+			const path = url.searchParams.get("path") ?? "";
+			const content = files.get(path);
+			return new Response(
+				JSON.stringify(content === undefined
+					? { error: "not found" }
+					: { path, name: path.split("/").at(-1), kind: "text", content }),
+				{
+					status: content === undefined ? 404 : 200,
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await inlineWorkspaceHtml(
+			[
+				'<link rel="stylesheet" href="../assets/site.css?v=3#theme">',
+				'<script defer src="./scripts/app.js?cache=1"></script>',
+			].join("\n"),
+			"reports/summary/index.html",
+			"course 1",
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(fetchMock.mock.calls.map(([input]) => input)).toEqual([
+			"/api/workspace/file?path=reports%2Fassets%2Fsite.css&workspaceId=course+1",
+			"/api/workspace/file?path=reports%2Fsummary%2Fscripts%2Fapp.js&workspaceId=course+1",
+		]);
+		expect(result).toContain(
+			'url("/api/workspace/raw?path=reports%2Fimages%2Flogo.svg&workspaceId=course+1#mark")',
+		);
+		expect(result).toContain('url("https://cdn.example.com/bg.png")');
+		expect(result).toContain("url(data:image/png;base64,abc)");
+		expect(result).toContain('<script defer>const marker = "$&"; console.log(marker);</script>');
+		expect(result).not.toContain("site.css?v=3#theme");
+		expect(result).not.toContain("app.js?cache=1");
+	});
+});

--- a/apps/inno-agent/web/src/api/workspace.ts
+++ b/apps/inno-agent/web/src/api/workspace.ts
@@ -103,21 +103,44 @@ const MAX_INLINE_BYTES = 512 * 1024;
 function isRelUrl(url: string): boolean {
   const t = url.trim();
   if (!t) return false;
-  if (/^(https?:)?\/\//i.test(t)) return false;
-  if (t.startsWith("/")) return false;
-  if (/^(?:data|blob):/i.test(t)) return false;
+  if (/^[a-z][a-z\d+.-]*:/i.test(t)) return false;
+  if (t.startsWith("//") || t.startsWith("/") || t.startsWith("?") || t.startsWith("#")) return false;
   return true;
 }
 
+function splitResourceRef(ref: string): { path: string; hash: string } {
+  const trimmed = ref.trim();
+  const hashIndex = trimmed.indexOf("#");
+  const hash = hashIndex >= 0 ? trimmed.slice(hashIndex) : "";
+  const withoutHash = hashIndex >= 0 ? trimmed.slice(0, hashIndex) : trimmed;
+  const queryIndex = withoutHash.indexOf("?");
+  const path = queryIndex >= 0 ? withoutHash.slice(0, queryIndex) : withoutHash;
+  return { path, hash };
+}
+
 function resolveRelPath(htmlFilePath: string, relativeRef: string): string {
-  const htmlDir = htmlFilePath.includes("/") ? htmlFilePath.split("/").slice(0, -1).join("/") : "";
+  const normalizedFilePath = htmlFilePath.replaceAll("\\", "/");
+  const normalizedRef = relativeRef.replaceAll("\\", "/");
+  const htmlDir = normalizedFilePath.includes("/") ? normalizedFilePath.split("/").slice(0, -1).join("/") : "";
   const segs = htmlDir ? htmlDir.split("/").filter(Boolean) : [];
-  for (const seg of relativeRef.split("/")) {
+  for (const seg of normalizedRef.split("/")) {
     if (seg === "." || seg === "") continue;
     if (seg === "..") { segs.pop(); continue; }
     segs.push(seg);
   }
   return segs.join("/");
+}
+
+function rewriteCssUrls(css: string, cssFilePath: string, wsId?: string): string {
+  return css.replace(/url\(\s*(["']?)([^"')]+)\1\s*\)/gi, (match, quote: string, ref: string) => {
+    const trimmedRef = ref.trim();
+    if (!isRelUrl(trimmedRef)) return match;
+    const { path, hash } = splitResourceRef(trimmedRef);
+    if (!path) return match;
+    const rawUrl = workspaceFileUrl(resolveRelPath(cssFilePath, path), wsId) + hash;
+    const wrapper = quote || '"';
+    return `url(${wrapper}${rawUrl}${wrapper})`;
+  });
 }
 
 export async function inlineWorkspaceHtml(html: string, filePath: string, wsId?: string): Promise<string> {
@@ -132,7 +155,9 @@ export async function inlineWorkspaceHtml(html: string, filePath: string, wsId?:
     const hm = attrs.match(/\bhref\s*=\s*["\']([^"\']+)["\']/i);
     if (!hm) continue;
     if (!isRelUrl(hm[1])) continue;
-    const rp = resolveRelPath(filePath, hm[1]);
+    const { path } = splitResourceRef(hm[1]);
+    if (!path) continue;
+    const rp = resolveRelPath(filePath, path);
     if (/\.(?:css|js|mjs)$/i.test(rp)) fetches.push({ tag: m[0], path: rp, type: "css" });
   }
 
@@ -140,7 +165,9 @@ export async function inlineWorkspaceHtml(html: string, filePath: string, wsId?:
   const scrRe = /<script\b([^>]*)\bsrc\s*=\s*["']([^"']+)["']([^>]*)>\s*<\/script>/gi;
   while ((m = scrRe.exec(html)) !== null) {
     if (!isRelUrl(m[2])) continue;
-    const rp = resolveRelPath(filePath, m[2]);
+    const { path } = splitResourceRef(m[2]);
+    if (!path) continue;
+    const rp = resolveRelPath(filePath, path);
     if (/\.(?:js|mjs)$/i.test(rp)) fetches.push({ tag: m[0], path: rp, type: "js", attrs: (m[1] + ' ' + m[3]).replace(/\bsrc\s*=\s*["'][^"']*["']/gi, '').replace(/\s+/g, ' ').trim() });
   }
 
@@ -164,11 +191,12 @@ export async function inlineWorkspaceHtml(html: string, filePath: string, wsId?:
   for (const r of results) {
     if (r.content == null) continue;
     if (r.type === "css") {
-      result = result.replace(r.tag, `<style>${r.content}</style>`);
+      const css = rewriteCssUrls(r.content, r.path, wsId);
+      result = result.replace(r.tag, () => `<style>${css}</style>`);
     } else {
       const attrs = r.attrs;
       const open = attrs ? `<script ${attrs}>` : "<script>";
-      result = result.replace(r.tag, `${open}${r.content}</script>`);
+      result = result.replace(r.tag, () => `${open}${r.content}</script>`);
     }
   }
   return result;

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -309,7 +309,7 @@ function HtmlPreview({ file }: { file: WorkspaceFileDetail }) {
     ? raw.replace(/<head([^>]*)>/i, `<head$1>${guardScript}`)
     : `<!doctype html><html><head>${guardScript}</head><body>${raw}</body></html>`;
 
-  return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox" srcDoc={html} title={file.name} />;
+  return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" sandbox="allow-scripts allow-same-origin allow-modals allow-popups allow-popups-to-escape-sandbox" srcDoc={html} title={file.name} />;
 }
 
 /* ---------- Preview (read-only) ---------- */


### PR DESCRIPTION
**Problem**

HTML previews are rendered through an iframe `srcdoc`, whose relative URLs resolve against the Inno Agent page rather than the HTML file's workspace directory.

This caused several related failures:

**Relative CSS and JavaScript could not be loaded reliably.** Linked files such as `../assets/site.css` and `./scripts/app.js` resolved against the application URL instead of the previewed file.

**Nested CSS assets resolved from the wrong directory.** Relative `url(...)` references for images and fonts still pointed at the host page after the stylesheet was inlined.

**Versioned and Windows-style paths were misinterpreted.** References such as `style.css?v=3#theme` failed the extension check, while backslash-separated paths were not normalized.

**Replacement-string tokens could corrupt inlined content.** JavaScript or CSS containing values such as `$&` was interpreted by `String.replace` as a replacement token instead of literal file content.

**Printing was blocked by the iframe sandbox.** HTML previews using `window.print()` could not open the print dialog, preventing the in-app “Save as PDF” workflow.

**Fix**

**Workspace asset resolution:**

- inline relative linked CSS and JavaScript files from the workspace
- normalize Windows backslashes before resolving paths
- remove query strings before filesystem lookup and preserve URL fragments in the final resource URL
- rebase relative CSS `url(...)` references onto the workspace raw-file endpoint
- leave HTTP(S), protocol-relative, `data:`, `blob:`, root-relative, query-only, and fragment-only references unchanged
- use callback-based replacements so `$&` and other replacement tokens remain literal content
- retain existing script attributes such as `defer`

**Printing support:**

- add `allow-modals` to the preview iframe sandbox so `window.print()` can open the browser print dialog
- this permission also enables `alert()`, `confirm()`, and `prompt()` inside the preview; no other sandbox permissions are added by this change

**Before**

<img width="1280" height="696" alt="image" src="https://github.com/user-attachments/assets/3c42d2be-9134-4249-8c25-ede063aea1b3" />

**After**

<img width="1262" height="689" alt="image" src="https://github.com/user-attachments/assets/3e1867f0-24f7-4dd6-8212-41f79ed086b1" />

**Print / Save as PDF**

<img width="1261" height="690" alt="image" src="https://github.com/user-attachments/assets/ba83b11b-cbe8-4a46-8387-f31ee6e527db" />

**Verification**

The new HTML preview regression test covers:

- relative CSS and JavaScript inlining ✓
- query/hash handling ✓
- nested CSS asset rebasing ✓
- workspace IDs containing spaces ✓
- external and embedded URLs remaining unchanged ✓
- literal `$&` JavaScript content ✓

`workspace.test.ts`: 1/1 passed ✓  
`npm run build` ✓