### PR TITLE
fix(scheduler): configurable timezone, serialized counter updates, jsonl rotation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is small (~17 files) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~25 files and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 

--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -203,7 +203,7 @@ export function createInnoExtension(
 		}
 
 		// 3. Register scheduler tools
-		const jobStore = new JobStore(paths.jobsDir);
+		const jobStore = new JobStore(paths.jobsDir, configHolder.current.scheduler?.timezone);
 		const schedulerTools = createSchedulerTools(jobStore, channelRegistry);
 		for (const tool of schedulerTools) {
 			pi.registerTool(tool);

--- a/apps/inno-agent/src/channels/run-log.ts
+++ b/apps/inno-agent/src/channels/run-log.ts
@@ -1,4 +1,4 @@
-import { appendJsonl, readJsonl } from "../storage/file-store.js";
+import { appendJsonl, readJsonlTail } from "../storage/file-store.js";
 
 export interface ChannelRun {
 	runId: string;
@@ -11,6 +11,11 @@ export interface ChannelRun {
 	error?: string;
 }
 
+/** The run log is rolled to a timestamped archive once it exceeds this size. */
+const RUN_LOG_MAX_BYTES = 10 * 1024 * 1024;
+/** list() only shows recent runs, so it reads just the tail of the file. */
+const RUN_LOG_TAIL_BYTES = 1024 * 1024;
+
 let runCounter = 0;
 
 export function generateRunId(): string {
@@ -21,11 +26,11 @@ export class ChannelRunLog {
 	constructor(private filePath: string) {}
 
 	append(run: ChannelRun): void {
-		appendJsonl(this.filePath, run);
+		appendJsonl(this.filePath, run, { maxBytes: RUN_LOG_MAX_BYTES });
 	}
 
 	list(limit = 100): ChannelRun[] {
-		const all = readJsonl<ChannelRun>(this.filePath);
+		const all = readJsonlTail<ChannelRun>(this.filePath, RUN_LOG_TAIL_BYTES);
 		return all.slice(-limit);
 	}
 }

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { RuntimePaths } from "./runtime.js";
+import { DEFAULT_SCHEDULER_TIMEZONE } from "./scheduler/cron-utils.js";
 import { writeJson } from "./storage/file-store.js";
 
 export type InnoProviderApi = "openai-completions" | "openai-responses" | "anthropic-messages" | string;
@@ -73,6 +74,15 @@ export interface InnoSimpleModeConfig {
  */
 export interface InnoMcpConfig {
 	enabled: boolean;
+}
+
+/**
+ * Scheduler defaults. `timezone` is the fallback IANA timezone for scheduled
+ * jobs that don't pin their own — previously hardcoded to Asia/Shanghai in
+ * several spots; now configurable for users in other regions.
+ */
+export interface InnoSchedulerConfig {
+	timezone: string;
 }
 
 /** What should happen when the desktop window's close button is clicked. */
@@ -175,6 +185,7 @@ export interface InnoConfig {
 	simpleMode?: InnoSimpleModeConfig;
 	mcp?: InnoMcpConfig;
 	ui?: InnoUiConfig;
+	scheduler?: InnoSchedulerConfig;
 	/**
 	 * Optional OCR API config (Baidu PaddleOCR-VL). When the configured model
 	 * cannot recognize images, the agent calls the `ocr_image` tool which uses
@@ -283,6 +294,13 @@ export function normalizeMcpConfig(mcp: Partial<InnoMcpConfig> | undefined): Inn
 	};
 }
 
+export function normalizeSchedulerConfig(scheduler: Partial<InnoSchedulerConfig> | undefined): InnoSchedulerConfig {
+	const timezone = typeof scheduler?.timezone === "string" && scheduler.timezone.trim()
+		? scheduler.timezone.trim()
+		: DEFAULT_SCHEDULER_TIMEZONE;
+	return { timezone };
+}
+
 export function normalizeUiConfig(ui: Partial<InnoUiConfig> | undefined): InnoUiConfig {
 	const theme = typeof ui?.theme === "string" && ui.theme.trim() ? ui.theme.trim() : "light";
 	const closeBehavior: InnoCloseBehavior = ui?.closeBehavior === "hide" || ui?.closeBehavior === "quit"
@@ -355,6 +373,7 @@ export function normalizeConfig(config: LegacyInnoConfig): InnoConfig {
 		simpleMode: normalizeSimpleModeConfig(config.simpleMode),
 		mcp: normalizeMcpConfig(config.mcp),
 		ui: normalizeUiConfig(config.ui),
+		scheduler: normalizeSchedulerConfig(config.scheduler),
 		ocrApi: config.ocrApi,
 		tavily: config.tavily,
 	} as InnoConfig;

--- a/apps/inno-agent/src/memory/learner/profile-store.ts
+++ b/apps/inno-agent/src/memory/learner/profile-store.ts
@@ -6,6 +6,9 @@ import { applyLearningEventToProfile } from "./auto-profile.js";
 const PROFILE_FILE = "profile.json";
 const EVENTS_FILE = "events.jsonl";
 
+/** events.jsonl is rolled to a timestamped archive once it exceeds this size. */
+const EVENTS_MAX_BYTES = 10 * 1024 * 1024;
+
 /**
  * Load the learner profile. Returns a default empty profile if not found.
  */
@@ -23,10 +26,12 @@ export function saveProfile(dataDir: string, profile: LearnerProfile): void {
 }
 
 /**
- * Record a learning event by appending to events.jsonl.
+ * Record a learning event by appending to events.jsonl. The log is rotated at
+ * EVENTS_MAX_BYTES; `loadEvents` (and therefore `rebuildProfileFromEvents`)
+ * only replays the current segment — older segments stay on disk as archives.
  */
 export function recordEvent(dataDir: string, event: LearningEvent): void {
-	appendJsonl(join(dataDir, EVENTS_FILE), event);
+	appendJsonl(join(dataDir, EVENTS_FILE), event, { maxBytes: EVENTS_MAX_BYTES });
 }
 
 /**

--- a/apps/inno-agent/src/scheduler/cron-utils.ts
+++ b/apps/inno-agent/src/scheduler/cron-utils.ts
@@ -1,6 +1,12 @@
 import { logger } from "../logger.js";
 import { CronExpressionParser } from "cron-parser";
 
+/**
+ * Default timezone for scheduled jobs when neither the job nor the global
+ * `scheduler.timezone` config specifies one.
+ */
+export const DEFAULT_SCHEDULER_TIMEZONE = "Asia/Shanghai";
+
 export function computeNextRunAt(
 	cron: string,
 	timezone: string,
@@ -9,7 +15,7 @@ export function computeNextRunAt(
 	try {
 		const expr = CronExpressionParser.parse(cron, {
 			currentDate,
-			tz: timezone || "Asia/Shanghai",
+			tz: timezone || DEFAULT_SCHEDULER_TIMEZONE,
 		});
 		return expr.next().toDate().toISOString();
 	} catch (err) {
@@ -27,7 +33,7 @@ export function isCronDue(
 	try {
 		const expr = CronExpressionParser.parse(cron, {
 			currentDate: now,
-			tz: timezone || "Asia/Shanghai",
+			tz: timezone || DEFAULT_SCHEDULER_TIMEZONE,
 		});
 		const prev = expr.prev().toDate();
 
@@ -47,7 +53,7 @@ export function isCronDue(
  * Validate a cron expression. Returns { ok: true } if parseable,
  * otherwise { ok: false, error: string }.
  */
-export function validateCron(cron: string, timezone = "Asia/Shanghai"): { ok: true } | { ok: false; error: string } {
+export function validateCron(cron: string, timezone = DEFAULT_SCHEDULER_TIMEZONE): { ok: true } | { ok: false; error: string } {
 	const value = (cron ?? "").trim();
 	if (!value) return { ok: false, error: "Cron expression is required" };
 	const fields = value.split(/\s+/);
@@ -55,7 +61,7 @@ export function validateCron(cron: string, timezone = "Asia/Shanghai"): { ok: tr
 		return { ok: false, error: `Cron must have 5 fields (minute hour day month weekday), got ${fields.length}` };
 	}
 	try {
-		CronExpressionParser.parse(value, { tz: timezone || "Asia/Shanghai" });
+		CronExpressionParser.parse(value, { tz: timezone || DEFAULT_SCHEDULER_TIMEZONE });
 		return { ok: true };
 	} catch (err) {
 		return { ok: false, error: err instanceof Error ? err.message : String(err) };

--- a/apps/inno-agent/src/scheduler/job-runner.ts
+++ b/apps/inno-agent/src/scheduler/job-runner.ts
@@ -95,15 +95,18 @@ export async function executeJob(
 				pushSkippedReason,
 				trigger,
 			});
-			jobStore.update(job.id, {
+			// mutate() re-reads fresh state inside a per-job chain — counters are
+			// incremented from the latest persisted values, not this run's stale
+			// `job` snapshot (overlapping runs would otherwise lose increments).
+			await jobStore.mutate(job.id, (current) => ({
 				lastRunAt: finishedAt.toISOString(),
 				nextRunAt: oneShot ? undefined : computeNextRunAt(job.cron, job.timezone, finishedAt),
 				lastStatus: "error",
 				lastError: error,
-				enabled: oneShot ? false : job.enabled,
-				runCount: job.runCount + 1,
-				failureCount: job.failureCount + 1,
-			});
+				enabled: oneShot ? false : current.enabled,
+				runCount: current.runCount + 1,
+				failureCount: current.failureCount + 1,
+			}));
 			return { jobId: job.id, runId, success: false, error };
 		}
 
@@ -120,14 +123,14 @@ export async function executeJob(
 			pushSkippedReason,
 			trigger,
 		});
-		jobStore.update(job.id, {
+		await jobStore.mutate(job.id, (current) => ({
 			lastRunAt: finishedAt.toISOString(),
 			nextRunAt: oneShot ? undefined : computeNextRunAt(job.cron, job.timezone, finishedAt),
 			lastStatus: "success",
 			lastError: undefined,
-			enabled: oneShot ? false : job.enabled,
-			runCount: job.runCount + 1,
-		});
+			enabled: oneShot ? false : current.enabled,
+			runCount: current.runCount + 1,
+		}));
 
 		return { jobId: job.id, runId, success: true, output, pushedToChannel };
 	} catch (err) {
@@ -146,15 +149,15 @@ export async function executeJob(
 			error,
 			trigger,
 		});
-		jobStore.update(job.id, {
+		await jobStore.mutate(job.id, (current) => ({
 			lastRunAt: finishedAt.toISOString(),
 			nextRunAt: oneShot ? undefined : computeNextRunAt(job.cron, job.timezone, finishedAt),
 			lastStatus: "error",
 			lastError: error,
-			enabled: oneShot ? false : job.enabled,
-			runCount: job.runCount + 1,
-			failureCount: job.failureCount + 1,
-		});
+			enabled: oneShot ? false : current.enabled,
+			runCount: current.runCount + 1,
+			failureCount: current.failureCount + 1,
+		}));
 		return { jobId: job.id, runId, success: false, error };
 	}
 }

--- a/apps/inno-agent/src/scheduler/job-store.test.ts
+++ b/apps/inno-agent/src/scheduler/job-store.test.ts
@@ -40,6 +40,33 @@ describe("JobStore.create", () => {
 		expect(new Date(job.nextRunAt!).getTime()).toBeGreaterThan(Date.now() - 60_000);
 	});
 
+	it("uses the constructor defaultTimezone when the job doesn't pin one", () => {
+		const utcStore = new JobStore(dir, "UTC");
+		expect(utcStore.defaultTimezone).toBe("UTC");
+		const job = utcStore.create({
+			name: "utc job",
+			cron: "0 9 * * *",
+			timezone: "",
+			enabled: true,
+			taskType: "custom_prompt",
+			prompt: "hi",
+		});
+		expect(job.timezone).toBe("UTC");
+	});
+
+	it("an explicit job timezone always wins over the store default", () => {
+		const utcStore = new JobStore(dir, "UTC");
+		const job = utcStore.create({
+			name: "pinned",
+			cron: "0 9 * * *",
+			timezone: "America/New_York",
+			enabled: true,
+			taskType: "custom_prompt",
+			prompt: "hi",
+		});
+		expect(job.timezone).toBe("America/New_York");
+	});
+
 	it("persists jobs to jobs.json so a fresh store sees them", () => {
 		const job = createJob();
 		const reloaded = new JobStore(dir);
@@ -63,6 +90,49 @@ describe("JobStore.update", () => {
 
 	it("returns undefined for an unknown id", () => {
 		expect(store.update("job_missing", { name: "x" })).toBeUndefined();
+	});
+});
+
+describe("JobStore.mutate", () => {
+	it("serializes concurrent counter increments against fresh state", async () => {
+		const job = createJob();
+		// Simulate overlapping runs finishing at the same time: each increment
+		// must observe the previous one, so all 5 land.
+		await Promise.all(
+			Array.from({ length: 5 }, () =>
+				store.mutate(job.id, (current) => ({ runCount: current.runCount + 1 })),
+			),
+		);
+		expect(store.get(job.id)?.runCount).toBe(5);
+	});
+
+	it("replicates update() semantics: clears nextRunAt when disabled", async () => {
+		const job = createJob();
+		const updated = await store.mutate(job.id, () => ({ enabled: false }));
+		expect(updated?.enabled).toBe(false);
+		expect(updated?.nextRunAt).toBeUndefined();
+	});
+
+	it("replicates update() semantics: recomputes nextRunAt on cron change", async () => {
+		const job = createJob();
+		const updated = await store.mutate(job.id, () => ({ cron: "*/5 * * * *" }));
+		expect(updated?.nextRunAt).toBeDefined();
+	});
+
+	it("keeps the chain alive after a mutator throws", async () => {
+		const job = createJob();
+		await expect(
+			store.mutate(job.id, () => {
+				throw new Error("boom");
+			}),
+		).rejects.toThrow("boom");
+		// A later mutation still runs and sees the un-modified state.
+		const updated = await store.mutate(job.id, (current) => ({ runCount: current.runCount + 1 }));
+		expect(updated?.runCount).toBe(1);
+	});
+
+	it("returns undefined for an unknown id", async () => {
+		await expect(store.mutate("job_missing", () => ({}))).resolves.toBeUndefined();
 	});
 });
 

--- a/apps/inno-agent/src/scheduler/job-store.ts
+++ b/apps/inno-agent/src/scheduler/job-store.ts
@@ -1,11 +1,16 @@
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
-import { appendJsonl, readJson, readJsonl, writeJson, ensureDir } from "../storage/file-store.js";
+import { appendJsonl, readJson, readJsonlTail, writeJson, ensureDir } from "../storage/file-store.js";
 import type { JobRunRecord, ScheduledJob } from "./types.js";
-import { computeNextRunAt } from "./cron-utils.js";
+import { computeNextRunAt, DEFAULT_SCHEDULER_TIMEZONE } from "./cron-utils.js";
 
 const JOBS_FILE = "jobs.json";
 const RUNS_FILE = "runs.jsonl";
+
+/** runs.jsonl is rolled to a timestamped archive once it exceeds this size. */
+const RUNS_MAX_BYTES = 10 * 1024 * 1024;
+/** listRuns only needs recent history, so it reads just the tail of the file. */
+const LIST_RUNS_TAIL_BYTES = 1024 * 1024;
 
 export type ScheduledJobCreateInput =
 	Omit<ScheduledJob, "id" | "createdAt" | "updatedAt" | "runCount" | "failureCount" | "lastStatus" | "lastError">
@@ -14,11 +19,21 @@ export type ScheduledJobCreateInput =
 export class JobStore {
 	private filePath: string;
 	private runsFilePath: string;
+	/** Fallback timezone for jobs that don't pin their own. */
+	readonly defaultTimezone: string;
+	/**
+	 * Per-job serialization chains for `mutate`: each mutation re-reads the
+	 * current state inside the chain, so concurrent runs (cron + manual + the
+	 * agent's run_scheduled_job tool) can't lose counter increments by writing
+	 * back values computed from a stale snapshot.
+	 */
+	private mutationChains = new Map<string, Promise<void>>();
 
-	constructor(jobsDir: string) {
+	constructor(jobsDir: string, defaultTimezone: string = DEFAULT_SCHEDULER_TIMEZONE) {
 		ensureDir(jobsDir);
 		this.filePath = join(jobsDir, JOBS_FILE);
 		this.runsFilePath = join(jobsDir, RUNS_FILE);
+		this.defaultTimezone = defaultTimezone;
 	}
 
 	list(): ScheduledJob[] {
@@ -38,7 +53,7 @@ export class JobStore {
 	create(input: ScheduledJobCreateInput): ScheduledJob {
 		const jobs = this.list();
 		const now = new Date().toISOString();
-		const timezone = input.timezone || "Asia/Shanghai";
+		const timezone = input.timezone || this.defaultTimezone;
 		const job: ScheduledJob = {
 			...input,
 			id: `job_${randomUUID().slice(0, 8)}`,
@@ -68,6 +83,36 @@ export class JobStore {
 		return jobs[idx];
 	}
 
+	/**
+	 * Serialized read-modify-write for one job. The mutator receives the job's
+	 * *fresh* state (re-read inside the per-job promise chain), so increments
+	 * like `runCount + 1` are computed from the latest persisted values instead
+	 * of a snapshot captured before a possibly minutes-long run. Semantics
+	 * (updatedAt bump, nextRunAt recompute) mirror `update()`.
+	 */
+	mutate(id: string, mutator: (current: ScheduledJob) => Partial<ScheduledJob>): Promise<ScheduledJob | undefined> {
+		const prev = this.mutationChains.get(id) ?? Promise.resolve();
+		const next = prev.then((): ScheduledJob | undefined => {
+			const jobs = this.list();
+			const idx = jobs.findIndex((j) => j.id === id);
+			if (idx < 0) return undefined;
+			const current = jobs[idx];
+			const patch = mutator(current);
+			const merged = { ...current, ...patch, updatedAt: new Date().toISOString() };
+			if (patch.cron || patch.timezone || patch.lastRunAt || patch.enabled !== undefined) {
+				merged.nextRunAt = merged.enabled ? computeNextRunAt(merged.cron, merged.timezone) : undefined;
+			}
+			jobs[idx] = merged;
+			writeJson(this.filePath, jobs);
+			return merged;
+		});
+		// Keep the chain alive even if this mutation rejects; swallow in the
+		// stored link so later mutations still run. The caller gets the real
+		// promise (with its rejection) as the return value.
+		this.mutationChains.set(id, next.then(() => undefined, () => undefined));
+		return next;
+	}
+
 	delete(id: string): boolean {
 		const jobs = this.list();
 		const filtered = jobs.filter((j) => j.id !== id);
@@ -77,11 +122,11 @@ export class JobStore {
 	}
 
 	appendRun(record: JobRunRecord): void {
-		appendJsonl(this.runsFilePath, record);
+		appendJsonl(this.runsFilePath, record, { maxBytes: RUNS_MAX_BYTES });
 	}
 
 	listRuns(jobId?: string, limit = 50): JobRunRecord[] {
-		const runs = readJsonl<JobRunRecord>(this.runsFilePath);
+		const runs = readJsonlTail<JobRunRecord>(this.runsFilePath, LIST_RUNS_TAIL_BYTES);
 		const filtered = jobId ? runs.filter((run) => run.jobId === jobId) : runs;
 		return filtered.slice(-limit).reverse();
 	}
@@ -112,7 +157,7 @@ export class JobStore {
 
 	private normalizeJob(job: Partial<ScheduledJob>): ScheduledJob {
 		const now = new Date().toISOString();
-		const timezone = job.timezone || "Asia/Shanghai";
+		const timezone = job.timezone || this.defaultTimezone;
 		const enabled = job.enabled ?? true;
 		return {
 			id: job.id ?? `job_${randomUUID().slice(0, 8)}`,

--- a/apps/inno-agent/src/scheduler/scheduler-tools.ts
+++ b/apps/inno-agent/src/scheduler/scheduler-tools.ts
@@ -58,7 +58,7 @@ export function createSchedulerTools(jobStore: JobStore, channelRegistry?: Chann
 			const job = jobStore.create({
 				name: params.name,
 				cron: params.cron,
-				timezone: "Asia/Shanghai",
+				timezone: jobStore.defaultTimezone,
 				enabled: true,
 				taskType: params.taskType,
 				prompt: params.prompt,

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -180,7 +180,7 @@ async function ensureBootstrapped(): Promise<void> {
 		ensureDir(paths.workspaceDir);
 
 		// ---- stores ----
-		jobStore = new JobStore(paths.jobsDir);
+		jobStore = new JobStore(paths.jobsDir, config.scheduler?.timezone);
 		jobStore.normalizePersistedJobs();
 
 		channelRegistry = new ChannelRegistry(join(dataDir, "channels", "default-targets.json"));

--- a/apps/inno-agent/src/storage/file-store.test.ts
+++ b/apps/inno-agent/src/storage/file-store.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { appendJsonl, readJsonl, readJsonlTail } from "./file-store.js";
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "inno-filestore-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+describe("appendJsonl rotation", () => {
+	it("appends without rotation when maxBytes is not set", () => {
+		const file = join(dir, "log.jsonl");
+		appendJsonl(file, { n: 1 });
+		appendJsonl(file, { n: 2 });
+		expect(readJsonl<{ n: number }>(file).map((r) => r.n)).toEqual([1, 2]);
+		expect(readdirSync(dir)).toEqual(["log.jsonl"]);
+	});
+
+	it("rolls the file to a timestamped archive once it exceeds maxBytes", () => {
+		const file = join(dir, "log.jsonl");
+		const record = { payload: "x".repeat(100) };
+		appendJsonl(file, record);
+		appendJsonl(file, record);
+		// File now holds ~230 bytes; a maxBytes below that must trigger rotation
+		// before the next append.
+		appendJsonl(file, record, { maxBytes: 200 });
+
+		const archives = readdirSync(dir).filter((f) => f.endsWith(".archive"));
+		expect(archives).toHaveLength(1);
+		expect(archives[0]).toMatch(/^log\.jsonl\..*\.archive$/);
+		// The archive holds the pre-rotation content; the live file holds the new record.
+		expect(readJsonl<{ payload: string }>(join(dir, archives[0]))).toHaveLength(2);
+		expect(readJsonl<{ payload: string }>(file)).toHaveLength(1);
+	});
+
+	it("does not rotate while the file is still below maxBytes", () => {
+		const file = join(dir, "log.jsonl");
+		appendJsonl(file, { n: 1 }, { maxBytes: 1024 * 1024 });
+		appendJsonl(file, { n: 2 }, { maxBytes: 1024 * 1024 });
+		expect(readdirSync(dir).filter((f) => f.endsWith(".archive"))).toHaveLength(0);
+		expect(readJsonl<{ n: number }>(file)).toHaveLength(2);
+	});
+});
+
+describe("readJsonlTail", () => {
+	it("returns empty array for a missing file", () => {
+		expect(readJsonlTail(join(dir, "nope.jsonl"), 1024)).toEqual([]);
+	});
+
+	it("reads everything when the file is smaller than maxBytes", () => {
+		const file = join(dir, "small.jsonl");
+		appendJsonl(file, { n: 1 });
+		appendJsonl(file, { n: 2 });
+		expect(readJsonlTail<{ n: number }>(file, 1024 * 1024).map((r) => r.n)).toEqual([1, 2]);
+	});
+
+	it("reads only the tail and drops the possibly-partial first line", () => {
+		const file = join(dir, "big.jsonl");
+		for (let n = 0; n < 50; n++) {
+			appendJsonl(file, { n, pad: "y".repeat(50) });
+		}
+		const tail = readJsonlTail<{ n: number }>(file, 400);
+		expect(tail.length).toBeGreaterThan(0);
+		expect(tail.length).toBeLessThan(50);
+		// Every returned record is intact (the partial line was dropped) and
+		// they are the newest records in original order.
+		expect(tail[tail.length - 1].n).toBe(49);
+		expect(tail.map((r) => r.n)).toEqual([...tail.map((r) => r.n)].sort((a, b) => a - b));
+	});
+
+	it("skips malformed lines without failing the whole read", () => {
+		const file = join(dir, "mixed.jsonl");
+		writeFileSync(file, '{"n":1}\nnot json\n{"n":2}\n', "utf-8");
+		expect(readJsonlTail<{ n: number }>(file, 1024).map((r) => r.n)).toEqual([1, 2]);
+	});
+});

--- a/apps/inno-agent/src/storage/file-store.ts
+++ b/apps/inno-agent/src/storage/file-store.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync, appendFileSync } from "node:fs";
+import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, renameSync, statSync, writeFileSync, appendFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { logger } from "../logger.js";
 
@@ -37,20 +37,30 @@ export function writeJson<T>(filePath: string, data: T): void {
 
 /**
  * Append a single JSON record as a line to a JSONL file.
+ *
+ * When `options.maxBytes` is set and the file already exceeds that size, the
+ * current file is first rolled to a `<path>.<timestamp>.archive` sibling and a
+ * fresh file is started. Append-only logs (runs, events, channel run-log) use
+ * this to bound unbounded growth; live-state logs (e.g. dedupe) must NOT, since
+ * rotation silently drops entries that are still meaningful.
  */
-export function appendJsonl<T>(filePath: string, record: T): void {
+export function appendJsonl<T>(filePath: string, record: T, options?: { maxBytes?: number }): void {
 	ensureDir(dirname(filePath));
+	if (options?.maxBytes && existsSync(filePath)) {
+		try {
+			if (statSync(filePath).size >= options.maxBytes) {
+				const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+				renameSync(filePath, `${filePath}.${stamp}.archive`);
+			}
+		} catch (err) {
+			// Rotation is best-effort: failing to archive must never drop the record.
+			logger.warn({ err }, `failed to rotate JSONL ${filePath}`);
+		}
+	}
 	appendFileSync(filePath, JSON.stringify(record) + "\n", "utf-8");
 }
 
-/**
- * Read all records from a JSONL file. Returns empty array if file does not exist.
- */
-export function readJsonl<T>(filePath: string): T[] {
-	if (!existsSync(filePath)) {
-		return [];
-	}
-	const raw = readFileSync(filePath, "utf-8");
+function parseJsonlLines<T>(raw: string, filePath: string): T[] {
 	const records: T[] = [];
 	for (const line of raw.split("\n")) {
 		if (!line.trim()) continue;
@@ -61,6 +71,44 @@ export function readJsonl<T>(filePath: string): T[] {
 		}
 	}
 	return records;
+}
+
+/**
+ * Read all records from a JSONL file. Returns empty array if file does not exist.
+ */
+export function readJsonl<T>(filePath: string): T[] {
+	if (!existsSync(filePath)) {
+		return [];
+	}
+	return parseJsonlLines(readFileSync(filePath, "utf-8"), filePath);
+}
+
+/**
+ * Read only the last `maxBytes` of a JSONL file. The first line of the window
+ * may be truncated mid-record and is dropped. Use for append-only logs whose
+ * consumers only need recent history.
+ */
+export function readJsonlTail<T>(filePath: string, maxBytes: number): T[] {
+	if (!existsSync(filePath)) {
+		return [];
+	}
+	const size = statSync(filePath).size;
+	if (size <= maxBytes) {
+		return parseJsonlLines(readFileSync(filePath, "utf-8"), filePath);
+	}
+	const start = size - maxBytes;
+	const fd = openSync(filePath, "r");
+	let raw: string;
+	try {
+		const buf = Buffer.alloc(maxBytes);
+		readSync(fd, buf, 0, maxBytes, start);
+		raw = buf.toString("utf-8");
+	} finally {
+		closeSync(fd);
+	}
+	const lines = raw.split("\n");
+	lines.shift(); // drop the possibly-partial first line of the window
+	return parseJsonlLines(lines.join("\n"), filePath);
 }
 
 /**

--- a/config.example.json
+++ b/config.example.json
@@ -65,6 +65,9 @@
 		"theme": "light",
 		"closeBehavior": "ask"
 	},
+	"scheduler": {
+		"timezone": "Asia/Shanghai"
+	},
 	"ocrApi": {
 		"token": "",
 		"model": "PaddleOCR-VL-1.6",

--- a/docs/quality-remediation-plan.md
+++ b/docs/quality-remediation-plan.md
@@ -90,9 +90,9 @@ src/server/
 
 ## P4 · 小坑批量修（各随所属模块的 PR 带走）
 
-- **时区**：`config.json` 加 `scheduler.timezone`，默认 `Asia/Shanghai`，`cron-utils.ts` 三处改读配置。默认中国时区合理，问题是不可配。
-- **runCount 竞态**：`JobStore` 读-改-写加 per-job promise chain 串行化。
-- **jsonl 只增不减**：`events.jsonl`/`runs.jsonl` 加 size 阈值（如 10MB）滚动归档，启动时 tail 读最近 N KB 而非全量解析。
+- ✅ **时区**：`config.json` 加 `scheduler.timezone`（`normalizeSchedulerConfig`，默认 `Asia/Shanghai` 收敛为 `cron-utils.ts` 的 `DEFAULT_SCHEDULER_TIMEZONE` 常量）；`JobStore` 构造参数 `defaultTimezone`（public readonly），server.ts / inno-extension.ts / scheduler-tools.ts 三处全部改读配置。
+- ✅ **runCount 竞态**：`JobStore.mutate(id, mutator)` —— per-job promise chain 串行化，mutator 拿链内重读的最新状态；语义（updatedAt、nextRunAt 重算）与 `update()` 完全一致。job-runner.ts 三处计数器更新全部改用 mutate。
+- ✅ **jsonl 只增不减**：`appendJsonl(path, record, { maxBytes })` 超阈值先滚动为时间戳 `.archive` 再追加（best-effort，失败不掉记录）；新增 `readJsonlTail(path, maxBytes)`（窗口首行残缺即丢）。runs.jsonl / events.jsonl / channel run-log 10MB 滚动；listRuns / run-log list 改 1MB tail 读。dedupe.jsonl（TTL 活状态，滚动会丢去重）与 manifest 不动。
 - **jiti 加载他包内部 .ts（定时炸弹）**：短期钉死 `pi-mcp-adapter` 版本（去 `^`）+ jiti 调用处 try-catch 报明确错误；中期给上游提 PR 加 `exports` 入口或 vendoring。
 - **xlsx**：评估 `exceljs`（npm 官方源）或把 tarball vendor 进 `vendor/`，消除离线安装即挂。
 
@@ -109,7 +109,8 @@ src/server/
 ✅ P1.1 web DOM 环境 + P1.3 server.ts smoke 测试 + P1.2 首批（PR #134）
 ✅ P3 语言正则修复 + 命名诚实性（PR #135）
 ✅ P2 server.ts 按域拆完（PR #136–#146,一次性连续完成）
-下一站: P1 尾巴（personal-dispatcher / L3 条件测试）+ P4 小坑批量修 + P5 README Non-goals
+✅ P4 时区可配 + runCount 竞态 + jsonl 滚动（chore/p4-scheduler-robustness）
+下一站: P4 依赖卫生（jiti 钉版本 + xlsx）+ P1 尾巴（personal-dispatcher / L3 条件测试）+ P5 README Non-goals
 ```
 
 依赖关系：P2 拆分的安全网（smoke 测试）已就位 ✅；P3 语言正则（唯一正在静默失效的用户可见 bug）已修 ✅。


### PR DESCRIPTION
Three P4 robustness fixes from `docs/quality-remediation-plan.md` (scheduler/storage group).

## 1. `scheduler.timezone` is now configurable

The default `Asia/Shanghai` was hardcoded in ~7 spots. It's now a single `DEFAULT_SCHEDULER_TIMEZONE` constant in `cron-utils.ts`, overridable via a new `scheduler.timezone` key in config.json (`normalizeSchedulerConfig`). `JobStore` takes it as a constructor param exposed as `readonly defaultTimezone`; `server.ts`, `inno-extension.ts` and `scheduler-tools.ts` all read from config. Default unchanged — existing installs behave identically.

## 2. runCount read-modify-write race

`executeJob` captured a `job` snapshot, ran the prompt (possibly minutes), then wrote back `runCount: job.runCount + 1` from that stale snapshot — overlapping runs (cron + manual `/api/jobs/:id/run` + the agent's `run_scheduled_job` tool) lost increments.

New `JobStore.mutate(id, mutator)` serializes per-job read-modify-write through a promise chain; the mutator receives the job's **fresh** persisted state. The chain survives a throwing mutator (the stored link swallows the rejection; the caller still gets it). `updatedAt` bump and `nextRunAt` recompute semantics mirror `update()` exactly. All three counter-carrying updates in `job-runner.ts` converted.

## 3. Unbounded jsonl growth

`appendJsonl(path, record, { maxBytes })` rolls the file to a timestamped `.archive` sibling once it exceeds the threshold (best-effort — a rotation failure never drops the record). New `readJsonlTail(path, maxBytes)` reads only the tail window and drops the possibly-partial first line.

Applied to scheduler `runs.jsonl`, learner `events.jsonl` and the channel run log (10MB rotation; `listRuns`/run-log `list` read a 1MB tail). `dedupe.jsonl` is deliberately excluded — it's TTL'd live state where rotation could cause duplicate sends.

## Tests

- New `storage/file-store.test.ts`: rotation triggers/idle cases, tail read drops partial first line, malformed-line tolerance.
- `job-store.test.ts`: `mutate` serializes 5 concurrent counter increments (all land), replicates `update()` nextRunAt semantics, chain survives a throwing mutator, unknown id → undefined; constructor `defaultTimezone` honored and overridden by an explicit job timezone.
- Full suite: **189 tests / 25 files** green; `npm run build` clean. CLAUDE.md suite-size fact updated in the same PR per its own rule.