### PR TITLE
test: P1 test infrastructure — jsdom, server smoke suite, scheduler/channels/terminal tests

### DIFF
--- a/apps/inno-agent/src/channels/dedupe-store.test.ts
+++ b/apps/inno-agent/src/channels/dedupe-store.test.ts
@@ -1,0 +1,62 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DedupeStore } from "./dedupe-store.js";
+
+let dir: string;
+let file: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "inno-dedupe-"));
+	file = join(dir, "dedupe.jsonl");
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("DedupeStore", () => {
+	it("treats an unmarked message as new and a marked one as duplicate", () => {
+		const store = new DedupeStore(file);
+		expect(store.isDuplicate("feishu", "msg-1")).toBe(false);
+		store.mark("feishu", "msg-1");
+		expect(store.isDuplicate("feishu", "msg-1")).toBe(true);
+	});
+
+	it("scopes duplicates per channel", () => {
+		const store = new DedupeStore(file);
+		store.mark("feishu", "msg-1");
+		expect(store.isDuplicate("qq", "msg-1")).toBe(false);
+	});
+
+	it("persists marks across instances (process restart)", () => {
+		new DedupeStore(file).mark("feishu", "msg-1");
+		const reloaded = new DedupeStore(file);
+		expect(reloaded.isDuplicate("feishu", "msg-1")).toBe(true);
+	});
+
+	it("expires entries past their TTL", () => {
+		const store = new DedupeStore(file, /* ttlMs */ -1);
+		store.mark("feishu", "msg-1");
+		expect(store.isDuplicate("feishu", "msg-1")).toBe(false);
+	});
+
+	it("does not load expired entries from disk", () => {
+		const past = new Date(Date.now() - 60_000).toISOString();
+		writeFileSync(
+			file,
+			JSON.stringify({ key: "feishu:msg-old", seenAt: past, expiresAt: past }) + "\n",
+			"utf-8",
+		);
+		const store = new DedupeStore(file);
+		expect(store.isDuplicate("feishu", "msg-old")).toBe(false);
+	});
+
+	it("cleanup() drops expired in-memory entries", () => {
+		const store = new DedupeStore(file, /* ttlMs */ -1);
+		store.mark("feishu", "msg-1");
+		store.cleanup();
+		expect(store.isDuplicate("feishu", "msg-1")).toBe(false);
+	});
+});

--- a/apps/inno-agent/src/scheduler/cron-utils.test.ts
+++ b/apps/inno-agent/src/scheduler/cron-utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { computeNextRunAt, isCronDue, isOneShotCron, validateCron } from "./cron-utils.js";
+
+describe("validateCron", () => {
+	it("accepts a valid 5-field expression", () => {
+		expect(validateCron("0 9 * * *")).toEqual({ ok: true });
+	});
+
+	it("rejects an empty expression", () => {
+		const result = validateCron("   ");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toMatch(/required/i);
+	});
+
+	it("rejects expressions with the wrong field count", () => {
+		const result = validateCron("0 9 * *");
+		expect(result.ok).toBe(false);
+		if (!result.ok) expect(result.error).toContain("5 fields");
+	});
+
+	it("rejects unparseable field values", () => {
+		const result = validateCron("99 9 * * *");
+		expect(result.ok).toBe(false);
+	});
+});
+
+describe("computeNextRunAt", () => {
+	it("returns a future ISO timestamp for a valid cron", () => {
+		const now = new Date("2026-08-09T10:00:00Z");
+		const next = computeNextRunAt("* * * * *", "Asia/Shanghai", now);
+		expect(next).toBeDefined();
+		expect(new Date(next!).getTime()).toBeGreaterThan(now.getTime());
+	});
+
+	it("returns undefined for an invalid cron instead of throwing", () => {
+		expect(computeNextRunAt("not a cron", "Asia/Shanghai")).toBeUndefined();
+	});
+
+	it("honours the timezone: 9am Shanghai is 01:00Z", () => {
+		// 2026-08-10 is a Monday; pick a cron that fires daily at 09:00.
+		const now = new Date("2026-08-09T00:00:00Z");
+		const next = computeNextRunAt("0 9 * * *", "Asia/Shanghai", now);
+		expect(next).toBe("2026-08-09T01:00:00.000Z");
+	});
+});
+
+describe("isCronDue", () => {
+	it("is due within the 2-minute catch-up window when never run", () => {
+		// Every-minute cron: prev fire is the start of the current minute.
+		const now = new Date("2026-08-09T10:00:30Z");
+		expect(isCronDue("* * * * *", "Asia/Shanghai", undefined, now)).toBe(true);
+	});
+
+	it("is not due when the previous fire is older than the catch-up window", () => {
+		// Hourly cron at minute 0; "now" is 30 minutes past the last fire.
+		const now = new Date("2026-08-09T10:30:00Z");
+		expect(isCronDue("0 * * * *", "Asia/Shanghai", undefined, now)).toBe(false);
+	});
+
+	it("is not due when it already ran after the previous fire", () => {
+		const now = new Date("2026-08-09T10:00:30Z");
+		const lastRunAt = "2026-08-09T10:00:05.000Z";
+		expect(isCronDue("* * * * *", "Asia/Shanghai", lastRunAt, now)).toBe(false);
+	});
+
+	it("returns false for an invalid cron instead of throwing", () => {
+		expect(isCronDue("garbage", "Asia/Shanghai", undefined)).toBe(false);
+	});
+});
+
+describe("isOneShotCron", () => {
+	it("flags a fully pinned date-time expression", () => {
+		expect(isOneShotCron("30 14 28 2 *")).toBe(true);
+	});
+
+	it("does not flag recurring expressions", () => {
+		expect(isOneShotCron("0 9 * * *")).toBe(false);
+		expect(isOneShotCron("30 14 28 * *")).toBe(false);
+	});
+
+	it("returns false for malformed input", () => {
+		expect(isOneShotCron("")).toBe(false);
+		expect(isOneShotCron("* * *")).toBe(false);
+	});
+});

