### PR TITLE
fix: P3 mastery-model honesty — generic goal-archive matching, semantic-chunker rename

### DIFF
--- a/apps/inno-agent/src/memory/l2/l2-search.ts
+++ b/apps/inno-agent/src/memory/l2/l2-search.ts
@@ -24,6 +24,11 @@ import type { L2IndexStore, L2PageMeta } from "./l2-index-store.js";
 const RANK_DECAY_K = 60;
 const LEX_CANDIDATES = 30;
 const GRAPH_SEEDS = 8;
+// NOTE: these graph-expansion weights are hand-picked, not calibrated against
+// a relevance dataset. Combined with the rank-decay base score (which drops
+// the raw BM25 magnitude), `score` in results is valid for ORDERING ONLY —
+// never compare scores across queries. Retrieval-quality regressions are
+// guarded by the eval thresholds instead of score assertions.
 const WEIGHT_DIRECT_LINK = 0.5;
 const WEIGHT_SOURCE_OVERLAP = 0.4;
 const WEIGHT_ADAMIC_ADAR = 0.3;

--- a/apps/inno-agent/src/memory/l2/structural-chunker.test.ts
+++ b/apps/inno-agent/src/memory/l2/structural-chunker.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { splitSemanticChunks } from "./semantic-chunker.js";
+import { splitStructuralChunks } from "./structural-chunker.js";
 
