### PR TITLE
ci: restore Linux release workflow on the current publish flow

### DIFF
--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,85 @@
+name: Linux Release
+
+# 触发方式：
+#   1. 推送版本 tag（如 git tag v0.3.0 && git push origin v0.3.0）
+#   2. GitHub 页面手动触发（可指定版本号）
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '版本号（如 0.3.0，留空则读 package.json）'
+        required: false
+        default: ''
+
+permissions:
+  contents: write   # 允许创建 GitHub Release 并上传产物
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+
+    steps:
+      # ── 1. 检出代码 ──────────────────────────────────────────────────────────
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # ── 2. 安装 Node.js ──────────────────────────────────────────────────────
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      # ── 3. 覆盖版本号（仅 workflow_dispatch 且输入了版本） ──────────────────
+      - name: Bump version
+        if: github.event_name == 'workflow_dispatch' && inputs.version != ''
+        run: npm version "${{ inputs.version }}" --no-git-tag-version
+
+      # ── 4. 安装依赖 ──────────────────────────────────────────────────────────
+      - name: Install dependencies
+        run: npm ci
+
+      # ── 4.5 跑测试（vitest，作为发版门禁）───────────────────────────────────
+      - name: Run tests
+        run: npm test
+
+      # ── 5. 编译后端 TypeScript ───────────────────────────────────────────────
+      - name: Build backend (tsc)
+        run: npm --workspace inno-agent run build
+
+      # ── 6. 编译前端（Vite）──────────────────────────────────────────────────
+      - name: Build frontend (vite)
+        run: npm --workspace inno-agent-web run build
+
+      # ── 7. 打包 Electron（AppImage x64 + arm64）──────────────────────────────
+      - name: Package Electron (Linux)
+        run: npx electron-builder --linux --x64 --arm64 --publish never
+
+      # ── 8. 读取实际版本号 ────────────────────────────────────────────────────
+      - name: Read version
+        id: pkg
+        run: |
+          version=$(node -p "require('./package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # ── 9. 上传产物（可在 Actions 页面直接下载，不走 Release） ───────────────
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: InnoAgent-${{ steps.pkg.outputs.version }}-linux
+          path: dist-electron/*.AppImage
+          retention-days: 30
+
+      # ── 10. 创建 / 更新 GitHub Release（仅 tag 触发时） ─────────────────────
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Inno Agent v${{ steps.pkg.outputs.version }}"
+          files: dist-electron/*.AppImage
+          generate_release_notes: true
+          draft: false
+          prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-rc') }}


### PR DESCRIPTION
Restores `release-linux.yml` (deleted in the 04350fb revert) so releases cover all three desktop platforms — requested for the v0.4.8 re-release.

Updated to the **current** publish flow (the old file was written for the deprecated `electron-builder --publish always` era):

- `npm ci` → `npm test` (release gate, same as win) → tsc → vite
- `electron-builder --linux --x64 --arm64 --publish never`
- `upload-artifact` + `softprops/action-gh-release` (tag pushes only), uploading `dist-electron/*.AppImage` to the shared release

The `build.linux` electron-builder config (AppImage x64/arm64) never left package.json — no other changes needed.

**Merge order matters** (v0.4.6 runbook): a tag only triggers workflows present in the tag's commit, so this must land on main *before* re-tagging v0.4.8. Sequence after merge: delete remote tag → re-tag on main HEAD → push → mac/win/linux all run.