### PR TITLE
fix: compact dedupe.jsonl instead of letting it grow unbounded

### DIFF
--- a/apps/inno-agent/src/channels/dedupe-store.test.ts
+++ b/apps/inno-agent/src/channels/dedupe-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -58,5 +58,55 @@ describe("DedupeStore", () => {
 		store.mark("feishu", "msg-1");
 		store.cleanup();
 		expect(store.isDuplicate("feishu", "msg-1")).toBe(false);
+	});
+
+	it("compacts the file on boot when it holds expired lines", () => {
+		const past = new Date(Date.now() - 60_000).toISOString();
+		const future = new Date(Date.now() + 60_000).toISOString();
+		writeFileSync(
+			file,
+			JSON.stringify({ key: "feishu:msg-old", seenAt: past, expiresAt: past }) + "\n"
+				+ JSON.stringify({ key: "feishu:msg-new", seenAt: future, expiresAt: future }) + "\n",
+			"utf-8",
+		);
+		const store = new DedupeStore(file);
+		expect(store.isDuplicate("feishu", "msg-new")).toBe(true);
+		// The expired line is gone from disk, not just from memory.
+		const onDisk = readFileSync(file, "utf-8").trim().split("\n");
+		expect(onDisk).toHaveLength(1);
+		expect(JSON.parse(onDisk[0]!).key).toBe("feishu:msg-new");
+	});
+
+	it("compacts the file on boot when it holds duplicate keys", () => {
+		const future = new Date(Date.now() + 60_000).toISOString();
+		const line = JSON.stringify({ key: "feishu:msg-1", seenAt: future, expiresAt: future }) + "\n";
+		writeFileSync(file, line + line + line, "utf-8");
+		new DedupeStore(file);
+		expect(readFileSync(file, "utf-8").trim().split("\n")).toHaveLength(1);
+	});
+
+	it("leaves an all-live file untouched on boot", () => {
+		const store = new DedupeStore(file);
+		store.mark("feishu", "msg-1");
+		const before = readFileSync(file, "utf-8");
+		new DedupeStore(file);
+		expect(readFileSync(file, "utf-8")).toBe(before);
+	});
+
+	it("compacts in mark() once the file exceeds maxBytes", () => {
+		const store = new DedupeStore(file, /* ttlMs */ 24 * 60 * 60 * 1000, /* maxBytes */ 200);
+		store.mark("feishu", "msg-live");
+		// Bloat the log with expired entries, as months of appends would.
+		const past = new Date(Date.now() - 60_000).toISOString();
+		const junk = JSON.stringify({ key: "feishu:expired", seenAt: past, expiresAt: past }) + "\n";
+		writeFileSync(file, readFileSync(file, "utf-8") + junk.repeat(50), "utf-8");
+		// This append crosses maxBytes → compaction drops the expired lines.
+		store.mark("feishu", "msg-live-2");
+		const lines = readFileSync(file, "utf-8").trim().split("\n");
+		expect(lines).toHaveLength(2);
+		// Live entries survive compaction: nothing is re-admitted as new.
+		const reloaded = new DedupeStore(file);
+		expect(reloaded.isDuplicate("feishu", "msg-live")).toBe(true);
+		expect(reloaded.isDuplicate("feishu", "msg-live-2")).toBe(true);
 	});
 });

