### PR TITLE
fix(content-hub): include category in presets index

### DIFF
--- a/scripts/content-hub-server/server.mjs
+++ b/scripts/content-hub-server/server.mjs
@@ -133,6 +133,7 @@ function buildIndex() {
 					name: meta.name.trim(),
 					description: (meta.description ?? "").trim(),
 					icon: meta.icon?.trim() || undefined,
+					category: meta.category?.trim() || undefined,
 				});
 			} catch {
 				// skip invalid preset.json


### PR DESCRIPTION
The bundle server's buildIndex() emitted category for skills but not for presets, so the index.json served to inno-agent had no category field on preset entries. When inno-agent merged remote presets over local ones, the missing category wiped out the local value and the Simple Mode grouping collapsed — visible on refresh once the indexCache served the category-less index.

Add `category: meta.category?.trim() || undefined` to the presets push, mirroring the skills path.