### PR TITLE
fix(l2): build wiki-relative paths with forward slashes on all platforms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~27 files (221 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~28 files (223 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 

--- a/apps/inno-agent/src/memory/l2/l2-indexer.ts
+++ b/apps/inno-agent/src/memory/l2/l2-indexer.ts
@@ -11,6 +11,7 @@
 import { createHash } from "node:crypto";
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { wikiPathJoin } from "./wiki-paths.js";
 import { readText, fileExists } from "../../storage/file-store.js";
 import { parseFrontmatter } from "./wiki-maintainer.js";
 import type { L2IndexStore, L2PageDoc } from "./l2-index-store.js";
@@ -81,7 +82,7 @@ export function indexAllPages(store: L2IndexStore, l2DataDir: string): { indexed
 			continue;
 		}
 		for (const f of files) {
-			const wikiPath = join("wiki", sub, f);
+			const wikiPath = wikiPathJoin("wiki", sub, f);
 			present.add(wikiPath);
 			if (indexPage(store, l2DataDir, wikiPath)) indexed++;
 		}

--- a/apps/inno-agent/src/memory/l2/l2-lint.ts
+++ b/apps/inno-agent/src/memory/l2/l2-lint.ts
@@ -1,5 +1,6 @@
 import { readdirSync } from "node:fs";
 import { basename, extname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { wikiPathJoin } from "./wiki-paths.js";
 import { parse as parseYaml } from "yaml";
 
 import { fileExists, readText } from "../../storage/file-store.js";
@@ -74,7 +75,7 @@ function wikiPagePaths(l2DataDir: string): string[] {
 		const absolute = join(l2DataDir, "wiki", directory);
 		if (!fileExists(absolute)) continue;
 		for (const file of readdirSync(absolute).filter((candidate) => candidate.endsWith(".md")).sort()) {
-			paths.push(join("wiki", directory, file));
+			paths.push(wikiPathJoin("wiki", directory, file));
 		}
 	}
 	return paths;

--- a/apps/inno-agent/src/memory/l2/wiki-graph.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-graph.ts
@@ -16,6 +16,7 @@
 
 import { readdirSync } from "node:fs";
 import { basename, extname, join } from "node:path";
+import { wikiPathJoin } from "./wiki-paths.js";
 import { UndirectedGraph } from "graphology";
 import louvainImport from "graphology-communities-louvain";
 
@@ -39,7 +40,7 @@ const MIN_COMMUNITY_SIZE = 3;
  * "connects everything" super-node AND inflate the degree of exactly the nodes
  * it ranks — a feedback loop. It is therefore excluded from the graph.
  */
-export const OVERVIEW_PATH = join("wiki", "analysis", "overview.md");
+export const OVERVIEW_PATH = wikiPathJoin("wiki", "analysis", "overview.md");
 
 export interface WikiGraphNode {
 	id: string;
@@ -128,7 +129,7 @@ function readAllPages(l2DataDir: string): PageRecord[] {
 		}
 		for (const file of files) {
 			if (!file.endsWith(".md")) continue;
-			const wikiPath = join("wiki", sub, file);
+			const wikiPath = wikiPathJoin("wiki", sub, file);
 			if (wikiPath === OVERVIEW_PATH) continue;
 			const { frontmatter, body } = parseFrontmatter(readText(join(l2DataDir, wikiPath)));
 			if (!frontmatter) continue;

--- a/apps/inno-agent/src/memory/l2/wiki-linker.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-linker.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { existsSync, readdirSync } from "node:fs";
 import { basename, extname, join } from "node:path";
+import { wikiPathJoin } from "./wiki-paths.js";
 
 import { complete } from "@earendil-works/pi-ai";
 import type { Model } from "@earendil-works/pi-ai";
@@ -270,7 +271,7 @@ function pageDirForType(type: LinkablePageType): string {
 }
 
 function relativePagePath(type: LinkablePageType, filename: string): string {
-	return join("wiki", pageDirForType(type), filename);
+	return wikiPathJoin("wiki", pageDirForType(type), filename);
 }
 
 function findExistingPage(l2DataDir: string, item: LinkedItem): string {
@@ -332,7 +333,7 @@ function readAllWikiPageAliases(l2DataDir: string): { title: string; path: strin
 		if (!existsSync(dir)) continue;
 		for (const file of readdirSync(dir)) {
 			if (!file.endsWith(".md")) continue;
-			const path = join("wiki", dirName, file);
+			const path = wikiPathJoin("wiki", dirName, file);
 			const { frontmatter } = parseFrontmatter(readText(join(l2DataDir, path)));
 			pages.push({ title: frontmatter?.title || basename(file, extname(file)), path });
 		}

--- a/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
@@ -1,5 +1,6 @@
 import { readdirSync } from "node:fs";
 import { join } from "node:path";
+import { wikiPathJoin } from "./wiki-paths.js";
 import { parse as parseYaml, Document as YamlDocument } from "yaml";
 import { ensureDir, writeText, readText, appendText, fileExists } from "../../storage/file-store.js";
 import type {
@@ -288,7 +289,7 @@ export function createSourcePage(
 	const ref = extractedPath ? `\n## 来源\n\n完整提取文本: \`${extractedPath}\`\n` : "";
 	const body = `\n# ${entry.title}\n\n${summaryBody}\n${ref}`;
 	writeText(join(dir, filename), serializeFrontmatter(fm) + body);
-	return join("wiki", "sources", filename);
+	return wikiPathJoin("wiki", "sources", filename);
 }
 
 // ============================================================================
@@ -431,7 +432,7 @@ function listWikiPagesForIndex(
 		if (!fileExists(dir)) continue;
 		const files = readDirectoryMdFiles(dir);
 		for (const file of files) {
-			const wikiPath = join("wiki", TYPE_DIR_MAP[type], file);
+			const wikiPath = wikiPathJoin("wiki", TYPE_DIR_MAP[type], file);
 			items.push(readWikiPageIndexItem(l2DataDir, fallbackTitleByPath.get(wikiPath) ?? file.replace(/\.md$/, ""), wikiPath));
 		}
 	}

--- a/apps/inno-agent/src/memory/l2/wiki-paths.test.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-paths.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { toWikiPath, wikiPathJoin } from "./wiki-paths.js";
+
+describe("wiki-paths", () => {
+	it("wikiPathJoin always uses forward slashes", () => {
+		expect(wikiPathJoin("wiki", "concepts", "foo.md")).toBe("wiki/concepts/foo.md");
+	});
+
+	it("toWikiPath normalizes Windows separators", () => {
+		expect(toWikiPath("wiki\\concepts\\foo.md")).toBe("wiki/concepts/foo.md");
+		expect(toWikiPath("wiki/concepts/foo.md")).toBe("wiki/concepts/foo.md");
+	});
+});

--- a/apps/inno-agent/src/memory/l2/wiki-paths.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-paths.ts
@@ -1,0 +1,24 @@
+/**
+ * Wiki-relative logical paths.
+ *
+ * A wiki path (`wiki/concepts/foo.md`) is an *identifier*: it appears in URLs
+ * (`/api/wiki/page?path=…`), frontmatter links, graph node ids, and the
+ * manifest. It must therefore always use forward slashes, regardless of the
+ * host OS. Using `path.join()` for these silently produces backslashes on
+ * Windows, which breaks link resolution, graph edges, and overview stats
+ * (caught by the Windows release CI in v0.4.8).
+ *
+ * Filesystem access keeps using `path.join(l2DataDir, wikiPath)` — Windows
+ * accepts forward slashes in file APIs, so a posix logical path is safe to
+ * embed in an OS path.
+ */
+
+/** Join segments into a wiki-relative logical path (always forward slashes). */
+export function wikiPathJoin(...segments: string[]): string {
+	return segments.join("/");
+}
+
+/** Normalize an OS-specific relative path to a wiki-relative logical path. */
+export function toWikiPath(osRelativePath: string): string {
+	return osRelativePath.replace(/\\/g, "/");
+}

--- a/apps/inno-agent/src/server/routes/practice.ts
+++ b/apps/inno-agent/src/server/routes/practice.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
 import { existsSync } from "node:fs";
 import { dirname, extname, join } from "node:path";
+import { wikiPathJoin } from "../../memory/l2/wiki-paths.js";
 import { logger } from "../../logger.js";
 import { serializeFrontmatter } from "../../memory/l2/wiki-maintainer.js";
 import { ensureDir, writeText } from "../../storage/file-store.js";
@@ -97,7 +98,7 @@ export async function handlePracticeRoutes(
 		const ws = workspaceRegistry.getWorkspace(record.workspaceId);
 
 		const now = new Date().toISOString();
-		const wikiRelPath = join("wiki", "analysis", `run-${record.id}.md`);
+		const wikiRelPath = wikiPathJoin("wiki", "analysis", `run-${record.id}.md`);
 		const fullPath = join(l2DataDir, wikiRelPath);
 		if (existsSync(fullPath)) {
 			json(res, 409, { error: "Run already archived", path: wikiRelPath });

--- a/apps/inno-agent/src/server/routes/wiki.ts
+++ b/apps/inno-agent/src/server/routes/wiki.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
 import { existsSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { basename, extname, join } from "node:path";
+import { wikiPathJoin } from "../../memory/l2/wiki-paths.js";
 import { logger } from "../../logger.js";
 import { getL2Memory } from "../../memory/l2/l2-memory.js";
 import { readManifest, removeWikiPathFromManifest } from "../../memory/l2/manifest-store.js";
@@ -30,7 +31,7 @@ function listWikiPagePaths(l2DataDir: string): string[] {
 		if (!existsSync(dir)) continue;
 		for (const file of readdirSync(dir)) {
 			if (file.endsWith(".md")) {
-				paths.push(join("wiki", dirName, file));
+				paths.push(wikiPathJoin("wiki", dirName, file));
 			}
 		}
 	}

--- a/docs/quality-remediation-plan.md
+++ b/docs/quality-remediation-plan.md
@@ -115,6 +115,8 @@ src/server/
 ✅ P1 尾巴：personal-dispatcher 路由测试 + L3 条件测试（PR #149）
 ✅ P5 README Non-goals + session_busy 覆盖审计（docs/p5-non-goals）
 整改计划全部完成 🎉（L1 profile-updater 增量测试随 L1 规则演进另行安排）
+
+> 后话（2026-08-09 v0.4.8 发版）：P0 加的 Windows CI 测试门禁当场抓到 3 个真实 bug——L2 wiki 逻辑路径用 `path.join` 构造，在 Windows 上产生反斜杠标识符，链接解析/图谱边/overview 统计全挂（`wiki-linker`/`wiki-graph`/`overview` 三个测试红）。修复：新增 `memory/l2/wiki-paths.ts`（`wikiPathJoin`/`toWikiPath`），10 处逻辑路径构造点全部改正斜杠。门禁价值即刻兑现。
 ```
 
 依赖关系：P2 拆分的安全网（smoke 测试）已就位 ✅；P3 语言正则（唯一正在静默失效的用户可见 bug）已修 ✅。


### PR DESCRIPTION
Found by the v0.4.8 Windows release run — the test gate added in P0 (PR #133) caught 3 real bugs on its first release: `wiki-linker`, `wiki-graph` and `overview` tests all red on Windows while macOS stayed green.

## Root cause

Wiki-relative paths (`wiki/concepts/foo.md`) are **logical identifiers** — they appear in URLs (`/api/wiki/page?path=…`), frontmatter links, graph node ids, and the manifest. But they were built with `path.join()`, which produces backslashes on Windows. Everything downstream that matches or compares them silently broke there:

- `wiki-linker` returned `wiki\concepts\shared-memory.md` — links never resolve to pages
- graph edges vanished (dedup pair keys never matched across separator styles)
- `buildWikiGraph` found 0 pages → `regenerateOverview` returned null → `overview.md` never written (the ENOENT)

## Fix

New `memory/l2/wiki-paths.ts`:
- `wikiPathJoin(...segments)` — always joins with `/`
- `toWikiPath(osPath)` — normalizes an OS-specific relative path

All 10 logical-path construction sites converted (`wiki-linker`, `wiki-graph`, `l2-lint`, `wiki-maintainer`, `l2-indexer`, `server/routes/wiki`, `server/routes/practice`). Filesystem access still uses `path.join(l2DataDir, wikiPath)` — Windows file APIs accept forward slashes, so a posix logical path embeds safely.

Includes a small `wiki-paths.test.ts`; the Windows CI gate is the real regression net.

## Verification

- macOS: 223 tests / 28 files green, build clean
- Windows: to be confirmed by re-running the v0.4.8 release after merge

## Release impact

v0.4.8's macOS artifacts are already published; Windows produced none. After this merges: delete remote tag `v0.4.8`, re-tag on main HEAD, push — both platforms rebuild and upload to the existing release (re-upload overwrites same-name mac assets harmlessly, per the v0.4.4/v0.4.6 runbook).