### PR TITLE
fix: process-level crash fallbacks + request body size cap (#162 items 1-2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~28 files (223 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~30 files (243 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~30 files (243 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~30 files (244 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 

--- a/apps/inno-agent/src/cli.ts
+++ b/apps/inno-agent/src/cli.ts
@@ -10,10 +10,15 @@ import { createMcpStatusExtension, loadMcpAdapterExtension } from "./agent/mcp-e
 import { ensureDir } from "./storage/file-store.js";
 import { seedManagedMcpConfig } from "./mcp/mcp-config-store.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
+import { installProcessFallbacks } from "./utils/process-fallback.js";
 import { logger } from "./logger.js";
 
 // Set process title
 process.title = "inno";
+
+// Last-resort handlers: log fatal-level and exit cleanly on stray
+// exceptions/rejections instead of dying silently mid-session.
+installProcessFallbacks();
 
 // Disable undici timeouts for long streaming responses
 // bodyTimeout: 15 min safety net for LLM provider requests. Provider-level

--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { request as httpRequest } from "node:http";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -369,5 +370,50 @@ describe("server smoke", () => {
 
 		const abort = await fetch(`http://127.0.0.1:${port}/api/chat/sess/turn/abort`, { method: "POST" });
 		expect(abort.status).toBe(404);
+	});
+
+	it("POST with a malformed JSON body returns 400 (not 500)", async () => {
+		const res = await fetch(`http://127.0.0.1:${port}/api/chat`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: "not json{",
+		});
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as { error: string }).error).toContain("Invalid JSON");
+	});
+
+	it("POST with an oversized declared Content-Length returns 413 and survives to serve the next request", async () => {
+		// Send headers only — the server must reject from the declared length
+		// without consuming a single body byte. (issue #162: readBody had no cap)
+		const { status, connection } = await new Promise<{ status: number; connection: string | undefined }>(
+			(resolveReq, rejectReq) => {
+				const req = httpRequest(
+					{
+						host: "127.0.0.1",
+						port,
+						path: "/api/chat",
+						method: "POST",
+						headers: {
+							"Content-Type": "application/json",
+							"Content-Length": String(33 * 1024 * 1024),
+						},
+					},
+					(res) => {
+						res.resume();
+						res.on("end", () =>
+							resolveReq({ status: res.statusCode ?? 0, connection: res.headers.connection }),
+						);
+					},
+				);
+				req.on("error", rejectReq);
+				req.flushHeaders();
+			},
+		);
+		expect(status).toBe(413);
+		expect(connection).toBe("close");
+
+		// The process must still be healthy after rejecting the oversized body.
+		const res = await api("/health");
+		expect(res.status).toBe(200);
 	});
 });

--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -416,4 +416,39 @@ describe("server smoke", () => {
 		const res = await api("/health");
 		expect(res.status).toBe(200);
 	});
+
+	it("upload endpoints honour the raised cap: 33 MB is accepted, 193 MB is rejected", async () => {
+		// 33 MB exceeds the default 32 MB cap but is under the upload cap, so
+		// the body is consumed and fails JSON parsing (400) rather than size
+		// rejection (413).
+		const accepted = await fetch(`http://127.0.0.1:${port}/api/skills/upload`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: "a".repeat(33 * 1024 * 1024),
+		});
+		expect(accepted.status).toBe(400);
+
+		// 193 MB exceeds even the upload cap — headers only, rejected early.
+		const { status } = await new Promise<{ status: number }>((resolveReq, rejectReq) => {
+			const req = httpRequest(
+				{
+					host: "127.0.0.1",
+					port,
+					path: "/api/skills/upload",
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"Content-Length": String(193 * 1024 * 1024),
+					},
+				},
+				(res) => {
+					res.resume();
+					res.on("end", () => resolveReq({ status: res.statusCode ?? 0 }));
+				},
+			);
+			req.on("error", rejectReq);
+			req.flushHeaders();
+		});
+		expect(status).toBe(413);
+	});
 });

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -34,7 +34,7 @@ import type { PersonalBridgeChannelConfig } from "./config.js";
 import { JobStore } from "./scheduler/job-store.js";
 import { seedManagedMcpConfig } from "./mcp/mcp-config-store.js";
 import { CronScheduler } from "./scheduler/cron-scheduler.js";