--- a/apps/inno-agent/src/scheduler/job-store.test.ts
+++ b/apps/inno-agent/src/scheduler/job-store.test.ts
@@ -1,0 +1,121 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { JobStore } from "./job-store.js";
+import type { ScheduledJob } from "./types.js";
+
+let dir: string;
+let store: JobStore;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "inno-jobstore-"));
+	store = new JobStore(dir);
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function createJob(overrides: Partial<Parameters<JobStore["create"]>[0]> = {}) {
+	return store.create({
+		name: "daily review",
+		cron: "0 9 * * *",
+		timezone: "",
+		enabled: true,
+		taskType: "daily_review",
+		prompt: "review my notes",
+		...overrides,
+	});
+}
+
+describe("JobStore.create", () => {
+	it("applies defaults: Asia/Shanghai timezone, counters, computed nextRunAt", () => {
+		const job = createJob();
+		expect(job.id).toMatch(/^job_/);
+		expect(job.timezone).toBe("Asia/Shanghai");
+		expect(job.runCount).toBe(0);
+		expect(job.failureCount).toBe(0);
+		expect(job.nextRunAt).toBeDefined();
+		expect(new Date(job.nextRunAt!).getTime()).toBeGreaterThan(Date.now() - 60_000);
+	});
+
+	it("persists jobs to jobs.json so a fresh store sees them", () => {
+		const job = createJob();
+		const reloaded = new JobStore(dir);
+		expect(reloaded.get(job.id)?.name).toBe("daily review");
+	});
+});
+
+describe("JobStore.update", () => {
+	it("clears nextRunAt when the job is disabled", () => {
+		const job = createJob();
+		const updated = store.update(job.id, { enabled: false });
+		expect(updated?.enabled).toBe(false);
+		expect(updated?.nextRunAt).toBeUndefined();
+	});
+
+	it("recomputes nextRunAt when the cron changes on an enabled job", () => {
+		const job = createJob();
+		const updated = store.update(job.id, { cron: "*/5 * * * *" });
+		expect(updated?.nextRunAt).toBeDefined();
+	});
+
+	it("returns undefined for an unknown id", () => {
+		expect(store.update("job_missing", { name: "x" })).toBeUndefined();
+	});
+});
+
+describe("JobStore.normalizePersistedJobs", () => {
+	it("backfills missing fields on legacy partial jobs", () => {
+		// Simulate a jobs.json written by an older version: bare minimum fields,
+		// no runCount/nextRunAt/createdAt.
+		const legacy = [{ id: "job_legacy1", name: "old job", cron: "0 9 * * *", taskType: "custom_prompt", prompt: "hi" }];
+		writeFileSync(join(dir, "jobs.json"), JSON.stringify(legacy), "utf-8");
+
+		const jobs = store.normalizePersistedJobs();
+		expect(jobs).toHaveLength(1);
+		const job = jobs[0];
+		expect(job.id).toBe("job_legacy1");
+		expect(job.timezone).toBe("Asia/Shanghai");
+		expect(job.runCount).toBe(0);
+		expect(job.nextRunAt).toBeDefined();
+		expect(job.createdAt).toBeDefined();
+
+		// The normalized shape must be written back to disk.
+		const onDisk = JSON.parse(readFileSync(join(dir, "jobs.json"), "utf-8")) as ScheduledJob[];
+		expect(onDisk[0].runCount).toBe(0);
+		expect(onDisk[0].nextRunAt).toBeDefined();
+	});
+
+	it("keeps nextRunAt undefined for disabled legacy jobs", () => {
+		const legacy = [{ id: "job_off", name: "disabled", cron: "0 9 * * *", enabled: false }];
+		writeFileSync(join(dir, "jobs.json"), JSON.stringify(legacy), "utf-8");
+		const jobs = store.normalizePersistedJobs();
+		expect(jobs[0].nextRunAt).toBeUndefined();
+	});
+});
+
+describe("JobStore runs", () => {
+	it("appends run records and lists newest first, filtered by jobId", () => {
+		const a = createJob({ name: "a" });
+		const b = createJob({ name: "b" });
+		store.appendRun({ id: "r1", jobId: a.id, jobName: "a", status: "success", startedAt: "2026-08-09T01:00:00Z", trigger: "scheduled" });
+		store.appendRun({ id: "r2", jobId: b.id, jobName: "b", status: "error", startedAt: "2026-08-09T02:00:00Z", trigger: "manual" });
+
+		expect(store.listRuns(a.id).map((r) => r.id)).toEqual(["r1"]);
+		expect(store.listRuns().map((r) => r.id)).toEqual(["r2", "r1"]);
+	});
+});
+
+describe("JobStore.getStatus", () => {
+	it("counts totals and picks the earliest upcoming run", () => {
+		createJob({ name: "enabled" });
+		createJob({ name: "disabled", enabled: false });
+		const status = store.getStatus();
+		expect(status.total).toBe(2);
+		expect(status.enabled).toBe(1);
+		expect(status.disabled).toBe(1);
+		expect(status.nextRunAt).toBeDefined();
+	});
+});

