### PR TITLE
test(channels,l3): personal-dispatcher routing tests + conditional L3 suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~25 files and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~27 files (221 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 

--- a/apps/inno-agent/src/channels/personal-dispatcher.test.ts
+++ b/apps/inno-agent/src/channels/personal-dispatcher.test.ts
@@ -1,0 +1,336 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { ChatChannel, ChannelStreamEvent, StreamingReplyChannel, StreamingReplyHandle } from "./channel.js";
+import { ChannelRegistry } from "./channel.js";
+import { PersonalChannelDispatcher, type PersonalChannelDispatcherOptions } from "./personal-dispatcher.js";
+import type { IncomingMessage } from "./types.js";
+
+let channelsDataDir: string;
+let sessionDir: string;
+
+beforeEach(() => {
+	channelsDataDir = mkdtempSync(join(tmpdir(), "inno-disp-ch-"));
+	sessionDir = mkdtempSync(join(tmpdir(), "inno-disp-sess-"));
+});
+
+afterEach(() => {
+	rmSync(channelsDataDir, { recursive: true, force: true });
+	rmSync(sessionDir, { recursive: true, force: true });
+});
+
+function fakeChannel(name: "feishu" | "qq" | "wechat" = "feishu") {
+	const replies: string[] = [];
+	const channel: ChatChannel = {
+		name,
+		verify: async () => true,
+		parse: async () => null,
+		reply: async (_msg, text) => {
+			replies.push(text);
+		},
+		push: async () => {},
+	};
+	return { channel, replies };
+}
+
+interface OptsProbe {
+	opts: PersonalChannelDispatcherOptions;
+	prompts: string[];
+	inSession: { sessionPath: string; prompt: string }[];
+	streaming: { sessionPath: string; prompt: string; events: ChannelStreamEvent[] }[];
+	createdSessions: string[];
+	recordedChannels: { channel: string; sessionId?: string }[];
+	failNextPrompt: { current: boolean };
+	nextSessionId: { current: number };
+}
+
+function makeOpts(): OptsProbe {
+	const probe: OptsProbe = {
+		prompts: [],
+		inSession: [],
+		streaming: [],
+		createdSessions: [],
+		recordedChannels: [],
+		failNextPrompt: { current: false },
+		nextSessionId: { current: 0 },
+		opts: undefined as unknown as PersonalChannelDispatcherOptions,
+	};
+	probe.opts = {
+		channelRegistry: new ChannelRegistry(),
+		runPrompt: async (prompt) => {
+			probe.prompts.push(prompt);
+			if (probe.failNextPrompt.current) {
+				probe.failNextPrompt.current = false;
+				throw new Error("LLM exploded");
+			}
+			return "global reply";
+		},
+		runPromptInSession: async (sessionPath, prompt) => {
+			probe.inSession.push({ sessionPath, prompt });
+			if (probe.failNextPrompt.current) {
+				probe.failNextPrompt.current = false;
+				throw new Error("LLM exploded");
+			}
+			return "session reply";
+		},
+		runPromptStreamingInSession: async (sessionPath, prompt, onEvent) => {
+			const record = { sessionPath, prompt, events: [] as ChannelStreamEvent[] };
+			probe.streaming.push(record);
+			if (probe.failNextPrompt.current) {
+				probe.failNextPrompt.current = false;
+				throw new Error("LLM exploded");
+			}
+			onEvent({ type: "text_delta", delta: "streamed " });
+			record.events.push({ type: "text_delta", delta: "streamed " });
+			return "streamed reply";
+		},
+		createNewSession: async () => {
+			const id = `sess_${++probe.nextSessionId.current}.jsonl`;
+			probe.createdSessions.push(id);
+			return id;
+		},
+		getCurrentSessionId: () => "current.jsonl",
+		recordSessionChannel: (channel, sessionId) => {
+			probe.recordedChannels.push({ channel, sessionId });
+		},
+		channelsDataDir,
+		sessionDir,
+	};
+	return probe;
+}
+
+function msg(overrides: Partial<IncomingMessage> = {}): IncomingMessage {
+	return {
+		channel: "feishu",
+		messageId: `m_${Math.random().toString(36).slice(2)}`,
+		chatId: "chat_1",
+		text: "今天学了什么？",
+		raw: {},
+		...overrides,
+	};
+}
+
+describe("PersonalChannelDispatcher routing", () => {
+	it("dedupes repeated messageIds", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies } = fakeChannel();
+		const m = msg({ messageId: "fixed-id" });
+
+		await dispatcher.handle(channel, m);
+		await dispatcher.handle(channel, m);
+
+		expect(probe.inSession).toHaveLength(1);
+		expect(replies).toHaveLength(1);
+	});
+
+	it("ignores empty messages with no attachments", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies } = fakeChannel();
+
+		await dispatcher.handle(channel, msg({ text: "   ", attachments: [] }));
+
+		expect(probe.prompts).toHaveLength(0);
+		expect(probe.inSession).toHaveLength(0);
+		expect(replies).toHaveLength(0);
+	});
+
+	it("registers the chatId as the channel default target", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel } = fakeChannel();
+
+		await dispatcher.handle(channel, msg({ chatId: "chat_xyz" }));
+
+		expect(probe.opts.channelRegistry.getDefaultTarget("feishu")).toEqual({ channel: "feishu", chatId: "chat_xyz" });
+	});
+
+	it("/new creates and binds a fresh session for the chat", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies } = fakeChannel();
+
+		await dispatcher.handle(channel, msg({ text: "/new" }));
+
+		expect(probe.createdSessions).toEqual(["sess_1.jsonl"]);
+		expect(replies[0]).toContain("已新建会话");
+		// A /new command must not run any prompt.
+		expect(probe.prompts).toHaveLength(0);
+		expect(probe.inSession).toHaveLength(0);
+		expect(probe.streaming).toHaveLength(0);
+	});
+
+	it("auto-creates a dedicated session for an unbound chat and reuses it afterwards", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel } = fakeChannel();
+
+		await dispatcher.handle(channel, msg({ text: "第一条" }));
+		expect(probe.createdSessions).toEqual(["sess_1.jsonl"]);
+		expect(probe.inSession).toHaveLength(1);
+		expect(probe.inSession[0].sessionPath).toBe(join(sessionDir, "sess_1.jsonl"));
+
+		// The PI SDK creates session files lazily; simulate the file existing now.
+		writeFileSync(join(sessionDir, "sess_1.jsonl"), "{}\n", "utf-8");
+
+		await dispatcher.handle(channel, msg({ text: "第二条" }));
+		// No new session created; the binding was reused.
+		expect(probe.createdSessions).toEqual(["sess_1.jsonl"]);
+		expect(probe.inSession).toHaveLength(2);
+		expect(probe.inSession[1].sessionPath).toBe(join(sessionDir, "sess_1.jsonl"));
+	});
+
+	it("drops a stale binding and re-creates when the session file is gone", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel } = fakeChannel();
+
+		await dispatcher.handle(channel, msg({ text: "/new" }));
+		expect(probe.createdSessions).toEqual(["sess_1.jsonl"]);
+		// Never create sess_1.jsonl on disk → the binding is stale.
+
+		await dispatcher.handle(channel, msg({ text: "hello" }));
+		// Stale mapping removed → a brand-new session is auto-created.
+		expect(probe.createdSessions).toEqual(["sess_1.jsonl", "sess_2.jsonl"]);
+		expect(probe.inSession[0].sessionPath).toBe(join(sessionDir, "sess_2.jsonl"));
+	});
+
+	it("falls back to the global session for messages without a chatId", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies } = fakeChannel();
+
+		await dispatcher.handle(channel, msg({ chatId: undefined }));
+
+		expect(probe.prompts).toHaveLength(1);
+		expect(probe.inSession).toHaveLength(0);
+		expect(replies).toEqual(["global reply"]);
+	});
+
+	it("replies with a failure notice and logs an error run when the prompt throws", async () => {
+		const probe = makeOpts();
+		probe.failNextPrompt.current = true;
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies } = fakeChannel();
+
+		await dispatcher.handle(channel, msg());
+
+		expect(replies[replies.length - 1]).toContain("这次处理失败了");
+		const runs = dispatcher.getRunLog().list();
+		expect(runs).toHaveLength(1);
+		expect(runs[0].status).toBe("error");
+		expect(runs[0].error).toContain("LLM exploded");
+	});
+
+	it("appends a success run log entry with duration", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel } = fakeChannel();
+
+		await dispatcher.handle(channel, msg());
+
+		const runs = dispatcher.getRunLog().list();
+		expect(runs).toHaveLength(1);
+		expect(runs[0].status).toBe("success");
+		expect(runs[0].durationMs).toBeGreaterThanOrEqual(0);
+	});
+
+	it("truncates over-long text and notifies the user", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies } = fakeChannel();
+
+		await dispatcher.handle(channel, msg({ text: "长".repeat(25_000) }));
+
+		expect(replies.some((r) => r.includes("已截断"))).toBe(true);
+		expect(probe.inSession[0].prompt.length).toBeLessThanOrEqual(20_000);
+	});
+
+	it("appends downloaded file attachments to the prompt", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel } = fakeChannel();
+
+		await dispatcher.handle(
+			channel,
+			msg({ attachments: [{ type: "file", filePath: "/tmp/report.pdf", fileName: "report.pdf" }] }),
+		);
+
+		expect(probe.inSession[0].prompt).toContain("[附件已下载到: /tmp/report.pdf]");
+	});
+});
+
+describe("PersonalChannelDispatcher streaming", () => {
+	function fakeStreamingChannel(opts: { failInit?: boolean } = {}) {
+		const replies: string[] = [];
+		const finalized: boolean[] = [];
+		const handleEvents: ChannelStreamEvent[] = [];
+		const channel: StreamingReplyChannel = {
+			name: "feishu",
+			supportsStreamingReply: true,
+			verify: async () => true,
+			parse: async () => null,
+			reply: async (_msg, text) => {
+				replies.push(text);
+			},
+			push: async () => {},
+			beginStreamingReply: async (): Promise<StreamingReplyHandle> => {
+				if (opts.failInit) throw new Error("no card permission");
+				return {
+					onEvent: (event) => {
+						handleEvents.push(event);
+					},
+					finalize: async () => {
+						finalized.push(true);
+					},
+				};
+			},
+		};
+		return { channel, replies, finalized, handleEvents };
+	}
+
+	it("uses the streaming path for streaming-capable channels", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies, finalized, handleEvents } = fakeStreamingChannel();
+
+		await dispatcher.handle(channel, msg());
+
+		expect(probe.streaming).toHaveLength(1);
+		expect(handleEvents.some((e) => e.type === "text_delta")).toBe(true);
+		expect(finalized).toHaveLength(1);
+		// Streaming card is the reply — no plain-text duplicate.
+		expect(replies).toHaveLength(0);
+		const runs = dispatcher.getRunLog().list();
+		expect(runs[0].status).toBe("success");
+	});
+
+	it("falls back to a plain reply when streaming-card init fails", async () => {
+		const probe = makeOpts();
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies } = fakeStreamingChannel({ failInit: true });
+
+		await dispatcher.handle(channel, msg());
+
+		expect(probe.streaming).toHaveLength(0);
+		expect(probe.inSession).toHaveLength(1);
+		expect(replies).toEqual(["session reply"]);
+		const runs = dispatcher.getRunLog().list();
+		expect(runs[0].status).toBe("success");
+	});
+
+	it("finalizes the card with an error event when the prompt fails mid-stream", async () => {
+		const probe = makeOpts();
+		probe.failNextPrompt.current = true;
+		const dispatcher = new PersonalChannelDispatcher(probe.opts);
+		const { channel, replies, finalized, handleEvents } = fakeStreamingChannel();
+
+		await dispatcher.handle(channel, msg());
+
+		expect(handleEvents.some((e) => e.type === "error")).toBe(true);
+		expect(finalized).toHaveLength(1);
+		expect(replies[replies.length - 1]).toContain("这次处理失败了");
+	});
+});

