### PR TITLE
fix: tail-read recent L1 events per turn; drop dead nextRunAt in job mutators

### DIFF
--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -8,7 +8,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { saveConfig, setDefaultModel, type InnoConfig } from "../config.js";
 import { createLearnerTools } from "../memory/learner/learner-tools.js";
-import { isProfileEmpty, loadEvents, loadProfile } from "../memory/learner/profile-store.js";
+import { isProfileEmpty, loadProfile, loadRecentEvents } from "../memory/learner/profile-store.js";
 import { buildContextPack, formatContextPackForPrompt } from "../memory/learner/context-pack.js";
 import { JobStore } from "../scheduler/job-store.js";
 import { createSchedulerTools } from "../scheduler/scheduler-tools.js";
@@ -364,7 +364,7 @@ export function createInnoExtension(
 						sections.push(ONBOARDING_GUIDE);
 					}
 
-					const recentEvents = loadEvents(paths.learnerDataDir).slice(-8);
+					const recentEvents = loadRecentEvents(paths.learnerDataDir, 8);
 					const contextPack = buildContextPack(profile, recentEvents);
 					const contextSection = formatContextPackForPrompt(contextPack);
 					sections.push(contextSection);

--- a/apps/inno-agent/src/memory/learner/profile-store.test.ts
+++ b/apps/inno-agent/src/memory/learner/profile-store.test.ts
@@ -1,0 +1,60 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadEvents, loadRecentEvents, recordEvent } from "./profile-store.js";
+import { createLearningEvent, type LearningEvent } from "./types.js";
+
+let dir: string;
+
+beforeEach(() => {
+	dir = mkdtempSync(join(tmpdir(), "inno-profile-store-"));
+});
+
+afterEach(() => {
+	rmSync(dir, { recursive: true, force: true });
+});
+
+function recordEvents(count: number, payloadSize = 0): LearningEvent[] {
+	const events: LearningEvent[] = [];
+	for (let i = 0; i < count; i++) {
+		const event = createLearningEvent("learner", "concept_explained", {}, { n: i, pad: "x".repeat(payloadSize) });
+		recordEvent(dir, event);
+		events.push(event);
+	}
+	return events;
+}
+
+describe("loadRecentEvents", () => {
+	it("returns the last N events in order", () => {
+		const events = recordEvents(5);
+		const recent = loadRecentEvents(dir, 3);
+		expect(recent.map((e) => e.event_id)).toEqual(events.slice(-3).map((e) => e.event_id));
+	});
+
+	it("returns everything when fewer than N events exist", () => {
+		const events = recordEvents(2);
+		expect(loadRecentEvents(dir, 8).map((e) => e.event_id)).toEqual(events.map((e) => e.event_id));
+	});
+
+	it("returns [] when no events have been recorded", () => {
+		expect(loadRecentEvents(dir, 8)).toEqual([]);
+	});
+
+	it("reads only the tail window and tolerates a partial first line", () => {
+		// Events padded so the file far exceeds the tail window: the window
+		// starts mid-record, and that partial record must be dropped rather
+		// than crash or corrupt the parse.
+		const events = recordEvents(10, 200);
+		const singleLineSize = JSON.stringify(events[0]).length + 1;
+		const recent = loadRecentEvents(dir, 10, singleLineSize * 3);
+		expect(recent.length).toBeGreaterThanOrEqual(2);
+		expect(recent.length).toBeLessThan(10);
+		expect(recent.map((e) => e.event_id)).toEqual(events.slice(-recent.length).map((e) => e.event_id));
+	});
+
+	it("loadEvents still replays the full log for rebuilds", () => {
+		const events = recordEvents(10, 200);
+		expect(loadEvents(dir).map((e) => e.event_id)).toEqual(events.map((e) => e.event_id));
+	});
+});

--- a/apps/inno-agent/src/memory/learner/profile-store.ts
+++ b/apps/inno-agent/src/memory/learner/profile-store.ts
@@ -1,5 +1,5 @@
 import { join } from "node:path";
-import { readJson, writeJson, appendJsonl, readJsonl } from "../../storage/file-store.js";
+import { readJson, writeJson, appendJsonl, readJsonl, readJsonlTail } from "../../storage/file-store.js";
 import { type LearnerProfile, type LearningEvent, createDefaultProfile } from "./types.js";
 import { applyLearningEventToProfile } from "./auto-profile.js";
 
@@ -8,6 +8,13 @@ const EVENTS_FILE = "events.jsonl";
 
 /** events.jsonl is rolled to a timestamped archive once it exceeds this size. */
 const EVENTS_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Tail window for `loadRecentEvents`. Events are small JSON records, so this
