### PR TITLE
refactor: P2 server split 1/N — extract /api/jobs route domain + shared http helpers

### DIFF
--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -145,6 +145,23 @@ describe("server smoke", () => {
 		expect(res.status).toBe(200);
 	});
 
+	it("POST /api/jobs with an invalid cron returns 400 (route-domain extraction guard)", async () => {
+		const res = await fetch(`http://127.0.0.1:${port}/api/jobs`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ name: "bad", cron: "not a cron", prompt: "x", taskType: "custom_prompt" }),
+		});
+		expect(res.status).toBe(400);
+		const body = (await res.json()) as { error: string };
+		expect(body.error).toContain("Invalid cron");
+	});
+
+	it("GET /api/jobs/:id/runs returns 200 for any id shape", async () => {
+		const res = await api("/api/jobs/job_missing/runs");
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual([]);
+	});
+
 	it("unknown /api/ route returns a JSON 404 (not the SPA index.html)", async () => {
 		const res = await api("/api/definitely-not-a-route");
 		expect(res.status).toBe(404);

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -62,9 +62,9 @@ import {
 	upsertManagedServer,
 	type McpServerEntry,
 } from "./mcp/mcp-config-store.js";
-import { executeJob } from "./scheduler/job-runner.js";
 import { CronScheduler } from "./scheduler/cron-scheduler.js";
-import { validateCron } from "./scheduler/cron-utils.js";
+import { json, matchRoute, readBody } from "./server/http-helpers.js";
+import { handleJobsRoutes } from "./server/routes/jobs.js";
 import { parseFrontmatter, serializeFrontmatter } from "./memory/l2/wiki-maintainer.js";
 import { readManifest, removeWikiPathFromManifest } from "./memory/l2/manifest-store.js";
 import { loadProfile, saveProfile } from "./memory/learner/profile-store.js";
@@ -425,32 +425,6 @@ async function reloadFeishuChannel(): Promise<void> {
 // HTTP helpers
 // ---------------------------------------------------------------------------
 
-function readBody(req: HttpReq): Promise<unknown> {
-	return new Promise((resolve, reject) => {
-		let data = "";
-		req.on("data", (chunk: Buffer) => {
-			data += chunk.toString();
-		});
-		req.on("end", () => {
-			try {
-				resolve(data ? JSON.parse(data) : {});
-			} catch (err) {
-				reject(new Error("Invalid JSON body"));
-			}
-		});
-		req.on("error", reject);
-	});
-}
-
-function json(res: ServerResponse, status: number, data: unknown): void {
-	const body = data !== null ? JSON.stringify(data) : "";
-	res.writeHead(status, {
-		"Content-Type": "application/json; charset=utf-8",
-		"Content-Length": Buffer.byteLength(body),
-	});
-	res.end(body);
-}
-
 function maskSecret(value: string | undefined): string {
 	return value ? `****${value.slice(-4)}` : "";
 }
@@ -697,37 +671,6 @@ function parseProviderPayload(body: Record<string, unknown>): {
 		preserveApiKey: Boolean(body.preserveApiKey),
 		preserveHeaders: !Object.prototype.hasOwnProperty.call(body, "headers"),
 	};
-}
-
-/**
- * Simple route matching with :param support.
- * Returns params object or null if no match.
- */
-function matchRoute(
-	method: string,
-	reqMethod: string,
-	reqUrl: string,
-	pattern: string,
-): Record<string, string> | null {
-	if (reqMethod !== method) return null;
-	const url = reqUrl.split("?")[0];
-	const patternParts = pattern.split("/");
-	const urlParts = url.split("/");
-	if (patternParts.length !== urlParts.length) return null;
-
-	const params: Record<string, string> = {};
-	for (let i = 0; i < patternParts.length; i++) {
-		if (patternParts[i].startsWith(":")) {
-			try {
-				params[patternParts[i].slice(1)] = decodeURIComponent(urlParts[i]);
-			} catch (err) {
-				params[patternParts[i].slice(1)] = urlParts[i];
-			}
-		} else if (patternParts[i] !== urlParts[i]) {
-			return null;
-		}
-	}
-	return params;
 }
 
 // ---------------------------------------------------------------------------
@@ -2508,21 +2451,8 @@ const server = createServer(async (req, res) => {
 			await ensureBootstrapped();
 		}
 
-		// --- Jobs CRUD ---
-		if (method === "GET" && url === "/api/jobs") {
-			json(res, 200, jobStore.list());
-			return;
-		}
-
-		if (method === "GET" && url === "/api/jobs/status") {
-			json(res, 200, jobStore.getStatus());
-			return;
-		}
-
-		if (method === "GET" && url === "/api/jobs/runs") {
-			json(res, 200, jobStore.listRuns());
-			return;
-		}
+		// --- Jobs CRUD (extracted to server/routes/jobs.ts) ---
+		if (await handleJobsRoutes(req, res, method, url, { jobStore, channelRegistry })) return;
 
 		if (method === "GET" && url === "/api/channels") {
 			json(res, 200, channelRegistry.all().map((channel) => {
@@ -2730,78 +2660,6 @@ const server = createServer(async (req, res) => {
 			} else {
 				json(res, 200, []);
 			}
-			return;
-		}
-
-		if (method === "POST" && url === "/api/jobs") {
-			const body = await readBody(req) as Record<string, unknown> & Parameters<JobStore["create"]>[0];
-			if (typeof body.cron !== "string") {
-				json(res, 400, { error: "cron is required" });
-				return;
-			}
-			const cronCheck = validateCron(body.cron, typeof body.timezone === "string" ? body.timezone : undefined);
-			if (!cronCheck.ok) {
-				json(res, 400, { error: `Invalid cron: ${cronCheck.error}` });
-				return;
-			}
-			if (body.channel && !channelRegistry.get(body.channel)) {
-				json(res, 400, { error: `Channel not registered: ${body.channel}. Enable it in settings first.` });
-				return;
-			}
-			const job = jobStore.create(body);
-			json(res, 201, job);
-			return;
-		}
-
-		const runsMatch = matchRoute("GET", method, url, "/api/jobs/:id/runs");
-		if (runsMatch) {
-			json(res, 200, jobStore.listRuns(runsMatch.id));
-			return;
-		}
-
-		const runMatch = matchRoute("POST", method, url, "/api/jobs/:id/run");
-		if (runMatch) {
-			const job = jobStore.get(runMatch.id);
-			if (!job) {
-				json(res, 404, { error: "Job not found" });
-				return;
-			}
-			const result = await executeJob(job, jobStore, channelRegistry, "api");
-			json(res, 200, result);
-			return;
-		}
-
-		const patchMatch = matchRoute("PATCH", method, url, "/api/jobs/:id");
-		if (patchMatch) {
-			const body = await readBody(req) as Partial<import("./scheduler/types.js").ScheduledJob>;
-			if (typeof body.cron === "string") {
-				const cronCheck = validateCron(body.cron, body.timezone);
-				if (!cronCheck.ok) {
-					json(res, 400, { error: `Invalid cron: ${cronCheck.error}` });
-					return;
-				}
-			}
-			if (body.channel && !channelRegistry.get(body.channel)) {
-				json(res, 400, { error: `Channel not registered: ${body.channel}. Enable it in settings first.` });
-				return;
-			}
-			const updated = jobStore.update(patchMatch.id, body);
-			if (!updated) {
-				json(res, 404, { error: "Job not found" });
-				return;
-			}
-			json(res, 200, updated);
-			return;
-		}
-
-		const deleteMatch = matchRoute("DELETE", method, url, "/api/jobs/:id");
-		if (deleteMatch) {
-			const deleted = jobStore.delete(deleteMatch.id);
-			if (!deleted) {
-				json(res, 404, { error: "Job not found" });
-				return;
-			}
-			json(res, 204, null);
 			return;
 		}
 

--- a/apps/inno-agent/src/server/http-helpers.ts
+++ b/apps/inno-agent/src/server/http-helpers.ts
@@ -1,0 +1,65 @@
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+
+/**
+ * Shared HTTP helpers for the server route domains.
+ * Extracted verbatim from server.ts during the P2 route split — behavior
+ * unchanged. Route modules under server/routes/ import from here instead of
+ * re-defining their own copies.
+ */
+
+export function readBody(req: HttpReq): Promise<unknown> {
+	return new Promise((resolve, reject) => {
+		let data = "";
+		req.on("data", (chunk: Buffer) => {
+			data += chunk.toString();
+		});
+		req.on("end", () => {
+			try {
+				resolve(data ? JSON.parse(data) : {});
+			} catch (err) {
+				reject(new Error("Invalid JSON body"));
+			}
+		});
+		req.on("error", reject);
+	});
+}
+
+export function json(res: ServerResponse, status: number, data: unknown): void {
+	const body = data !== null ? JSON.stringify(data) : "";
+	res.writeHead(status, {
+		"Content-Type": "application/json; charset=utf-8",
+		"Content-Length": Buffer.byteLength(body),
+	});
+	res.end(body);
+}
+
+/**
+ * Simple route matching with :param support.
+ * Returns params object or null if no match.
+ */
+export function matchRoute(
+	method: string,
+	reqMethod: string,
+	reqUrl: string,
+	pattern: string,
+): Record<string, string> | null {
+	if (reqMethod !== method) return null;
+	const url = reqUrl.split("?")[0];
+	const patternParts = pattern.split("/");
+	const urlParts = url.split("/");
+	if (patternParts.length !== urlParts.length) return null;
+
+	const params: Record<string, string> = {};
+	for (let i = 0; i < patternParts.length; i++) {
+		if (patternParts[i].startsWith(":")) {
+			try {
+				params[patternParts[i].slice(1)] = decodeURIComponent(urlParts[i]);
+			} catch (err) {
+				params[patternParts[i].slice(1)] = urlParts[i];
+			}
+		} else if (patternParts[i] !== urlParts[i]) {
+			return null;
+		}
+	}
+	return params;
+}

--- a/apps/inno-agent/src/server/routes/jobs.ts
+++ b/apps/inno-agent/src/server/routes/jobs.ts
@@ -1,0 +1,117 @@
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import type { ChannelRegistry } from "../../channels/channel.js";
+import type { JobStore } from "../../scheduler/job-store.js";
+import type { ScheduledJob } from "../../scheduler/types.js";
+import { executeJob } from "../../scheduler/job-runner.js";
+import { validateCron } from "../../scheduler/cron-utils.js";
+import { json, matchRoute, readBody } from "../http-helpers.js";
+
+export interface JobsRouteContext {
+	jobStore: JobStore;
+	channelRegistry: ChannelRegistry;
+}
+
+/**
+ * /api/jobs* route domain. Returns true when the request was handled.
+ * Extracted verbatim from server.ts during the P2 route split (blocks were
+ * originally at two sites in the giant handler; relative order within the
+ * domain is preserved) — behavior unchanged.
+ */
+export async function handleJobsRoutes(
+	req: HttpReq,
+	res: ServerResponse,
+	method: string,
+	url: string,
+	ctx: JobsRouteContext,
+): Promise<boolean> {
+	const { jobStore, channelRegistry } = ctx;
+
+	if (method === "GET" && url === "/api/jobs") {
+		json(res, 200, jobStore.list());
+		return true;
+	}
+
+	if (method === "GET" && url === "/api/jobs/status") {
+		json(res, 200, jobStore.getStatus());
+		return true;
+	}
+
+	if (method === "GET" && url === "/api/jobs/runs") {
+		json(res, 200, jobStore.listRuns());
+		return true;
+	}
+
+	if (method === "POST" && url === "/api/jobs") {
+		const body = await readBody(req) as Record<string, unknown> & Parameters<JobStore["create"]>[0];
+		if (typeof body.cron !== "string") {
+			json(res, 400, { error: "cron is required" });
+			return true;
+		}
+		const cronCheck = validateCron(body.cron, typeof body.timezone === "string" ? body.timezone : undefined);
+		if (!cronCheck.ok) {
+			json(res, 400, { error: `Invalid cron: ${cronCheck.error}` });
+			return true;
+		}
+		if (body.channel && !channelRegistry.get(body.channel)) {
+			json(res, 400, { error: `Channel not registered: ${body.channel}. Enable it in settings first.` });
+			return true;
+		}
+		const job = jobStore.create(body);
+		json(res, 201, job);
+		return true;
+	}
+
+	const runsMatch = matchRoute("GET", method, url, "/api/jobs/:id/runs");
+	if (runsMatch) {
+		json(res, 200, jobStore.listRuns(runsMatch.id));
+		return true;
+	}
+
+	const runMatch = matchRoute("POST", method, url, "/api/jobs/:id/run");
+	if (runMatch) {
+		const job = jobStore.get(runMatch.id);
+		if (!job) {
+			json(res, 404, { error: "Job not found" });
+			return true;
+		}
+		const result = await executeJob(job, jobStore, channelRegistry, "api");
+		json(res, 200, result);
+		return true;
+	}
+
+	const patchMatch = matchRoute("PATCH", method, url, "/api/jobs/:id");
+	if (patchMatch) {
+		const body = await readBody(req) as Partial<ScheduledJob>;
+		if (typeof body.cron === "string") {
+			const cronCheck = validateCron(body.cron, body.timezone);
+			if (!cronCheck.ok) {
+				json(res, 400, { error: `Invalid cron: ${cronCheck.error}` });
+				return true;
+			}
+		}
+		if (body.channel && !channelRegistry.get(body.channel)) {
+			json(res, 400, { error: `Channel not registered: ${body.channel}. Enable it in settings first.` });
+			return true;
+		}
+		const updated = jobStore.update(patchMatch.id, body);
+		if (!updated) {
+			json(res, 404, { error: "Job not found" });
+			return true;
+		}
+		json(res, 200, updated);
+		return true;
+	}
+
+	const deleteMatch = matchRoute("DELETE", method, url, "/api/jobs/:id");
+	if (deleteMatch) {
+		const deleted = jobStore.delete(deleteMatch.id);
+		if (!deleted) {
+			json(res, 404, { error: "Job not found" });
+			return true;
+		}
+		json(res, 204, null);
+		return true;
+	}
+
+	return false;
+}

--- a/docs/quality-remediation-plan.md
+++ b/docs/quality-remediation-plan.md
@@ -41,7 +41,7 @@
    - **terminal** ✅：`command-resolver` 扩展名映射与路径引用。PTY 交互不测
 3. **server.ts smoke 层** ✅：`server.smoke.test.ts` 以子进程方式起真实 server（`--import tsx` + 临时 `--home` + dummy provider），断言 `/health`、`/api/settings`（含 API key 脱敏）、`/api/sessions`、`/api/jobs`、未匹配 `/api/*` 的 JSON 404。**该测试当场抓到一个真 bug**：SPA fallback 对未匹配的 `/api/*` 也返回 200 index.html——已修（fallback 跳过 `/api` 前缀）。
 
-## P2 · server.ts 拆分（2–3 周，纯搬运零行为变更）
+## P2 · server.ts 拆分 🚧 进行中（首个域 jobs 已抽出，`refactor/p2-server-split`）
 
 判断标准：它是全仓库改得最多、历史 bug 最密集的文件（队列焊死、SSE 重连都在这里），值得拆。
 
@@ -49,20 +49,22 @@
 
 ```
 src/server/
-  index.ts            # createServer + 路由表装配（<300 行）
-  routes/chat.ts      # /api/chat/* 含 SSE + 事件回放
-  routes/wiki.ts      # /api/wiki/*
-  routes/jobs.ts      # /api/jobs/*
-  routes/skills.ts    # /api/skills/*
-  routes/settings.ts  # /api/settings/* + config 热写
-  routes/workspaces.ts
-  routes/terminal.ts  # WebSocket upgrade
-  context.ts          # 各路由共享依赖（paths、store、registry）显式注入
+  http-helpers.ts     # ✅ readBody / json / matchRoute（原样搬家）
+  routes/jobs.ts      # ✅ /api/jobs* 全部 8 个路由块（handleJobsRoutes → boolean）
+  routes/chat.ts      # ⬜ /api/chat/* 含 SSE + 事件回放
+  routes/wiki.ts      # ⬜ /api/wiki/*
+  routes/skills.ts    # ⬜ /api/skills/*
+  routes/settings.ts  # ⬜ /api/settings/* + config 热写
+  routes/workspaces.ts # ⬜
+  routes/terminal.ts  # ⬜ WebSocket upgrade
+  context.ts          # ⬜ 第二个域需要共享状态时再建，从 JobsRouteContext 长出来
 ```
+
+进度：server.ts 5295 → 5155 行（-140），jobs 域 ~150 行落位 `routes/jobs.ts`。模式已定型：每域一个 `handle<Domain>Routes(req, res, method, url, ctx): Promise<boolean>`，server.ts 在原位置留一行委托。
 
 约束：
 - **禁止顺手重构**。每个 PR 只移动一个路由域，diff 应为纯 cut-paste + import 调整。
-- 共享状态经 `context.ts` 显式传参，不引入 DI 框架。
+- 共享状态经 ctx 显式传参，不引入 DI 框架。
 - 拆完后各路由域独立可测，测试再逐步下沉。
 
 ## P3 · 模型与命名的诚实性 ✅ 已合并（PR #135）


### PR DESCRIPTION
## Summary

First route-domain extraction of the server.ts split (`docs/quality-remediation-plan.md`, P2). **Pure cut-paste, zero behavior change.** server.ts 5295 → 5155 lines.

- **`server/http-helpers.ts`** (new): `readBody` / `json` / `matchRoute` moved verbatim from server.ts and exported.
- **`server/routes/jobs.ts`** (new): all 8 `/api/jobs*` blocks — previously at two separate sites in the giant request handler, relative order within the domain preserved — become `handleJobsRoutes(req, res, method, url, ctx): Promise<boolean>`. server.ts keeps a single delegation line at the original position.
- Removed the `executeJob` / `validateCron` imports left unused in server.ts.
- Smoke test gains two jobs assertions (`POST /api/jobs` invalid cron → 400; `GET /api/jobs/:id/runs` → 200 empty) to lock the extracted domain's behavior.

## The pattern (for the remaining domains)

Each domain becomes `handle<Domain>Routes(req, res, method, url, ctx): Promise<boolean>` in `server/routes/<domain>.ts`, with shared state passed via an explicit ctx object. server.ts keeps one delegation line per extracted domain. Remaining: chat (SSE), wiki, skills, settings, workspaces, terminal (WS), channels — one domain per PR to keep diffs reviewable.

## Review guide

- `routes/jobs.ts` should read as identical logic to the deleted blocks; the only mechanical changes are `return;` → `return true;` and the inline `import("./scheduler/types.js")` type becoming a top-level type import.
- Ordering safety: the GET-collection blocks and the write blocks were merged into one function called at the first block's original position. No other route pattern can match `/api/jobs*` URLs, so the relocation cannot shadow or be shadowed.

## Verification

- `npm run build` — pass
- `npm test` — 25 files, 155 tests, all green (incl. the server smoke suite that boots the real server and exercises `/api/jobs`)