### PR TITLE
refactor: P2 server split 8/N — extract wiki route domain

### DIFF
--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -273,6 +273,32 @@ describe("server smoke", () => {
 		expect(await res.json()).toEqual([]);
 	});
 
+	it("wiki: pages/graph/stats return 200, missing page 404, traversal 400", async () => {
+		expect((await api("/api/wiki/pages")).status).toBe(200);
+		expect((await api("/api/wiki/graph")).status).toBe(200);
+		expect((await api("/api/wiki/stats")).status).toBe(200);
+		expect((await api("/api/wiki/page?path=wiki/concepts/nope.md")).status).toBe(404);
+		expect((await api("/api/wiki/page?path=../escape.md")).status).toBe(400);
+	});
+
+	it("POST /api/l2/raw/upload stores a file and rejects empty payloads", async () => {
+		const bad = await fetch(`http://127.0.0.1:${port}/api/l2/raw/upload`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ fileName: "x.md" }),
+		});
+		expect(bad.status).toBe(400);
+
+		const ok = await fetch(`http://127.0.0.1:${port}/api/l2/raw/upload`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ fileName: "notes.md", mimeType: "text/markdown", dataBase64: Buffer.from("# hi").toString("base64") }),
+		});
+		expect(ok.status).toBe(201);
+		const body = (await ok.json()) as { rawPath: string };
+		expect(body.rawPath).toMatch(/^raw[\\/]uploads[\\/].*\.md$/);
+	});
+
 	it("GET /api/workspaces returns 200 with the default workspaces", async () => {
 		const res = await api("/api/workspaces");
 		expect(res.status).toBe(200);

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -8,8 +8,6 @@ import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statS
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
-import { getL2Memory } from "./memory/l2/l2-memory.js";
-import { buildWikiGraph } from "./memory/l2/wiki-graph.js";
 import { loadConfig, saveConfig, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
 import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
@@ -54,6 +52,7 @@ import { handleSkillsRoutes, type SkillLibraryItem } from "./server/routes/skill
 import { handleWorkspacesRoutes } from "./server/routes/workspaces.js";
 import { handleSessionsRoutes } from "./server/routes/sessions.js";
 import { handleLearnerRoutes } from "./server/routes/learner.js";
+import { handleWikiRoutes } from "./server/routes/wiki.js";
 import {
 	mergeChannels,
 	type SessionChannel,
@@ -63,8 +62,7 @@ import {
 	type SessionSummary,
 	type SessionTopicMetadata,
 } from "./server/session-model.js";
-import { parseFrontmatter, serializeFrontmatter } from "./memory/l2/wiki-maintainer.js";
-import { readManifest, removeWikiPathFromManifest } from "./memory/l2/manifest-store.js";
+import { serializeFrontmatter } from "./memory/l2/wiki-maintainer.js";
 import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
 import { questionBridge, type QuestionBridgeResult } from "./agent/question-bridge.js";
@@ -661,27 +659,6 @@ function imagesFromContent(content: unknown): Array<{ previewUrl: string; mimeTy
 	return result;
 }
 
-function sanitizeUploadName(name: string): string {
-	const cleaned = name
-		.replace(/[/\\?%*:|"<>]/g, "-")
-		.replace(/\s+/g, " ")
-		.trim();
-	return cleaned || "upload";
-}
-
-function uploadExtension(fileName: string, mimeType: string): string {
-	const ext = extname(fileName);
-	if (ext) return ext;
-	if (mimeType === "application/pdf") return ".pdf";
-	if (mimeType.includes("wordprocessingml")) return ".docx";
-	if (mimeType.includes("spreadsheetml")) return ".xlsx";
-	if (mimeType.includes("presentationml")) return ".pptx";
-	if (mimeType === "text/markdown") return ".md";
-	if (mimeType.startsWith("image/")) return `.${mimeType.slice("image/".length).replace("jpeg", "jpg")}`;
-	if (mimeType.startsWith("text/")) return ".txt";
-	return ".bin";
-}
-
 function parseSkillFrontmatter(content: string): Record<string, string | boolean> {
 	const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
 	const match = normalized.match(/^---\n([\s\S]*?)\n---\n?/);
@@ -1086,9 +1063,6 @@ function scheduleSkillsReload(): void {
 	});
 }
 
-
-const WIKI_PAGE_DIRS = ["sources", "entities", "concepts", "analysis"] as const;
-
 interface WorkspaceFileChange {
 	path: string;
 	change: "created" | "modified" | "deleted";
@@ -1188,32 +1162,6 @@ function createWorkspaceChangeMonitor(
 		},
 	};
 }
-
-function listWikiPagePaths(): string[] {
-	const wikiRoot = join(l2DataDir, "wiki");
-	const paths: string[] = [];
-	for (const dirName of WIKI_PAGE_DIRS) {
-		const dir = join(wikiRoot, dirName);
-		if (!existsSync(dir)) continue;
-		for (const file of readdirSync(dir)) {
-			if (file.endsWith(".md")) {
-				paths.push(join("wiki", dirName, file));
-			}
-		}
-	}
-	return paths.sort((a, b) => a.localeCompare(b, "zh-CN"));
-}
-
-function manifestSourceIdByWikiPath(): Map<string, string> {
-	const map = new Map<string, string>();
-	for (const entry of readManifest(l2DataDir)) {
-		for (const wikiPath of entry.wikiPages) {
-			map.set(wikiPath, entry.id);
-		}
-	}
-	return map;
-}
-
 function sessionTopicMetadataPath(): string {
 	return join(dataDir, "sessions", "meta.json");
 }
@@ -1716,129 +1664,8 @@ const server = createServer(async (req, res) => {
 			sessionFileFromId, releaseQueueFromQuestionBlockedTurn, runQueueOpWithTimeout,
 		})) return;
 
-		// --- Wiki API ---
-		if (method === "GET" && url === "/api/wiki/pages") {
-			try {
-				const sourceIds = manifestSourceIdByWikiPath();
-				const pages: unknown[] = [];
-				for (const wikiPath of listWikiPagePaths()) {
-					const fullPath = join(l2DataDir, wikiPath);
-					if (existsSync(fullPath)) {
-						const content = readText(fullPath);
-						const { frontmatter, body } = parseFrontmatter(content);
-						pages.push({
-							path: wikiPath,
-							frontmatter,
-							bodyPreview: body.slice(0, 200),
-							sourceId: sourceIds.get(wikiPath) ?? "",
-						});
-					}
-				}
-				json(res, 200, pages);
-			} catch (err) {
-				logger.warn({ err }, "failed to list wiki pages");
-				json(res, 200, []);
-			}
-			return;
-		}
-
-		if (method === "GET" && url.startsWith("/api/wiki/page?")) {
-			const params = new URL(url, "http://localhost").searchParams;
-			const path = params.get("path");
-			if (!path) {
-				json(res, 400, { error: "Missing path parameter" });
-				return;
-			}
-			const fullPath = safeJoin(l2DataDir, path);
-			if (!fullPath) {
-				json(res, 400, { error: "Invalid wiki path" });
-				return;
-			}
-			if (!existsSync(fullPath)) {
-				json(res, 404, { error: "Wiki page not found" });
-				return;
-			}
-			const content = readText(fullPath);
-			json(res, 200, { path, content });
-			return;
-		}
-
-		if (method === "PUT" && url === "/api/wiki/page") {
-			const body = (await readBody(req)) as Record<string, unknown>;
-			const path = body.path as string | undefined;
-			const content = body.content as string | undefined;
-			if (!path || content === undefined) {
-				json(res, 400, { error: "Missing path or content" });
-				return;
-			}
-			const fullPath = safeJoin(l2DataDir, path);
-			if (!fullPath) {
-				json(res, 400, { error: "Invalid wiki path" });
-				return;
-			}
-			writeText(fullPath, content);
-			await getL2Memory(l2DataDir).indexPageByPath(path);
-			json(res, 200, { path, saved: true });
-			return;
-		}
-
-		if (method === "DELETE" && url.startsWith("/api/wiki/page?")) {
-			const params = new URL(url, "http://localhost").searchParams;
-			const path = params.get("path");
-			if (!path) {
-				json(res, 400, { error: "Missing path parameter" });
-				return;
-			}
-			const fullPath = safeJoin(l2DataDir, path);
-			if (!fullPath) {
-				json(res, 400, { error: "Invalid wiki path" });
-				return;
-			}
-			if (!existsSync(fullPath)) {
-				json(res, 404, { error: "Wiki page not found" });
-				return;
-			}
-			try {
-				rmSync(fullPath);
-				removeWikiPathFromManifest(l2DataDir, path);
-				await getL2Memory(l2DataDir).removePage(path);
-				json(res, 200, { path, deleted: true });
-			} catch (err) {
-				logger.warn({ err }, "failed to delete wiki page");
-				json(res, 500, { error: "Failed to delete wiki page" });
-			}
-			return;
-		}
-
-		if (method === "GET" && url === "/api/wiki/graph") {
-			try {
-				json(res, 200, buildWikiGraph(l2DataDir));
-			} catch (err) {
-				logger.warn({ err }, "failed to build wiki graph");
-				json(res, 200, { nodes: [], edges: [] });
-			}
-			return;
-		}
-
-		if (method === "GET" && url === "/api/wiki/stats") {
-			try {
-				const entries = readManifest(l2DataDir);
-				let totalSize = 0;
-				let pageCount = 0;
-				for (const wikiPath of listWikiPagePaths()) {
-					const fullPath = join(l2DataDir, wikiPath);
-					if (existsSync(fullPath)) {
-						totalSize += statSync(fullPath).size;
-						pageCount++;
-					}
-				}
-				json(res, 200, { pageCount, totalSize, entryCount: entries.length });
-			} catch (err) {
-				logger.warn({ err }, "failed to compute wiki stats");
-				json(res, 200, { pageCount: 0, totalSize: 0, entryCount: 0 });
-			}
-			return;
-		}
+		// --- Wiki + L2 raw upload API (extracted to server/routes/wiki.ts) ---
+		if (await handleWikiRoutes(req, res, method, url, { l2DataDir })) return;
 
 		// --- Learner profile API (extracted to server/routes/learner.ts) ---
 		if (await handleLearnerRoutes(req, res, method, url, { paths })) return;
@@ -1995,38 +1822,6 @@ const server = createServer(async (req, res) => {
 			const content = `${frontmatter}\n\n${bodyLines.join("\n")}\n`;
 			writeText(fullPath, content);
 			json(res, 201, { path: wikiRelPath, title, runId: record.id });
-			return;
-		}
-
-
-		// --- L2 Raw Upload API ---
-		if (method === "POST" && url === "/api/l2/raw/upload") {
-			const body = (await readBody(req)) as Record<string, unknown>;
-			const fileName = typeof body.fileName === "string" ? body.fileName : "";
-			const mimeType = typeof body.mimeType === "string" ? body.mimeType : "application/octet-stream";
-			const dataBase64 = typeof body.dataBase64 === "string" ? body.dataBase64 : "";
-			if (!fileName || !dataBase64) {
-				json(res, 400, { error: "Missing fileName or dataBase64" });
-				return;
-			}
-
-			const dir = join(l2DataDir, "raw", "uploads");
-			ensureDir(dir);
-			const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-			const safeName = sanitizeUploadName(fileName);
-			const ext = uploadExtension(safeName, mimeType);
-			const base = basename(safeName, ext).slice(0, 80) || "upload";
-			const outputName = `${timestamp}-${base}${ext}`;
-			const outputPath = join(dir, outputName);
-			const data = Buffer.from(dataBase64, "base64");
-			writeFileSync(outputPath, data);
-			const rawPath = join("raw", "uploads", outputName);
-			json(res, 201, {
-				fileName,
-				mimeType,
-				size: data.length,
-				rawPath,
-			});
 			return;
 		}
 

--- a/apps/inno-agent/src/server/routes/wiki.ts
+++ b/apps/inno-agent/src/server/routes/wiki.ts
@@ -1,0 +1,242 @@
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import { existsSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+import { logger } from "../../logger.js";
+import { getL2Memory } from "../../memory/l2/l2-memory.js";
+import { readManifest, removeWikiPathFromManifest } from "../../memory/l2/manifest-store.js";
+import { buildWikiGraph } from "../../memory/l2/wiki-graph.js";
+import { parseFrontmatter } from "../../memory/l2/wiki-maintainer.js";
+import { ensureDir, readText, writeText } from "../../storage/file-store.js";
+import { safeJoin } from "../file-helpers.js";
+import { json, readBody } from "../http-helpers.js";
+
+export interface WikiRouteContext {
+	l2DataDir: string;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers moved verbatim from server.ts (P2 route split). The two wiki
+// listing helpers closed over server.ts's module-level l2DataDir; they take
+// it as an explicit parameter instead.
+// ---------------------------------------------------------------------------
+
+const WIKI_PAGE_DIRS = ["sources", "entities", "concepts", "analysis"] as const;
+
+function listWikiPagePaths(l2DataDir: string): string[] {
+	const wikiRoot = join(l2DataDir, "wiki");
+	const paths: string[] = [];
+	for (const dirName of WIKI_PAGE_DIRS) {
+		const dir = join(wikiRoot, dirName);
+		if (!existsSync(dir)) continue;
+		for (const file of readdirSync(dir)) {
+			if (file.endsWith(".md")) {
+				paths.push(join("wiki", dirName, file));
+			}
+		}
+	}
+	return paths.sort((a, b) => a.localeCompare(b, "zh-CN"));
+}
+
+function manifestSourceIdByWikiPath(l2DataDir: string): Map<string, string> {
+	const map = new Map<string, string>();
+	for (const entry of readManifest(l2DataDir)) {
+		for (const wikiPath of entry.wikiPages) {
+			map.set(wikiPath, entry.id);
+		}
+	}
+	return map;
+}
+
+function sanitizeUploadName(name: string): string {
+	const cleaned = name
+		.replace(/[/\\?%*:|"<>]/g, "-")
+		.replace(/\s+/g, " ")
+		.trim();
+	return cleaned || "upload";
+}
+
+function uploadExtension(fileName: string, mimeType: string): string {
+	const ext = extname(fileName);
+	if (ext) return ext;
+	if (mimeType === "application/pdf") return ".pdf";
+	if (mimeType.includes("wordprocessingml")) return ".docx";
+	if (mimeType.includes("spreadsheetml")) return ".xlsx";
+	if (mimeType.includes("presentationml")) return ".pptx";
+	if (mimeType === "text/markdown") return ".md";
+	if (mimeType.startsWith("image/")) return `.${mimeType.slice("image/".length).replace("jpeg", "jpg")}`;
+	if (mimeType.startsWith("text/")) return ".txt";
+	return ".bin";
+}
+
+/**
+ * /api/wiki/* and /api/l2/raw/upload route domain. Returns true when the
+ * request was handled. Extracted verbatim from server.ts during the P2 route
+ * split — behavior unchanged. (The L2 upload route previously sat ~170 lines
+ * below the wiki routes; exact-path matching makes the reordering inert.)
+ */
+export async function handleWikiRoutes(
+	req: HttpReq,
+	res: ServerResponse,
+	method: string,
+	url: string,
+	ctx: WikiRouteContext,
+): Promise<boolean> {
+	const { l2DataDir } = ctx;
+
+	// --- Wiki API ---
+	if (method === "GET" && url === "/api/wiki/pages") {
+		try {
+			const sourceIds = manifestSourceIdByWikiPath(l2DataDir);
+			const pages: unknown[] = [];
+			for (const wikiPath of listWikiPagePaths(l2DataDir)) {
+				const fullPath = join(l2DataDir, wikiPath);
+				if (existsSync(fullPath)) {
+					const content = readText(fullPath);
+					const { frontmatter, body } = parseFrontmatter(content);
+					pages.push({
+						path: wikiPath,
+						frontmatter,
+						bodyPreview: body.slice(0, 200),
+						sourceId: sourceIds.get(wikiPath) ?? "",
+					});
+				}
+			}
+			json(res, 200, pages);
+		} catch (err) {
+			logger.warn({ err }, "failed to list wiki pages");
+			json(res, 200, []);
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/wiki/page?")) {
+		const params = new URL(url, "http://localhost").searchParams;
+		const path = params.get("path");
+		if (!path) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const fullPath = safeJoin(l2DataDir, path);
+		if (!fullPath) {
+			json(res, 400, { error: "Invalid wiki path" });
+			return true;
+		}
+		if (!existsSync(fullPath)) {
+			json(res, 404, { error: "Wiki page not found" });
+			return true;
+		}
+		const content = readText(fullPath);
+		json(res, 200, { path, content });
+		return true;
+	}
+
+	if (method === "PUT" && url === "/api/wiki/page") {
+		const body = (await readBody(req)) as Record<string, unknown>;
+		const path = body.path as string | undefined;
+		const content = body.content as string | undefined;
+		if (!path || content === undefined) {
+			json(res, 400, { error: "Missing path or content" });
+			return true;
+		}
+		const fullPath = safeJoin(l2DataDir, path);
+		if (!fullPath) {
+			json(res, 400, { error: "Invalid wiki path" });
+			return true;
+		}
+		writeText(fullPath, content);
+		await getL2Memory(l2DataDir).indexPageByPath(path);
+		json(res, 200, { path, saved: true });
+		return true;
+	}
+
+	if (method === "DELETE" && url.startsWith("/api/wiki/page?")) {
+		const params = new URL(url, "http://localhost").searchParams;
+		const path = params.get("path");
+		if (!path) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const fullPath = safeJoin(l2DataDir, path);
+		if (!fullPath) {
+			json(res, 400, { error: "Invalid wiki path" });
+			return true;
+		}
+		if (!existsSync(fullPath)) {
+			json(res, 404, { error: "Wiki page not found" });
+			return true;
+		}
+		try {
+			rmSync(fullPath);
+			removeWikiPathFromManifest(l2DataDir, path);
+			await getL2Memory(l2DataDir).removePage(path);
+			json(res, 200, { path, deleted: true });
+		} catch (err) {
+			logger.warn({ err }, "failed to delete wiki page");
+			json(res, 500, { error: "Failed to delete wiki page" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url === "/api/wiki/graph") {
+		try {
+			json(res, 200, buildWikiGraph(l2DataDir));
+		} catch (err) {
+			logger.warn({ err }, "failed to build wiki graph");
+			json(res, 200, { nodes: [], edges: [] });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url === "/api/wiki/stats") {
+		try {
+			const entries = readManifest(l2DataDir);
+			let totalSize = 0;
+			let pageCount = 0;
+			for (const wikiPath of listWikiPagePaths(l2DataDir)) {
+				const fullPath = join(l2DataDir, wikiPath);
+				if (existsSync(fullPath)) {
+					totalSize += statSync(fullPath).size;
+					pageCount++;
+				}
+			}
+			json(res, 200, { pageCount, totalSize, entryCount: entries.length });
+		} catch (err) {
+			logger.warn({ err }, "failed to compute wiki stats");
+			json(res, 200, { pageCount: 0, totalSize: 0, entryCount: 0 });
+		}
+		return true;
+	}
+
+	// --- L2 Raw Upload API ---
+	if (method === "POST" && url === "/api/l2/raw/upload") {
+		const body = (await readBody(req)) as Record<string, unknown>;
+		const fileName = typeof body.fileName === "string" ? body.fileName : "";
+		const mimeType = typeof body.mimeType === "string" ? body.mimeType : "application/octet-stream";
+		const dataBase64 = typeof body.dataBase64 === "string" ? body.dataBase64 : "";
+		if (!fileName || !dataBase64) {
+			json(res, 400, { error: "Missing fileName or dataBase64" });
+			return true;
+		}
+
+		const dir = join(l2DataDir, "raw", "uploads");
+		ensureDir(dir);
+		const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+		const safeName = sanitizeUploadName(fileName);
+		const ext = uploadExtension(safeName, mimeType);
+		const base = basename(safeName, ext).slice(0, 80) || "upload";
+		const outputName = `${timestamp}-${base}${ext}`;
+		const outputPath = join(dir, outputName);
+		const data = Buffer.from(dataBase64, "base64");
+		writeFileSync(outputPath, data);
+		const rawPath = join("raw", "uploads", outputName);
+		json(res, 201, {
+			fileName,
+			mimeType,
+			size: data.length,
+			rawPath,
+		});
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
Eighth route-domain extraction per `docs/quality-remediation-plan.md` (P2). Pure cut-paste, no behavior change.

**Moves out of `server.ts` → `server/routes/wiki.ts`:** `/api/wiki/*` (pages, page GET/PUT/DELETE, graph, stats) + `/api/l2/raw/upload`, with domain-private helpers (`WIKI_PAGE_DIRS`, `listWikiPagePaths`, `manifestSourceIdByWikiPath`, `sanitizeUploadName`, `uploadExtension`). All L2 imports leave server.ts — nothing outside the domain used them.

`server.ts`: 2612 → 2407 lines.

**Verification:** `npm run build` + `npm test` green (24 files / 172 tests). New smoke assertions: wiki pages/graph/stats 200, missing page 404, path-traversal 400, L2 upload 201 + empty-payload 400.