--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -1,0 +1,153 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * HTTP smoke tests for server.ts — the safety net for the route-domain
+ * extraction in docs/quality-remediation-plan.md (P2).
+ *
+ * server.ts is a side-effect-only entry point (no exports), so these tests
+ * spawn it as a child process against a throwaway --home with a dummy
+ * provider, then assert status codes / redaction on a handful of endpoints.
+ * No LLM calls are made.
+ */
+
+const SERVER_ENTRY = resolve(import.meta.dirname, "server.ts");
+const REPO_ROOT = resolve(import.meta.dirname, "../../..");
+
+const DUMMY_API_KEY = "sk-test-secret-key-12345";
+
+let home: string;
+let workspace: string;
+let port: number;
+let child: ChildProcess;
+let childLog = "";
+
+async function getFreePort(): Promise<number> {
+	return new Promise((resolvePort, reject) => {
+		const srv = createServer();
+		srv.listen(0, "127.0.0.1", () => {
+			const freePort = (srv.address() as AddressInfo).port;
+			srv.close(() => resolvePort(freePort));
+		});
+		srv.on("error", reject);
+	});
+}
+
+function api(path: string): Promise<Response> {
+	return fetch(`http://127.0.0.1:${port}${path}`);
+}
+
+beforeAll(async () => {
+	home = mkdtempSync(join(tmpdir(), "inno-smoke-home-"));
+	workspace = mkdtempSync(join(tmpdir(), "inno-smoke-ws-"));
+	mkdirSync(join(home, "config"), { recursive: true });
+	writeFileSync(
+		join(home, "config", "config.json"),
+		JSON.stringify({
+			defaultProvider: "dummy",
+			defaultModel: "dummy-model",
+			providers: {
+				dummy: {
+					baseUrl: "http://127.0.0.1:9", // nothing listens here; no LLM call is made
+					apiKey: DUMMY_API_KEY,
+					api: "openai-completions",
+					models: [{ id: "dummy-model" }],
+				},
+			},
+		}),
+		"utf-8",
+	);
+
+	port = await getFreePort();
+	child = spawn(
+		process.execPath,
+		["--import", "tsx", SERVER_ENTRY, "--home", home, "--workspace", workspace, "--port", String(port)],
+		{ cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] },
+	);
+	child.stdout?.on("data", (chunk) => (childLog += chunk));
+	child.stderr?.on("data", (chunk) => (childLog += chunk));
+
+	// Wait for readiness: poll /health (it answers before any bootstrap).
+	const deadline = Date.now() + 90_000;
+	let ready = false;
+	let exitCode: number | null = null;
+	child.on("exit", (code) => {
+		exitCode = code;
+	});
+	while (Date.now() < deadline) {
+		if (exitCode !== null) {
+			throw new Error(`server exited early with code ${exitCode}\n--- child log ---\n${childLog}`);
+		}
+		try {
+			const res = await api("/health");
+			if (res.status === 200) {
+				ready = true;
+				break;
+			}
+		} catch {
+			// connection refused while the server is still starting
+		}
+		await new Promise((r) => setTimeout(r, 250));
+	}
+	if (!ready) {
+		throw new Error(`server did not become ready within 90s\n--- child log ---\n${childLog}`);
+	}
+}, 120_000);
+
+afterAll(async () => {
+	if (child && !child.killed) {
+		child.kill("SIGTERM");
+		await new Promise<void>((resolveDone) => {
+			const force = setTimeout(() => {
+				child.kill("SIGKILL");
+				resolveDone();
+			}, 5_000);
+			child.on("exit", () => {
+				clearTimeout(force);
+				resolveDone();
+			});
+		});
+	}
+	rmSync(home, { recursive: true, force: true });
+	rmSync(workspace, { recursive: true, force: true });
+}, 30_000);
+
+describe("server smoke", () => {
+	it("GET /health returns 200 ok without bootstrap side effects", async () => {
+		const res = await api("/health");
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual({ status: "ok" });
+	});
+
+	it("GET /api/settings returns 200 with provider API keys redacted", async () => {
+		const res = await api("/api/settings");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as {
+			providers: Record<string, { apiKey: string }>;
+		};
+		const apiKey = body.providers.dummy.apiKey;
+		expect(apiKey).not.toBe(DUMMY_API_KEY);
+		expect(apiKey).toMatch(/^\*\*\*\*/);
+		expect(apiKey.endsWith(DUMMY_API_KEY.slice(-4))).toBe(true);
+	}, 60_000 /* first /api/* call triggers lazy bootstrap */);
+
+	it("GET /api/sessions returns 200", async () => {
+		const res = await api("/api/sessions");
+		expect(res.status).toBe(200);
+	}, 60_000);
+
+	it("GET /api/jobs returns 200", async () => {
+		const res = await api("/api/jobs");
+		expect(res.status).toBe(200);
+	});
+
+	it("unknown /api/ route returns a JSON 404 (not the SPA index.html)", async () => {
+		const res = await api("/api/definitely-not-a-route");
+		expect(res.status).toBe(404);
+		expect(res.headers.get("content-type")).toContain("application/json");
+	});
+});

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -5156,8 +5156,10 @@ const server = createServer(async (req, res) => {
 			const sendBody = method === "GET";
 			// Try exact file in web/dist
 			if (staticPath && serveStatic(req, res, staticPath, sendBody)) return;
-			// SPA fallback: serve index.html for non-API paths
-			if (serveStatic(req, res, join(webDistDir, "index.html"), sendBody)) return;
+			// SPA fallback: serve index.html for non-API paths only. An unmatched
+			// /api/* route must fall through to the JSON 404 — returning HTML with
+			// a 200 status breaks API client error handling.
+			if (urlPath !== "/api" && !urlPath.startsWith("/api/") && serveStatic(req, res, join(webDistDir, "index.html"), sendBody)) return;
 		}
 
 		// --- 404 ---

--- a/apps/inno-agent/src/terminal/command-resolver.test.ts
+++ b/apps/inno-agent/src/terminal/command-resolver.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { defaultRunCommand, isRunnable } from "./command-resolver.js";
+
+describe("defaultRunCommand", () => {
+	it("maps each runnable extension to its runner", () => {
+		expect(defaultRunCommand("main.py")).toBe("python main.py");
+		expect(defaultRunCommand("app.js")).toBe("node app.js");
+		expect(defaultRunCommand("mod.mjs")).toBe("node mod.mjs");
+		expect(defaultRunCommand("cli.cjs")).toBe("node cli.cjs");
+		expect(defaultRunCommand("script.ts")).toBe("npx tsx script.ts");
+		expect(defaultRunCommand("comp.tsx")).toBe("npx tsx comp.tsx");
+		expect(defaultRunCommand("run.sh")).toBe("bash run.sh");
+		expect(defaultRunCommand("env.bash")).toBe("bash env.bash");
+		expect(defaultRunCommand("rc.zsh")).toBe("bash rc.zsh");
+	});
+
+	it("returns null for non-runnable files", () => {
+		expect(defaultRunCommand("notes.md")).toBeNull();
+		expect(defaultRunCommand("image.png")).toBeNull();
+		expect(defaultRunCommand("Makefile")).toBeNull();
+	});
+
+	it("matches extensions case-insensitively", () => {
+		expect(defaultRunCommand("MAIN.PY")).toBe("python MAIN.PY");
+	});
+
+	it("quotes paths containing spaces", () => {
+		const cmd = defaultRunCommand("my dir/hello world.py");
+		// POSIX: " escaped as \"; PowerShell: "" — both wrap in double quotes.
+		expect(cmd).toBe('python "my dir/hello world.py"');
+	});
+
+	it("leaves simple paths unquoted", () => {
+		expect(defaultRunCommand("src/main.py")).toBe("python src/main.py");
+	});
+});
+
+describe("isRunnable", () => {
+	it("mirrors defaultRunCommand", () => {
+		expect(isRunnable("a.py")).toBe(true);
+		expect(isRunnable("a.txt")).toBe(false);
+	});
+});

--- a/apps/inno-agent/web/src/react/ui/Switch.test.tsx
+++ b/apps/inno-agent/web/src/react/ui/Switch.test.tsx
@@ -1,0 +1,29 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Switch } from "./Switch.js";
+
+afterEach(cleanup);
+
+describe("Switch", () => {
+	it("renders as a switch with the checked state exposed to a11y", () => {
+		render(<Switch checked={true} onChange={() => {}} aria-label="toggle memory" />);
+		const el = screen.getByRole("switch", { name: "toggle memory" });
+		expect(el.getAttribute("aria-checked")).toBe("true");
+	});
+
+	it("calls onChange with the inverted value on click", () => {
+		const onChange = vi.fn();
+		render(<Switch checked={false} onChange={onChange} />);
+		fireEvent.click(screen.getByRole("switch"));
+		expect(onChange).toHaveBeenCalledWith(true);
+	});
+
+	it("does not fire onChange when disabled", () => {
+		const onChange = vi.fn();
+		render(<Switch checked={false} onChange={onChange} disabled />);
+		const el = screen.getByRole("switch");
+		expect(el).toHaveProperty("disabled", true);
+		fireEvent.click(el);
+		expect(onChange).not.toHaveBeenCalled();
+	});
+});