--- a/apps/inno-agent/src/memory/l3/l3.test.ts
+++ b/apps/inno-agent/src/memory/l3/l3.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { indexAllSessions, indexSession } from "./indexer.js";
+import { formatRecallForPrompt, recall } from "./recall.js";
+import { openL3Store, segmentForFts, type L3Store } from "./sqlite-store.js";
+
+/**
+ * L3 tests. `segmentForFts` is a pure function and always runs. The store /
+ * indexer / recall suites need node:sqlite (Node >= 22.5); on older runtimes
+ * the whole point is that L3 degrades to disabled, so they skip conditionally.
+ */
+function nodeSqliteAvailable(): boolean {
+	const [major, minor] = process.versions.node.split(".").map((v) => Number.parseInt(v, 10));
+	return major > 22 || (major === 22 && minor >= 5);
+}
+
+describe("segmentForFts (pure)", () => {
+	it("splits CJK runs into overlapping bigrams", () => {
+		expect(segmentForFts("学习计划")).toBe("学习 习计 计划");
+	});
+
+	it("keeps ASCII runs whole and lowercased", () => {
+		expect(segmentForFts("Python AsyncIO")).toBe("python asyncio");
+	});
+
+	it("handles mixed CJK/ASCII and punctuation (single CJK chars stay unigrams)", () => {
+		expect(segmentForFts("用Node.js写爬虫")).toBe("用 node js 写爬 爬虫");
+	});
+
+	it("returns empty string for empty input", () => {
+		expect(segmentForFts("")).toBe("");
+	});
+});
+
+describe.skipIf(!nodeSqliteAvailable())("L3 store + recall (node:sqlite)", () => {
+	let l3Dir: string;
+	let sessionDir: string;
+	let store: L3Store | null;
+
+	beforeEach(async () => {
+		l3Dir = mkdtempSync(join(tmpdir(), "inno-l3-db-"));
+		sessionDir = mkdtempSync(join(tmpdir(), "inno-l3-sess-"));
+		store = await openL3Store(l3Dir);
+		expect(store).not.toBeNull();
+	});
+
+	afterEach(() => {
+		store?.close();
+		rmSync(l3Dir, { recursive: true, force: true });
+		rmSync(sessionDir, { recursive: true, force: true });
+	});
+
+	function upsert(sessionId: string, texts: string[], role: "user" | "assistant" = "user") {
+		store!.upsertChunks(
+			texts.map((text, i) => ({
+				id: `${sessionId}:${i}`,
+				sessionId,
+				role,
+				text,
+				ts: Date.parse("2026-08-01T10:00:00Z") + i,
+			})),
+		);
+	}
+
+	it("upserts chunks and finds them via CJK bigram search", () => {
+		upsert("s1", ["我们在整理机器学习的学习笔记和公式推导"]);
+		const hits = store!.searchLexical("机器学习");
+		expect(hits).toHaveLength(1);
+		expect(hits[0].sessionId).toBe("s1");
+		expect(hits[0].bm25).toBeLessThan(0);
+	});
+
+	it("returns no hits for lexically absent queries", () => {
+		upsert("s1", ["我们在整理机器学习的学习笔记和公式推导"]);
+		expect(store!.searchLexical("烹饪食谱")).toHaveLength(0);
+	});
+
+	it("recall gates on coverage: unrelated queries inject nothing", () => {
+		upsert("s1", ["我们在整理机器学习的学习笔记和公式推导"]);
+		expect(recall(store, "机器学习")).toHaveLength(1);
+		expect(recall(store, "烹饪食谱")).toHaveLength(0);
+	});
+
+	it("recall rejects too-short queries (single CJK char)", () => {
+		upsert("s1", ["我们在整理机器学习的学习笔记和公式推导"]);
+		expect(recall(store, "机")).toHaveLength(0);
+	});
+
+	it("recall excludes the active session", () => {
+		upsert("s1", ["我们在整理机器学习的学习笔记和公式推导"]);
+		expect(recall(store, "机器学习", { excludeSessionId: "s1" })).toHaveLength(0);
+	});
+
+	it("recall dedups near-identical snippets", () => {
+		const text = "我们在整理机器学习的学习笔记和公式推导";
+		upsert("s1", [text]);
+		upsert("s2", [text]);
+		const results = recall(store, "机器学习");
+		expect(results).toHaveLength(1);
+	});
+
+	it("recall on a null store degrades to empty", () => {
+		expect(recall(null, "机器学习")).toEqual([]);
+	});
+
+	it("deleteSession removes chunks, FTS rows, and index state", () => {
+		upsert("s1", ["我们在整理机器学习的学习笔记和公式推导"]);
+		store!.setIndexState("s1", 100, 200, 1);
+		expect(store!.chunkCount()).toBe(1);
+
+		store!.deleteSession("s1");
+
+		expect(store!.chunkCount()).toBe(0);
+		expect(store!.searchLexical("机器学习")).toHaveLength(0);
+		expect(store!.getIndexState("s1")).toBeNull();
+	});
+
+	it("index state round-trips", () => {
+		expect(store!.getIndexState("s1")).toBeNull();
+		store!.setIndexState("s1", 123, 456, 7);
+		expect(store!.getIndexState("s1")).toEqual({ lastOffset: 123, lastMtimeMs: 456, chunkCount: 7 });
+	});
+
+	function writeSession(name: string, lines: unknown[]): string {
+		const path = join(sessionDir, name);
+		writeFileSync(path, lines.map((l) => JSON.stringify(l)).join("\n") + "\n", "utf-8");
+		return path;
+	}
+
+	function messageEvent(role: string, text: string, stopReason?: string) {
+		return {
+			type: "message",
+			timestamp: "2026-08-01T10:00:00Z",
+			message: { role, content: [{ type: "text", text }], ...(stopReason ? { stopReason } : {}) },
+		};
+	}
+
+	it("indexSession extracts user/assistant text and skips thinking/toolCall noise", () => {
+		const path = writeSession("sess_a.jsonl", [
+			messageEvent("user", "今天学习了机器学习的基础概念"),
+			{
+				type: "message",
+				timestamp: "2026-08-01T10:00:01Z",
+				message: {
+					role: "assistant",
+					content: [
+						{ type: "thinking", thinking: "内部推理不应进索引" },
+						{ type: "text", text: "好的，我们从梯度下降开始复习" },
+					],
+					stopReason: "stop",
+				},
+			},
+			{ type: "message", timestamp: "2026-08-01T10:00:02Z", message: { role: "toolResult", content: "noise" } },
+		]);
+
+		const written = indexSession(store!, path);
+		expect(written).toBe(2);
+		expect(store!.chunkCount()).toBe(2);
+		expect(store!.searchLexical("机器学习")).toHaveLength(1);
+		expect(store!.searchLexical("内部推理")).toHaveLength(0);
+	});
+
+	it("indexSession skips unchanged files (mtime-gated incremental indexing)", () => {
+		const path = writeSession("sess_b.jsonl", [messageEvent("user", "今天学习了机器学习的基础概念")]);
+		expect(indexSession(store!, path)).toBe(1);
+		// Same mtime → skipped entirely.
+		expect(indexSession(store!, path)).toBe(0);
+	});
+
+	it("indexAllSessions backfills a directory of session files", () => {
+		writeSession("sess_c.jsonl", [messageEvent("user", "今天学习了机器学习的基础概念")]);
+		writeSession("sess_d.jsonl", [messageEvent("user", "晚上复习了线性代数的特征值分解")]);
+		writeFileSync(join(sessionDir, "not-a-session.txt"), "ignored", "utf-8");
+
+		const summary = indexAllSessions(store!, sessionDir);
+		expect(summary).toEqual({ sessions: 2, chunks: 2 });
+	});
+
+	it("end-to-end: indexed history is recallable from a later session", () => {
+		writeSession("sess_old.jsonl", [messageEvent("user", "上周我们讨论了机器学习的学习笔记")]);
+		indexAllSessions(store!, sessionDir);
+
+		const results = recall(store, "机器学习", { excludeSessionId: "sess_new.jsonl" });
+		expect(results).toHaveLength(1);
+		const promptSection = formatRecallForPrompt(results);
+		expect(promptSection).toContain("相关历史对话");
+		expect(promptSection).toContain("机器学习");
+	});
+
+	it("formatRecallForPrompt returns empty string when there is nothing to inject", () => {
+		expect(formatRecallForPrompt([])).toBe("");
+	});
+});