-describe("semantic L2 chunking", () => {
+describe("structural L2 chunking", () => {
 	it("keeps short content on the existing single-chunk path", () => {
-		expect(splitSemanticChunks("short text")).toEqual(["short text"]);
+		expect(splitStructuralChunks("short text")).toEqual(["short text"]);
 	});
 
-	it("prefers semantic boundaries and preserves the document tail", () => {
+	it("prefers structural boundaries and preserves the document tail", () => {
 		const content = `${"A".repeat(1_200)}\n\n## 第二节\n${"B".repeat(1_200)}\n\nTAIL_FACT`;
-		const chunks = splitSemanticChunks(content, { targetChars: 1_500, overlapChars: 50 });
+		const chunks = splitStructuralChunks(content, { targetChars: 1_500, overlapChars: 50 });
 
 		expect(chunks.length).toBeGreaterThan(1);
 		expect(chunks[0]).toMatch(/\n\n$/);

--- a/apps/inno-agent/src/memory/l2/structural-chunker.ts
+++ b/apps/inno-agent/src/memory/l2/structural-chunker.ts
@@ -1,4 +1,4 @@
-export interface SemanticChunkOptions {
+export interface StructuralChunkOptions {
 	targetChars?: number;
 	overlapChars?: number;
 }
@@ -31,7 +31,7 @@ function lastBoundary(content: string, start: number, hardEnd: number): number {
  * Split text without dropping content. Breaks prefer headings, paragraphs and
  * sentence endings; a small read-only overlap gives adjacent chunks context.
  */
-export function splitSemanticChunks(content: string, options: SemanticChunkOptions = {}): string[] {
+export function splitStructuralChunks(content: string, options: StructuralChunkOptions = {}): string[] {
 	if (!content) return [];
 	const targetChars = Math.max(1_000, Math.trunc(options.targetChars ?? DEFAULT_TARGET_CHARS));
 	const overlapChars = Math.max(0, Math.min(Math.trunc(options.overlapChars ?? DEFAULT_OVERLAP_CHARS), targetChars / 4));

--- a/apps/inno-agent/src/memory/l2/summarizer.ts
+++ b/apps/inno-agent/src/memory/l2/summarizer.ts
@@ -7,7 +7,7 @@ import { logger } from "../../logger.js";
 import { complete } from "@earendil-works/pi-ai";
 import type { Model } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
-import { splitSemanticChunks } from "./semantic-chunker.js";
+import { splitStructuralChunks } from "./structural-chunker.js";
 
 const SUMMARIZE_PROMPT = `你是一个知识库管理助手。请为以下资料生成结构化的 Wiki 摘要页。
 
@@ -125,7 +125,7 @@ export async function summarizeContent(
 		return completeSummary(model, modelRegistry, prompt, 4096);
 	}
 
-	const chunks = splitSemanticChunks(content);
+	const chunks = splitStructuralChunks(content);
 	if (chunks.length > MAX_MODEL_CHUNKS) {
 		logger.warn(
 			{ chunks: chunks.length, characters: content.length },

--- a/apps/inno-agent/src/memory/l2/wiki-linker.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-linker.ts
@@ -9,7 +9,7 @@ import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { ensureDir, readText, writeText } from "../../storage/file-store.js";
 import type { ManifestEntry, WikiPageType, WikiPageFrontmatter } from "./types.js";
 import { parseFrontmatter, serializeFrontmatter } from "./wiki-maintainer.js";
-import { splitSemanticChunks } from "./semantic-chunker.js";
+import { splitStructuralChunks } from "./structural-chunker.js";
 import { buildAliasIndex, normalizeWikiLink } from "./wiki-links.js";
 import { logger } from "../../logger.js";
 
@@ -242,7 +242,7 @@ async function extractLinkedItemsAcrossChunks(
 		return extractLinkedItems(model, modelRegistry, title, content);
 	}
 
-	const chunks = splitSemanticChunks(content, { targetChars: 24_000, overlapChars: 400 });
+	const chunks = splitStructuralChunks(content, { targetChars: 24_000, overlapChars: 400 });
 	if (chunks.length > MAX_LINK_MODEL_CHUNKS) return fallbackItems(content);
 
 	const items: LinkedItem[] = [];

--- a/apps/inno-agent/src/memory/learner/auto-profile.test.ts
+++ b/apps/inno-agent/src/memory/learner/auto-profile.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { applyLearningEventToProfile, MASTERY_DELTAS } from "./auto-profile.js";
+import { createDefaultProfile, createLearningEvent, type LearningGoal } from "./types.js";
+
+function makeGoal(title: string, overrides: Partial<LearningGoal> = {}): LearningGoal {
+	return {
+		goal_id: `goal_${title}`,
+		title,
+		type: "skill",
+		priority: 0.8,
+		status: "active",
+		success_criteria: [],
+		source: "user_declared",
+		updated_at: "2026-08-01T00:00:00.000Z",
+		...overrides,
+	};
+}
+
+function archiveEvent(goalDescription: string) {
+	return createLearningEvent("default", "goal_declared", {}, {
+		goal_description: goalDescription,
+		action: "archived",
+	});
+}
+
+describe("goal archiving: generic topic matching", () => {
+	it("archives a non-programming goal (the hardcoded-regex blind spot)", () => {
+		const profile = createDefaultProfile();
+		profile.goals.push(makeGoal("吉他入门"));
+
+		const changed = applyLearningEventToProfile(profile, archiveEvent("不再学习吉他"), { updateSummary: false });
+
+		expect(changed).toBe(true);
+		expect(profile.goals[0].status).toBe("archived");
+		expect(profile.goals[0].priority).toBe(0);
+	});
+
+	it("still archives programming-language goals after the regex removal", () => {
+		const profile = createDefaultProfile();
+		profile.goals.push(makeGoal("Rust 所有权进阶"));
+
+		applyLearningEventToProfile(profile, archiveEvent("stop learning rust"), { updateSummary: false });
+
+		expect(profile.goals[0].status).toBe("archived");
+	});
+
+	it("matches a partial topic mention against a longer goal title", () => {
+		const profile = createDefaultProfile();
+		profile.goals.push(makeGoal("高等数学·微积分专项"));
+
+		applyLearningEventToProfile(profile, archiveEvent("我不想学数学了"), { updateSummary: false });
+
+		expect(profile.goals[0].status).toBe("archived");
+	});
+
+	it("does not archive goals on unrelated text", () => {
+		const profile = createDefaultProfile();
+		profile.goals.push(makeGoal("吉他入门"));
+
+		applyLearningEventToProfile(profile, archiveEvent("我不想学做饭了"), { updateSummary: false });
+
+		expect(profile.goals[0].status).toBe("active");
+	});
+
+	it("matches 2-char language tokens only on word boundaries", () => {
+		const profile = createDefaultProfile();
+		profile.goals.push(makeGoal("Build good habits"));
+
+		// "go" must not substring-match "good".
+		applyLearningEventToProfile(profile, archiveEvent("stop learning go"), { updateSummary: false });
+
+		expect(profile.goals[0].status).toBe("active");
+	});
+
+	it("archives knowledge states tied to the archived topic", () => {
+		const profile = createDefaultProfile();
+		profile.goals.push(makeGoal("吉他入门"));
+		applyLearningEventToProfile(
+			profile,
+			createLearningEvent("default", "concept_explained", { concept_ids: ["music.吉他基础和弦"] }, { topic: "吉他和弦" }),
+			{ updateSummary: false },
+		);
+		expect(profile.knowledge_states[0].next_actions.length).toBeGreaterThan(0);
+
+		applyLearningEventToProfile(profile, archiveEvent("不再学习吉他"), { updateSummary: false });
+
+		expect(profile.knowledge_states[0].next_actions).toEqual([]);
+		expect(profile.knowledge_states[0].diagnosis).toContain("归档");
+	});
+});
+
+describe("mastery deltas", () => {
+	it("applies the documented fixed increments per event type", () => {
+		const profile = createDefaultProfile();
+		const ctx = { concept_ids: ["programming.python.decorators"] };
+
+		applyLearningEventToProfile(profile, createLearningEvent("default", "exercise_attempt", ctx, {}), { updateSummary: false });
+		const after = profile.knowledge_states[0].mastery;
+
+		// Initial mastery is 0.05 (ensureKnowledgeState), then +MASTERY_DELTAS.exercise_attempt.
+		expect(MASTERY_DELTAS.exercise_attempt).toBe(0.03);
+		expect(after).toBeCloseTo(0.05 + 0.03, 6);
+	});
+
+	it("prefers an explicit derived_signals.mastery_delta over the defaults", () => {
+		const profile = createDefaultProfile();
+		applyLearningEventToProfile(
+			profile,
+			createLearningEvent("default", "exercise_attempt", { concept_ids: ["a.b"] }, {}, { mastery_delta: -0.02 }),
+			{ updateSummary: false },
+		);
+		expect(profile.knowledge_states[0].mastery).toBeCloseTo(0.05 - 0.02, 6);
+	});
+
+	it("never counts the same event twice (evidence idempotency)", () => {
+		const profile = createDefaultProfile();
+		const event = createLearningEvent("default", "concept_explained", { concept_ids: ["a.b"] }, {});
+		applyLearningEventToProfile(profile, event, { updateSummary: false });
+		const once = profile.knowledge_states[0].mastery;
+		applyLearningEventToProfile(profile, event, { updateSummary: false });
+		expect(profile.knowledge_states[0].mastery).toBe(once);
+	});
+});

--- a/apps/inno-agent/src/memory/learner/auto-profile.ts
+++ b/apps/inno-agent/src/memory/learner/auto-profile.ts
@@ -46,6 +46,57 @@ function hasArchiveIntent(text: string): boolean {
 	return /不学|不学习|不再学习|放弃|停止学习|取消.*目标|归档|archive|archived|stop learning|quit/i.test(text);
 }
 
+/**
+ * Words that express the archiving intent itself rather than the topic.
+ * Stripped before keyword extraction so "不再学习" never becomes a keyword.
+ */
+const INTENT_WORDS =
+	/不再学习|不想学习|不想学|不学习|不学|停止学习|放弃学习|放弃|停止|取消|归档|别再学|目标|学习|stop learning|quit learning|quit|archived?|drop|learn|learning/gi;
+
+/**
+ * Extract topic keywords from free text: latin tokens (length >= 2, so
+ * "c++" / "ts" / "go" survive) and CJK bigrams (so "吉他入门" still matches
+ * a goal titled "吉他"). Returns lowercase keywords.
+ */
+function extractTopicKeywords(text: string): string[] {
+	const cleaned = text.toLowerCase().replace(INTENT_WORDS, " ");
+	const keywords: string[] = [];
+	for (const match of cleaned.matchAll(/[a-z0-9][a-z0-9+#._-]*/g)) {
+		if (match[0].length >= 2) keywords.push(match[0]);
+	}
+	for (const match of cleaned.matchAll(/[一-鿿]+/g)) {
+		const run = match[0];
+		for (let i = 0; i < run.length - 1; i++) keywords.push(run.slice(i, i + 2));
+	}
+	return keywords;
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Generic topic matcher: does the archive target mention anything the
+ * haystack (goal title / concept id / domain) talks about? Replaces the
+ * former hardcoded rust|c++|python|typescript regexes that silently failed
+ * for every other topic.
+ *
+ * Matching rules: latin keywords of 3+ chars match as substrings ("rust" in
+ * "rust-ownership"); 2-char tokens ("go", "ts") require a non-alphanumeric
+ * boundary to avoid "go" matching "good habits". CJK bigrams match as
+ * substrings.
+ */
+function topicKeywordsMatch(haystack: string, targetText: string): boolean {
+	for (const keyword of extractTopicKeywords(targetText)) {
+		if (/^[a-z0-9+#._-]+$/.test(keyword) && keyword.length === 2) {
+			if (new RegExp(`(^|[^a-z0-9])${escapeRegExp(keyword)}([^a-z0-9]|$)`, "i").test(haystack)) return true;
+			continue;
+		}
+		if (haystack.includes(keyword)) return true;
+	}
+	return false;
+}
+
 function targetMatchesGoal(goal: LearningGoal, targetText: string, targetGoalId?: string): boolean {
 	const haystack = `${goal.goal_id} ${goal.title}`.toLowerCase();
 	const target = targetText.toLowerCase();
@@ -53,11 +104,7 @@ function targetMatchesGoal(goal: LearningGoal, targetText: string, targetGoalId?
 	if (target.includes(goal.goal_id.toLowerCase())) return true;
 	if (target.includes(goal.title.toLowerCase())) return true;
 
-	if (/rust/i.test(target)) return /rust/i.test(haystack);
-	if (/c\+\+|cpp/i.test(target)) return /c\+\+|cpp/i.test(haystack);
-	if (/python/i.test(target)) return /python/i.test(haystack);
-	if (/typescript|\bts\b/i.test(target)) return /typescript|\bts\b/i.test(haystack);
-	return false;
+	return topicKeywordsMatch(haystack, target);
 }
 
 function archiveMatchingGoals(profile: LearnerProfile, targetText: string, timestamp: string, targetGoalId?: string): boolean {
@@ -78,11 +125,7 @@ function targetMatchesKnowledge(state: KnowledgeState, targetText: string): bool
 	const haystack = `${state.concept_id} ${state.concept_name} ${state.domain}`.toLowerCase();
 	const target = targetText.toLowerCase();
 	if (target.includes(state.concept_id.toLowerCase())) return true;
-	if (/rust/i.test(target)) return /rust/i.test(haystack);
-	if (/c\+\+|cpp/i.test(target)) return /c\+\+|cpp/i.test(haystack);
-	if (/python/i.test(target)) return /python/i.test(haystack);
-	if (/typescript|\bts\b/i.test(target)) return /typescript|\bts\b/i.test(haystack);
-	return false;
+	return topicKeywordsMatch(haystack, target);
 }
 
 function archiveMatchingKnowledge(profile: LearnerProfile, targetText: string): boolean {
@@ -183,6 +226,22 @@ function ensureKnowledgeState(profile: LearnerProfile, conceptId: string): Knowl
 	return state;
 }
 
+/**
+ * Fixed mastery increments per event type, applied only when an event carries
+ * no explicit `derived_signals.mastery_delta`.
+ *
+ * HONESTY NOTE: these are hand-tuned heuristics, not a calibrated model
+ * (no forgetting curve, no item difficulty). `mastery` / `confidence` /
+ * `stability` in the profile should be read as relative ordering signals
+ * ("which concept needs review first"), never as probabilities.
+ */
+export const MASTERY_DELTAS: Partial<Record<LearningEvent["event_type"], number>> = {
+	exercise_attempt: 0.03,
+	concept_explained: 0.02,
+	milestone_reached: 0.02,
+	self_assessed: 0.01,
+};
+
 function updateKnowledgeFromEvent(profile: LearnerProfile, event: LearningEvent): boolean {
 	const conceptIds = event.context.concept_ids ?? [];
 	if (conceptIds.length === 0) return false;
@@ -190,15 +249,7 @@ function updateKnowledgeFromEvent(profile: LearnerProfile, event: LearningEvent)
 	const delta =
 		typeof event.derived_signals?.mastery_delta === "number"
 			? event.derived_signals.mastery_delta
-			: event.event_type === "exercise_attempt"
-				? 0.03
-				: event.event_type === "concept_explained"
-					? 0.02
-					: event.event_type === "milestone_reached"
-						? 0.02
-						: event.event_type === "self_assessed"
-							? 0.01
-							: 0;
+			: (MASTERY_DELTAS[event.event_type] ?? 0);
 
 	let changed = false;
 	for (const conceptId of conceptIds) {

--- a/apps/inno-agent/src/memory/learner/types.ts
+++ b/apps/inno-agent/src/memory/learner/types.ts
@@ -30,8 +30,15 @@ export interface KnowledgeState {
 	concept_id: string;
 	concept_name: string;
 	domain: string;
+	/**
+	 * Heuristic score in [0,1] accumulated from fixed per-event increments
+	 * (see MASTERY_DELTAS in auto-profile.ts). NOT a calibrated probability —
+	 * use for relative ordering (what to review first), not absolute claims.
+	 */
 	mastery: number;
+	/** Heuristic: how much evidence backs the mastery score. Not statistical confidence. */
 	confidence: number;
+	/** Heuristic: resistance to decay. Grows with positive deltas; no real forgetting model. */
 	stability: number;
 	last_practiced_at?: string;
 	review_due_at?: string;

--- a/docs/quality-remediation-plan.md
+++ b/docs/quality-remediation-plan.md
@@ -4,7 +4,7 @@
 >
 > 状态图例：✅ 已完成 / 🚧 进行中 / ⬜ 未开始
 >
-> 进度速览：**P0 已合并（PR #133），P1 主体已合并（PR #134，测试 17 文件/101 用例 → 23 文件/144 用例）**。下一站 P3（L1 语言正则 + 命名诚实性），然后 P2 拆 server.ts。
+> 进度速览：**P0 已合并（PR #133），P1 主体已合并（PR #134，测试 17 文件/101 用例 → 23 文件/144 用例），P3 完成待合并（`fix/p3-mastery-honesty`）**。下一站 P2 拆 server.ts。
 
 ## 总体原则
 
@@ -65,19 +65,20 @@ src/server/
 - 共享状态经 `context.ts` 显式传参，不引入 DI 框架。
 - 拆完后各路由域独立可测，测试再逐步下沉。
 
-## P3 · 模型与命名的诚实性（需拍板）
+## P3 · 模型与命名的诚实性 ✅（`fix/p3-mastery-honesty`）
 
 共同点："演示能跑、泛化不行"。修法不是换更强算法，而是让系统声称的和做的一致。
 
-**L1 掌握度模型**
-- 最小修（推荐先做这个）：`confidence`/`stability` 改名或标注 `heuristic: true`；固定增量 +0.03/+0.02 收敛为配置项。
-- 彻底修：换简化 BKT/Elo（每知识点一个难度参数，练习对错驱动更新），3–5 天，可复用 `rebuildProfileFromEvents` 的事件重放。
-- **四语言正则必须修（这是 bug 不是风格）**：硬编码 Rust/C++/Python/TypeScript 让其他主题目标归档静默失效。改成从 L2 wiki 主题/用户目标文本动态匹配，正则只作兜底。
+**L1 掌握度模型** ✅（最小修路线）
+- ✅ 固定增量收敛为命名常量 `MASTERY_DELTAS`（auto-profile.ts），附 HONESTY NOTE 注释：无遗忘曲线、无题目难度，分数仅用于排序。
+- ✅ `KnowledgeState.mastery/confidence/stability` 三个字段加 JSDoc 标注启发式、非概率。
+- ✅ **四语言正则 bug 已修**：`targetMatchesGoal`/`targetMatchesKnowledge` 的 rust/c++/python/typescript 硬编码正则替换为通用主题匹配（提取拉丁 token ≥2 字符 + CJK bigram，意图词先剥离；2 字符 token 要求词边界防 "go" 误配 "good"）。新增 `auto-profile.test.ts` 9 个用例覆盖：非编程主题归档（"不再学习吉他"→"吉他入门"）、部分匹配、"go"/"good" 边界、知识点联动归档、幂等性。
+- ⬜ 彻底修（简化 BKT/Elo）暂缓——等最小修实际用起来再评估。
 
-**"语义检索"**
-- 诚实路线（推荐，1 天）：`semantic-chunker` 改名 `structural-chunker`，L2 检索统一表述为「词法检索 + 图扩展」。
-- 能力路线（暂缓）：PI SDK 无 embedding API，需自接 provider embedding 端点 + sqlite 向量表（schema 已预留 embeddings 表），1 周以上。个人知识库规模下 BM25+图扩展大概率够用，等真有检索质量投诉再做。
-- BM25 分值丢弃 / 图扩展分数拍脑袋：有 eval 阈值兜底，不算 bug。加注释标明"分数未标定，仅排序有效"。
+**"语义检索"** ✅（诚实路线）
+- ✅ `semantic-chunker` → `structural-chunker`（文件、符号、测试全改），其 doc 注释本就如实描述"按标题/段落/句读切分"。
+- ✅ l2-search.ts 图扩展权重处加注释：分数未标定、仅排序有效、跨查询不可比，质量回归靠 eval 阈值兜底。
+- ⬜ 能力路线（真 embedding 检索）暂缓：PI SDK 无 embedding API，需自接 provider 端点 + sqlite 向量表（schema 已预留），等真有检索质量投诉再做。
 
 ## P4 · 小坑批量修（各随所属模块的 PR 带走）
 
@@ -98,9 +99,9 @@ src/server/
 ```
 ✅ P0 全部（PR #133）
 ✅ P1.1 web DOM 环境 + P1.3 server.ts smoke 测试 + P1.2 首批（PR #134）
-下一站: P3 语言正则修复 + 命名诚实性（用户可感知，优先级高于拆文件）
-之后:   P2 server.ts 按域拆（每周 1–2 个域，穿插正常 feature 开发）
+✅ P3 语言正则修复 + 命名诚实性（fix/p3-mastery-honesty）
+下一站: P2 server.ts 按域拆（每周 1–2 个域，穿插正常 feature 开发）
 随手:   P1 尾巴（personal-dispatcher / L3 条件测试）+ P4 各项跟随所属模块的 PR
 ```
 
-依赖关系：P2 拆分的安全网（smoke 测试）已就位 ✅；P3 语言正则是唯一正在静默失效的用户可见 bug，提前于拆分。
+依赖关系：P2 拆分的安全网（smoke 测试）已就位 ✅；P3 语言正则（唯一正在静默失效的用户可见 bug）已修 ✅。


### PR DESCRIPTION
## Summary

Third batch of the quality remediation plan (`docs/quality-remediation-plan.md`, P3): make the system claim only what it actually does. Includes the audit's one **user-visible silent-failure bug**.

- **Fix silently-failing goal archiving**: `targetMatchesGoal` / `targetMatchesKnowledge` in `auto-profile.ts` had hardcoded `rust|c++|python|typescript` regexes. Archiving a goal in any other topic (e.g. "不再学习吉他") matched nothing and silently no-op'd. Replaced with a generic topic matcher:
  - latin tokens ≥2 chars, substring match; 2-char tokens (`go`, `ts`) require word boundaries so "go" doesn't match "good habits"
  - CJK bigram overlap, so "吉他入门" matches a goal titled "吉他"
  - archiving-intent words ("不再学习", "stop learning", …) are stripped before keyword extraction
- **Mastery model honesty (minimal-fix route)**: fixed increments (+0.03/+0.02/…) collected into an exported `MASTERY_DELTAS` constant with a note that these are hand-tuned heuristics (no forgetting curve, no item difficulty); `mastery`/`confidence`/`stability` JSDoc'd as ordering signals, not probabilities. Field renames and a real BKT/Elo model deliberately deferred.
- **`semantic-chunker` → `structural-chunker`**: the "semantic" was heading/paragraph/sentence splitting — no embeddings anywhere. File, symbols, importers (`summarizer`, `wiki-linker`) and tests renamed (git history preserved via rename detection).
- **l2-search score annotation**: graph-expansion weights marked as uncalibrated; scores valid for ordering only, cross-query comparison explicitly disclaimed; eval thresholds remain the regression guard.

## Tests

New `auto-profile.test.ts` (9 tests): non-programming-topic archiving (the old blind spot), partial topic match, go/good boundary, knowledge-state cascade on archive, explicit `mastery_delta` precedence over defaults, evidence idempotency.

## Verification

- `npm run build` — pass
- `npm test` — 24 files, 153 tests, all green

## Out of scope (documented in the plan)

- BKT/Elo mastery model — deferred until the minimal fix has been exercised
- Real embedding retrieval — PI SDK has no embedding API; would need a provider endpoint + sqlite vector table (schema already reserves one). Revisit only if retrieval-quality complaints appear.