-import { json } from "./server/http-helpers.js";
+import { HttpError, json } from "./server/http-helpers.js";
 import {
 	safeJoin,
 	slugifySkillName,
@@ -61,6 +61,7 @@ import {
 } from "./server/session-model.js";
 import { logger } from "./logger.js";
 import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "./runtime.js";
+import { installProcessFallbacks } from "./utils/process-fallback.js";
 import { questionBridge } from "./agent/question-bridge.js";
 import { streamRegistry } from "./chat/stream-registry.js";
 import { DEFAULT_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
@@ -1472,6 +1473,24 @@ const server = createServer(async (req, res) => {
 		json(res, 404, { error: "Not found" });
 	} catch (err) {
 		logger.error({ err }, "unhandled error in HTTP handler");
+		// SSE/streaming responses have already sent headers — calling json()
+		// here would throw ERR_HTTP_HEADERS_SENT from inside this catch block
+		// and kill the process. The only safe move is to end the stream.
+		if (res.headersSent) {
+			try { res.end(); } catch { /* best effort */ }
+			return;
+		}
+		// readBody failures carry a client-facing status (400/413); anything
+		// else is an internal error and must not leak details.
+		if (err instanceof HttpError) {
+			if (err.statusCode === 413) {
+				// The oversized body was never consumed, so this connection is
+				// unsafe for keep-alive — Node closes it after the response.
+				res.setHeader("Connection", "close");
+			}
+			json(res, err.statusCode, { error: err.message });
+			return;
+		}
 		json(res, 500, { error: "Internal server error" });
 	}
 });
@@ -1594,6 +1613,19 @@ questionBridge.setPersistence({
 			delete meta[sessionId];
 			writeSessionQuestionMetadata(meta);
 		}
+	},
+});
+
+// Process-level last resort: a stray rejection or an exception escaping a
+// catch block would otherwise kill the process silently (or via a secondary
+// ERR_HTTP_HEADERS_SENT from the catch-all). Log at fatal level, close the
+// HTTP/WS servers so clients see a clean close, then exit — after an
+// uncaught exception the process state is untrustworthy, so we do not
+// attempt to continue serving.
+installProcessFallbacks({
+	onFatal: () => {
+		try { server.close(); } catch { /* best effort */ }
+		try { wss.close(); } catch { /* best effort */ }
 	},
 });
 

--- a/apps/inno-agent/src/server/http-helpers.test.ts
+++ b/apps/inno-agent/src/server/http-helpers.test.ts
@@ -1,0 +1,69 @@
+import { PassThrough } from "node:stream";
+import type { IncomingMessage as HttpReq } from "node:http";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_MAX_BODY_BYTES, HttpError, readBody } from "./http-helpers.js";
+
+/**
+ * Unit tests for the readBody size cap and HttpError plumbing
+ * (issue #162: unbounded body accumulation allowed memory DoS).
+ */
+
+function fakeReq(headers: Record<string, string> = {}): HttpReq & PassThrough {
+	const stream = new PassThrough() as HttpReq & PassThrough;
+	stream.headers = headers;
+	return stream;
+}
+
+async function expectHttpError(promise: Promise<unknown>, statusCode: number): Promise<void> {
+	await expect(promise).rejects.toSatisfy(
+		(err) => err instanceof HttpError && err.statusCode === statusCode,
+	);
+}
+
+describe("readBody", () => {
+	it("parses a valid JSON body", async () => {
+		const req = fakeReq();
+		const body = readBody(req);
+		req.end(JSON.stringify({ hello: "world" }));
+		await expect(body).resolves.toEqual({ hello: "world" });
+	});
+
+	it("resolves to {} for an empty body", async () => {
+		const req = fakeReq();
+		const body = readBody(req);
+		req.end();
+		await expect(body).resolves.toEqual({});
+	});
+
+	it("rejects with HttpError 400 on invalid JSON", async () => {
+		const req = fakeReq();
+		const body = readBody(req);
+		req.end("not json{");
+		await expectHttpError(body, 400);
+	});
+
+	it("rejects with HttpError 413 when declared Content-Length exceeds the cap", async () => {
+		const req = fakeReq({ "content-length": String(DEFAULT_MAX_BODY_BYTES + 1) });
+		const body = readBody(req);
+		await expectHttpError(body, 413);
+	});
+
+	it("rejects with HttpError 413 mid-stream and stops consuming", async () => {
+		const req = fakeReq();
+		const body = readBody(req);
+		// First chunk under the cap, second pushes the total over it.
+		req.write(Buffer.alloc(DEFAULT_MAX_BODY_BYTES, "a"));
+		req.write(Buffer.alloc(1, "a"));
+		await expectHttpError(body, 413);
+		// After the cap trips, further data must not accumulate or crash.
+		req.write(Buffer.alloc(16, "b"));
+		req.end();
+	});
+
+	it("honours a per-call maxBytes override", async () => {
+		const req = fakeReq();
+		const body = readBody(req, { maxBytes: 16 });
+		req.end(JSON.stringify({ payload: "this is definitely longer than sixteen bytes" }));
+		await expectHttpError(body, 413);
+	});
+});