--- a/docs/quality-remediation-plan.md
+++ b/docs/quality-remediation-plan.md
@@ -30,14 +30,14 @@
 
 测试偏科的根因是"只有纯函数好测"。补三层：
 
-1. **web 端 DOM 环境**：`web/vitest.config.ts` 加 `environment: "jsdom"`（或 happy-dom）+ `@testing-library/react`，组件测试从此可行。存量 4 个 web 测试是纯 store/util，不受影响。
+1. **web 端 DOM 环境** ✅（`chore/p1-test-infra`）：`vitest.config.ts` 用 `environmentMatchGlobs` 把 `*.test.tsx` 路由到 jsdom，装了 `@testing-library/react`；`react/ui/Switch.test.tsx` 是首个组件测试示例。纯 store/util 测试留在 node 环境。
 2. **后端补测，按风险排序而非按目录平均分配**：
-   - **scheduler**：cron 解析、runCount 竞态、`normalizePersistedJobs` 迁移——纯逻辑好测，管后台任务正确性
-   - **channels**：`dedupe-store`、`personal-dispatcher` 消息路由——错了就是用户可见的重复/丢消息
-   - **L1 learner**：profile-updater 增量逻辑（与 P2 模型修正一起测）
-   - **L3**：依赖 Node ≥22.5，用 `describe.skipIf(...)` 做条件测试
-   - **terminal**：先只测 `command-resolver` 的扩展名映射和路径引用（纯函数），PTY 交互不测
-3. **server.ts smoke 层**：`listen(0)` 起实例，打 `/health` + 5–6 个关键端点的 200/4xx 断言。**必须先于 P2 拆分落地**，是拆文件的安全网。
+   - **scheduler** ✅：`cron-utils`（解析/校验/due 判定/one-shot 检测）+ `job-store`（create 默认值、update 清 nextRunAt、`normalizePersistedJobs` 迁移、runs、getStatus）
+   - **channels** ✅（部分）：`dedupe-store`（TTL、按渠道隔离、重启持久化）。`personal-dispatcher` 消息路由待补 ⬜
+   - **L1 learner**：profile-updater 增量逻辑（与 P2 模型修正一起测）⬜
+   - **L3**：依赖 Node ≥22.5，用 `describe.skipIf(...)` 做条件测试 ⬜
+   - **terminal** ✅：`command-resolver` 扩展名映射与路径引用。PTY 交互不测
+3. **server.ts smoke 层** ✅：`server.smoke.test.ts` 以子进程方式起真实 server（`--import tsx` + 临时 `--home` + dummy provider），断言 `/health`、`/api/settings`（含 API key 脱敏）、`/api/sessions`、`/api/jobs`、未匹配 `/api/*` 的 JSON 404。**该测试当场抓到一个真 bug**：SPA fallback 对未匹配的 `/api/*` 也返回 200 index.html——已修（fallback 跳过 `/api` 前缀）。
 
 ## P2 · server.ts 拆分（2–3 周，纯搬运零行为变更）
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,13 @@
 			],
 			"devDependencies": {
 				"@tailwindcss/vite": "^4.1.7",
+				"@testing-library/dom": "^10.4.1",
+				"@testing-library/react": "^16.3.2",
 				"@types/node": "^24.3.0",
 				"concurrently": "^9.2.1",
 				"electron": "^42.3.0",
 				"electron-builder": "^26.8.1",
+				"jsdom": "^30.0.1",
 				"shx": "^0.4.0",
 				"tailwindcss": "^4.1.7",
 				"tsx": "^4.20.3",
@@ -262,6 +265,59 @@
 				"zod": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/@asamuzakjp/css-color": {
+			"version": "6.0.7",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+			"integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/css-calc": "^3.3.0",
+				"@csstools/css-color-parser": "^4.1.10",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0",
+				"lru-cache": "^11.5.2"
+			},
+			"engines": {
+				"node": "^22.13.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+			"integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.5.2"
+			},
+			"engines": {
+				"node": "^22.13.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@aws-crypto/crc32": {
@@ -1030,6 +1086,19 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
 		"node_modules/@carderne/sandbox-runtime": {
 			"version": "0.0.49",
 			"resolved": "https://registry.npmmirror.com/@carderne/sandbox-runtime/-/sandbox-runtime-0.0.49.tgz",
@@ -1317,6 +1386,146 @@
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
+			}
+		},
+		"node_modules/@csstools/color-helpers": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+			"integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"engines": {
+				"node": ">=20.19.0"
+			}
+		},
+		"node_modules/@csstools/css-calc": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+			"integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-color-parser": {
+			"version": "4.1.10",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+			"integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@csstools/color-helpers": "^6.1.0",
+				"@csstools/css-calc": "^3.3.0"
+			},
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-parser-algorithms": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"peerDependencies": {
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+			"integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@csstools/css-tokenizer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@develar/schema-utils": {
@@ -3979,6 +4188,24 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@google/genai": {
 			"version": "1.52.0",
 			"resolved": "https://registry.npmmirror.com/@google/genai/-/genai-1.52.0.tgz",
@@ -6604,6 +6831,54 @@
 				"js-tiktoken": "^1.0.14"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@testing-library/react": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+			"integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": "^10.0.0",
+				"@types/react": "^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^18.0.0 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
 		"node_modules/@tokenizer/inflate": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmmirror.com/@tokenizer/inflate/-/inflate-0.4.1.tgz",
@@ -6625,6 +6900,13 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmmirror.com/@tokenizer/token/-/token-0.3.0.tgz",
 			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/babel__core": {
@@ -7527,6 +7809,16 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"dequal": "^2.0.3"
+			}
+		},
 		"node_modules/assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmmirror.com/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -7699,6 +7991,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
 			}
 		},
 		"node_modules/bignumber.js": {
@@ -8539,6 +8841,20 @@
 			],
 			"license": "MIT"
 		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/csstype": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmmirror.com/csstype/-/csstype-3.2.3.tgz",
