### PR TITLE
fix(web): preserve workspace file selection

### DIFF
--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -932,10 +932,16 @@ export function WorkspaceBrowser() {
 	}, [deleteConfirm]);
 
 	const toggleMultiSelectMode = useCallback(() => {
+		const currentPath = workspaceStore.currentFile?.path;
 		treeRef.current?.deselectAll();
-		setSelectedFileIds([]);
+		if (multiSelectMode) {
+			setSelectedFileIds([]);
+			if (currentPath) treeRef.current?.get(currentPath)?.select();
+		} else {
+			setSelectedFileIds(currentPath ? [currentPath] : []);
+		}
 		setMultiSelectMode((enabled) => !enabled);
-	}, []);
+	}, [multiSelectMode]);
 
 	const toggleSelectedFile = useCallback((path: string) => {
 		setSelectedFileIds((current) => current.includes(path)

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -638,6 +638,10 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 						multiSelect.toggleFile(node.data.path);
 						return;
 					}
+					if (node.isSelected) {
+						node.deselect();
+						return;
+					}
 					node.select();
 					workspaceStore.clearStreamingPreview();
 					if (appStore.workspaceWidth < CONTENT_REVEAL_WIDTH) {


### PR DESCRIPTION
## Summary

Preserves workspace file selection across multi-select mode changes and makes the current file selection toggleable.

- Keep the current file selected when entering multi-select mode.
- Restore the current file selection when leaving multi-select mode.
- Allow clicking an already-selected file to deselect it.

## Why

Toggling multi-select mode cleared the active workspace file selection, and clicking an already-selected file did not provide a way to deselect it through the normal tree interaction.

## User impact

Users can enter or leave multi-select mode without losing the file they are viewing, and can clear a single-file selection with the same click interaction.

## Verification

- `npm run build` ✓
- `npm test` — 17 test files, 98 tests passed
- `git diff --check upstream/main...HEAD` ✓
