### PR TITLE
refactor: P2 server split 9/N — extract presets route domain

### DIFF
--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -208,6 +208,14 @@ describe("server smoke", () => {
 		expect(await res.json()).toEqual([]);
 	});
 
+	it("GET /api/presets returns 200 with the bundled presets", async () => {
+		const res = await api("/api/presets");
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as Array<{ id: string }>;
+		expect(Array.isArray(body)).toBe(true);
+		expect(body.length).toBeGreaterThan(0);
+	});
+
 	it("POST /api/bridge/messages returns 404 when no bridge is configured", async () => {
 		const res = await fetch(`http://127.0.0.1:${port}/api/bridge/messages`, {
 			method: "POST",

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -53,6 +53,7 @@ import { handleWorkspacesRoutes } from "./server/routes/workspaces.js";
 import { handleSessionsRoutes } from "./server/routes/sessions.js";
 import { handleLearnerRoutes } from "./server/routes/learner.js";
 import { handleWikiRoutes } from "./server/routes/wiki.js";
+import { handlePresetsRoutes } from "./server/routes/presets.js";
 import {
 	mergeChannels,
 	type SessionChannel,
@@ -68,7 +69,6 @@ import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "
 import { questionBridge, type QuestionBridgeResult } from "./agent/question-bridge.js";
 import { hasCompleteTurnAfterBaseline, streamRegistry, type SessionStreamState, type StreamPersistence } from "./chat/stream-registry.js";
 import { DEFAULT_WORKSPACE_ID, TEMP_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
-import { listPresets, listRemotePresets } from "./presets/preset-store.js";
 import { createContentSource, type RemoteContentSource } from "./content-source/index.js";
 import { mapWithConcurrency } from "./content-source/types.js";
 import { RunRecordStore } from "./terminal/run-record-store.js";
@@ -1677,33 +1677,8 @@ const server = createServer(async (req, res) => {
 			sessionFileFromId, releaseQueueFromQuestionBlockedTurn, runQueueOpWithTimeout,
 		})) return;
 
-		// --- Presets API (ready-to-use workspace templates) ---
-		// Local cache listing (offline fallback / already-downloaded presets).
-		if (method === "GET" && url === "/api/presets") {
-			json(res, 200, listPresets(paths));
-			return;
-		}
-
-		// Live catalog from the remote content hub (Simple Mode preset cards).
-		// Falls back to the bundled/cached presets when the hub is empty or
-		// unreachable, so the shipped templates always appear.
-		if (method === "GET" && url.split("?")[0] === "/api/preset-library") {
-			const forceRefresh = new URL(url, "http://localhost").searchParams.get("refresh") === "1";
-			try {
-				const remote = await listRemotePresets(getContentSource(), forceRefresh);
-				if (remote.length > 0) {
-					const merged = new Map(listPresets(paths).map((preset) => [preset.id, preset]));
-					for (const preset of remote) merged.set(preset.id, preset);
-					json(res, 200, Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name)));
-				} else {
-					json(res, 200, listPresets(paths));
-				}
-			} catch (err) {
-				logger.warn({ err }, "failed to list preset library; falling back to bundled presets");
-				json(res, 200, listPresets(paths));
-			}
-			return;
-		}
+		// --- Presets API (extracted to server/routes/presets.ts) ---
+		if (await handlePresetsRoutes(req, res, method, url, { paths, getContentSource })) return;
 
 		// --- Terminal sessions ---
 		if (method === "POST" && url === "/api/terminal/sessions") {

--- a/apps/inno-agent/src/server/routes/presets.ts
+++ b/apps/inno-agent/src/server/routes/presets.ts
@@ -1,0 +1,56 @@
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import type { RemoteContentSource } from "../../content-source/index.js";
+import { logger } from "../../logger.js";
+import { listPresets, listRemotePresets } from "../../presets/preset-store.js";
+import type { RuntimePaths } from "../../runtime.js";
+import { json } from "../http-helpers.js";
+
+export interface PresetsRouteContext {
+	paths: RuntimePaths;
+	getContentSource: () => RemoteContentSource;
+}
+
+/**
+ * /api/presets and /api/preset-library route domain (ready-to-use workspace
+ * templates). Returns true when the request was handled. Extracted verbatim
+ * from server.ts during the P2 route split — behavior unchanged.
+ */
+export async function handlePresetsRoutes(
+	req: HttpReq,
+	res: ServerResponse,
+	method: string,
+	url: string,
+	ctx: PresetsRouteContext,
+): Promise<boolean> {
+	const { paths, getContentSource } = ctx;
+
+	// --- Presets API (ready-to-use workspace templates) ---
+	// Local cache listing (offline fallback / already-downloaded presets).
+	if (method === "GET" && url === "/api/presets") {
+		json(res, 200, listPresets(paths));
+		return true;
+	}
+
+	// Live catalog from the remote content hub (Simple Mode preset cards).
+	// Falls back to the bundled/cached presets when the hub is empty or
+	// unreachable, so the shipped templates always appear.
+	if (method === "GET" && url.split("?")[0] === "/api/preset-library") {
+		const forceRefresh = new URL(url, "http://localhost").searchParams.get("refresh") === "1";
+		try {
+			const remote = await listRemotePresets(getContentSource(), forceRefresh);
+			if (remote.length > 0) {
+				const merged = new Map(listPresets(paths).map((preset) => [preset.id, preset]));
+				for (const preset of remote) merged.set(preset.id, preset);
+				json(res, 200, Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name)));
+			} else {
+				json(res, 200, listPresets(paths));
+			}
+		} catch (err) {
+			logger.warn({ err }, "failed to list preset library; falling back to bundled presets");
+			json(res, 200, listPresets(paths));
+		}
+		return true;
+	}
+
+	return false;
+}


### PR DESCRIPTION
Ninth route-domain extraction per `docs/quality-remediation-plan.md` (P2). Pure cut-paste, no behavior change.

**Moves out of `server.ts` → `server/routes/presets.ts`:** `/api/presets` + `/api/preset-library`. The preset-store import leaves server.ts entirely; `getContentSource` stays (skill-library ctx still needs it) and is injected.

`server.ts`: 2407 → 2382 lines.

**Verification:** `npm run build` + `npm test` green (24 files / 173 tests). New smoke assertion: bundled presets list 200.