--- a/apps/inno-agent/src/server/http-helpers.ts
+++ b/apps/inno-agent/src/server/http-helpers.ts
@@ -7,17 +7,62 @@ import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
  * re-defining their own copies.
  */
 
-export function readBody(req: HttpReq): Promise<unknown> {
+/**
+ * Error carrying a client-facing HTTP status code. The server catch-all
+ * honours `statusCode`/`message` instead of collapsing to a bare 500.
+ */
+export class HttpError extends Error {
+	readonly statusCode: number;
+	constructor(statusCode: number, message: string) {
+		super(message);
+		this.name = "HttpError";
+		this.statusCode = statusCode;
+	}
+}
+
+/**
+ * Default request body cap (32 MB). Chat messages carry base64-encoded
+ * images and skill/L2 uploads carry base64-encoded archives, so the limit
+ * must be generous — but unbounded accumulation lets any client exhaust
+ * server memory with a single oversized POST.
+ */
+export const DEFAULT_MAX_BODY_BYTES = 32 * 1024 * 1024;
+
+export function readBody(req: HttpReq, options?: { maxBytes?: number }): Promise<unknown> {
+	const maxBytes = options?.maxBytes ?? DEFAULT_MAX_BODY_BYTES;
 	return new Promise((resolve, reject) => {
+		// Stop consuming without destroying the socket: the catch-all still
+		// needs to write the 413 response on this connection. The response is
+		// sent with `Connection: close` and the socket is torn down after the
+		// response flushes (an unconsumed body makes keep-alive unsafe).
+		const tooLarge = (): void => {
+			req.removeAllListeners("data");
+			req.pause();
+			reject(new HttpError(413, `Request body too large (limit ${maxBytes} bytes)`));
+		};
+
+		// Reject early when the declared size already exceeds the cap.
+		const declared = Number.parseInt(req.headers["content-length"] ?? "", 10);
+		if (Number.isFinite(declared) && declared > maxBytes) {
+			tooLarge();
+			return;
+		}
+
 		let data = "";
+		let received = 0;
 		req.on("data", (chunk: Buffer) => {
+			received += chunk.length;
+			if (received > maxBytes) {
+				tooLarge();
+				return;
+			}
 			data += chunk.toString();
 		});
 		req.on("end", () => {
 			try {
 				resolve(data ? JSON.parse(data) : {});
 			} catch (err) {
-				reject(new Error("Invalid JSON body"));
+				reject(new HttpError(400, "Invalid JSON body"));
 			}
 		});
 		req.on("error", reject);

--- a/apps/inno-agent/src/server/http-helpers.ts
+++ b/apps/inno-agent/src/server/http-helpers.ts
@@ -28,6 +28,14 @@ export class HttpError extends Error {
  */
 export const DEFAULT_MAX_BODY_BYTES = 32 * 1024 * 1024;
 
+/**
+ * Raised cap for the base64 upload endpoints (skill zip upload, L2 raw
+ * document upload). Base64 inflates the payload by 4/3, so 192 MB on the
+ * wire covers source files up to ~128 MB — large PDFs/Office docs are
+ * legitimate inputs there, unlike on the chat/CRUD endpoints.
+ */
+export const UPLOAD_MAX_BODY_BYTES = 192 * 1024 * 1024;
+
 export function readBody(req: HttpReq, options?: { maxBytes?: number }): Promise<unknown> {
 	const maxBytes = options?.maxBytes ?? DEFAULT_MAX_BODY_BYTES;
 	return new Promise((resolve, reject) => {

--- a/apps/inno-agent/src/server/routes/sessions.ts
+++ b/apps/inno-agent/src/server/routes/sessions.ts
@@ -23,7 +23,7 @@ import {
 import { readJson, writeJson } from "../../storage/file-store.js";
 import { TEMP_WORKSPACE_ID, type WorkspaceRegistry } from "../../workspace/workspace-registry.js";
 import { contentDispositionAttachment } from "../file-helpers.js";
-import { json, matchRoute, readBody } from "../http-helpers.js";
+import { HttpError, json, matchRoute, readBody } from "../http-helpers.js";
 import {
 	mergeChannels,
 	type SessionChannel,
@@ -317,7 +317,12 @@ export async function handleSessionsRoutes(
 			json(res, 404, { error: "Session not found" });
 			return true;
 		}
-		const body = await readBody(req).catch(() => ({})) as Record<string, unknown>;
+		const body = await readBody(req).catch((err: unknown) => {
+			// An oversized body must still surface as 413 — only a missing or
+			// malformed payload is treated as {}.
+			if (err instanceof HttpError && err.statusCode === 413) throw err;
+			return {};
+		}) as Record<string, unknown>;
 		const sessionFile = basename(sessionPath);
 		const sessionInfo = readSessionCwd(sessionPath);
 		const parsed = parseSessionFile(sessionPath);
@@ -454,7 +459,12 @@ export async function handleSessionsRoutes(
 	}
 
 	if (method === "POST" && url === "/api/sessions") {
-		const body = await readBody(req).catch(() => ({})) as Record<string, unknown>;
+		const body = await readBody(req).catch((err: unknown) => {
+			// An oversized body must still surface as 413 — only a missing or
+			// malformed payload is treated as {}.
+			if (err instanceof HttpError && err.statusCode === 413) throw err;
+			return {};
+		}) as Record<string, unknown>;
 		// A new session is always a different session — release the queue
 		// from a question-blocked turn before enqueueing (issue #124).
 		releaseQueueFromQuestionBlockedTurn("");

--- a/apps/inno-agent/src/server/routes/skills.ts
+++ b/apps/inno-agent/src/server/routes/skills.ts
@@ -12,7 +12,7 @@ import {
 	WORKSPACE_TREE_MAX_DEPTH,
 	type WorkspaceTreeNode,
 } from "../file-helpers.js";
-import { json, matchRoute, readBody } from "../http-helpers.js";
+import { json, matchRoute, readBody, UPLOAD_MAX_BODY_BYTES } from "../http-helpers.js";
 
 export interface SkillLibraryItem {
 	/** Directory name under the skills path (used as the skill name). */
@@ -66,7 +66,7 @@ export async function handleSkillsRoutes(
 	}
 
 	if (method === "POST" && url === "/api/skills/upload") {
-		const body = (await readBody(req)) as Record<string, unknown>;
+		const body = (await readBody(req, { maxBytes: UPLOAD_MAX_BODY_BYTES })) as Record<string, unknown>;
 		const fileName = typeof body.fileName === "string" ? body.fileName : "";
 		const dataBase64 = typeof body.dataBase64 === "string" ? body.dataBase64 : "";
 		if (!fileName || !dataBase64) {

--- a/apps/inno-agent/src/server/routes/wiki.ts
+++ b/apps/inno-agent/src/server/routes/wiki.ts
@@ -9,7 +9,7 @@ import { buildWikiGraph } from "../../memory/l2/wiki-graph.js";
 import { parseFrontmatter } from "../../memory/l2/wiki-maintainer.js";
 import { ensureDir, readText, writeText } from "../../storage/file-store.js";
 import { safeJoin } from "../file-helpers.js";
-import { json, readBody } from "../http-helpers.js";
+import { json, readBody, UPLOAD_MAX_BODY_BYTES } from "../http-helpers.js";
 
 export interface WikiRouteContext {
 	l2DataDir: string;
@@ -210,7 +210,7 @@ export async function handleWikiRoutes(
 
 	// --- L2 Raw Upload API ---
 	if (method === "POST" && url === "/api/l2/raw/upload") {
-		const body = (await readBody(req)) as Record<string, unknown>;
+		const body = (await readBody(req, { maxBytes: UPLOAD_MAX_BODY_BYTES })) as Record<string, unknown>;
 		const fileName = typeof body.fileName === "string" ? body.fileName : "";
 		const mimeType = typeof body.mimeType === "string" ? body.mimeType : "application/octet-stream";
 		const dataBase64 = typeof body.dataBase64 === "string" ? body.dataBase64 : "";

--- a/apps/inno-agent/src/utils/process-fallback.ts
+++ b/apps/inno-agent/src/utils/process-fallback.ts
@@ -1,0 +1,55 @@
+/**
+ * Process-level last-resort handlers (`uncaughtException` / `unhandledRejection`).
+ *
+ * Without these, a single stray rejection or an exception thrown from inside a
+ * catch block (e.g. the HTTP catch-all calling `json()` after SSE headers were
+ * already sent) takes the whole process down with no log entry and no cleanup.
+ * Node's own stance is that the process state is untrustworthy after an
+ * uncaught exception, so these handlers log at fatal level and then shut down
+ * gracefully rather than trying to soldier on.
+ */
+
+import { logger } from "../logger.js";
+
+export interface ProcessFallbackOptions {
+	/**
+	 * Best-effort cleanup before exit (e.g. closing the HTTP server so
+	 * in-flight SSE/terminal clients get a close frame instead of a hang).
+	 * A thrown error here is ignored — the process exits regardless.
+	 */
+	onFatal?: () => void | Promise<void>;
+	/** Max milliseconds to wait for `onFatal` before forcing exit. */
+	exitTimeoutMs?: number;
+}
+
+let installed = false;
+let shuttingDown = false;
+
+export function installProcessFallbacks(options: ProcessFallbackOptions = {}): void {
+	if (installed) return;
+	installed = true;
+
+	const fatal = (kind: string, err: unknown): void => {
+		// A second fault while shutting down (e.g. cleanup throws, or another
+		// rejection lands) must not recurse — exit immediately.
+		if (shuttingDown) {
+			process.exit(1);
+		}
+		shuttingDown = true;
+
+		logger.fatal({ err }, `[inno] ${kind} — shutting down`);
+
+		const forceExit = setTimeout(() => process.exit(1), options.exitTimeoutMs ?? 3_000);
+		forceExit.unref();
+
+		Promise.resolve()
+			.then(() => options.onFatal?.())
+			.catch(() => {
+				// Cleanup is best-effort; never let it block or prevent the exit.
+			})
+			.finally(() => process.exit(1));
+	};
+
+	process.on("uncaughtException", (err) => fatal("uncaughtException", err));
+	process.on("unhandledRejection", (reason) => fatal("unhandledRejection", reason));
+}


### PR DESCRIPTION
## 背景

#162 清单中的第 1、2 项（PR-1 健壮性批次）。逐项核实后修复。

## 改动

### 1. 进程级兜底（issue 第 1 项）

- 新增 `src/utils/process-fallback.ts`：注册 `uncaughtException` / `unhandledRejection`，fatal 级落日志后优雅退出（server 侧关闭 HTTP/WS server 让客户端看到干净 close;3s 兜底强制退出；二次 fault 立即 exit 防递归）。`server.ts` 与 `cli.ts` 均已接入。
- `server.ts` catch-all 先判 `res.headersSent`:SSE/流式响应已发头时改为 `res.end()` 收尾，不再 `json(res, 500)`——原写法会在 catch 块内抛 `ERR_HTTP_HEADERS_SENT`,一条漏网异常即可打挂进程。

### 2. readBody 大小上限（issue 第 2 项）

- `readBody` 新增 32MB 默认上限（可 per-call `maxBytes` 覆盖）,`Content-Length` 声明超限提前拒绝 + 流式累计超限中途拒绝，均 reject `HttpError(413)`。
- 超限时**不 destroy socket**（否则 413 响应发不出去）：停止消费、`Connection: close` 由 Node 在响应后关闭连接。
- 新增 `HttpError` 类型，catch-all 透传其 statusCode/message；顺带把非法 JSON body 从 500 修正为 400。

### 3. Review follow-up: upload cap + 413 propagation

- `/api/skills/upload` and `/api/l2/raw/upload` carry base64 payloads, so the 32 MB default silently capped source files at ~24 MB. Both now use `UPLOAD_MAX_BODY_BYTES` (192 MB ≈ 128 MB source files).
- The sessions routes' `readBody(...).catch(() => ({}))` fallback now rethrows 413 `HttpError`s — only missing/malformed payloads are treated as `{}`.

## 测试

- 新增 `http-helpers.test.ts` 单元测试 ×6（正常解析 / 空 body / 400 / 声明超限 / 流式超限 / 自定义上限）。
- smoke 测试 +3：非法 JSON → 400；声明 33MB Content-Length → 413 + `Connection: close` + 后续 `/health` 仍 200（验证进程未被拖挂）；上传端口 33MB 接受（400 而非 413）/ 193MB 拒绝（413），双向验证提额边界。
- 全套 30 文件 / 244 测试通过；`npm run build` 通过。CLAUDE.md 测试计数已同步。

## 未覆盖

清单其余项按计划拆分：realpath(PR-2)、文件权限/日志脱敏/Electron scheme/timingSafeEqual(PR-3)、Origin/Host(随 #159)。