+ * holds far more than the handful a context pack needs — while never
+ * re-reading the whole (up to EVENTS_MAX_BYTES) log.
+ */
+const EVENTS_TAIL_BYTES = 256 * 1024;
 
 /**
  * Load the learner profile. Returns a default empty profile if not found.
@@ -62,8 +69,19 @@ export function isProfileEmpty(profile: LearnerProfile): boolean {
 }
 
 /**
- * Load all recorded learning events.
+ * Load all recorded learning events. Full replay — used by
+ * `rebuildProfileFromEvents`. Per-turn callers should use `loadRecentEvents`.
  */
 export function loadEvents(dataDir: string): LearningEvent[] {
 	return readJsonl<LearningEvent>(join(dataDir, EVENTS_FILE));
+}
+
+/**
+ * Load only the most recent learning events, read from the tail of
+ * events.jsonl. The per-turn context pack needs just the last few events, so
+ * it must not re-read and re-parse the whole (rotated, up to EVENTS_MAX_BYTES)
+ * log on every turn.
+ */
+export function loadRecentEvents(dataDir: string, count: number, tailBytes: number = EVENTS_TAIL_BYTES): LearningEvent[] {
+	return readJsonlTail<LearningEvent>(join(dataDir, EVENTS_FILE), tailBytes).slice(-count);
 }

--- a/apps/inno-agent/src/scheduler/job-runner.ts
+++ b/apps/inno-agent/src/scheduler/job-runner.ts
@@ -2,7 +2,7 @@ import type { ScheduledJob } from "./types.js";
 import type { JobStore } from "./job-store.js";
 import type { ChannelRegistry } from "../channels/channel.js";
 import { appendAssistantNotification, getCurrentSessionChannelHint, runPromptSerialized } from "../agent/pi-runner.js";
-import { computeNextRunAt, isOneShotCron } from "./cron-utils.js";
+import { isOneShotCron } from "./cron-utils.js";
 import { randomUUID } from "node:crypto";
 import { logger } from "../logger.js";
 
@@ -98,9 +98,10 @@ export async function executeJob(
 			// mutate() re-reads fresh state inside a per-job chain — counters are
 			// incremented from the latest persisted values, not this run's stale
 			// `job` snapshot (overlapping runs would otherwise lose increments).
+			// nextRunAt is intentionally omitted: mutate() recomputes it from
+			// cron/timezone/enabled, so any value passed here would be dead code.
 			await jobStore.mutate(job.id, (current) => ({
 				lastRunAt: finishedAt.toISOString(),
-				nextRunAt: oneShot ? undefined : computeNextRunAt(job.cron, job.timezone, finishedAt),
 				lastStatus: "error",
 				lastError: error,
 				enabled: oneShot ? false : current.enabled,
@@ -125,7 +126,6 @@ export async function executeJob(
 		});
 		await jobStore.mutate(job.id, (current) => ({
 			lastRunAt: finishedAt.toISOString(),
-			nextRunAt: oneShot ? undefined : computeNextRunAt(job.cron, job.timezone, finishedAt),
 			lastStatus: "success",
 			lastError: undefined,
 			enabled: oneShot ? false : current.enabled,
@@ -151,7 +151,6 @@ export async function executeJob(
 		});
 		await jobStore.mutate(job.id, (current) => ({
 			lastRunAt: finishedAt.toISOString(),
-			nextRunAt: oneShot ? undefined : computeNextRunAt(job.cron, job.timezone, finishedAt),
 			lastStatus: "error",
 			lastError: error,
 			enabled: oneShot ? false : current.enabled,


### PR DESCRIPTION
## What

Two leftovers from the P4 robustness work:

1. **`before_agent_start` re-read all of `events.jsonl` every turn.** After P4 rotation the log is capped at ~10MB, and `inno-extension.ts` did `loadEvents().slice(-8)` — a full read + parse per turn just to keep 8 records. Adds `loadRecentEvents(dataDir, count)` in `profile-store.ts` built on the `readJsonlTail` helper P4 introduced (256KB tail window, partial first line dropped). `loadEvents()` stays for `rebuildProfileFromEvents` full replays.
2. **Dead `nextRunAt` in the three `job-runner` mutators.** `mutate()` recomputes `nextRunAt` whenever the patch touches `cron`/`timezone`/`lastRunAt`/`enabled`, and all three patches do — the explicit value was always overwritten. Removed, along with the now-unused `computeNextRunAt` import.

## Tests

- New `profile-store.test.ts` (5 tests): last-N ordering, fewer-than-N, empty log, tail-window with partial first line, full `loadEvents` replay unaffected.
- Full suite: 29 files / 228 tests green.