### PR TITLE
refactor: P2 server split 2/N — extract /api/channels + /api/bridge route domain

### DIFF
--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -156,6 +156,21 @@ describe("server smoke", () => {
 		expect(body.error).toContain("Invalid cron");
 	});
 
+	it("GET /api/channels returns 200 with an empty list (no channels configured)", async () => {
+		const res = await api("/api/channels");
+		expect(res.status).toBe(200);
+		expect(await res.json()).toEqual([]);
+	});
+
+	it("POST /api/bridge/messages returns 404 when no bridge is configured", async () => {
+		const res = await fetch(`http://127.0.0.1:${port}/api/bridge/messages`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		expect(res.status).toBe(404);
+	});
+
 	it("GET /api/jobs/:id/runs returns 200 for any id shape", async () => {
 		const res = await api("/api/jobs/job_missing/runs");
 		expect(res.status).toBe(200);

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -47,10 +47,8 @@ import type { ImageContent } from "@earendil-works/pi-ai";
 import { ChannelRegistry } from "./channels/channel.js";
 import type { ChannelStreamEvent } from "./channels/channel.js";
 import { FeishuChannel } from "./channels/feishu/feishu-channel.js";
-import { feishuRegistrationBegin, feishuRegistrationPoll } from "./channels/feishu/feishu-registration.js";
 import { PersonalChannelDispatcher } from "./channels/personal-dispatcher.js";
 import { BridgeChannel } from "./channels/bridge/bridge-channel.js";
-import { handleBridgeMessage } from "./channels/bridge/bridge-server.js";
 import { WeChatChannel } from "./channels/wechat/wechat-channel.js";
 import type { PersonalBridgeChannelConfig } from "./config.js";
 import { JobStore } from "./scheduler/job-store.js";
@@ -64,6 +62,7 @@ import {
 } from "./mcp/mcp-config-store.js";
 import { CronScheduler } from "./scheduler/cron-scheduler.js";
 import { json, matchRoute, readBody } from "./server/http-helpers.js";
+import { handleChannelsRoutes } from "./server/routes/channels.js";
 import { handleJobsRoutes } from "./server/routes/jobs.js";
 import { parseFrontmatter, serializeFrontmatter } from "./memory/l2/wiki-maintainer.js";
 import { readManifest, removeWikiPathFromManifest } from "./memory/l2/manifest-store.js";
@@ -2454,214 +2453,19 @@ const server = createServer(async (req, res) => {
 		// --- Jobs CRUD (extracted to server/routes/jobs.ts) ---
 		if (await handleJobsRoutes(req, res, method, url, { jobStore, channelRegistry })) return;
 
-		if (method === "GET" && url === "/api/channels") {
-			json(res, 200, channelRegistry.all().map((channel) => {
-				const isBridge = channel instanceof BridgeChannel;
-				return {
-					name: channel.name,
-					mode: isBridge ? "bridge" : "native",
-					enabled: true,
-					hasDefaultTarget: Boolean(channelRegistry.getDefaultTarget(channel.name)),
-				};
-			}));
-			return;
-		}
-
-		const defaultTargetMatch = matchRoute("POST", method, url, "/api/channels/:name/default-target");
-		if (defaultTargetMatch) {
-			const body = await readBody(req) as Record<string, unknown>;
-			const channel = channelRegistry.get(defaultTargetMatch.name);
-			const chatId = typeof body.chatId === "string" ? body.chatId.trim() : "";
-			if (!channel) {
-				json(res, 404, { error: "Channel not found" });
-				return;
-			}
-			if (!chatId) {
-				json(res, 400, { error: "Missing chatId" });
-				return;
-			}
-			channelRegistry.setDefaultTarget({
-				channel: defaultTargetMatch.name as import("./channels/types.js").ChannelName,
-				chatId,
-			});
-			json(res, 200, { channel: defaultTargetMatch.name, chatId });
-			return;
-		}
-
-		const channelTestMatch = matchRoute("POST", method, url, "/api/channels/:name/test");
-		if (channelTestMatch) {
-			const body = await readBody(req) as Record<string, unknown>;
-			const channel = channelRegistry.get(channelTestMatch.name);
-			const target = channelRegistry.getDefaultTarget(channelTestMatch.name);
-			const text = typeof body.text === "string" && body.text.trim()
-				? body.text.trim()
-				: "Inno Agent 飞书主动推送测试。";
-			if (!channel) {
-				json(res, 404, { error: "Channel not found" });
-				return;
-			}
-			if (!target) {
-				json(res, 400, { error: "No default target configured" });
-				return;
-			}
-			await channel.push(target, text);
-			json(res, 200, { channel: channelTestMatch.name, chatId: target.chatId, pushed: true });
-			return;
-		}
-
-		// Bridge message endpoint
-		if (method === "POST" && url === "/api/bridge/messages") {
-			if (!bridgeToken || !dispatcher) {
-				json(res, 404, { error: "Bridge not configured" });
-				return;
-			}
-			const body = await readBody(req);
-			const authHeader = req.headers.authorization;
-			const result = handleBridgeMessage(
-				{ token: bridgeToken, channelRegistry, dispatcher },
-				authHeader,
-				body,
-			);
-			json(res, result.status, result.body);
-			return;
-		}
-
-		// Channel health endpoint
-		const channelHealthMatch = matchRoute("GET", method, url, "/api/channels/:name/health");
-		if (channelHealthMatch) {
-			const channel = channelRegistry.get(channelHealthMatch.name);
-			if (!channel) {
-				json(res, 404, { error: "Channel not found" });
-				return;
-			}
-			if (channel instanceof BridgeChannel) {
-				const health = await channel.checkHealth();
-				json(res, 200, health);
-			} else {
-				json(res, 200, { channel: channel.name, mode: "native", healthy: true, checkedAt: new Date().toISOString() });
-			}
-			return;
-		}
-
-		// Feishu QR device-flow registration
-		if (method === "POST" && url === "/api/channels/feishu/qr-register") {
-			try {
-				const result = await feishuRegistrationBegin();
-				json(res, 200, {
-					deviceCode: result.deviceCode,
-					qrUrl: result.verificationUri,
-					expiresIn: result.expiresIn,
-					interval: result.interval,
-				});
-			} catch (err) {
-				logger.error({ err }, "[feishu] QR registration begin failed");
-				json(res, 502, { error: err instanceof Error ? err.message : "Failed to start Feishu registration" });
-			}
-			return;
-		}
-
-		if (method === "GET" && url.startsWith("/api/channels/feishu/qr-status")) {
-			const deviceCode = new URL(url, "http://localhost").searchParams.get("deviceCode");
-			if (!deviceCode) {
-				json(res, 400, { error: "Missing deviceCode" });
-				return;
-			}
-			try {
-				const result = await feishuRegistrationPoll(deviceCode);
-				if (result.status === "confirmed" && result.appId && result.appSecret) {
-					// Save credentials to config and start channel
-					config.feishu = { appId: result.appId, appSecret: result.appSecret };
-					if (!config.channels) config.channels = {};
-					config.channels.feishu = {
-						enabled: true,
-						personalOnly: true,
-						allowedUserIds: result.openId ? [result.openId] : [],
-					};
-					config = saveConfig(paths.configPath, config);
-					await reloadFeishuChannel();
-				}
-				json(res, 200, { status: result.status });
-			} catch (err) {
-				logger.error({ err }, "[feishu] QR registration poll failed");
-				json(res, 502, { error: err instanceof Error ? err.message : "Failed to poll Feishu registration" });
-			}
-			return;
-		}
-
-		// WeChat iLink QR login
-		if (method === "POST" && url === "/api/channels/wechat/qr-login") {
-			// Lazily create the WeChat channel if not yet instantiated
-			if (!wechatChannel) {
-				wechatChannel = new WeChatChannel(dataDir, config.channels?.wechat);
-				channelRegistry.register(wechatChannel);
-			}
-			try {
-				const qr = await wechatChannel.getClient().getQrCode();
-				const raw = qr.qrcode_img_content ?? "";
-				logger.info(`[wechat] QR response: qrcode=${qr.qrcode}, img_content length=${raw.length}, prefix=${raw.slice(0, 40)}`);
-				let qrUrl = raw;
-				if (qrUrl && !qrUrl.startsWith("data:") && !qrUrl.startsWith("http")) {
-					qrUrl = `data:image/png;base64,${qrUrl}`;
-				}
-				json(res, 200, { qrId: qr.qrcode, qrUrl });
-			} catch (err) {
-				logger.error({ err }, "WeChat QR login failed");
-				json(res, 500, { error: err instanceof Error ? err.message : "Failed to get QR code" });
-			}
-			return;
-		}
-
-		if (method === "GET" && url.startsWith("/api/channels/wechat/qr-status")) {
-			const qrId = new URL(url, "http://localhost").searchParams.get("qrId");
-			if (!qrId) {
-				json(res, 400, { error: "Missing qrId" });
-				return;
-			}
-			if (!wechatChannel) {
-				json(res, 400, { error: "WeChat channel not initialized" });
-				return;
-			}
-			try {
-				const status = await wechatChannel.getClient().getQrCodeStatus(qrId);
-				if (status.status === "confirmed" && status.bot_token) {
-					wechatChannel.getClient().confirmLogin(status);
-					// Start polling if not already running
-					if (!wechatChannel.isConnected && dispatcher) {
-						wechatChannel.onMessage((msg) => dispatcher!.handle(wechatChannel!, msg));
-						wechatChannel.start();
-					}
-				}
-				json(res, 200, { status: status.status, botId: status.ilink_bot_id });
-			} catch (err) {
-				logger.error({ err }, "WeChat QR status check failed");
-				json(res, 500, { error: err instanceof Error ? err.message : "Failed to check QR status" });
-			}
-			return;
-		}
-
-		if (method === "GET" && url === "/api/channels/wechat/status") {
-			if (!wechatChannel) {
-				json(res, 200, { configured: false, connected: false });
-				return;
-			}
-			json(res, 200, {
-				configured: true,
-				connected: wechatChannel.isConnected,
-				botId: wechatChannel.botId || undefined,
-				loggedIn: wechatChannel.getClient().isLoggedIn,
-			});
-			return;
-		}
-
-		// Channel runs log
-		if (method === "GET" && url === "/api/channels/runs") {
-			if (dispatcher) {
-				json(res, 200, dispatcher.getRunLog().list());
-			} else {
-				json(res, 200, []);
-			}
-			return;
-		}
+		// --- Channels + bridge (extracted to server/routes/channels.ts) ---
+		if (await handleChannelsRoutes(req, res, method, url, {
+			channelRegistry,
+			dataDir,
+			configPath: paths.configPath,
+			getConfig: () => config,
+			setConfig: (next) => { config = next; },
+			getDispatcher: () => dispatcher,
+			getBridgeToken: () => bridgeToken,
+			reloadFeishuChannel,
+			getWechatChannel: () => wechatChannel,
+			setWechatChannel: (channel) => { wechatChannel = channel; },
+		})) return;
 
 		// --- Skills API ---
 		if (method === "GET" && url === "/api/skills") {

--- a/apps/inno-agent/src/server/routes/channels.ts
+++ b/apps/inno-agent/src/server/routes/channels.ts
@@ -1,0 +1,264 @@
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import { BridgeChannel } from "../../channels/bridge/bridge-channel.js";
+import { handleBridgeMessage } from "../../channels/bridge/bridge-server.js";
+import type { ChannelRegistry } from "../../channels/channel.js";
+import { feishuRegistrationBegin, feishuRegistrationPoll } from "../../channels/feishu/feishu-registration.js";
+import type { PersonalChannelDispatcher } from "../../channels/personal-dispatcher.js";
+import type { ChannelName } from "../../channels/types.js";
+import { WeChatChannel } from "../../channels/wechat/wechat-channel.js";
+import { saveConfig, type InnoConfig } from "../../config.js";
+import { logger } from "../../logger.js";
+import { json, matchRoute, readBody } from "../http-helpers.js";
+
+/**
+ * Mutable server state the channels routes touch. `config` and
+ * `wechatChannel` are reassigned at runtime (QR login flows), so they are
+ * accessed through getters/setters rather than captured by value.
+ */
+export interface ChannelsRouteContext {
+	channelRegistry: ChannelRegistry;
+	dataDir: string;
+	configPath: string;
+	getConfig: () => InnoConfig;
+	setConfig: (config: InnoConfig) => void;
+	getDispatcher: () => PersonalChannelDispatcher | null;
+	getBridgeToken: () => string | undefined;
+	reloadFeishuChannel: () => Promise<void>;
+	getWechatChannel: () => WeChatChannel | null;
+	setWechatChannel: (channel: WeChatChannel) => void;
+}
+
+/**
+ * /api/channels* and /api/bridge/* route domain. Returns true when the
+ * request was handled. Extracted verbatim from server.ts during the P2
+ * route split — behavior unchanged.
+ */
+export async function handleChannelsRoutes(
+	req: HttpReq,
+	res: ServerResponse,
+	method: string,
+	url: string,
+	ctx: ChannelsRouteContext,
+): Promise<boolean> {
+	const { channelRegistry } = ctx;
+
+	if (method === "GET" && url === "/api/channels") {
+		json(res, 200, channelRegistry.all().map((channel) => {
+			const isBridge = channel instanceof BridgeChannel;
+			return {
+				name: channel.name,
+				mode: isBridge ? "bridge" : "native",
+				enabled: true,
+				hasDefaultTarget: Boolean(channelRegistry.getDefaultTarget(channel.name)),
+			};
+		}));
+		return true;
+	}
+
+	const defaultTargetMatch = matchRoute("POST", method, url, "/api/channels/:name/default-target");
+	if (defaultTargetMatch) {
+		const body = await readBody(req) as Record<string, unknown>;
+		const channel = channelRegistry.get(defaultTargetMatch.name);
+		const chatId = typeof body.chatId === "string" ? body.chatId.trim() : "";
+		if (!channel) {
+			json(res, 404, { error: "Channel not found" });
+			return true;
+		}
+		if (!chatId) {
+			json(res, 400, { error: "Missing chatId" });
+			return true;
+		}
+		channelRegistry.setDefaultTarget({
+			channel: defaultTargetMatch.name as ChannelName,
+			chatId,
+		});
+		json(res, 200, { channel: defaultTargetMatch.name, chatId });
+		return true;
+	}
+
+	const channelTestMatch = matchRoute("POST", method, url, "/api/channels/:name/test");
+	if (channelTestMatch) {
+		const body = await readBody(req) as Record<string, unknown>;
+		const channel = channelRegistry.get(channelTestMatch.name);
+		const target = channelRegistry.getDefaultTarget(channelTestMatch.name);
+		const text = typeof body.text === "string" && body.text.trim()
+			? body.text.trim()
+			: "Inno Agent 飞书主动推送测试。";
+		if (!channel) {
+			json(res, 404, { error: "Channel not found" });
+			return true;
+		}
+		if (!target) {
+			json(res, 400, { error: "No default target configured" });
+			return true;
+		}
+		await channel.push(target, text);
+		json(res, 200, { channel: channelTestMatch.name, chatId: target.chatId, pushed: true });
+		return true;
+	}
+
+	// Bridge message endpoint
+	if (method === "POST" && url === "/api/bridge/messages") {
+		const bridgeToken = ctx.getBridgeToken();
+		const dispatcher = ctx.getDispatcher();
+		if (!bridgeToken || !dispatcher) {
+			json(res, 404, { error: "Bridge not configured" });
+			return true;
+		}
+		const body = await readBody(req);
+		const authHeader = req.headers.authorization;
+		const result = handleBridgeMessage(
+			{ token: bridgeToken, channelRegistry, dispatcher },
+			authHeader,
+			body,
+		);
+		json(res, result.status, result.body);
+		return true;
+	}
+
+	// Channel health endpoint
+	const channelHealthMatch = matchRoute("GET", method, url, "/api/channels/:name/health");
+	if (channelHealthMatch) {
+		const channel = channelRegistry.get(channelHealthMatch.name);
+		if (!channel) {
+			json(res, 404, { error: "Channel not found" });
+			return true;
+		}
+		if (channel instanceof BridgeChannel) {
+			const health = await channel.checkHealth();
+			json(res, 200, health);
+		} else {
+			json(res, 200, { channel: channel.name, mode: "native", healthy: true, checkedAt: new Date().toISOString() });
+		}
+		return true;
+	}
+
+	// Feishu QR device-flow registration
+	if (method === "POST" && url === "/api/channels/feishu/qr-register") {
+		try {
+			const result = await feishuRegistrationBegin();
+			json(res, 200, {
+				deviceCode: result.deviceCode,
+				qrUrl: result.verificationUri,
+				expiresIn: result.expiresIn,
+				interval: result.interval,
+			});
+		} catch (err) {
+			logger.error({ err }, "[feishu] QR registration begin failed");
+			json(res, 502, { error: err instanceof Error ? err.message : "Failed to start Feishu registration" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/channels/feishu/qr-status")) {
+		const deviceCode = new URL(url, "http://localhost").searchParams.get("deviceCode");
+		if (!deviceCode) {
+			json(res, 400, { error: "Missing deviceCode" });
+			return true;
+		}
+		try {
+			const result = await feishuRegistrationPoll(deviceCode);
+			if (result.status === "confirmed" && result.appId && result.appSecret) {
+				// Save credentials to config and start channel
+				const config = ctx.getConfig();
+				config.feishu = { appId: result.appId, appSecret: result.appSecret };
+				if (!config.channels) config.channels = {};
+				config.channels.feishu = {
+					enabled: true,
+					personalOnly: true,
+					allowedUserIds: result.openId ? [result.openId] : [],
+				};
+				ctx.setConfig(saveConfig(ctx.configPath, config));
+				await ctx.reloadFeishuChannel();
+			}
+			json(res, 200, { status: result.status });
+		} catch (err) {
+			logger.error({ err }, "[feishu] QR registration poll failed");
+			json(res, 502, { error: err instanceof Error ? err.message : "Failed to poll Feishu registration" });
+		}
+		return true;
+	}
+
+	// WeChat iLink QR login
+	if (method === "POST" && url === "/api/channels/wechat/qr-login") {
+		// Lazily create the WeChat channel if not yet instantiated
+		let wechatChannel = ctx.getWechatChannel();
+		if (!wechatChannel) {
+			wechatChannel = new WeChatChannel(ctx.dataDir, ctx.getConfig().channels?.wechat);
+			channelRegistry.register(wechatChannel);
+			ctx.setWechatChannel(wechatChannel);
+		}
+		try {
+			const qr = await wechatChannel.getClient().getQrCode();
+			const raw = qr.qrcode_img_content ?? "";
+			logger.info(`[wechat] QR response: qrcode=${qr.qrcode}, img_content length=${raw.length}, prefix=${raw.slice(0, 40)}`);
+			let qrUrl = raw;
+			if (qrUrl && !qrUrl.startsWith("data:") && !qrUrl.startsWith("http")) {
+				qrUrl = `data:image/png;base64,${qrUrl}`;
+			}
+			json(res, 200, { qrId: qr.qrcode, qrUrl });
+		} catch (err) {
+			logger.error({ err }, "WeChat QR login failed");
+			json(res, 500, { error: err instanceof Error ? err.message : "Failed to get QR code" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/channels/wechat/qr-status")) {
+		const qrId = new URL(url, "http://localhost").searchParams.get("qrId");
+		if (!qrId) {
+			json(res, 400, { error: "Missing qrId" });
+			return true;
+		}
+		const wechatChannel = ctx.getWechatChannel();
+		if (!wechatChannel) {
+			json(res, 400, { error: "WeChat channel not initialized" });
+			return true;
+		}
+		try {
+			const status = await wechatChannel.getClient().getQrCodeStatus(qrId);
+			if (status.status === "confirmed" && status.bot_token) {
+				wechatChannel.getClient().confirmLogin(status);
+				// Start polling if not already running
+				const dispatcher = ctx.getDispatcher();
+				if (!wechatChannel.isConnected && dispatcher) {
+					wechatChannel.onMessage((msg) => dispatcher.handle(wechatChannel, msg));
+					wechatChannel.start();
+				}
+			}
+			json(res, 200, { status: status.status, botId: status.ilink_bot_id });
+		} catch (err) {
+			logger.error({ err }, "WeChat QR status check failed");
+			json(res, 500, { error: err instanceof Error ? err.message : "Failed to check QR status" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url === "/api/channels/wechat/status") {
+		const wechatChannel = ctx.getWechatChannel();
+		if (!wechatChannel) {
+			json(res, 200, { configured: false, connected: false });
+			return true;
+		}
+		json(res, 200, {
+			configured: true,
+			connected: wechatChannel.isConnected,
+			botId: wechatChannel.botId || undefined,
+			loggedIn: wechatChannel.getClient().isLoggedIn,
+		});
+		return true;
+	}
+
+	// Channel runs log
+	if (method === "GET" && url === "/api/channels/runs") {
+		const dispatcher = ctx.getDispatcher();
+		if (dispatcher) {
+			json(res, 200, dispatcher.getRunLog().list());
+		} else {
+			json(res, 200, []);
+		}
+		return true;
+	}
+
+	return false;
+}

--- a/docs/quality-remediation-plan.md
+++ b/docs/quality-remediation-plan.md
@@ -51,6 +51,7 @@
 src/server/
   http-helpers.ts     # ✅ readBody / json / matchRoute（原样搬家）
   routes/jobs.ts      # ✅ /api/jobs* 全部 8 个路由块（handleJobsRoutes → boolean）
+  routes/channels.ts  # ✅ /api/channels* + /api/bridge/*（QR 登录的可变状态走 getter/setter ctx）
   routes/chat.ts      # ⬜ /api/chat/* 含 SSE + 事件回放
   routes/wiki.ts      # ⬜ /api/wiki/*
   routes/skills.ts    # ⬜ /api/skills/*
@@ -60,7 +61,7 @@ src/server/
   context.ts          # ⬜ 第二个域需要共享状态时再建，从 JobsRouteContext 长出来
 ```
 
-进度：server.ts 5295 → 5155 行（-140），jobs 域 ~150 行落位 `routes/jobs.ts`。模式已定型：每域一个 `handle<Domain>Routes(req, res, method, url, ctx): Promise<boolean>`，server.ts 在原位置留一行委托。
+进度：server.ts 5295 → 4959 行。jobs 域（PR #136）+ channels 域（含 /api/bridge/* 和飞书/微信 QR 登录）已落位。模式已定型：每域一个 `handle<Domain>Routes(req, res, method, url, ctx): Promise<boolean>`，可变模块状态（config、wechatChannel）经 getter/setter 注入，server.ts 在原位置留一行委托。
 
 约束：
 - **禁止顺手重构**。每个 PR 只移动一个路由域，diff 应为纯 cut-paste + import 调整。


### PR DESCRIPTION
## Summary

Second route-domain extraction of the server.ts split (`docs/quality-remediation-plan.md`, P2). **Pure cut-paste, zero behavior change.** server.ts 5155 → 4959 lines.

- **`server/routes/channels.ts`** (new): all 10 blocks covering `/api/channels*` (list, default-target, test-push, health, Feishu QR register/status, WeChat iLink QR login/qr-status/status, runs log) and `/api/bridge/messages` become `handleChannelsRoutes(...): Promise<boolean>`.
- **Mutable-state handling**: the QR flows reassign module state (`config`, `wechatChannel`), and `dispatcher`/`bridgeToken` are lazily initialized during bootstrap — these are injected through getter/setter pairs on `ChannelsRouteContext` instead of being captured by value. This sets the ctx pattern for the remaining domains with shared mutable state.
- server.ts keeps one delegation call at the first block's original position; drops the now-unused `feishu-registration` and `bridge-server` imports.
- Smoke test gains two channels assertions (empty channel list 200; bridge 404 when unconfigured).

## Review guide

- Each block should read identical to the deleted code; mechanical changes only: `return;` → `return true;`, `config = ...` → `ctx.setConfig(...)`, `wechatChannel` reads/writes → `ctx.get/setWechatChannel`, and the `dispatcher!.handle(wechatChannel!, msg)` non-null assertions became ordinary locals narrowed by the getter.
- Route-order safety: all blocks were contiguous in the original handler; the domain's internal order is preserved verbatim.

## Verification

- `npm run build` — pass
- `npm test` — 25 files, 157 tests, all green (smoke suite boots the real server and exercises both domains)