@@ -8630,6 +8946,58 @@
 				"node": ">= 12"
 			}
 		},
+		"node_modules/data-urls": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/data-urls/node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls/node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/data-urls/node_modules/whatwg-url": {
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/debug": {
 			"version": "4.4.3",
 			"resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
@@ -8646,6 +9014,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/decimal.js": {
+			"version": "10.6.0",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/decode-named-character-reference": {
 			"version": "1.3.0",
@@ -8981,6 +9356,13 @@
 			"dependencies": {
 				"jszip": ">=3.0.0"
 			}
+		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/dotenv": {
 			"version": "16.6.1",
@@ -10807,6 +11189,19 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.6.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
 		"node_modules/html-parse-string": {
 			"version": "0.0.9",
 			"resolved": "https://registry.npmmirror.com/html-parse-string/-/html-parse-string-0.0.9.tgz",
@@ -11223,6 +11618,13 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-promise": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -11353,6 +11755,131 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
+			}
+		},
+		"node_modules/jsdom": {
+			"version": "30.0.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+			"integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/css-color": "^6.0.5",
+				"@asamuzakjp/dom-selector": "^8.3.0",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+				"@exodus/bytes": "^1.15.1",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
+				"is-potential-custom-element-name": "^1.0.1",
+				"lru-cache": "^11.5.2",
+				"parse5": "^8.0.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^6.0.2",
+				"undici": "^8.9.0",
+				"w3c-xmlserializer": "^5.0.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^17.1.0",
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^3.2.3"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/entities": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20.19.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
+			}
+		},
+		"node_modules/jsdom/node_modules/parse5": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^8.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/jsdom/node_modules/tr46": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/jsdom/node_modules/undici": {
+			"version": "8.10.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+			"integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.19.0"
+			}
+		},
+		"node_modules/jsdom/node_modules/webidl-conversions": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=20"
+			}
+		},
+		"node_modules/jsdom/node_modules/whatwg-url": {
+			"version": "17.1.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+			"integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@exodus/bytes": "^1.15.1",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
+			},
+			"engines": {
+				"node": "^22.14.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jsesc": {
@@ -11942,6 +12469,16 @@
 				"node": ">=12"
 			}
 		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"license": "MIT",
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
+		},
 		"node_modules/magic-string": {
 			"version": "0.30.21",
 			"resolved": "https://registry.npmmirror.com/magic-string/-/magic-string-0.30.21.tgz",
@@ -12278,6 +12815,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/media-typer": {
 			"version": "1.1.1",
@@ -13966,6 +14510,41 @@
 				"node": "^12.20.0 || >=14"
 			}
 		},
