### PR TITLE
fix(web): harden answered questionnaires and HTML preview inlining

### DIFF
--- a/apps/inno-agent/web/src/api/workspace.test.ts
+++ b/apps/inno-agent/web/src/api/workspace.test.ts
@@ -59,4 +59,54 @@ describe("inlineWorkspaceHtml", () => {
 		expect(result).not.toContain("site.css?v=3#theme");
 		expect(result).not.toContain("app.js?cache=1");
 	});
+
+	it.each([
+		["absolute http URL", "https://cdn.example.com/site.css"],
+		["absolute https URL", "http://cdn.example.com/site.css"],
+		["protocol-relative URL", "//cdn.example.com/site.css"],
+		["root-relative URL", "/static/site.css"],
+		["data URL", "data:text/css,body{}"],
+		["blob URL", "blob:https://example.com/id"],
+		["non-http scheme", "mailto:a@b.c"],
+		["query-only ref", "?v=3"],
+		["fragment-only ref", "#theme"],
+	])("leaves %s untouched", async (_label, href) => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const tag = `<link rel="stylesheet" href="${href}">`;
+
+		const result = await inlineWorkspaceHtml(tag, "index.html");
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result).toBe(tag);
+	});
+
+	it("does not inline a script referenced from a stylesheet link tag", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const tag = '<link rel="stylesheet" href="app.js">';
+
+		const result = await inlineWorkspaceHtml(tag, "index.html");
+
+		expect(fetchMock).not.toHaveBeenCalled();
+		expect(result).toBe(tag);
+	});
+
+	it("resolves Windows-style backslash paths", async () => {
+		const fetchMock = vi.fn(async (_input: string | URL | Request) =>
+			new Response(
+				JSON.stringify({ path: "assets\\site.css", name: "site.css", kind: "text", content: "body{}" }),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			));
+		vi.stubGlobal("fetch", fetchMock);
+
+		const result = await inlineWorkspaceHtml(
+			'<link rel="stylesheet" href="..\\assets\\site.css">',
+			"reports\\summary\\index.html",
+		);
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(String(fetchMock.mock.calls[0]?.[0])).toContain("path=reports%2Fassets%2Fsite.css");
+		expect(result).toContain("<style>body{}</style>");
+	});
 });

