### PR TITLE
chore: remove dead imports/locals and enable noUnusedLocals

### DIFF
--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -28,7 +28,6 @@ let _runtime: AgentSessionRuntime | null = null;
 let _queue: Promise<void> = Promise.resolve();
 let _workspaceDir = "";
 let _currentCwd = "";
-let _config: InnoConfig | null = null;
 let _configHolder: ConfigHolder | null = null;
 let _cwdResolver: ((sessionPath: string) => string | null) | null = null;
 let _activePromptToken: string | null = null;
@@ -311,7 +310,6 @@ export async function initSession(
 	runtime.setRebindSession(bindSessionExtensions);
 
 	_runtime = runtime;
-	_config = config;
 	_configHolder = configHolder;
 	_workspaceDir = paths.workspaceDir;
 	_currentCwd = cwd;
@@ -345,7 +343,6 @@ function modelConfigToProviderModel(model: InnoConfig["providers"][string]["mode
  */
 export async function refreshConfiguredProviders(config: InnoConfig): Promise<void> {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
-	_config = config;
 	if (_configHolder) _configHolder.current = config;
 
 	// Drop providers that were registered before but are no longer in config.
@@ -380,7 +377,6 @@ export async function refreshConfiguredProviders(config: InnoConfig): Promise<vo
 }
 
 export function syncConfig(config: InnoConfig): void {
-	_config = config;
 	if (_configHolder) _configHolder.current = config;
 }
 

--- a/apps/inno-agent/src/agent/practice-tools.ts
+++ b/apps/inno-agent/src/agent/practice-tools.ts
@@ -3,7 +3,6 @@ import { Type } from "typebox";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, relative, resolve } from "node:path";
 import type { WorkspaceRegistry } from "../workspace/workspace-registry.js";
-import { logger } from "../logger.js";
 
 interface PracticeToolDeps {
 	registry: WorkspaceRegistry;

--- a/apps/inno-agent/src/channels/stubs.ts
+++ b/apps/inno-agent/src/channels/stubs.ts
@@ -1,5 +1,5 @@
 import type { ChatChannel } from "./channel.js";
-import type { IncomingMessage, PushTarget } from "./types.js";
+import type { IncomingMessage } from "./types.js";
 
 /**
  * WeChat Enterprise (WeCom) channel stub — not yet implemented.

--- a/apps/inno-agent/src/channels/wechat/wechat-channel.ts
+++ b/apps/inno-agent/src/channels/wechat/wechat-channel.ts
@@ -13,14 +13,12 @@ export class WeChatChannel implements RealtimeChatChannel {
 	private running = false;
 	private pollAbort: AbortController | null = null;
 	private processedMessages = new Set<number>();
-	private personalOnly: boolean;
 	private allowedUserIds: Set<string> | null;
 	private contextTokens = new Map<string, string>();
 
 	constructor(dataDir: string, channelConfig?: PersonalChannelConfig) {
 		const tokenPath = join(dataDir, "channels", "wechat-token.json");
 		this.client = new ILinkClient(tokenPath);
-		this.personalOnly = channelConfig?.personalOnly ?? true;
 		this.allowedUserIds = channelConfig?.allowedUserIds?.length
 			? new Set(channelConfig.allowedUserIds)
 			: null;

--- a/apps/inno-agent/src/cli.ts
+++ b/apps/inno-agent/src/cli.ts
@@ -5,7 +5,7 @@ import { installFetchLogger } from "./utils/fetch-logger.js";
 import { main, type ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { loadConfig } from "./config.js";
 import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
-import { createInnoExtension, type ConfigHolder } from "./agent/inno-extension.js";
+import { createInnoExtension } from "./agent/inno-extension.js";
 import { createMcpStatusExtension, loadMcpAdapterExtension } from "./agent/mcp-extension.js";
 import { ensureDir } from "./storage/file-store.js";
 import { seedManagedMcpConfig } from "./mcp/mcp-config-store.js";

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -8,7 +8,7 @@ import { cpSync, existsSync, readFileSync, readdirSync, rmSync, statSync, writeF
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
-import { loadConfig, saveConfig, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig } from "./config.js";
+import { loadConfig, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
 import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
 import { ensureDir, readJson, readText, writeJson, writeText } from "./storage/file-store.js";
@@ -21,9 +21,6 @@ import {
 	initSession,
 	isQueueTaskCancelled,
 	reloadResources,
-	switchSessionFile,
-	syncConfig,
-	applyWorkspaceCwd,
 	setWorkspaceCwdResolver,
 } from "./agent/pi-runner.js";
 import { completePromptOnce, runPromptSerialized, runPromptStreamingInSession, runPromptInSession, abortPromptForTurnToken } from "./agent/pi-runner.js";
@@ -37,12 +34,10 @@ import type { PersonalBridgeChannelConfig } from "./config.js";
 import { JobStore } from "./scheduler/job-store.js";
 import { seedManagedMcpConfig } from "./mcp/mcp-config-store.js";
 import { CronScheduler } from "./scheduler/cron-scheduler.js";
-import { json, matchRoute, readBody } from "./server/http-helpers.js";
+import { json } from "./server/http-helpers.js";
 import {
-	contentDispositionAttachment,
 	safeJoin,
 	slugifySkillName,
-	WORKSPACE_IGNORES,
 } from "./server/file-helpers.js";
 import { handleChannelsRoutes } from "./server/routes/channels.js";
 import { handleJobsRoutes } from "./server/routes/jobs.js";
@@ -68,7 +63,7 @@ import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
 import { questionBridge } from "./agent/question-bridge.js";
 import { streamRegistry } from "./chat/stream-registry.js";
-import { DEFAULT_WORKSPACE_ID, TEMP_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
+import { DEFAULT_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
 import { createContentSource, type RemoteContentSource } from "./content-source/index.js";
 import { mapWithConcurrency } from "./content-source/types.js";
 import { RunRecordStore } from "./terminal/run-record-store.js";

--- a/apps/inno-agent/src/storage/file-store.ts
+++ b/apps/inno-agent/src/storage/file-store.ts
@@ -1,5 +1,5 @@
 import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, renameSync, statSync, writeFileSync, appendFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname } from "node:path";
 import { logger } from "../logger.js";
 
 /**

--- a/apps/inno-agent/tsconfig.json
+++ b/apps/inno-agent/tsconfig.json
@@ -7,6 +7,7 @@
 		"outDir": "./dist",
 		"rootDir": "./src",
 		"strict": true,
+		"noUnusedLocals": true,
 		"esModuleInterop": true,
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## What

Mechanical dead-code removal, verified by `tsc --noUnusedLocals`:

- **server.ts** (9): `saveConfig`, `syncConfig`, `applyWorkspaceCwd`, `switchSessionFile`, `matchRoute`, `readBody`, `contentDispositionAttachment`, `WORKSPACE_IGNORES`, `TEMP_WORKSPACE_ID` — leftovers from the P2 route-domain extraction.
- **pi-runner.ts**: `_config` module field — written in three places, never read.
- **practice-tools.ts**: `logger` import.
- **stubs.ts**: `PushTarget` type import.
- **wechat-channel.ts**: `personalOnly` field — assigned from config in the constructor but never read, so the knob is currently inert on the iLink WeChat channel. Removing it is behavior-preserving; if the gate should actually be enforced there, that's a separate behavior change.
- **cli.ts**: `ConfigHolder` type import.
- **file-store.ts**: `join` import.

Root cause these accumulated: `noUnusedLocals` was off. Now enabled in `apps/inno-agent/tsconfig.json` — `tsc --noEmit` (and therefore `npm run build` + release CI) fails on the next one.

## Verification

`npx tsc --noEmit` clean, full build green, 223 tests pass.