--- a/apps/inno-agent/src/channels/dedupe-store.ts
+++ b/apps/inno-agent/src/channels/dedupe-store.ts
@@ -1,4 +1,5 @@
-import { readJsonl, appendJsonl } from "../storage/file-store.js";
+import { statSync } from "node:fs";
+import { readJsonl, appendJsonl, writeJsonl } from "../storage/file-store.js";
 
 interface DedupeEntry {
 	key: string;
@@ -8,17 +9,33 @@ interface DedupeEntry {
 
 const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * dedupe.jsonl is compacted (rewritten with live entries only) once it
+ * exceeds this size. Rotation is unsafe here — it would drop live entries
+ * and re-admit duplicates — so growth is bounded by compaction instead.
+ */
+const DEFAULT_MAX_BYTES = 1024 * 1024;
+
 export class DedupeStore {
 	private seen = new Map<string, number>();
 
-	constructor(private filePath: string, private ttlMs = DEFAULT_TTL_MS) {
+	constructor(
+		private filePath: string,
+		private ttlMs = DEFAULT_TTL_MS,
+		private maxBytes = DEFAULT_MAX_BYTES,
+	) {
 		const now = Date.now();
+		let total = 0;
 		for (const entry of readJsonl<DedupeEntry>(filePath)) {
+			total++;
 			const expires = new Date(entry.expiresAt).getTime();
 			if (expires > now) {
 				this.seen.set(entry.key, expires);
 			}
 		}
+		// Boot-time compaction: if the file held expired or duplicate-key lines,
+		// rewrite it with live entries only so it doesn't grow across restarts.
+		if (total > this.seen.size) this.compact();
 	}
 
 	isDuplicate(channel: string, messageId: string): boolean {
@@ -38,6 +55,8 @@ export class DedupeStore {
 			seenAt: now.toISOString(),
 			expiresAt: expiresAt.toISOString(),
 		});
+		// Long-running processes never reboot, so bound the file here too.
+		if (statSync(this.filePath).size > this.maxBytes) this.compact();
 	}
 
 	cleanup(): void {
@@ -45,5 +64,23 @@ export class DedupeStore {
 		for (const [key, expires] of this.seen) {
 			if (expires <= now) this.seen.delete(key);
 		}
+	}
+
+	/** Rewrite the log with live entries only (atomic via writeJsonl). */
+	private compact(): void {
+		const now = Date.now();
+		const live: DedupeEntry[] = [];
+		for (const [key, expires] of this.seen) {
+			if (expires <= now) {
+				this.seen.delete(key);
+				continue;
+			}
+			live.push({
+				key,
+				seenAt: new Date(now).toISOString(),
+				expiresAt: new Date(expires).toISOString(),
+			});
+		}
+		writeJsonl(this.filePath, live);
 	}
 }

--- a/apps/inno-agent/src/storage/file-store.ts
+++ b/apps/inno-agent/src/storage/file-store.ts
@@ -36,6 +36,18 @@ export function writeJson<T>(filePath: string, data: T): void {
 }
 
 /**
+ * Write records as a JSONL file (one JSON line each), atomically
+ * (tmp + rename). Used to compact live-state logs such as dedupe.jsonl,
+ * where rotation is unsafe (it would drop still-live entries).
+ */
+export function writeJsonl<T>(filePath: string, records: T[]): void {
+	ensureDir(dirname(filePath));
+	const tmp = filePath + ".tmp";
+	writeFileSync(tmp, records.map((r) => JSON.stringify(r)).join("\n") + (records.length > 0 ? "\n" : ""), "utf-8");
+	renameSync(tmp, filePath);
+}
+
+/**
  * Append a single JSON record as a line to a JSONL file.
  *
  * When `options.maxBytes` is set and the file already exceeds that size, the


### PR DESCRIPTION
## What

P4 bounded the append-only logs (runs/events/run-log) with rotation, but deliberately left `dedupe.jsonl` alone: rotation would silently drop live entries and re-admit duplicate IM messages. Left as-is, the file still grows without bound — `cleanup()` only prunes the in-memory map, never the file.

This PR takes the safe path: **compaction** (rewrite live entries only, atomic tmp+rename via a new `writeJsonl()` in file-store):

- **Boot**: the constructor already reads every line; when the line count exceeds the live-entry count (expired or duplicate-key lines present), it rewrites the file.
- **Runtime**: `mark()` compacts once the file exceeds 1MB, so long-running server processes stay bounded without a restart.

Behavior is unchanged for callers — `isDuplicate`/`mark`/`cleanup` semantics identical.

## Tests

4 new cases in `dedupe-store.test.ts`: boot compaction of expired lines, boot compaction of duplicate keys, all-live file untouched on boot, size-triggered compaction in `mark()` preserving live entries across reload. Full suite green.