+		"node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/pretty-format/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/proc-log": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmmirror.com/proc-log/-/proc-log-6.1.0.tgz",
@@ -15126,6 +15705,19 @@
 				"node": ">=11.0.0"
 			}
 		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
+			}
+		},
 		"node_modules/scheduler": {
 			"version": "0.27.0",
 			"resolved": "https://registry.npmmirror.com/scheduler/-/scheduler-0.27.0.tgz",
@@ -15793,6 +16385,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/synckit": {
 			"version": "0.9.2",
 			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
@@ -16054,6 +16653,26 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/tldts": {
+			"version": "7.4.10",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+			"integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tldts-core": "^7.4.10"
+			},
+			"bin": {
+				"tldts": "bin/cli.js"
+			}
+		},
+		"node_modules/tldts-core": {
+			"version": "7.4.10",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+			"integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/tmp": {
 			"version": "0.2.7",
 			"resolved": "https://registry.npmmirror.com/tmp/-/tmp-0.2.7.tgz",
@@ -16113,6 +16732,19 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"tldts": "^7.0.5"
+			},
+			"engines": {
+				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
@@ -17242,6 +17874,19 @@
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"license": "MIT"
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/wasm-feature-detect": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmmirror.com/wasm-feature-detect/-/wasm-feature-detect-1.8.0.tgz",
@@ -17290,6 +17935,16 @@
 			"resolved": "https://registry.npmmirror.com/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
 			"integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
 			"license": "MIT"
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			}
 		},
 		"node_modules/whatwg-url": {
 			"version": "5.0.0",
@@ -17406,6 +18061,16 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/xml-name-validator": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/xml-naming": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmmirror.com/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -17430,6 +18095,13 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/y18n": {
 			"version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -116,10 +116,13 @@
 	},
 	"devDependencies": {
 		"@tailwindcss/vite": "^4.1.7",
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/react": "^16.3.2",
 		"@types/node": "^24.3.0",
 		"concurrently": "^9.2.1",
 		"electron": "^42.3.0",
 		"electron-builder": "^26.8.1",
+		"jsdom": "^30.0.1",
 		"shx": "^0.4.0",
 		"tailwindcss": "^4.1.7",
 		"tsx": "^4.20.3",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,5 +5,8 @@ export default defineConfig({
 		include: ["apps/inno-agent/src/**/*.test.ts", "apps/inno-agent/web/src/**/*.test.{ts,tsx}"],
 		exclude: ["**/node_modules/**", "runtime/**", "workspace/**"],
 		setupFiles: ["./vitest.setup.ts"],
+		// Component tests (*.test.tsx) render real DOM; pure store/util tests
+		// (*.test.ts) stay in the faster node environment.
+		environmentMatchGlobs: [["apps/inno-agent/web/src/**/*.test.tsx", "jsdom"]],
 	},
 });


