### PR TITLE
fix(chat): release the prompt queue when switching or creating sessions

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -70,10 +70,53 @@ async function switchToSession(sessionPath: string, opts?: { force?: boolean; cw
 	_currentCwd = desiredCwd;
 }
 
-function enqueue<T>(task: () => Promise<T>): Promise<T> {
-	const run = _queue.then(task, task);
-	_queue = run.then(() => undefined, () => undefined);
-	return run;
+/** Error thrown when a queued task is cancelled before it starts executing. */
+export class QueueTaskCancelledError extends Error {
+	constructor(message = "Queue task was cancelled before it started") {
+		super(message);
+		this.name = "QueueTaskCancelledError";
+	}
+}
+
+export function isQueueTaskCancelled(err: unknown): boolean {
+	return err instanceof QueueTaskCancelledError;
+}
+
+function enqueue<T>(task: () => Promise<T>, opts?: { signal?: AbortSignal }): Promise<T> {
+	// A cancelled task must NEVER execute once its slot arrives — otherwise
+	// ops whose caller already gave up (client disconnected / timed out)
+	// would run later in a jumbled order (ghost sessions, surprise session
+	// switches). Cancellation is also EAGER: the returned promise rejects as
+	// soon as the signal fires, so HTTP handlers waiting on a queued op can
+	// answer 409 immediately instead of hanging until the slot frees up.
+	// See https://github.com/hhyqhh/inno-agent/issues/124.
+	return new Promise<T>((resolve, reject) => {
+		const signal = opts?.signal;
+		let settled = false;
+		const onAbort = () => {
+			if (settled) return;
+			settled = true;
+			reject(new QueueTaskCancelledError());
+		};
+		if (signal) {
+			if (signal.aborted) {
+				reject(new QueueTaskCancelledError());
+				return;
+			}
+			signal.addEventListener("abort", onAbort, { once: true });
+		}
+		const guarded = () => {
+			if (signal?.aborted) return Promise.reject(new QueueTaskCancelledError());
+			return task();
+		};
+		const run = _queue.then(guarded, guarded);
+		_queue = run.then(() => undefined, () => undefined);
+		const cleanup = () => signal?.removeEventListener("abort", onAbort);
+		run.then(
+			(value) => { cleanup(); if (!settled) { settled = true; resolve(value); } },
+			(err) => { cleanup(); if (!settled) { settled = true; reject(err); } },
+		);
+	});
 }
 
 /**
@@ -880,11 +923,11 @@ export async function reloadResources(): Promise<void> {
  * sessions is a UI-level navigation action. The backend task continues
  * running and the client can reconnect to its event stream later.
  */
-export async function switchSessionFile(sessionPath: string): Promise<void> {
+export async function switchSessionFile(sessionPath: string, opts?: { signal?: AbortSignal }): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
 	await enqueue(async () => {
 		await switchToSession(sessionPath);
-	});
+	}, opts);
 }
 
 /**
@@ -893,11 +936,11 @@ export async function switchSessionFile(sessionPath: string): Promise<void> {
  * agent's tools pick up the new cwd on the next prompt without a full
  * session-path change.
  */
-export async function applyWorkspaceCwd(sessionPath: string): Promise<void> {
+export async function applyWorkspaceCwd(sessionPath: string, opts?: { signal?: AbortSignal }): Promise<void> {
 	if (!_runtime) return;
 	await enqueue(async () => {
 		await switchToSession(sessionPath, { force: true });
-	});
+	}, opts);
 }
 
 /**
@@ -906,7 +949,7 @@ export async function applyWorkspaceCwd(sessionPath: string): Promise<void> {
  * task for the previous session continues running in the background.
  * The client can reconnect to its event stream when switching back.
  */
