### PR TITLE
fix: close two L1 topic-matcher boundary holes

### DIFF
--- a/apps/inno-agent/src/memory/learner/auto-profile.test.ts
+++ b/apps/inno-agent/src/memory/learner/auto-profile.test.ts
@@ -87,6 +87,43 @@ describe("goal archiving: generic topic matching", () => {
 		expect(profile.knowledge_states[0].next_actions).toEqual([]);
 		expect(profile.knowledge_states[0].diagnosis).toContain("归档");
 	});
+
+	it("matches a single-char CJK topic against a longer goal title", () => {
+		const profile = createDefaultProfile();
+		profile.goals.push(makeGoal("钢琴入门"));
+
+		// "琴" is a lone CJK char after intent stripping — no bigram exists,
+		// so only the unigram fallback can match it.
+		applyLearningEventToProfile(profile, archiveEvent("不学琴"), { updateSummary: false });
+
+		expect(profile.goals[0].status).toBe("archived");
+	});
+
+	it("never matches a goal with an empty title (includes(\"\") is always true)", () => {
+		const profile = createDefaultProfile();
+		profile.goals.push(makeGoal("", { goal_id: "goal_empty" }));
+
+		applyLearningEventToProfile(profile, archiveEvent("不再学习吉他"), { updateSummary: false });
+
+		expect(profile.goals[0].status).toBe("active");
+	});
+
+	it("never matches a knowledge state with an empty concept_id", () => {
+		const profile = createDefaultProfile();
+		applyLearningEventToProfile(
+			profile,
+			createLearningEvent("default", "concept_explained", { concept_ids: [""] }, { topic: "x" }),
+			{ updateSummary: false },
+		);
+		const state = profile.knowledge_states.find((s) => s.concept_id === "");
+		expect(state).toBeDefined();
+		const actionsBefore = state!.next_actions.length;
+
+		applyLearningEventToProfile(profile, archiveEvent("不再学习吉他"), { updateSummary: false });
+
+		// A match would have cleared next_actions; they must be untouched.
+		expect(state!.next_actions).toHaveLength(actionsBefore);
+	});
 });
 
 describe("mastery deltas", () => {

--- a/apps/inno-agent/src/memory/learner/auto-profile.ts
+++ b/apps/inno-agent/src/memory/learner/auto-profile.ts
@@ -56,7 +56,9 @@ const INTENT_WORDS =
 /**
  * Extract topic keywords from free text: latin tokens (length >= 2, so
  * "c++" / "ts" / "go" survive) and CJK bigrams (so "吉他入门" still matches
- * a goal titled "吉他"). Returns lowercase keywords.
+ * a goal titled "吉他"). A lone CJK character yields no bigrams, so it is
+ * kept as a unigram — otherwise a single-char topic ("琴") could never match
+ * anything. Returns lowercase keywords.
  */
 function extractTopicKeywords(text: string): string[] {
 	const cleaned = text.toLowerCase().replace(INTENT_WORDS, " ");
@@ -66,6 +68,10 @@ function extractTopicKeywords(text: string): string[] {
 	}
 	for (const match of cleaned.matchAll(/[一-鿿]+/g)) {
 		const run = match[0];
+		if (run.length === 1) {
+			keywords.push(run);
+			continue;
+		}
 		for (let i = 0; i < run.length - 1; i++) keywords.push(run.slice(i, i + 2));
 	}
 	return keywords;
@@ -101,8 +107,9 @@ function targetMatchesGoal(goal: LearningGoal, targetText: string, targetGoalId?
 	const haystack = `${goal.goal_id} ${goal.title}`.toLowerCase();
 	const target = targetText.toLowerCase();
 	if (targetGoalId && goal.goal_id === targetGoalId) return true;
-	if (target.includes(goal.goal_id.toLowerCase())) return true;
-	if (target.includes(goal.title.toLowerCase())) return true;
+	// Empty id/title must never match — includes("") is always true.
+	if (goal.goal_id && target.includes(goal.goal_id.toLowerCase())) return true;
+	if (goal.title && target.includes(goal.title.toLowerCase())) return true;
 
 	return topicKeywordsMatch(haystack, target);
 }
@@ -124,7 +131,8 @@ function archiveMatchingGoals(profile: LearnerProfile, targetText: string, times
 function targetMatchesKnowledge(state: KnowledgeState, targetText: string): boolean {
 	const haystack = `${state.concept_id} ${state.concept_name} ${state.domain}`.toLowerCase();
 	const target = targetText.toLowerCase();
-	if (target.includes(state.concept_id.toLowerCase())) return true;
+	// Empty concept_id must never match — includes("") is always true.
+	if (state.concept_id && target.includes(state.concept_id.toLowerCase())) return true;
 	return topicKeywordsMatch(haystack, target);
 }
 


### PR DESCRIPTION
## What

Two boundary holes in the L1 archive-target matcher (`auto-profile.ts`):

1. **`includes("") `is always true.** `targetMatchesGoal` did `target.includes(goal.title.toLowerCase())` (and same for `goal_id` / `concept_id`) without checking for empty strings — a goal with an empty title would be archived by *any* archive text. All three direct-substring checks now guard on non-empty values.
2. **Single-char CJK topics could never match.** Keyword extraction emits CJK bigrams, but a length-1 CJK run (e.g. the topic "琴" after intent-word stripping) yields zero bigrams, so `topicKeywordsMatch` always returned false. Length-1 runs now fall back to a unigram keyword, letting "琴" match a goal titled "钢琴入门".

## Tests

3 new cases in `auto-profile.test.ts`: single-char CJK topic archives a longer-titled goal; empty-title goal survives an unrelated archive text; empty-`concept_id` knowledge state keeps its `next_actions`. Full suite: 226 tests green.