### PR DESCRIPTION
## Summary

Second batch of the quality remediation plan (`docs/quality-remediation-plan.md`, P1). Grows the suite from **17 files / 101 tests → 23 files / 144 tests** and builds the safety net for the upcoming server.ts route extraction (P2).

- **Web component tests are now possible**: `vitest.config.ts` routes `*.test.tsx` to jsdom via `environmentMatchGlobs` (pure store/util tests stay in the faster node environment). Adds `@testing-library/react` and a first component test (`react/ui/Switch.test.tsx`) proving the setup.
- **server.ts smoke suite** (`server.smoke.test.ts`): spawns the real server as a child process (`node --import tsx`) against a throwaway `--home` with a dummy provider — no LLM calls. Asserts `/health`, `/api/settings` (including API-key redaction), `/api/sessions`, `/api/jobs`, and JSON 404 for unknown `/api/*` routes.
- **Backend unit tests for previously bare modules**:
  - `scheduler/cron-utils` — validation, next-run computation, 2-minute due window, one-shot cron detection (14 tests)
  - `scheduler/job-store` — create defaults, update semantics (disable clears `nextRunAt`), legacy `normalizePersistedJobs` migration, run records, status aggregation (9 tests)
  - `terminal/command-resolver` — extension → runner mapping, shell quoting (6 tests)
  - `channels/dedupe-store` — TTL expiry, per-channel scoping, persistence across restarts (6 tests)

## Bug fix included (caught by the new smoke test)

The SPA fallback served `index.html` with **HTTP 200** for unmatched `/api/*` GET routes — the comment said "non-API paths" but the code never checked, so API clients received HTML disguised as success. Now unmatched `/api/*` falls through to the JSON 404. One-condition change, covered by the smoke test.

## Verification

- `npm run build` — backend + frontend pass
- `npm test` — 23 files, 144 tests, all green (~1.4s)

## Notes

- Remaining P1 tail (tracked in the plan doc): `personal-dispatcher` routing tests, L1 profile-updater (lands together with the P3 mastery-model fix), L3 conditional tests (`describe.skipIf` on Node <22.5).
- The smoke test asserts behavior, not internals — it stays valid through the P2 route extraction.