--- a/docs/quality-remediation-plan.md
+++ b/docs/quality-remediation-plan.md
@@ -35,9 +35,9 @@
 1. **web 端 DOM 环境** ✅（`chore/p1-test-infra`）：`vitest.config.ts` 用 `environmentMatchGlobs` 把 `*.test.tsx` 路由到 jsdom，装了 `@testing-library/react`；`react/ui/Switch.test.tsx` 是首个组件测试示例。纯 store/util 测试留在 node 环境。
 2. **后端补测，按风险排序而非按目录平均分配**：
    - **scheduler** ✅：`cron-utils`（解析/校验/due 判定/one-shot 检测）+ `job-store`（create 默认值、update 清 nextRunAt、`normalizePersistedJobs` 迁移、runs、getStatus）
-   - **channels** ✅（部分）：`dedupe-store`（TTL、按渠道隔离、重启持久化）。`personal-dispatcher` 消息路由待补 ⬜
+   - **channels** ✅：`dedupe-store`（TTL、按渠道隔离、重启持久化）+ `personal-dispatcher` 消息路由（去重、空消息、/new 绑定、自动建会话与复用、失效绑定重建、无 chatId 回退全局会话、失败通知 + run-log、截断、附件注入、流式路径与卡片初始化失败回退）
    - **L1 learner**：profile-updater 增量逻辑（与 P2 模型修正一起测）⬜
