### PR TITLE
fix(web): stabilize custom workspace sorting controls

### DIFF
--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -1051,7 +1051,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 
 				{/* Channel filters + workspace ordering — hidden in Simple Mode. */}
 				{!simpleMode && (
-					<div className="relative flex items-center gap-1">
+					<div className="relative flex h-6 items-center gap-1">
 						{state.availableChannels.length > 1 ? (
 							<div className="chip-scroll flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
 								<button

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -639,15 +639,17 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 
 	const beginCustomSort = useCallback(() => {
 		setCustomOrderDraft(sortableGroupIds);
+		setCollapsedGroups(new Set(groups.map((group) => group.id)));
 		setDraggingWorkspaceId(null);
 		setIsCustomSorting(true);
 		setSortMenuOpen(false);
-	}, [sortableGroupIds]);
+	}, [groups, sortableGroupIds]);
 
 	const finishCustomSort = useCallback(() => {
 		setCustomOrder(customOrderDraft);
 		setWorkspaceSort("custom");
 		setIsCustomSorting(false);
+		setCollapsedGroups(new Set());
 		setDraggingWorkspaceId(null);
 		window.localStorage.setItem(WORKSPACE_SORT_STORAGE_KEY, "custom");
 		window.localStorage.setItem(WORKSPACE_CUSTOM_ORDER_STORAGE_KEY, JSON.stringify(customOrderDraft));
@@ -655,6 +657,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 
 	const cancelCustomSort = useCallback(() => {
 		setIsCustomSorting(false);
+		setCollapsedGroups(new Set());
 		setDraggingWorkspaceId(null);
 		setCustomOrderDraft([]);
 	}, []);


### PR DESCRIPTION
## Summary

Improves the workspace custom-sorting experience and keeps the sorting controls visually stable.

## Changes

- Collapse all workspace groups when custom sorting starts so the drag-and-drop order is clear.
- Restore the expanded workspace view after saving or cancelling custom sorting.
- Keep the channel-control row at a fixed height to prevent layout shifts while sorting.

## User impact

Custom workspace ordering is easier to follow, and the sidebar no longer changes height when the sorting controls appear.

## Verification

- `npm --workspace inno-agent-web run build` ✓
- `npm test` ✓ (17 files, 101 tests)

## Preview

<img width="1200" height="800" alt="GIFSpeed-4" src="https://github.com/user-attachments/assets/ef6f8d64-6869-40f7-8284-71d2ffe0699f" />