--- a/apps/inno-agent/web/src/api/workspace.ts
+++ b/apps/inno-agent/web/src/api/workspace.ts
@@ -132,6 +132,8 @@ function resolveRelPath(htmlFilePath: string, relativeRef: string): string {
 }
 
 function rewriteCssUrls(css: string, cssFilePath: string, wsId?: string): string {
+  // Known limitation: the [^"')]+ body cannot match a quoted URL containing
+  // ")" — those are left untouched (relative, likely broken in preview).
   return css.replace(/url\(\s*(["']?)([^"')]+)\1\s*\)/gi, (match, quote: string, ref: string) => {
     const trimmedRef = ref.trim();
     if (!isRelUrl(trimmedRef)) return match;
@@ -158,7 +160,9 @@ export async function inlineWorkspaceHtml(html: string, filePath: string, wsId?:
     const { path } = splitResourceRef(hm[1]);
     if (!path) continue;
     const rp = resolveRelPath(filePath, path);
-    if (/\.(?:css|js|mjs)$/i.test(rp)) fetches.push({ tag: m[0], path: rp, type: "css" });
+    // Stylesheets only: a .js href inlined into a <style> block would be
+    // broken CSS anyway. Scripts are handled by the <script> pass below.
+    if (/\.css$/i.test(rp)) fetches.push({ tag: m[0], path: rp, type: "css" });
   }
 
   // Collect <script src="...">...</script>

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -610,7 +610,8 @@
 		"submit": "Submit",
 		"submitNext": "Next",
 		"optionSelectedHint": "Option selected; deselect to enter custom text",
-		"answered": "Selected"
+		"answered": "Selected",
+		"answeredViaChat": "Answered via chat"
 	},
 	"sidebar": {
 		"expand": "Expand",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -610,7 +610,8 @@
 		"submit": "提交",
 		"submitNext": "下一题",
 		"optionSelectedHint": "已选择选项，如需自定义请先取消选择",
-		"answered": "已选择"
+		"answered": "已选择",
+		"answeredViaChat": "已通过对话回答"
 	},
 	"sidebar": {
 		"expand": "展开",

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -84,6 +84,11 @@ export function AnsweredQuestionCard({ questionnaire }: { questionnaire: Answere
 										{answer.answer}
 									</div>
 								) : null}
+								{answer.kind === "chat" ? (
+									<div className="text-xs text-[var(--inno-text-muted)]">
+										{answer.answer ?? t("question.answeredViaChat")}
+									</div>
+								) : null}
 							</div>
 						</div>
 					);

--- a/apps/inno-agent/web/src/stores/chat-store.test.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.test.ts
@@ -191,6 +191,93 @@ describe("ChatStore stream ownership", () => {
 		await sending;
 	});
 
+	it("restores the pending question when the submit fails before tool_end", async () => {
+		let releaseTool!: () => void;
+		let rejectSubmit!: (err: Error) => void;
+		const toolFinished = new Promise<void>((resolve) => { releaseTool = resolve; });
+		mocks.submitChatQuestion.mockReturnValue(new Promise((_, reject) => { rejectSubmit = reject; }));
+		const params = {
+			questions: [{
+				question: "Choose one",
+				header: "Choice",
+				options: [{ label: "A", description: "First" }, { label: "B", description: "Second" }],
+			}],
+		};
+		const result: QuestionnaireResult = {
+			answers: [{ questionIndex: 0, question: "Choose one", kind: "option", answer: "B" }],
+			cancelled: false,
+		};
+		mocks.streamChat.mockImplementation(async function* () {
+			yield envelope(1, { type: "stream_state", status: "running" });
+			yield envelope(2, { type: "tool_start", toolCallId: "question-tool", toolName: "ask_user_question", args: params });
+			yield envelope(3, { type: "question", questionId: "question-card", params });
+			await toolFinished;
+			yield envelope(4, { type: "tool_end", toolCallId: "question-tool", toolName: "ask_user_question", result, isError: false });
+			yield envelope(5, { type: "aborted", message: "Stopped", persisted: false });
+		});
+
+		const store = new ChatStoreImpl();
+		const sending = store.send("hello");
+		await vi.waitFor(() => expect(store.pendingQuestion?.questionId).toBe("question-card"));
+		const submitting = store.submitQuestionResponse("question-card", result);
+		await vi.waitFor(() => expect(store.completedTools).toHaveLength(1));
+		rejectSubmit(new Error("network down"));
+		await submitting;
+
+		expect(store.pendingQuestion?.questionId).toBe("question-card");
+		expect(store.completedTools).toHaveLength(0);
+		expect(store.activeTools.map((tool) => tool.toolCallId)).toEqual(["question-tool"]);
+		expect(store.streamingError).toBe("network down");
+
+		releaseTool();
+		await sending;
+	});
+
+	it("keeps the completed card when tool_end lands before a failed submit", async () => {
+		let releaseTool!: () => void;
+		let rejectSubmit!: (err: Error) => void;
+		const toolFinished = new Promise<void>((resolve) => { releaseTool = resolve; });
+		mocks.submitChatQuestion.mockReturnValue(new Promise((_, reject) => { rejectSubmit = reject; }));
+		const params = {
+			questions: [{
+				question: "Choose one",
+				header: "Choice",
+				options: [{ label: "A", description: "First" }, { label: "B", description: "Second" }],
+			}],
+		};
+		const result: QuestionnaireResult = {
+			answers: [{ questionIndex: 0, question: "Choose one", kind: "option", answer: "B" }],
+			cancelled: false,
+		};
+		mocks.streamChat.mockImplementation(async function* () {
+			yield envelope(1, { type: "stream_state", status: "running" });
+			yield envelope(2, { type: "tool_start", toolCallId: "question-tool", toolName: "ask_user_question", args: params });
+			yield envelope(3, { type: "question", questionId: "question-card", params });
+			await toolFinished;
+			yield envelope(4, { type: "tool_end", toolCallId: "question-tool", toolName: "ask_user_question", result, isError: false });
+			yield envelope(5, { type: "aborted", message: "Stopped", persisted: false });
+		});
+
+		const store = new ChatStoreImpl();
+		const sending = store.send("hello");
+		await vi.waitFor(() => expect(store.pendingQuestion?.questionId).toBe("question-card"));
+		const submitting = store.submitQuestionResponse("question-card", result);
+		releaseTool();
+		// tool_end arrives while the answer POST is still in flight: the server
+		// has already consumed the answer, so a client-side failure must not
+		// resurrect the editable question. Wait for the stream to settle so the
+		// trailing aborted event cannot overwrite the submit error.
+		await sending;
+		expect(store.messages.at(-1)?.tools).toHaveLength(1);
+		rejectSubmit(new Error("network down"));
+		await submitting;
+
+		expect(store.pendingQuestion).toBeNull();
+		expect(store.activeTools).toHaveLength(0);
+		expect(store.messages.at(-1)?.tools?.[0]?.result).toEqual(result);
+		expect(store.streamingError).toBe("network down");
+	});
+
 	it("does not replace a transient turn with stale canonical history", async () => {
 		vi.useFakeTimers();
 		try {

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -61,6 +61,12 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	 *  (backend may re-push a question event before the answer POST lands) and
 	 *  guards restored cards against reappearing from a stale cache. */
 	private answeredQuestionIds = new Set<string>();
+	/** Tool calls swapped to a completed questionnaire card before the answer
+	 *  POST returned. tool_end removes the id; a submit failure may only roll
+	 *  the card back while the id is still here — once tool_end landed, the
+	 *  server already consumed the answer and restoring the editable card
+	 *  would resurrect a resolved question. */
+	private optimisticQuestionToolIds = new Set<string>();
 	canReconnect = false;
 	private abortController: AbortController | null = null;
 	private detachMode = false;
@@ -449,6 +455,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			case "tool_end":
 				this.flushStreamChange();
 				this.maybeFinishFileToolPreview(event.toolCallId, event.toolName, event.result, event.isError, owner);
+				this.optimisticQuestionToolIds.delete(event.toolCallId);
 				const existingTool = this.completedTools.find((tool) => tool.toolCallId === event.toolCallId)
 					?? this.activeTools.find((tool) => tool.toolCallId === event.toolCallId);
 				this.completedTools = [
@@ -545,6 +552,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.streamingError = "";
 		this.activeTools = [];
 		this.completedTools = [];
+		this.optimisticQuestionToolIds.clear();
 		this.pendingQuestion = null;
 		if (this.workspacePreviewId) workspaceStore.clearStreamingPreview(this.workspacePreviewId);
 		this.resetWorkspaceStreamState();
@@ -709,6 +717,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		// so subsequent streamed text grows below it without changing the card.
 		this.pendingQuestion = null;
 		if (activeQuestionTool && !result.cancelled) {
+			this.optimisticQuestionToolIds.add(activeQuestionTool.toolCallId);
 			this.activeTools = this.activeTools.filter((tool) => tool.toolCallId !== activeQuestionTool.toolCallId);
 			this.completedTools = [
 				...this.completedTools.filter((tool) => tool.toolCallId !== activeQuestionTool.toolCallId),
@@ -733,12 +742,17 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			}
 		} catch (err) {
 			if (!this.activeOwner || this.owns(this.activeOwner)) {
-				if (optimisticToolCallId) {
+				// Roll back only while the optimistic card is still ours. If
+				// tool_end already arrived, the server consumed the answer
+				// despite the failed POST — keep the completed card and only
+				// surface the error instead of resurrecting the question.
+				if (optimisticToolCallId && this.optimisticQuestionToolIds.has(optimisticToolCallId)) {
+					this.optimisticQuestionToolIds.delete(optimisticToolCallId);
 					this.completedTools = this.completedTools.filter((tool) => tool.toolCallId !== optimisticToolCallId);
 					if (activeQuestionTool) this.activeTools = [...this.activeTools, activeQuestionTool];
+					this.pendingQuestion = pending;
+					this.answeredQuestionIds.delete(questionId);
 				}
-				this.pendingQuestion = pending;
-				this.answeredQuestionIds.delete(questionId);
 				this.streamingError = err instanceof Error ? err.message : "提交回答失败";
 				this.emit("change", undefined);
 			}
@@ -753,6 +767,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.detach();
 		this.messages = [];
 		this.answeredQuestionIds.clear();
+		this.optimisticQuestionToolIds.clear();
 		this.emit("change", undefined);
 	}
 

--- a/apps/inno-agent/web/src/utils/questionnaire.test.ts
+++ b/apps/inno-agent/web/src/utils/questionnaire.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
-import type { ChatToolRecord } from "../types/chat.js";
+import type { ChatToolRecord, QuestionData } from "../types/chat.js";
 import {
+	answeredQuestionnaireFromTool,
 	buildAnsweredQuestionnaireTimeline,
 	type AnsweredQuestionnaire,
 	type AnsweredQuestionnaireView,
@@ -55,5 +56,61 @@ describe("buildAnsweredQuestionnaireTimeline", () => {
 
 		expect(timeline.entries[0]?.before).toBe("already shown");
 		expect(timeline.tail).toBe("");
+	});
+});
+
+describe("answeredQuestionnaireFromTool", () => {
+	const questions: QuestionData[] = [
+		{ question: "Pick one", header: "Pick", options: [{ label: "A", description: "" }, { label: "B", description: "" }] },
+		{ question: "Pick many", header: "Multi", options: [{ label: "X", description: "" }, { label: "Y", description: "" }], multiSelect: true },
+	];
+
+	function tool(result: unknown, extra: Partial<ChatToolRecord> = {}): ChatToolRecord {
+		return { toolCallId: "question-tool", toolName: "ask_user_question", args: { questions }, result, ...extra };
+	}
+
+	it("returns null for errored tools even when the result parses", () => {
+		const result = { answers: [{ questionIndex: 0, question: "Pick one", kind: "option", answer: "A" }], cancelled: false };
+		expect(answeredQuestionnaireFromTool(tool(result, { isError: true }))).toBeNull();
+	});
+
+	it("recovers a structured result from the live { content, details } envelope", () => {
+		const details = { answers: [{ questionIndex: 0, question: "Pick one", kind: "option", answer: "B" }], cancelled: false };
+		const result = { content: [{ type: "text", text: "User has answered your questions: ..." }], details };
+
+		expect(answeredQuestionnaireFromTool(tool(result))).toEqual({ questions, result: details });
+	});
+
+	it("ignores cancelled structured results", () => {
+		const result = { answers: [], cancelled: true };
+		expect(answeredQuestionnaireFromTool(tool(result))).toBeNull();
+	});
+
+	it("parses legacy human-readable envelopes", () => {
+		const text = 'User has answered your questions: "Pick one"="A". "Pick many"="X, Y". You can now continue with the user\'s answers in mind.';
+
+		expect(answeredQuestionnaireFromTool(tool(text))).toEqual({
+			questions,
+			result: {
+				cancelled: false,
+				answers: [
+					{ questionIndex: 0, question: "Pick one", kind: "option", answer: "A" },
+					{ questionIndex: 1, question: "Pick many", kind: "multi", answer: null, selected: ["X", "Y"] },
+				],
+			},
+		});
+	});
+
+	it("marks legacy answers that match no option as custom", () => {
+		const text = 'User has answered your questions: "Pick one"="Something else". You can now continue.';
+
+		const recovered = answeredQuestionnaireFromTool(tool(text));
+		expect(recovered?.result.answers).toEqual([
+			{ questionIndex: 0, question: "Pick one", kind: "custom", answer: "Something else" },
+		]);
+	});
+
+	it("returns null when no answer marker matches the questions", () => {
+		expect(answeredQuestionnaireFromTool(tool("User declined to answer questions"))).toBeNull();
 	});
 });

--- a/apps/inno-agent/web/src/utils/questionnaire.ts
+++ b/apps/inno-agent/web/src/utils/questionnaire.ts
@@ -38,6 +38,9 @@ export function buildAnsweredQuestionnaireTimeline(content: string, views: Answe
  */
 export function answeredQuestionnaireFromTool(tool: ChatToolRecord): AnsweredQuestionnaire | null {
 	if (tool.toolName !== "ask_user_question") return null;
+	// An errored tool stays in the generic tool-call details even when its
+	// result happens to parse — it is a failure record, not an answered card.
+	if (tool.isError) return null;
 	const questions = readQuestions(tool.args);
 	if (!questions.length) return null;
 


### PR DESCRIPTION
Follow-up fixes from the code review of #120 and #121 (both already merged).

## Questionnaires (#120 follow-ups)

**Errored tools no longer render as answered cards.** `answeredQuestionnaireFromTool` now returns `null` for `isError` records, so a failed `ask_user_question` stays in the generic tool-call details even when its result happens to parse.

**Submit-failure rollback no longer races `tool_end`.** Optimistic completed records are tracked in a set; `tool_end` removes the id. A failed answer POST rolls the card back only while the id is still tracked — once `tool_end` landed, the server already consumed the answer, so the completed card is kept and only the error is surfaced, instead of restoring an editable question the backend considers resolved (and leaving a zombie active tool that would never receive its `tool_end`).

**Chat-kind answers render.** Previously a `kind: "chat"` answer produced an answered card with every option unselected and no visible answer. It now shows the answer text, or an "answered via chat" marker (i18n: en + zh-CN).

**Test coverage for the legacy envelope parser.** `readAnswersFromEnvelope` (delimiter-based parsing of pre-#120 human-readable results) had no direct tests. New cases pin the option/multi/custom answer shapes, decline text, structured `{ content, details }` envelopes, cancelled results, and errored records. Two new store tests cover both sides of the submit/`tool_end` race.

## HTML preview (#121 follow-ups)

**`<link>` whitelist narrowed to `.css`.** A `<link rel="stylesheet" href="app.js">` was inlined into a `<style>` block as broken CSS. Scripts are only handled by the `<script>` pass now.

**Documented the CSS `url()` rewriter limitation** (quoted URLs containing `)\n` are left untouched).

**Table-driven tests** for references that must stay untouched (absolute/protocol-relative/root-relative URLs, `data:`/`blob:`/non-http schemes, query-only, fragment-only) and for Windows-style backslash path resolution.

## Verification

- `vitest run`: 33/33 passed (4 files) ✓
- `npm run build` ✓