-export async function createNewSession(): Promise<string> {
+export async function createNewSession(opts?: { signal?: AbortSignal }): Promise<string> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
 	return enqueue(async () => {
 		await _runtime!.newSession();
@@ -922,7 +965,12 @@ export async function createNewSession(): Promise<string> {
 		// the registry mapping is in place.
 		_currentCwd = _workspaceDir;
 		return sessionId;
-	});
+	}, opts);
+}
+
+/** Token (turnId) of the prompt currently occupying the shared queue, if any. */
+export function getActivePromptToken(): string | null {
+	return _activePromptToken;
 }
 
 /**

--- a/apps/inno-agent/src/agent/question-bridge.ts
+++ b/apps/inno-agent/src/agent/question-bridge.ts
@@ -91,8 +91,15 @@ export class QuestionBridge {
 		});
 	}
 
-	respond(input: { sessionId: string; turnId: string; questionId: string; result: QuestionBridgeResult }): QuestionResponseStatus {
+	/** Info about the currently parked question, if a turn is waiting on one. */
+	pendingInfo(): { sessionId: string; turnId: string; questionId: string } | null {
 		const pending = this.pending;
+		return pending
+			? { sessionId: pending.sessionId, turnId: pending.turnId, questionId: pending.questionId }
+			: null;
+	}
+
+	respond(input: { sessionId: string; turnId: string; questionId: string; result: QuestionBridgeResult }): QuestionResponseStatus {		const pending = this.pending;
 		if (!pending || pending.questionId !== input.questionId) {
 			return this.lastResolved?.questionId === input.questionId
 				&& this.lastResolved.sessionId === input.sessionId

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -23,7 +23,9 @@ import {
 	getAvailableModels,
 	getLoadedSkills,
 	getSession,
+	getActivePromptToken,
 	initSession,
+	isQueueTaskCancelled,
 	refreshConfiguredProviders,
 	reloadResources,
 	switchModel,
@@ -2394,6 +2396,79 @@ function maybeAutoGenerateTopic(sessionId: string): void {
 // HTTP Server
 // ---------------------------------------------------------------------------
 
+/**
+ * The prompt currently holding the shared serial queue, if any. Only prompts
+ * hold queue slots for a meaningful duration; switch/create are instant.
+ */
+function getQueueBlocker(): { sessionId: string; turnId: string; questionPending: boolean } | null {
+	const token = getActivePromptToken();
+	if (!token) return null;
+	const state = streamRegistry.getByTurn(token);
+	if (!state || (state.status !== "queued" && state.status !== "running")) return null;
+	const pending = questionBridge.pendingInfo();
+	return {
+		sessionId: state.sessionId,
+		turnId: state.turnId,
+		questionPending: pending?.turnId === state.turnId,
+	};
+}
+
+/**
+ * Session-retention policy (issue #124): a turn parked on a question card can
+ * never progress without the user, yet it holds the shared prompt queue for
+ * up to the 30-minute question timeout — blocking every session switch /
+ * creation behind it. Navigating to a DIFFERENT session implicitly abandons
+ * the card, so abort that turn to release the queue. Turns that are actively
+ * generating are left alone (they end on their own; the user can still stop
+ * them explicitly via the scoped abort endpoint).
+ *
+ * Mirrors the scoped abort route: cancel the registry state, resolve the
+ * parked question (session.abort() alone cannot wake it), then abort.
+ */
+function releaseQueueFromQuestionBlockedTurn(targetSessionId: string): void {
+	const blocker = getQueueBlocker();
+	if (!blocker || !blocker.questionPending || blocker.sessionId === targetSessionId) return;
+	const state = streamRegistry.getByTurn(blocker.turnId);
+	if (!state) return;
+	logger.info({ blockedSession: blocker.sessionId, turnId: blocker.turnId, targetSessionId }, "auto-aborting question-blocked turn to release the prompt queue");
+	streamRegistry.requestCancel(state);
+	questionBridge.unbindTurn({ sessionId: state.sessionId, turnId: state.turnId, reason: "switched_away" });
+	if (state.status === "running") void abortPromptForTurnToken(state.turnId);
+}
+
+/**
+ * Run an enqueue-backed operation with a hard wait bound. If the queue is
+ * held by a long turn the caller gets a 409 with blocker details instead of
+ * hanging for minutes; a client disconnect cancels the still-queued task so
+ * it never executes out from under a user who already gave up.
+ */
+async function runQueueOpWithTimeout<T>(
+	req: HttpReq,
+	res: ServerResponse,
+	op: (signal: AbortSignal) => Promise<T>,
+	timeoutMs = 8_000,
+): Promise<T | null> {
+	const aborter = new AbortController();
+	// res "close" with the response unfinished = the client went away. (req
+	// "close" is unusable here: it fires as soon as the request body is fully
+	// received, long before we answer.)
+	res.on("close", () => { if (!res.writableFinished) aborter.abort(); });
+	const timer = setTimeout(() => aborter.abort(), timeoutMs);
+	try {
+		return await op(aborter.signal);
+	} catch (err) {
+		if (isQueueTaskCancelled(err)) {
+			if (!res.writableFinished && !res.destroyed) {
+				json(res, 409, { error: "session_busy", blocking: getQueueBlocker() ?? undefined });
+			}
+			return null;
+		}
+		throw err;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
 const server = createServer(async (req, res) => {
 	const url = req.url ?? "/";
 	const method = req.method ?? "GET";
@@ -3120,14 +3195,22 @@ const server = createServer(async (req, res) => {
 				json(res, 404, { error: "Session not found" });
 				return;
 			}
-			await switchSessionFile(sessionPath);
+			// If the queue is held by another session's question-blocked turn,
+			// abort it first — otherwise this switch could wait up to 30 min.
+			releaseQueueFromQuestionBlockedTurn(basename(sessionPath));
+			const switched = await runQueueOpWithTimeout(req, res, (signal) => switchSessionFile(sessionPath, { signal }));
+			if (switched === null) return; // 409 session_busy already sent (or client gone)
 			json(res, 200, { id: basename(sessionPath), active: getCurrentSessionId() === basename(sessionPath) });
 			return;
 		}
 
 		if (method === "POST" && url === "/api/sessions") {
 			const body = await readBody(req).catch(() => ({})) as Record<string, unknown>;
-			const id = await createNewSession();
+			// A new session is always a different session — release the queue
+			// from a question-blocked turn before enqueueing (issue #124).
+			releaseQueueFromQuestionBlockedTurn("");
+			const id = await runQueueOpWithTimeout(req, res, (signal) => createNewSession({ signal }));
+			if (id === null) return; // 409 session_busy already sent (or client gone)
 			// This endpoint is exclusively the Web UI's session-creation path.
 			// Record the origin immediately so Simple Mode includes the new empty
 			// session before the first assistant response has finished streaming.
@@ -3143,6 +3226,11 @@ const server = createServer(async (req, res) => {
 			const newWorkspaceSpec = body.newWorkspace && typeof body.newWorkspace === "object"
 				? body.newWorkspace as { name?: unknown; isTemp?: unknown }
 				: null;
+			// The follow-up cwd apply re-enters the queue; if the client goes
+			// away, cancel it while queued rather than switching the runtime's
+			// cwd out from under whatever the user moved on to.
+			const cwdAborter = new AbortController();
+			res.on("close", () => { if (!res.writableFinished) cwdAborter.abort(); });
 			try {
 				if (presetId) {
 					// Ensure the preset's files are in the local cache (download on
@@ -3164,7 +3252,7 @@ const server = createServer(async (req, res) => {
 				// tools (read/write/bash) operate inside the bound directory.
 				const sessionPath = sessionFileFromId(join(dataDir, "sessions"), id);
 				if (sessionPath) {
-					await applyWorkspaceCwd(sessionPath);
+					await applyWorkspaceCwd(sessionPath, { signal: cwdAborter.signal });
 				}
 			} catch (err) {
 				logger.warn({ err }, `failed to bind workspace for session ${id}`);
@@ -3191,7 +3279,9 @@ const server = createServer(async (req, res) => {
 			// first so the agent runtime doesn't keep writing to a deleted file.
 			let newActiveId: string | null = null;
 			if (getCurrentSessionId() === sessionId) {
-				newActiveId = await createNewSession();
+				releaseQueueFromQuestionBlockedTurn("");
+				newActiveId = await runQueueOpWithTimeout(req, res, (signal) => createNewSession({ signal }));
+				if (newActiveId === null) return; // 409 session_busy already sent (or client gone)
 			}
 
 			// If this session is the sole owner of a temp workspace, remove the
@@ -3998,7 +4088,9 @@ const server = createServer(async (req, res) => {
 			if (getCurrentSessionId() === sessionId) {
 				const sessionPath = sessionFileFromId(join(dataDir, "sessions"), sessionId);
 				if (sessionPath) {
-					await applyWorkspaceCwd(sessionPath);
+					releaseQueueFromQuestionBlockedTurn(sessionId);
+					const applied = await runQueueOpWithTimeout(req, res, (signal) => applyWorkspaceCwd(sessionPath, { signal }));
+					if (applied === null) return; // 409 session_busy already sent (or client gone)
 				}
 			}
 			json(res, 200, { sessionId, workspaceId });
@@ -4675,6 +4767,9 @@ const server = createServer(async (req, res) => {
 				json(res, 409, { error: "Session already has an active chat turn" });
 				return;
 			}
+			// Sending in a different session implicitly abandons another
+			// session's unanswered question card — release the queue (issue #124).
+			releaseQueueFromQuestionBlockedTurn(requestedSessionId);
 			const targetSessionPath = sessionFileFromId(join(dataDir, "sessions"), requestedSessionId);
 			if (!targetSessionPath || !existsSync(targetSessionPath)) {
 				json(res, 404, { error: "Session not found" });

--- a/apps/inno-agent/web/src/api/client.ts
+++ b/apps/inno-agent/web/src/api/client.ts
@@ -2,6 +2,8 @@ export class ApiError extends Error {
 	constructor(
 		public status: number,
 		message: string,
+		/** Parsed error response body, when the server sent one (e.g. 409 session_busy carries `blocking`). */
+		public data?: Record<string, unknown>,
 	) {
 		super(message);
 		this.name = "ApiError";
@@ -17,11 +19,20 @@ export async function apiFetch<T>(path: string, options?: RequestInit): Promise<
 	});
 	if (!res.ok) {
 		const body = await res.json().catch(() => ({}));
-		throw new ApiError(res.status, (body as Record<string, string>).error || res.statusText);
+		throw new ApiError(res.status, (body as Record<string, string>).error || res.statusText, body as Record<string, unknown>);
 	}
 	// 204 No Content
 	if (res.status === 204) return undefined as T;
 	return res.json() as Promise<T>;
+}
+
+/** Reject with `message` if the promise doesn't settle within `ms`. */
+export function withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(message)), ms);
+	});
+	return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
 }
 
 /**

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -43,7 +43,11 @@
 		"pasteCollapsed": "«Pasted {{count}} lines»",
 		"pasteCollapsedUndo": "Undo paste",
 		"questionPending": "Please answer the question above before continuing",
-		"questionPendingJump": "View question"
+		"questionPendingJump": "View question",
+		"sessionBusy": "Another session's task is still running and blocking this action",
+		"sessionBusyQuestion": "Another session is waiting for your answer, blocking this action",
+		"sessionBusyStop": "Stop it and retry",
+		"sessionBusyDismiss": "Dismiss"
 	},
 	"desktop": {
 		"closeDialog": {

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -43,7 +43,11 @@
 		"pasteCollapsed": "«已粘贴 {{count}} 行»",
 		"pasteCollapsedUndo": "撤销粘贴",
 		"questionPending": "请完成上方问卷后再继续对话",
-		"questionPendingJump": "查看问卷"
+		"questionPendingJump": "查看问卷",
+		"sessionBusy": "另一个会话的任务仍在运行，阻塞了当前操作",
+		"sessionBusyQuestion": "另一个会话正在等待你的回答，阻塞了当前操作",
+		"sessionBusyStop": "停止并重试",
+		"sessionBusyDismiss": "知道了"
 	},
 	"desktop": {
 		"closeDialog": {

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -772,6 +772,7 @@ export function ChatCenter() {
 	const sessions = useStoreSnapshot(sessionsStore, () => ({
 		currentSessionId: sessionsStore.currentSessionId,
 		preselectedWorkspaceId: sessionsStore.preselectedWorkspaceId,
+		busyBlocker: sessionsStore.busyBlocker,
 		// Single source of truth for the welcome-vs-session view (see store).
 		// Depends on chatStore too, but ChatCenter subscribes to chatStore via
 		// the `chat` snapshot above, so this re-evaluates on chat changes.
@@ -1239,6 +1240,27 @@ export function ChatCenter() {
 		) : null
 	);
 
+	const renderBusyBlocker = () => (
+		sessions.busyBlocker ? (
+			<div className="mb-2 flex items-center gap-2 rounded-md border border-[var(--inno-border)] bg-[var(--inno-accent-soft)] px-3 py-1.5 text-xs text-[var(--inno-text-muted)]">
+				<AlertTriangle size={14} className="shrink-0 text-[var(--inno-warning)]" />
+				<span>{t(sessions.busyBlocker.questionPending ? "common.sessionBusyQuestion" : "common.sessionBusy")}</span>
+				<button
+					className="ml-auto shrink-0 rounded px-2 py-0.5 font-medium text-[var(--inno-warning)] hover:bg-[var(--inno-surface-muted)]"
+					onClick={() => void sessionsStore.stopBusyBlockerAndRetry()}
+				>
+					{t("common.sessionBusyStop")}
+				</button>
+				<button
+					className="shrink-0 rounded px-2 py-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)]"
+					onClick={() => sessionsStore.dismissBusyBlocker()}
+				>
+					{t("common.sessionBusyDismiss")}
+				</button>
+			</div>
+		) : null
+	);
+
 	const renderComposer = (placeholder: string) => (
 		<div className="inno-composer flex items-end gap-2 rounded-lg p-2">
 			<input ref={fileInputRef} id="file-input" type="file" className="hidden" multiple onChange={handleFiles} />
@@ -1357,6 +1379,7 @@ export function ChatCenter() {
 						{renderUploadChips()}
 						{renderInlineImagePreviews()}
 						{renderQuestionHint()}
+						{renderBusyBlocker()}
 						{renderComposer(t("chat.welcomePlaceholder"))}
 
 						{simpleMode && presets.length > 0 ? (
@@ -1536,6 +1559,7 @@ export function ChatCenter() {
 					{renderUploadChips()}
 					{renderInlineImagePreviews()}
 					{renderQuestionHint()}
+					{renderBusyBlocker()}
 					{wsError ? <p className="mb-2 text-xs text-[var(--inno-danger)]">{wsError}</p> : null}
 					{renderComposer(t("chat.composerPlaceholder"))}
 				</div>

--- a/apps/inno-agent/web/src/stores/sessions-store.test.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
 	createSession: vi.fn(),
 	activateSession: vi.fn(),
 	getChatStatus: vi.fn(),
+	abortChat: vi.fn(),
 	chatDetach: vi.fn(),
 	chatClear: vi.fn(),
 	chatLoadHistory: vi.fn(),
@@ -24,7 +25,7 @@ vi.mock("../api/sessions.js", () => ({
 	unarchiveSession: vi.fn(),
 	updateSessionName: vi.fn(),
 }));
-vi.mock("../api/chat.js", () => ({ getChatStatus: mocks.getChatStatus }));
+vi.mock("../api/chat.js", () => ({ getChatStatus: mocks.getChatStatus, abortChat: mocks.abortChat }));
 vi.mock("../api/workspaces.js", () => ({ getSessionWorkspace: vi.fn().mockResolvedValue({ workspaceId: "workspace-1" }) }));
 vi.mock("./chat-store.js", () => ({
 	chatStore: {
@@ -44,6 +45,7 @@ vi.mock("./workspaces-store.js", () => ({ workspacesStore: { load: vi.fn() } }))
 vi.mock("./terminal-store.js", () => ({ terminalStore: { disconnect: vi.fn() } }));
 
 import { SessionsStoreImpl } from "./sessions-store.js";
+import { ApiError } from "../api/client.js";
 
 function session(id: string) {
 	return {
@@ -109,5 +111,46 @@ describe("SessionsStore navigation", () => {
 		await openingA;
 		expect(store.currentSessionId).toBe("b.jsonl");
 		expect(mocks.chatLoadHistory).toHaveBeenLastCalledWith([], "b.jsonl");
+	});
+
+	it("beginNewSession invalidates an in-flight openSession", async () => {
+		let resolveA!: (value: ReturnType<typeof session>) => void;
+		const a = new Promise<ReturnType<typeof session>>((resolve) => { resolveA = resolve; });
+		mocks.getSession.mockImplementation((id: string) => id === "a.jsonl" ? a : Promise.resolve(session(id)));
+		const store = new SessionsStoreImpl();
+		store.currentSessionId = "x.jsonl";
+		const openingA = store.openSession("a.jsonl", { historyMode: "none" });
+		await Promise.resolve();
+		store.beginNewSession();
+		resolveA(session("a.jsonl"));
+		await openingA;
+		expect(store.currentSessionId).toBeNull();
+		expect(store.pendingNewSession).toBe(true);
+		expect(mocks.chatSetLoadingHistory).toHaveBeenCalledWith(false);
+	});
+
+	it("surfaces a busy blocker when session creation hits a queue-blocked 409", async () => {
+		mocks.createSession.mockRejectedValue(
+			new ApiError(409, "session_busy", { error: "session_busy", blocking: { sessionId: "old.jsonl", turnId: "t-1", questionPending: true } }),
+		);
+		const store = new SessionsStoreImpl();
+		await store.createSessionWith({ workspaceId: "workspace-1" });
+		expect(store.busyBlocker).toEqual({ sessionId: "old.jsonl", turnId: "t-1", questionPending: true });
+		expect(store.currentSessionId).toBeNull();
+		expect(mocks.chatShowError).not.toHaveBeenCalled();
+	});
+
+	it("stopBusyBlockerAndRetry aborts the blocking turn and retries creation", async () => {
+		mocks.createSession
+			.mockRejectedValueOnce(new ApiError(409, "session_busy", { error: "session_busy", blocking: { sessionId: "old.jsonl", turnId: "t-1" } }))
+			.mockResolvedValueOnce({ id: "new.jsonl", active: true, workspaceId: "workspace-1" });
+		mocks.abortChat.mockResolvedValue(undefined);
+		const store = new SessionsStoreImpl();
+		await store.createSessionWith({ workspaceId: "workspace-1" });
+		expect(store.busyBlocker?.turnId).toBe("t-1");
+		await store.stopBusyBlockerAndRetry();
+		expect(mocks.abortChat).toHaveBeenCalledWith("old.jsonl", "t-1");
+		expect(store.currentSessionId).toBe("new.jsonl");
+		expect(store.busyBlocker).toBeNull();
 	});
 });

--- a/apps/inno-agent/web/src/stores/sessions-store.ts
+++ b/apps/inno-agent/web/src/stores/sessions-store.ts
@@ -14,7 +14,8 @@ import {
 	type SessionMeta,
 } from "../api/sessions.js";
 import { getSessionWorkspace } from "../api/workspaces.js";
-import { getChatStatus } from "../api/chat.js";
+import { abortChat, getChatStatus } from "../api/chat.js";
+import { ApiError, withTimeout } from "../api/client.js";
 import { chatStore } from "./chat-store.js";
 import type { PendingQuestion } from "../types/chat.js";
 import { workspaceStore } from "./workspace-store.js";
@@ -42,6 +43,11 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	/** When set, a new session should be pre-bound to this workspace (set from the sidebar). */
 	preselectedWorkspaceId: string | null = null;
 	private _openRequestId = 0;
+	/** Set when a queue-backed op (create/activate) got a 409 session_busy:
+	 *  another session's turn holds the shared prompt queue. The UI offers to
+	 *  stop that turn and retry. */
+	busyBlocker: { sessionId: string; turnId: string; questionPending: boolean } | null = null;
+	private _lastCreateInput: CreateSessionInput | null = null;
 	private _messageCache = new Map<string, Awaited<ReturnType<typeof getSession>>["messages"]>();
 	/** Caches an unanswered question card across session switches so it can be
 	 *  restored instantly when switching back (the backend replay/persistence
@@ -203,8 +209,10 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 				console.warn(`[sessions] failed to load workspace for ${id}:`, err instanceof Error ? err.message : err);
 			});
 
-		try {
-			const session = await getSession(id);
+			try {
+			// Hard bound on history load: without it a stuck request would pin
+			// isLoadingHistory forever ("正在加载会话…" with no way out, #124).
+			const session = await withTimeout(getSession(id), 15_000, "加载会话超时，请重试");
 			const chatStatus = await getChatStatus(id).catch((error) => {
 				console.warn(`[sessions] failed to load chat status for ${id}:`, error instanceof Error ? error.message : error);
 				return { found: false } as Awaited<ReturnType<typeof getChatStatus>>;
@@ -290,6 +298,11 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 	 * can't keep `chatStore.isSending` true and block the chooser / input.
 	 */
 	beginNewSession(): void {
+		// Invalidate any in-flight openSession so its late completion can't
+		// clobber the new-session state (load old messages into it, or leave
+		// isLoadingHistory stuck on). Matches showWelcomeFromHistory.
+		this._openRequestId++;
+		chatStore.setLoadingHistory(false);
 		if (this.currentSessionId && chatStore.isSending) {
 			this._backgroundRunningSessions.add(this.currentSessionId);
 			this._messageCache.set(this.currentSessionId, chatStore.messages);
@@ -339,7 +352,12 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 		void terminalStore.disconnect();
 		this.emit("change", undefined);
 		try {
-			const created = await createSession(input);
+			// Server answers 409 session_busy within ~8s when another session's
+			// turn holds the queue; the 45s ceiling is only a last-resort guard
+			// (first-time preset downloads can legitimately take a while).
+			const created = await withTimeout(createSession(input), 45_000, "创建会话超时，请重试");
+			this.busyBlocker = null;
+			this._lastCreateInput = null;
 			this._messageCache.clear();
 			chatStore.clear();
 			// Refresh side panels so the new workspace shows up.
@@ -351,10 +369,48 @@ export class SessionsStoreImpl extends EventEmitter<SessionsStoreEvents> {
 				void workspaceStore.setActiveWorkspace(created.workspaceId);
 			}
 			this.emit("change", undefined);
+		} catch (err) {
+			const blocking = err instanceof ApiError && err.status === 409
+				? (err.data?.blocking as { sessionId: string; turnId: string; questionPending?: boolean } | undefined)
+				: undefined;
+			if (blocking?.sessionId && blocking.turnId) {
+				// Another session's turn holds the queue — offer to stop it and retry.
+				this.busyBlocker = {
+					sessionId: blocking.sessionId,
+					turnId: blocking.turnId,
+					questionPending: blocking.questionPending === true,
+				};
+				this._lastCreateInput = input;
+			} else {
+				chatStore.showError(err instanceof Error ? err.message : "创建会话失败");
+			}
+			this.emit("change", undefined);
 		} finally {
 			this.isLoading = false;
 			this.emit("change", undefined);
 		}
+	}
+
+	/** Stop the turn holding the prompt queue, then retry the session creation it blocked. */
+	async stopBusyBlockerAndRetry(): Promise<void> {
+		const blocker = this.busyBlocker;
+		if (!blocker) return;
+		try {
+			await abortChat(blocker.sessionId, blocker.turnId);
+		} catch {
+			// The turn may have ended on its own — proceed to retry regardless.
+		}
+		this.busyBlocker = null;
+		this.emit("change", undefined);
+		const input = this._lastCreateInput;
+		this._lastCreateInput = null;
+		if (input) await this.createSessionWith(input);
+	}
+
+	dismissBusyBlocker(): void {
+		this.busyBlocker = null;
+		this._lastCreateInput = null;
+		this.emit("change", undefined);
 	}
 
 	async clearSelection() {


### PR DESCRIPTION
## Summary

Fixes #124 — switching sessions or creating a new one while an old session was thinking / waiting on a question card could leave the UI permanently stuck ("正在加载会话…", unsendable messages).

### Root cause (reproduced live)

A turn parked on an `ask_user_question` card holds the shared serial prompt queue for up to the 30-minute question timeout. `createNewSession` / `switchSessionFile` / other sessions' prompts all enqueue behind it, so they hang for minutes. Worse, queued ops still executed after the caller gave up — measured: a `createSession` whose client disconnected at 2s ran ~30s later, producing a ghost session and jumbled runtime switches.

| Scenario (question-blocked turn) | Before | After |
|---|---|---|
| Switch to another session (activate) | hung up to 30 min | **~50ms** (auto-abort releases queue) |
| Create new session | hung up to 30 min | **~55ms** |
| Switch while other session actively generating | hung until turn end | **409 in 8s** with blocker details |
| Client gives up mid-queue | ghost session executes later | **never executes** |

## Changes

**Backend**
- `enqueue()` accepts an `AbortSignal`: cancelled tasks reject *eagerly* (handlers answer immediately) and *never execute* once their slot arrives.
- `POST /api/sessions`, `/api/sessions/:id/activate`, session delete, and workspace rebind run queue ops with an 8s bound → `409 session_busy` + `blocking: {sessionId, turnId, questionPending}`; client disconnect (`res.close` before finish) cancels the queued op.
- Session-retention policy (per maintainer decision): navigating to a *different* session implicitly abandons an unanswered question card → activate/create/stream auto-abort a question-blocked turn. The scoped abort already unbinds the card and clears its persisted record. Actively generating turns are never auto-aborted.
- `QuestionBridge.pendingInfo()` for blocker introspection.

**Frontend**
- `openSession` (15s) and `createSessionWith` (45s) have hard timeouts — the loading state always has an exit.
- `409 session_busy` surfaces a banner: "另一个会话正在等待你的回答… [停止并重试]" — aborts the blocking turn via the existing scoped-abort API and retries.
- `beginNewSession()` now invalidates in-flight `openSession` requests (previously a late completion could clobber the new-session state).

## Verification

- `npm run build` ✓, `npm test` ✓ (17 files, 101 tests — 3 new store tests for the invalidation + busy-blocker flows)
- End-to-end against a live server with a real LLM turn: the four scenarios in the table above, plus a regression check that normal activate stays instant (~7ms).
- Deliberate deviation caught by testing: first version rejected cancelled tasks only lazily and used `req.close` (which fires when the request body finishes, not on disconnect) — fixed to eager rejection + `res.close` before finishing.

## Out of scope (documented follow-ups)

- Sending in session B while session A is *actively generating* still queues B's turn until A finishes (bounded by the provider timeout). The queued state is visible in the UI; the busy banner covers switch/create paths.
- Longer-term redesign option: turn-boundary questions (ask_user_question ends the turn; answering starts a new one) would eliminate queue-holding waits entirely.