### PR TITLE
fix: stop promising the inert personalOnly knob on the WeChat channel

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -384,7 +384,7 @@ Full config.json structure (see `config.example.json`):
   "server": { "port": 3000 },
   "channels": {
     "feishu": { "enabled": false, "personalOnly": true, "allowedUserIds": [] },
-    "wechat": { "enabled": false, "mode": "bridge", "personalOnly": true, "allowedUserIds": [], "sidecarBaseUrl": "http://127.0.0.1:4319" }
+    "wechat": { "enabled": false, "mode": "bridge", "allowedUserIds": [], "sidecarBaseUrl": "http://127.0.0.1:4319" }
   },
   "bridge": { "token": "replace-me-with-a-secret" },
   "subagents": { "enabled": false },
@@ -417,7 +417,7 @@ Note: `simpleMode` and `ui.theme` are not in `config.example.json` but are added
 - `memory.l1Enabled` / `l2Enabled` / `l3Enabled` individually gate each memory layer. Simple Mode force-disables all three without overwriting these preferences.
 - `simpleMode.enabled` toggles Simple Mode (hides advanced features, surfaces preset workspaces).
 - `ui.theme` persists the UI theme preference.
-- `bridge.token` is the shared secret for bridge-mode IM channels (QQ, WeChat). Each channel supports `personalOnly` (restrict to specified users) and `allowedUserIds` (whitelist of user IDs).
+- `bridge.token` is the shared secret for bridge-mode IM channels (QQ, WeChat). `personalOnly` (p2p-only) and `allowedUserIds` (whitelist) are enforced by Feishu; WeChat iLink enforces `allowedUserIds` only (its `personalOnly` field was removed as inert); bridge-mode channels (QQ, WeChat bridge) enforce neither — filtering there is the sidecar's responsibility.
 - `ocrApi` configures PaddleOCR-VL for image OCR. Agent uses this via `ocr-tools.ts`. Requires a `token` from Baidu PaddleOCR.
 
 ### Runtime PI SDK settings (`<configDir>/settings.json`)

--- a/apps/inno-agent/web/src/react/settings/ChannelsSettings.tsx
+++ b/apps/inno-agent/web/src/react/settings/ChannelsSettings.tsx
@@ -86,20 +86,24 @@ function QrActionButton({ label, onClick }: { label: string; onClick: () => void
 	);
 }
 
-/** Access control fields shared by all channels: personal-only + allowed user IDs. */
+/** Access control fields shared by channel cards. `personalOnly` is optional:
+ * only channels whose backend enforces it (Feishu) should pass it — WeChat
+ * iLink never read the knob and its backend field was removed. */
 function AccessControl({ personalOnly, onPersonalOnlyChange, userIds, onUserIdsChange }: {
-	personalOnly: boolean;
-	onPersonalOnlyChange: (next: boolean) => void;
+	personalOnly?: boolean;
+	onPersonalOnlyChange?: (next: boolean) => void;
 	userIds: string;
 	onUserIdsChange: (next: string) => void;
 }) {
 	const { t } = useTranslation();
 	return (
 		<div className="grid gap-2">
-			<label className={checkCls}>
-				<input type="checkbox" className={checkboxCls} checked={personalOnly} onChange={(e) => onPersonalOnlyChange(e.target.checked)} />
-				{t("settings.channels.personalOnly")}
-			</label>
+			{personalOnly !== undefined && (
+				<label className={checkCls}>
+					<input type="checkbox" className={checkboxCls} checked={personalOnly} onChange={(e) => onPersonalOnlyChange?.(e.target.checked)} />
+					{t("settings.channels.personalOnly")}
+				</label>
+			)}
 			<div>
 				<label className={labelCls}>{t("settings.channels.allowedUserIds")}</label>
 				<textarea
@@ -250,10 +254,9 @@ function WechatChannel({ settings, state, onStateChange }: {
 	settings: InnoSettings;
 	state: {
 		enabled: boolean;
-		personalOnly: boolean;
 		allowedUsers: string;
 	};
-	onStateChange: (patch: Partial<{ enabled: boolean; personalOnly: boolean; allowedUsers: string }>) => void;
+	onStateChange: (patch: Partial<{ enabled: boolean; allowedUsers: string }>) => void;
 }) {
 	const { t } = useTranslation();
 
@@ -362,8 +365,6 @@ function WechatChannel({ settings, state, onStateChange }: {
 
 			{state.enabled && (
 				<AccessControl
-					personalOnly={state.personalOnly}
-					onPersonalOnlyChange={(v) => onStateChange({ personalOnly: v })}
 					userIds={state.allowedUsers}
 					onUserIdsChange={(v) => onStateChange({ allowedUsers: v })}
 				/>
@@ -405,7 +406,6 @@ export function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 	const wechatConfig = settings.channels?.wechat;
 	const [wechat, setWechat] = useState({
 		enabled: wechatConfig?.enabled ?? false,
-		personalOnly: wechatConfig?.personalOnly ?? true,
 		allowedUsers: (wechatConfig?.allowedUserIds ?? []).join("\n"),
 	});
 	const patchWechat = useCallback((patch: Partial<typeof wechat>) => setWechat((s) => ({ ...s, ...patch })), []);
@@ -439,7 +439,6 @@ export function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 					wechat: {
 						enabled: wechat.enabled,
 						mode: "ilink",
-						personalOnly: wechat.personalOnly,
 						allowedUserIds: parseUserIds(wechat.allowedUsers),
 					},
 				},

--- a/config.example.json
+++ b/config.example.json
@@ -32,7 +32,6 @@
 		"wechat": {
 			"enabled": false,
 			"mode": "bridge",
-			"personalOnly": true,
 			"allowedUserIds": [],
 			"sidecarBaseUrl": "http://127.0.0.1:4319"
 		}


### PR DESCRIPTION
## What

Follow-up to #156's dead-field removal: the WeChat iLink channel never read `personalOnly`, but the config surface still advertised it — the "known-inert but still promised" state. This PR converges the surface to what the code actually enforces:

- **`config.example.json`**: drop `personalOnly` from the `wechat` block (inert in both bridge and ilink modes — `bridge-channel.ts` never references it either). The `feishu` block keeps it: `feishu-channel.ts:129` enforces it.
- **`ChannelsSettings.tsx`**: `AccessControl`'s personalOnly checkbox is now optional and only rendered when the channel enforces it. The WeChat card stops passing it, and the save payload no longer writes `channels.wechat.personalOnly`. Feishu's card is unchanged. (QQ's card is behind `QQ_CHANNEL_READY = false` and untouched — the channel is unimplemented.)
- **`CLAUDE.md`**: the channels doc now states the real enforcement matrix instead of "each channel supports personalOnly": Feishu enforces both knobs; WeChat iLink enforces `allowedUserIds` only; bridge-mode channels enforce neither (filtering is the sidecar's responsibility).

One correction to the audit note: `routes/channels.ts:168` writes `personalOnly: true` into the **Feishu** config during QR registration — that knob is live there, so it stays.

Existing user configs that already contain `channels.wechat.personalOnly` are unaffected (the key is simply inert and no longer rewritten).

## Verification

Full build green (backend tsc with `noUnusedLocals` + web vite), 235 tests pass.