-   - **L3**：依赖 Node ≥22.5，用 `describe.skipIf(...)` 做条件测试 ⬜
+   - **L3** ✅：`l3.test.ts`——`segmentForFts` 纯函数常跑；store/indexer/recall 套件用 `describe.skipIf(node < 22.5)` 条件执行（覆盖 bigram 检索、coverage 阈值门控、excludeSession、去重、deleteSession、mtime 增量索引、端到端 recall）
    - **terminal** ✅：`command-resolver` 扩展名映射与路径引用。PTY 交互不测
 3. **server.ts smoke 层** ✅：`server.smoke.test.ts` 以子进程方式起真实 server（`--import tsx` + 临时 `--home` + dummy provider），断言 `/health`、`/api/settings`（含 API key 脱敏）、`/api/sessions`、`/api/jobs`、未匹配 `/api/*` 的 JSON 404。**该测试当场抓到一个真 bug**：SPA fallback 对未匹配的 `/api/*` 也返回 200 index.html——已修（fallback 跳过 `/api` 前缀）。
 
@@ -110,8 +110,9 @@ src/server/
 ✅ P3 语言正则修复 + 命名诚实性（PR #135）
 ✅ P2 server.ts 按域拆完（PR #136–#146,一次性连续完成）
 ✅ P4 时区可配 + runCount 竞态 + jsonl 滚动（PR #147）
