### PR TITLE
test(l2): forward-slash expected wiki path in wiki-graph test (Windows CI)

### DIFF
--- a/apps/inno-agent/src/memory/l2/wiki-graph.test.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-graph.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { writeText } from "../../storage/file-store.js";
 import { buildWikiGraph } from "./wiki-graph.js";
 import { ensureL2Directories, serializeFrontmatter } from "./wiki-maintainer.js";
+import { wikiPathJoin } from "./wiki-paths.js";
 
 const tempDirs: string[] = [];
 
@@ -14,7 +15,10 @@ afterEach(() => {
 });
 
 function writePage(root: string, name: string, title: string, sourceId: string, body: string): string {
-	const path = join("wiki", "concepts", `${name}.md`);
+	// The returned path is the page's logical identity and must always use
+	// forward slashes — building it with join() would produce backslashes on
+	// Windows and never match the graph's node/edge ids.
+	const path = wikiPathJoin("wiki", "concepts", `${name}.md`);
 	writeText(
 		join(root, path),
 		`${serializeFrontmatter({


### PR DESCRIPTION
Follow-up to #151. The second v0.4.8 Windows run went from 3 failures to 1: `wiki-linker` and `overview` are green now, but `wiki-graph` still failed with `expected [] to have a length of 1`.

Cause: with the product now correctly returning forward-slash wiki paths, the **test's own expectation** became the Windows bug — `writePage()` built the expected page path with `path.join()`, producing `wiki\concepts\alpha.md` on Windows, which never matches the graph's forward-slash edge ids.

Fix: use `wikiPathJoin` for the logical path (the physical write still goes through `join()`, which is correct). One line + comment.

After merge: re-tag v0.4.8 again (same runbook) and the Windows gate should go green end-to-end.