### PR TITLE
refactor: P2 server split 7/N — extract learner profile route domain

### DIFF
--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -223,6 +223,36 @@ describe("server smoke", () => {
 		expect(Array.isArray(await res.json())).toBe(true);
 	});
 
+	it("learner profile: goal create → patch → delete round-trip", async () => {
+		const profile = await api("/api/learner/profile");
+		expect(profile.status).toBe(200);
+
+		const created = await fetch(`http://127.0.0.1:${port}/api/learner/profile/goals`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ title: "smoke goal" }),
+		});
+		expect(created.status).toBe(201);
+		const goal = (await created.json()) as { goal_id: string; title: string };
+		expect(goal.title).toBe("smoke goal");
+
+		const patched = await fetch(`http://127.0.0.1:${port}/api/learner/profile/goals/${goal.goal_id}`, {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ status: "paused" }),
+		});
+		expect(patched.status).toBe(200);
+
+		const removed = await fetch(`http://127.0.0.1:${port}/api/learner/profile/goals/${goal.goal_id}`, { method: "DELETE" });
+		expect(removed.status).toBe(200);
+		const gone = await fetch(`http://127.0.0.1:${port}/api/learner/profile/goals/${goal.goal_id}`, {
+			method: "PATCH",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ status: "active" }),
+		});
+		expect(gone.status).toBe(404);
+	});
+
 	it("POST /api/skills/upload validates required fields", async () => {
 		const res = await fetch(`http://127.0.0.1:${port}/api/skills/upload`, {
 			method: "POST",

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -53,6 +53,7 @@ import { handleSettingsRoutes } from "./server/routes/settings.js";
 import { handleSkillsRoutes, type SkillLibraryItem } from "./server/routes/skills.js";
 import { handleWorkspacesRoutes } from "./server/routes/workspaces.js";
 import { handleSessionsRoutes } from "./server/routes/sessions.js";
+import { handleLearnerRoutes } from "./server/routes/learner.js";
 import {
 	mergeChannels,
 	type SessionChannel,
@@ -64,9 +65,6 @@ import {
 } from "./server/session-model.js";
 import { parseFrontmatter, serializeFrontmatter } from "./memory/l2/wiki-maintainer.js";
 import { readManifest, removeWikiPathFromManifest } from "./memory/l2/manifest-store.js";
-import { loadProfile, saveProfile } from "./memory/learner/profile-store.js";
-import type { LearnerProfile, LearningGoal, KnowledgeState, Misconception, LearnerPreferences } from "./memory/learner/types.js";
-import { randomUUID } from "node:crypto";
 import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
 import { questionBridge, type QuestionBridgeResult } from "./agent/question-bridge.js";
@@ -622,26 +620,6 @@ function serveStatic(req: HttpReq, res: ServerResponse, filePath: string, sendBo
 // ---------------------------------------------------------------------------
 // Local data helpers
 // ---------------------------------------------------------------------------
-
-function clamp01(n: number): number {
-	if (!Number.isFinite(n)) return 0;
-	if (n < 0) return 0;
-	if (n > 1) return 1;
-	return n;
-}
-
-function normalizePreferences(input: Partial<LearnerPreferences>): LearnerPreferences {
-	function arr(value: unknown): string[] {
-		if (!Array.isArray(value)) return [];
-		return value.filter((s): s is string => typeof s === "string" && s.trim().length > 0);
-	}
-	return {
-		explanation_style: arr(input.explanation_style),
-		practice_style: arr(input.practice_style),
-		feedback_tone: arr(input.feedback_tone),
-		avoid: arr(input.avoid),
-	};
-}
 
 function sessionFileFromId(sessionDir: string, id: string): string | null {
 	const fileName = basename(id);
@@ -1862,132 +1840,8 @@ const server = createServer(async (req, res) => {
 			return;
 		}
 
-		// --- Learner profile API (L1) ---
-		if (method === "GET" && url === "/api/learner/profile") {
-			const profile = loadProfile(paths.learnerDataDir);
-			json(res, 200, profile);
-			return;
-		}
-
-		if (method === "PATCH" && url === "/api/learner/profile") {
-			const body = await readBody(req) as Partial<LearnerProfile>;
-			const profile = loadProfile(paths.learnerDataDir);
-			if (typeof body.profile_summary === "string") {
-				profile.profile_summary = body.profile_summary;
-			}
-			if (body.preferences && typeof body.preferences === "object") {
-				profile.preferences = normalizePreferences(body.preferences as Partial<LearnerPreferences>);
-			}
-			saveProfile(paths.learnerDataDir, profile);
-			json(res, 200, profile);
-			return;
-		}
-
-		if (method === "POST" && url === "/api/learner/profile/goals") {
-			const body = await readBody(req) as Partial<LearningGoal>;
-			const profile = loadProfile(paths.learnerDataDir);
-			const goal: LearningGoal = {
-				goal_id: `goal_${randomUUID().slice(0, 8)}`,
-				title: typeof body.title === "string" ? body.title : "新目标",
-				type: (body.type as LearningGoal["type"]) || "skill",
-				priority: typeof body.priority === "number" ? body.priority : 0.5,
-				status: (body.status as LearningGoal["status"]) || "active",
-				success_criteria: Array.isArray(body.success_criteria) ? body.success_criteria.filter((s) => typeof s === "string") : [],
-				source: "user_declared",
-				updated_at: new Date().toISOString(),
-			};
-			profile.goals = [goal, ...profile.goals];
-			saveProfile(paths.learnerDataDir, profile);
-			json(res, 201, goal);
-			return;
-		}
-
-		const goalPatchMatch = matchRoute("PATCH", method, url, "/api/learner/profile/goals/:goalId");
-		if (goalPatchMatch) {
-			const body = await readBody(req) as Partial<LearningGoal>;
-			const profile = loadProfile(paths.learnerDataDir);
-			const index = profile.goals.findIndex((g) => g.goal_id === goalPatchMatch.goalId);
-			if (index < 0) {
-				json(res, 404, { error: "Goal not found" });
-				return;
-			}
-			const current = profile.goals[index];
-			profile.goals[index] = {
-				...current,
-				title: typeof body.title === "string" ? body.title : current.title,
-				type: (body.type as LearningGoal["type"]) ?? current.type,
-				priority: typeof body.priority === "number" ? body.priority : current.priority,
-				status: (body.status as LearningGoal["status"]) ?? current.status,
-				success_criteria: Array.isArray(body.success_criteria)
-					? body.success_criteria.filter((s) => typeof s === "string")
-					: current.success_criteria,
-				updated_at: new Date().toISOString(),
-			};
-			saveProfile(paths.learnerDataDir, profile);
-			json(res, 200, profile.goals[index]);
-			return;
-		}
-
-		const goalDeleteMatch = matchRoute("DELETE", method, url, "/api/learner/profile/goals/:goalId");
-		if (goalDeleteMatch) {
-			const profile = loadProfile(paths.learnerDataDir);
-			const before = profile.goals.length;
-			profile.goals = profile.goals.filter((g) => g.goal_id !== goalDeleteMatch.goalId);
-			if (profile.goals.length === before) {
-				json(res, 404, { error: "Goal not found" });
-				return;
-			}
-			saveProfile(paths.learnerDataDir, profile);
-			json(res, 200, { deleted: true });
-			return;
-		}
-
-		const knowledgePatchMatch = matchRoute("PATCH", method, url, "/api/learner/profile/knowledge/:conceptId");
-		if (knowledgePatchMatch) {
-			const body = await readBody(req) as Partial<KnowledgeState>;
-			const profile = loadProfile(paths.learnerDataDir);
-			const index = profile.knowledge_states.findIndex((k) => k.concept_id === knowledgePatchMatch.conceptId);
-			if (index < 0) {
-				json(res, 404, { error: "Concept not found" });
-				return;
-			}
-			const current = profile.knowledge_states[index];
-			profile.knowledge_states[index] = {
-				...current,
-				mastery: typeof body.mastery === "number" ? clamp01(body.mastery) : current.mastery,
-				confidence: typeof body.confidence === "number" ? clamp01(body.confidence) : current.confidence,
-				stability: typeof body.stability === "number" ? clamp01(body.stability) : current.stability,
-				diagnosis: typeof body.diagnosis === "string" ? body.diagnosis : current.diagnosis,
-				next_actions: Array.isArray(body.next_actions)
-					? body.next_actions.filter((s) => typeof s === "string")
-					: current.next_actions,
-			};
-			saveProfile(paths.learnerDataDir, profile);
-			json(res, 200, profile.knowledge_states[index]);
-			return;
-		}
-
-		const misconceptionPatchMatch = matchRoute("PATCH", method, url, "/api/learner/profile/misconceptions/:miscId");
-		if (misconceptionPatchMatch) {
-			const body = await readBody(req) as Partial<Misconception>;
-			const profile = loadProfile(paths.learnerDataDir);
-			const index = profile.misconceptions.findIndex((m) => m.misconception_id === misconceptionPatchMatch.miscId);
-			if (index < 0) {
-				json(res, 404, { error: "Misconception not found" });
-				return;
-			}
-			const current = profile.misconceptions[index];
-			profile.misconceptions[index] = {
-				...current,
-				status: (body.status as Misconception["status"]) ?? current.status,
-				severity: typeof body.severity === "number" ? clamp01(body.severity) : current.severity,
-				repair_strategy: typeof body.repair_strategy === "string" ? body.repair_strategy : current.repair_strategy,
-				last_seen_at: new Date().toISOString(),
-			};
-			saveProfile(paths.learnerDataDir, profile);
-			json(res, 200, profile.misconceptions[index]);
-			return;
-		}
+		// --- Learner profile API (extracted to server/routes/learner.ts) ---
+		if (await handleLearnerRoutes(req, res, method, url, { paths })) return;
 
 		// --- Workspace API + registry + session binding (extracted to server/routes/workspaces.ts) ---
 		if (await handleWorkspacesRoutes(req, res, method, url, {

--- a/apps/inno-agent/src/server/routes/learner.ts
+++ b/apps/inno-agent/src/server/routes/learner.ts
@@ -1,0 +1,184 @@
+import { randomUUID } from "node:crypto";
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import { loadProfile, saveProfile } from "../../memory/learner/profile-store.js";
+import type {
+	KnowledgeState,
+	LearnerPreferences,
+	LearnerProfile,
+	LearningGoal,
+	Misconception,
+} from "../../memory/learner/types.js";
+import type { RuntimePaths } from "../../runtime.js";
+import { json, matchRoute, readBody } from "../http-helpers.js";
+
+export interface LearnerRouteContext {
+	paths: RuntimePaths;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers moved verbatim from server.ts (P2 route split)
+// ---------------------------------------------------------------------------
+
+function clamp01(n: number): number {
+	if (!Number.isFinite(n)) return 0;
+	if (n < 0) return 0;
+	if (n > 1) return 1;
+	return n;
+}
+
+function normalizePreferences(input: Partial<LearnerPreferences>): LearnerPreferences {
+	function arr(value: unknown): string[] {
+		if (!Array.isArray(value)) return [];
+		return value.filter((s): s is string => typeof s === "string" && s.trim().length > 0);
+	}
+	return {
+		explanation_style: arr(input.explanation_style),
+		practice_style: arr(input.practice_style),
+		feedback_tone: arr(input.feedback_tone),
+		avoid: arr(input.avoid),
+	};
+}
+
+/**
+ * /api/learner/* route domain (L1 profile inspect/edit). Returns true when
+ * the request was handled. Extracted verbatim from server.ts during the P2
+ * route split — behavior unchanged.
+ */
+export async function handleLearnerRoutes(
+	req: HttpReq,
+	res: ServerResponse,
+	method: string,
+	url: string,
+	ctx: LearnerRouteContext,
+): Promise<boolean> {
+	const { paths } = ctx;
+
+	// --- Learner profile API (L1) ---
+	if (method === "GET" && url === "/api/learner/profile") {
+		const profile = loadProfile(paths.learnerDataDir);
+		json(res, 200, profile);
+		return true;
+	}
+
+	if (method === "PATCH" && url === "/api/learner/profile") {
+		const body = await readBody(req) as Partial<LearnerProfile>;
+		const profile = loadProfile(paths.learnerDataDir);
+		if (typeof body.profile_summary === "string") {
+			profile.profile_summary = body.profile_summary;
+		}
+		if (body.preferences && typeof body.preferences === "object") {
+			profile.preferences = normalizePreferences(body.preferences as Partial<LearnerPreferences>);
+		}
+		saveProfile(paths.learnerDataDir, profile);
+		json(res, 200, profile);
+		return true;
+	}
+
+	if (method === "POST" && url === "/api/learner/profile/goals") {
+		const body = await readBody(req) as Partial<LearningGoal>;
+		const profile = loadProfile(paths.learnerDataDir);
+		const goal: LearningGoal = {
+			goal_id: `goal_${randomUUID().slice(0, 8)}`,
+			title: typeof body.title === "string" ? body.title : "新目标",
+			type: (body.type as LearningGoal["type"]) || "skill",
+			priority: typeof body.priority === "number" ? body.priority : 0.5,
+			status: (body.status as LearningGoal["status"]) || "active",
+			success_criteria: Array.isArray(body.success_criteria) ? body.success_criteria.filter((s) => typeof s === "string") : [],
+			source: "user_declared",
+			updated_at: new Date().toISOString(),
+		};
+		profile.goals = [goal, ...profile.goals];
+		saveProfile(paths.learnerDataDir, profile);
+		json(res, 201, goal);
+		return true;
+	}
+
+	const goalPatchMatch = matchRoute("PATCH", method, url, "/api/learner/profile/goals/:goalId");
+	if (goalPatchMatch) {
+		const body = await readBody(req) as Partial<LearningGoal>;
+		const profile = loadProfile(paths.learnerDataDir);
+		const index = profile.goals.findIndex((g) => g.goal_id === goalPatchMatch.goalId);
+		if (index < 0) {
+			json(res, 404, { error: "Goal not found" });
+			return true;
+		}
+		const current = profile.goals[index];
+		profile.goals[index] = {
+			...current,
+			title: typeof body.title === "string" ? body.title : current.title,
+			type: (body.type as LearningGoal["type"]) ?? current.type,
+			priority: typeof body.priority === "number" ? body.priority : current.priority,
+			status: (body.status as LearningGoal["status"]) ?? current.status,
+			success_criteria: Array.isArray(body.success_criteria)
+				? body.success_criteria.filter((s) => typeof s === "string")
+				: current.success_criteria,
+			updated_at: new Date().toISOString(),
+		};
+		saveProfile(paths.learnerDataDir, profile);
+		json(res, 200, profile.goals[index]);
+		return true;
+	}
+
+	const goalDeleteMatch = matchRoute("DELETE", method, url, "/api/learner/profile/goals/:goalId");
+	if (goalDeleteMatch) {
+		const profile = loadProfile(paths.learnerDataDir);
+		const before = profile.goals.length;
+		profile.goals = profile.goals.filter((g) => g.goal_id !== goalDeleteMatch.goalId);
+		if (profile.goals.length === before) {
+			json(res, 404, { error: "Goal not found" });
+			return true;
+		}
+		saveProfile(paths.learnerDataDir, profile);
+		json(res, 200, { deleted: true });
+		return true;
+	}
+
+	const knowledgePatchMatch = matchRoute("PATCH", method, url, "/api/learner/profile/knowledge/:conceptId");
+	if (knowledgePatchMatch) {
+		const body = await readBody(req) as Partial<KnowledgeState>;
+		const profile = loadProfile(paths.learnerDataDir);
+		const index = profile.knowledge_states.findIndex((k) => k.concept_id === knowledgePatchMatch.conceptId);
+		if (index < 0) {
+			json(res, 404, { error: "Concept not found" });
+			return true;
+		}
+		const current = profile.knowledge_states[index];
+		profile.knowledge_states[index] = {
+			...current,
+			mastery: typeof body.mastery === "number" ? clamp01(body.mastery) : current.mastery,
+			confidence: typeof body.confidence === "number" ? clamp01(body.confidence) : current.confidence,
+			stability: typeof body.stability === "number" ? clamp01(body.stability) : current.stability,
+			diagnosis: typeof body.diagnosis === "string" ? body.diagnosis : current.diagnosis,
+			next_actions: Array.isArray(body.next_actions)
+				? body.next_actions.filter((s) => typeof s === "string")
+				: current.next_actions,
+		};
+		saveProfile(paths.learnerDataDir, profile);
+		json(res, 200, profile.knowledge_states[index]);
+		return true;
+	}
+
+	const misconceptionPatchMatch = matchRoute("PATCH", method, url, "/api/learner/profile/misconceptions/:miscId");
+	if (misconceptionPatchMatch) {
+		const body = await readBody(req) as Partial<Misconception>;
+		const profile = loadProfile(paths.learnerDataDir);
+		const index = profile.misconceptions.findIndex((m) => m.misconception_id === misconceptionPatchMatch.miscId);
+		if (index < 0) {
+			json(res, 404, { error: "Misconception not found" });
+			return true;
+		}
+		const current = profile.misconceptions[index];
+		profile.misconceptions[index] = {
+			...current,
+			status: (body.status as Misconception["status"]) ?? current.status,
+			severity: typeof body.severity === "number" ? clamp01(body.severity) : current.severity,
+			repair_strategy: typeof body.repair_strategy === "string" ? body.repair_strategy : current.repair_strategy,
+			last_seen_at: new Date().toISOString(),
+		};
+		saveProfile(paths.learnerDataDir, profile);
+		json(res, 200, profile.misconceptions[index]);
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
Seventh route-domain extraction per `docs/quality-remediation-plan.md` (P2). Pure cut-paste, no behavior change.

**Moves out of `server.ts` → `server/routes/learner.ts`:** all `/api/learner/*` routes (profile GET/PATCH, goals CRUD, knowledge PATCH, misconceptions PATCH) plus the domain-private helpers `clamp01` / `normalizePreferences`. The learner imports leave server.ts entirely — nothing else used them.

`server.ts`: 2758 → 2612 lines.

**Verification:** `npm run build` + `npm test` green (24 files / 170 tests). New smoke assertion: goal create → patch → delete round-trip, 404 after delete.