-✅ P4 依赖卫生：pi-mcp-adapter/pi-sandbox 钉版本 + xlsx vendoring（chore/p4-dependency-hygiene）
-下一站: P1 尾巴（personal-dispatcher / L3 条件测试）+ P5 README Non-goals
+✅ P4 依赖卫生：pi-mcp-adapter/pi-sandbox 钉版本 + xlsx vendoring（PR #148）
+✅ P1 尾巴：personal-dispatcher 路由测试 + L3 条件测试（test/p1-tail）
+下一站: P5 README Non-goals（L1 profile-updater 增量测试随 L1 规则演进另行安排）
 ```
 
 依赖关系：P2 拆分的安全网（smoke 测试）已就位 ✅；P3 语言正则（唯一正在静默失效的用户可见 bug）已修 ✅。


### PR DESCRIPTION
The P1 tail from `docs/quality-remediation-plan.md` — the last two unchecked test-infrastructure items.

## `channels/personal-dispatcher.test.ts` (14 tests)

Message routing, tested with a fake channel and mocked prompt runners:

- **Dedup**: repeated `messageId` handled once
- **Empty messages** (whitespace text, no attachments) ignored
- **Default push target**: incoming `chatId` registered on the channel registry
- **`/new` command**: creates + binds a fresh session, replies with confirmation, runs no prompt
- **Dedicated sessions**: unbound chats auto-create their own session (never piggy-back on the web/global session) and reuse the binding afterwards
- **Stale bindings**: session file gone → mapping dropped, new session auto-created
- **No chatId** → global-session fallback (`runPrompt`)
- **Failure path**: prompt throws → failure notice replied + error entry in the run log
- **Truncation**: >20k-char text sliced with user notice; **file attachments** injected into the prompt
- **Streaming**: event forwarding + finalize on the happy path; card-init failure falls back to a plain reply; mid-stream prompt failure finalizes the card with an error event

## `memory/l3/l3.test.ts` (18 tests)

`segmentForFts` pure-function tests run unconditionally. The store/indexer/recall suites use `describe.skipIf(node < 22.5)` — on older runtimes `node:sqlite` is unavailable and L3 degrades to disabled by design, so skipping there is the correct expectation.

Covers: CJK bigram segmentation (incl. single-char unigrams, ASCII lowercasing), FTS hits/misses, recall coverage-threshold gating, too-short query rejection, `excludeSessionId`, snippet dedup, null-store degradation, `deleteSession` cleanup, index-state round-trip, mtime-gated incremental indexing, directory backfill, and an end-to-end recall-across-sessions flow with prompt-section formatting.

## Verification

- Full suite: **189 → 221 tests, 25 → 27 files**, all green
- `npm run build` clean
- CLAUDE.md suite-size fact updated in the same PR per its own rule