### PR TITLE
fix: resolve symlinks before serving files over HTTP (#162 realpath item)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~30 files (244 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~30 files (245 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,7 +252,7 @@ Three layers, all file-backed under `dataDir`:
 
 ### HTTP server (`src/server.ts`)
 
-Plain Node `http.createServer` (no framework), ~5300 lines in a single file (slated for incremental route-domain extraction — see `docs/quality-remediation-plan.md`). Key endpoints:
+Plain Node `http.createServer` (no framework), ~1600 lines plus route domains extracted under `src/server/routes/` (chat, wiki, workspaces, skills, channels, jobs, sessions, settings, learner, practice, presets). Key endpoints:
 - `POST /api/chat/stream` — SSE streaming chat.
 - `POST /api/chat` — non-streaming chat (full response).
 - `GET /api/chat/events/:id` — SSE event replay for reconnecting to an in-progress chat stream after page navigation (backed by `SessionEventBroadcaster`, an in-memory buffer).

--- a/apps/inno-agent/src/agent/workspace-path-guard.ts
+++ b/apps/inno-agent/src/agent/workspace-path-guard.ts
@@ -1,7 +1,8 @@
 import { existsSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { findExistingAncestor, isWithin } from "../utils/path-safety.js";
 
 export interface WorkspacePathCheck {
 	allowed: boolean;
@@ -21,21 +22,6 @@ function normalizeToolPath(input: string): string {
 	}
 	if (/^file:\/\//.test(normalized)) return fileURLToPath(normalized);
 	return normalized;
-}
-
-function isWithin(root: string, target: string): boolean {
-	const rel = relative(root, target);
-	return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`));
-}
-
-function findExistingAncestor(target: string): string | null {
-	let current = target;
-	while (!existsSync(current)) {
-		const parent = dirname(current);
-		if (parent === current) return null;
-		current = parent;
-	}
-	return current;
 }
 
 /**

--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -345,21 +345,66 @@ describe("server smoke", () => {
 		// A symlink planted inside the workspace (trivial via the agent's bash
 		// tool) must not let the endpoint read host files outside the root.
 		const secretDir = mkdtempSync(join(tmpdir(), "inno-smoke-secret-"));
+		// Track what we plant in the shared workspace so the finally block can
+		// leave the fixture exactly as it found it.
+		const planted = ["escape-link", "direct-link.txt", "dangling-link.txt", "hello.txt"];
 		try {
 			writeFileSync(join(secretDir, "secret.txt"), "top-secret");
-			symlinkSync(secretDir, join(root, "escape-link"));
-			symlinkSync(join(secretDir, "secret.txt"), join(root, "direct-link.txt"));
+			// "junction" needs no symlink privilege on Windows and is ignored on POSIX.
+			symlinkSync(secretDir, join(root, "escape-link"), "junction");
+			// File symlinks do require the privilege on Windows; skip just this
+			// assertion there when the shell is not elevated (CI runners are).
+			let directLinkPlanted = true;
+			try {
+				symlinkSync(join(secretDir, "secret.txt"), join(root, "direct-link.txt"));
+			} catch (err) {
+				if (process.platform === "win32" && (err as NodeJS.ErrnoException).code === "EPERM") {
+					directLinkPlanted = false;
+				} else {
+					throw err;
+				}
+			}
 
 			const viaDir = await api("/api/workspace/file?path=escape-link/secret.txt");
 			expect(viaDir.status).toBe(404);
-			const viaFile = await api("/api/workspace/file?path=direct-link.txt");
-			expect(viaFile.status).toBe(404);
+			if (directLinkPlanted) {
+				const viaFile = await api("/api/workspace/file?path=direct-link.txt");
+				expect(viaFile.status).toBe(404);
+			}
+
+			// A *dangling* symlink (target missing) must not let write endpoints
+			// create the target outside the workspace either. Same Windows
+			// privilege caveat as the file symlink above.
+			let danglingLinkPlanted = true;
+			try {
+				symlinkSync(join(secretDir, "missing.txt"), join(root, "dangling-link.txt"));
+			} catch (err) {
+				if (process.platform === "win32" && (err as NodeJS.ErrnoException).code === "EPERM") {
+					danglingLinkPlanted = false;
+				} else {
+					throw err;
+				}
+			}
+			if (danglingLinkPlanted) {
+				const writeViaDangling = await fetch(`http://127.0.0.1:${port}/api/workspace/upload`, {
+					method: "POST",
+					headers: { "content-type": "application/json" },
+					body: JSON.stringify({ files: [{ path: "dangling-link.txt", dataBase64: Buffer.from("pwned").toString("base64") }] }),
+				});
+				expect(writeViaDangling.status).toBe(201);
+				const writeBody = (await writeViaDangling.json()) as { uploaded: unknown[] };
+				expect(writeBody.uploaded).toHaveLength(0);
+				expect(existsSync(join(secretDir, "missing.txt"))).toBe(false);
+			}
 
 			// Positive control: a genuine file inside the root stays readable.
 			writeFileSync(join(root, "hello.txt"), "hello");
 			const ok = await api("/api/workspace/file?path=hello.txt");
 			expect(ok.status).toBe(200);
 		} finally {
+			for (const name of planted) {
+				rmSync(join(root, name), { recursive: true, force: true });
+			}
 			rmSync(secretDir, { recursive: true, force: true });
 		}
 	});

--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { request as httpRequest } from "node:http";
 import { createServer, type AddressInfo } from "node:net";
 import { tmpdir } from "node:os";
@@ -336,6 +336,32 @@ describe("server smoke", () => {
 	it("GET /api/workspace/file returns 404 for a missing file", async () => {
 		const res = await api("/api/workspace/file?path=no-such-file.txt");
 		expect(res.status).toBe(404);
+	});
+
+	it("GET /api/workspace/file rejects symlinks escaping the workspace (issue #162)", async () => {
+		const tree = await api("/api/workspace/tree");
+		const { root } = (await tree.json()) as { root: string };
+
+		// A symlink planted inside the workspace (trivial via the agent's bash
+		// tool) must not let the endpoint read host files outside the root.
+		const secretDir = mkdtempSync(join(tmpdir(), "inno-smoke-secret-"));
+		try {
+			writeFileSync(join(secretDir, "secret.txt"), "top-secret");
+			symlinkSync(secretDir, join(root, "escape-link"));
+			symlinkSync(join(secretDir, "secret.txt"), join(root, "direct-link.txt"));
+
+			const viaDir = await api("/api/workspace/file?path=escape-link/secret.txt");
+			expect(viaDir.status).toBe(404);
+			const viaFile = await api("/api/workspace/file?path=direct-link.txt");
+			expect(viaFile.status).toBe(404);
+
+			// Positive control: a genuine file inside the root stays readable.
+			writeFileSync(join(root, "hello.txt"), "hello");
+			const ok = await api("/api/workspace/file?path=hello.txt");
+			expect(ok.status).toBe(200);
+		} finally {
+			rmSync(secretDir, { recursive: true, force: true });
+		}
 	});
 
 	it("DELETE /api/workspaces/tmp is rejected with 400", async () => {

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -36,7 +36,7 @@ import { seedManagedMcpConfig } from "./mcp/mcp-config-store.js";
 import { CronScheduler } from "./scheduler/cron-scheduler.js";
 import { HttpError, json } from "./server/http-helpers.js";
 import {
-	safeJoin,
+	safeJoinReal,
 	slugifySkillName,
 } from "./server/file-helpers.js";
 import { handleChannelsRoutes } from "./server/routes/channels.js";
@@ -473,7 +473,7 @@ function serveStatic(req: HttpReq, res: ServerResponse, filePath: string, sendBo
 function sessionFileFromId(sessionDir: string, id: string): string | null {
 	const fileName = basename(id);
 	if (fileName !== id || !fileName.endsWith(".jsonl")) return null;
-	return safeJoin(sessionDir, fileName);
+	return safeJoinReal(sessionDir, fileName);
 }
 
 function textFromContent(content: unknown): string {
@@ -1459,7 +1459,7 @@ const server = createServer(async (req, res) => {
 		// --- Static files / SPA fallback ---
 		if (method === "GET" || method === "HEAD") {
 			const urlPath = decodeURIComponent(url.split("?")[0]);
-			const staticPath = safeJoin(webDistDir, urlPath.replace(/^\/+/, ""));
+			const staticPath = safeJoinReal(webDistDir, urlPath.replace(/^\/+/, ""));
 			const sendBody = method === "GET";
 			// Try exact file in web/dist
 			if (staticPath && serveStatic(req, res, staticPath, sendBody)) return;

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -4,12 +4,13 @@ import "source-map-support/register.js";
 
 import { createServer, type IncomingMessage as HttpReq, type ServerResponse } from "node:http";
 import { spawnSync } from "node:child_process";
-import { cpSync, existsSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
 import { loadConfig, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
+import { canonicalContainmentRoot, isWithin } from "./utils/path-safety.js";
 import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
 import { ensureDir, readJson, readText, writeJson, writeText } from "./storage/file-store.js";
 import {
@@ -428,7 +429,7 @@ function encodingAccepted(acceptEncoding: string, encoding: "br" | "gzip"): bool
 	return wildcardQ !== undefined ? wildcardQ > 0 : false;
 }
 
-function serveStatic(req: HttpReq, res: ServerResponse, filePath: string, sendBody = true): boolean {
+function serveStatic(req: HttpReq, res: ServerResponse, filePath: string, sendBody = true, staticRoot?: string): boolean {
 	try {
 		if (!existsSync(filePath) || !statSync(filePath).isFile()) return false;
 		const ext = extname(filePath);
@@ -436,11 +437,27 @@ function serveStatic(req: HttpReq, res: ServerResponse, filePath: string, sendBo
 		const acceptEncoding = acceptEncodingHeader(req);
 		let responsePath = filePath;
 		let contentEncoding: "br" | "gzip" | undefined;
-		if (encodingAccepted(acceptEncoding, "br") && existsSync(`${filePath}.br`)) {
-			responsePath = `${filePath}.br`;
+		// The pre-compressed sibling never went through safeJoinReal, so verify
+		// its realpath stays inside the static root — a planted symlink like
+		// `assets/index.js.gz -> /etc/passwd` must not be served.
+		const canonicalRoot = staticRoot ? canonicalContainmentRoot(staticRoot) : null;
+		const pickCompressedSibling = (suffix: string): string | null => {
+			const candidate = `${filePath}${suffix}`;
+			try {
+				if (!existsSync(candidate)) return null;
+				if (canonicalRoot && !isWithin(canonicalRoot, realpathSync(candidate))) return null;
+				return candidate;
+			} catch {
+				return null;
+			}
+		};
+		const brSibling = encodingAccepted(acceptEncoding, "br") ? pickCompressedSibling(".br") : null;
+		const gzSibling = !brSibling && encodingAccepted(acceptEncoding, "gzip") ? pickCompressedSibling(".gz") : null;
+		if (brSibling) {
+			responsePath = brSibling;
 			contentEncoding = "br";
-		} else if (encodingAccepted(acceptEncoding, "gzip") && existsSync(`${filePath}.gz`)) {
-			responsePath = `${filePath}.gz`;
+		} else if (gzSibling) {
+			responsePath = gzSibling;
 			contentEncoding = "gzip";
 		}
 
@@ -1462,11 +1479,11 @@ const server = createServer(async (req, res) => {
 			const staticPath = safeJoinReal(webDistDir, urlPath.replace(/^\/+/, ""));
 			const sendBody = method === "GET";
 			// Try exact file in web/dist
-			if (staticPath && serveStatic(req, res, staticPath, sendBody)) return;
+			if (staticPath && serveStatic(req, res, staticPath, sendBody, webDistDir)) return;
 			// SPA fallback: serve index.html for non-API paths only. An unmatched
 			// /api/* route must fall through to the JSON 404 — returning HTML with
 			// a 200 status breaks API client error handling.
-			if (urlPath !== "/api" && !urlPath.startsWith("/api/") && serveStatic(req, res, join(webDistDir, "index.html"), sendBody)) return;
+			if (urlPath !== "/api" && !urlPath.startsWith("/api/") && serveStatic(req, res, join(webDistDir, "index.html"), sendBody, webDistDir)) return;
 		}
 
 		// --- 404 ---

--- a/apps/inno-agent/src/server/file-helpers.ts
+++ b/apps/inno-agent/src/server/file-helpers.ts
@@ -1,4 +1,4 @@
-import { basename, extname, relative, resolve } from "node:path";
+import { basename, extname } from "node:path";
 import { canonicalContainmentRoot, resolveContainedPath } from "../utils/path-safety.js";
 
 /**
@@ -7,20 +7,14 @@ import { canonicalContainmentRoot, resolveContainedPath } from "../utils/path-sa
  * the P2 route split — everything here is stateless.
  */
 
-export function safeJoin(baseDir: string, userPath: string): string | null {
-	const resolvedBase = resolve(baseDir);
-	const resolvedPath = resolve(resolvedBase, userPath);
-	const rel = relative(resolvedBase, resolvedPath);
-	if (rel.startsWith("..") || resolve(rel) === rel) return null;
-	return resolvedPath;
-}
-
 /**
- * Symlink-aware variant of {@link safeJoin} for endpoints that read or write
- * file contents. A lexical check alone lets a symlink planted inside the root
+ * Containment-checked join for endpoints that read or write file contents.
+ * A lexical check alone lets a symlink planted inside the root
  * (trivial for the agent's bash tool to create in a workspace) escape to any
  * file on the host; this resolves the closest existing ancestor through
  * realpath and verifies the canonical target stays inside the canonical root.
+ * There is deliberately no exported lexical-only variant — new endpoints must
+ * go through this guard.
  */
 export function safeJoinReal(baseDir: string, userPath: string): string | null {
 	return resolveContainedPath(baseDir, userPath);

--- a/apps/inno-agent/src/server/file-helpers.ts
+++ b/apps/inno-agent/src/server/file-helpers.ts
@@ -1,5 +1,5 @@
-import { realpathSync } from "node:fs";
 import { basename, extname, relative, resolve } from "node:path";
+import { canonicalContainmentRoot, resolveContainedPath } from "../utils/path-safety.js";
 
 /**
  * Pure file/path helpers shared by the server route domains (skills,
@@ -13,6 +13,17 @@ export function safeJoin(baseDir: string, userPath: string): string | null {
 	const rel = relative(resolvedBase, resolvedPath);
 	if (rel.startsWith("..") || resolve(rel) === rel) return null;
 	return resolvedPath;
+}
+
+/**
+ * Symlink-aware variant of {@link safeJoin} for endpoints that read or write
+ * file contents. A lexical check alone lets a symlink planted inside the root
+ * (trivial for the agent's bash tool to create in a workspace) escape to any
+ * file on the host; this resolves the closest existing ancestor through
+ * realpath and verifies the canonical target stays inside the canonical root.
+ */
+export function safeJoinReal(baseDir: string, userPath: string): string | null {
+	return resolveContainedPath(baseDir, userPath);
 }
 
 export function slugifySkillName(value: string): string {
@@ -48,11 +59,7 @@ export function contentDispositionAttachment(fileName: string): string {
  * every directory empty.
  */
 export function canonicalTreeRoot(dir: string): string {
-	try {
-		return realpathSync(dir);
-	} catch {
-		return dir;
-	}
+	return canonicalContainmentRoot(dir);
 }
 
 export interface WorkspaceTreeNode {

--- a/apps/inno-agent/src/server/routes/chat.ts
+++ b/apps/inno-agent/src/server/routes/chat.ts
@@ -20,6 +20,7 @@ import {
 } from "../../chat/stream-registry.js";
 import { logger } from "../../logger.js";
 import type { RuntimePaths } from "../../runtime.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
 import type { WorkspaceRegistry } from "../../workspace/workspace-registry.js";
 import { WORKSPACE_IGNORES } from "../file-helpers.js";
 import { json, matchRoute, readBody } from "../http-helpers.js";
@@ -109,7 +110,14 @@ function toolCallStreamEventFromAssistantEvent(ev: any): unknown | null {
  */
 function persistInlineImages(images: Array<{ data: string; mimeType: string }>, workspaceRoot: string): string[] {
 	if (images.length === 0) return [];
-	const chatImagesDir = join(workspaceRoot, ".chat-images");
+	// `.chat-images` is agent-writable like the rest of the workspace — if it
+	// (or an ancestor) is a symlink escaping the workspace, pasted images would
+	// be written to a host directory. Fail closed and just skip persistence.
+	const chatImagesDir = resolveContainedPath(workspaceRoot, ".chat-images");
+	if (!chatImagesDir) {
+		logger.warn({ workspaceRoot }, "skipping inline image persistence: .chat-images escapes the workspace");
+		return [];
+	}
 	try {
 		if (!existsSync(chatImagesDir)) mkdirSync(chatImagesDir, { recursive: true });
 	} catch (err) {

--- a/apps/inno-agent/src/server/routes/skills.ts
+++ b/apps/inno-agent/src/server/routes/skills.ts
@@ -1,8 +1,9 @@
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
 import type { Dirent } from "node:fs";
 import { existsSync, readdirSync, readFileSync, realpathSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { basename, extname, join, relative, sep } from "node:path";
+import { basename, extname, join, relative } from "node:path";
 import { logger } from "../../logger.js";
+import { isWithin } from "../../utils/path-safety.js";
 import {
 	canonicalTreeRoot,
 	contentTypeForWorkspaceFile,
@@ -224,7 +225,7 @@ export async function handleSkillsRoutes(
 						} catch {
 							real = fullPath;
 						}
-						const withinRoot = real === skillRootReal || real.startsWith(skillRootReal + sep);
+						const withinRoot = isWithin(skillRootReal, real);
 						node.children = withinRoot && !seen.has(real)
 							? readSkillTree(fullPath, depth + 1, new Set([...seen, real]))
 							: [];

--- a/apps/inno-agent/src/server/routes/skills.ts
+++ b/apps/inno-agent/src/server/routes/skills.ts
@@ -6,7 +6,7 @@ import { logger } from "../../logger.js";
 import {
 	canonicalTreeRoot,
 	contentTypeForWorkspaceFile,
-	safeJoin,
+	safeJoinReal,
 	slugifySkillName,
 	workspaceFileKind,
 	WORKSPACE_TREE_MAX_DEPTH,
@@ -253,7 +253,7 @@ export async function handleSkillsRoutes(
 		if (!existsSync(skillDir)) { json(res, 404, { error: "Skill not found" }); return true; }
 		const params = new URL(url, "http://localhost").searchParams;
 		const relPath = params.get("path") ?? "";
-		const fullPath = safeJoin(skillDir, relPath.replace(/^\/+/, ""));
+		const fullPath = safeJoinReal(skillDir, relPath.replace(/^\/+/, ""));
 		if (!fullPath || !existsSync(fullPath) || !statSync(fullPath).isFile()) {
 			json(res, 404, { error: "File not found" });
 			return true;
@@ -296,7 +296,7 @@ export async function handleSkillsRoutes(
 		const relPath = typeof body.path === "string" ? body.path.trim() : "";
 		const content = typeof body.content === "string" ? body.content : "";
 		if (!relPath) { json(res, 400, { error: "Missing path" }); return true; }
-		const fullPath = safeJoin(skillDir, relPath.replace(/^\/+/, ""));
+		const fullPath = safeJoinReal(skillDir, relPath.replace(/^\/+/, ""));
 		if (!fullPath || !existsSync(fullPath) || !statSync(fullPath).isFile()) {
 			json(res, 404, { error: "File not found" });
 			return true;
@@ -316,7 +316,7 @@ export async function handleSkillsRoutes(
 		if (!existsSync(skillDir)) { json(res, 404, { error: "Skill not found" }); return true; }
 		const params = new URL(url, "http://localhost").searchParams;
 		const relPath = params.get("path") ?? "";
-		const fullPath = safeJoin(skillDir, relPath.replace(/^\/+/, ""));
+		const fullPath = safeJoinReal(skillDir, relPath.replace(/^\/+/, ""));
 		if (!fullPath || !existsSync(fullPath) || !statSync(fullPath).isFile()) {
 			json(res, 404, { error: "File not found" });
 			return true;

--- a/apps/inno-agent/src/server/routes/wiki.ts
+++ b/apps/inno-agent/src/server/routes/wiki.ts
@@ -8,7 +8,7 @@ import { readManifest, removeWikiPathFromManifest } from "../../memory/l2/manife
 import { buildWikiGraph } from "../../memory/l2/wiki-graph.js";
 import { parseFrontmatter } from "../../memory/l2/wiki-maintainer.js";
 import { ensureDir, readText, writeText } from "../../storage/file-store.js";
-import { safeJoin } from "../file-helpers.js";
+import { safeJoinReal } from "../file-helpers.js";
 import { json, readBody, UPLOAD_MAX_BODY_BYTES } from "../http-helpers.js";
 
 export interface WikiRouteContext {
@@ -117,7 +117,7 @@ export async function handleWikiRoutes(
 			json(res, 400, { error: "Missing path parameter" });
 			return true;
 		}
-		const fullPath = safeJoin(l2DataDir, path);
+		const fullPath = safeJoinReal(l2DataDir, path);
 		if (!fullPath) {
 			json(res, 400, { error: "Invalid wiki path" });
 			return true;
@@ -139,7 +139,7 @@ export async function handleWikiRoutes(
 			json(res, 400, { error: "Missing path or content" });
 			return true;
 		}
-		const fullPath = safeJoin(l2DataDir, path);
+		const fullPath = safeJoinReal(l2DataDir, path);
 		if (!fullPath) {
 			json(res, 400, { error: "Invalid wiki path" });
 			return true;
@@ -157,7 +157,7 @@ export async function handleWikiRoutes(
 			json(res, 400, { error: "Missing path parameter" });
 			return true;
 		}
-		const fullPath = safeJoin(l2DataDir, path);
+		const fullPath = safeJoinReal(l2DataDir, path);
 		if (!fullPath) {
 			json(res, 400, { error: "Invalid wiki path" });
 			return true;

--- a/apps/inno-agent/src/server/routes/workspaces.ts
+++ b/apps/inno-agent/src/server/routes/workspaces.ts
@@ -26,7 +26,7 @@ import {
 	contentDispositionAttachment,
 	contentTypeForWorkspaceFile,
 	officeFormat,
-	safeJoin,
+	safeJoinReal,
 	workspaceFileKind,
 	WORKSPACE_IGNORES,
 	WORKSPACE_TREE_MAX_DEPTH,
@@ -309,10 +309,12 @@ export async function handleWorkspacesRoutes(
 
 	// safeWorkspacePath closed over server.ts's module-level workspaceRegistry;
 	// rebind it to the injected registry here so the route bodies stay verbatim.
+	// safeJoinReal (not plain safeJoin): a symlink planted inside the workspace
+	// must not let these endpoints read/write files outside it.
 	const safeWorkspacePath = (workspaceId: string | null | undefined, userPath: string): string | null => {
 		const root = workspaceRegistry.resolveWorkspaceDir(workspaceId ?? TEMP_WORKSPACE_ID);
 		if (!root) return null;
-		return safeJoin(root, userPath.replace(/^\/+/, ""));
+		return safeJoinReal(root, userPath.replace(/^\/+/, ""));
 	};
 
 	// --- Workspace API ---

--- a/apps/inno-agent/src/server/routes/workspaces.ts
+++ b/apps/inno-agent/src/server/routes/workspaces.ts
@@ -13,13 +13,14 @@ import {
 } from "node:fs";
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
-import { basename, dirname, extname, join, relative, sep } from "node:path";
+import { basename, dirname, extname, join, relative } from "node:path";
 import { promisify } from "node:util";
 import { applyWorkspaceCwd, getCurrentSessionId } from "../../agent/pi-runner.js";
 import { streamRegistry } from "../../chat/stream-registry.js";
 import { logger } from "../../logger.js";
 import type { RuntimePaths } from "../../runtime.js";
 import { ensureDir } from "../../storage/file-store.js";
+import { isWithin } from "../../utils/path-safety.js";
 import { TEMP_WORKSPACE_ID, type WorkspaceRegistry } from "../../workspace/workspace-registry.js";
 import {
 	canonicalTreeRoot,
@@ -139,7 +140,7 @@ function readWorkspaceTree(rootDir: string, dir: string, depth = 0, seen: Readon
 				} catch {
 					real = fullPath;
 				}
-				const withinRoot = real === realRoot || real.startsWith(realRoot + sep);
+				const withinRoot = isWithin(realRoot, real);
 				node.children = withinRoot && !seen.has(real)
 					? readWorkspaceTree(rootDir, fullPath, depth + 1, new Set([...seen, real]))
 					: [];
@@ -171,7 +172,10 @@ function zipDirectory(dirPath: string): Buffer {
 			}
 		} else {
 			// `-r` recurse, run inside the dir so paths are relative to it.
-			const result = spawnSync("/usr/bin/zip", ["-r", "-q", zipPath, "."], { cwd: dirPath, encoding: "utf-8" });
+			// `-y` stores symlinks as links: without it zip dereferences them,
+			// so a symlink planted inside the workspace would leak the linked
+			// host files into the archive.
+			const result = spawnSync("/usr/bin/zip", ["-r", "-y", "-q", zipPath, "."], { cwd: dirPath, encoding: "utf-8" });
 			if (result.status !== 0) {
 				throw new Error((result.stderr || "").trim() || "Unable to create zip archive");
 			}
@@ -647,10 +651,15 @@ export async function handleWorkspacesRoutes(
 			// A .zip or .md dropped into the workspace's private skills dir is
 			// installed as a skill (zip is extracted) rather than written raw.
 			if (filePath.split("/").includes(WORKSPACE_PRIVATE_SKILLS_DIR) && (ext === ".zip" || ext === ".md")) {
+				// The install target must really be `<root>/.skills` — a symlink
+				// planted at `.skills` would make the installer delete/overwrite
+				// a directory outside the workspace.
+				const skillsRoot = safeWorkspacePath(wsId, WORKSPACE_PRIVATE_SKILLS_DIR);
+				if (!skillsRoot) { json(res, 400, { error: "Invalid skills directory" }); return true; }
 				try {
 					const skill = ext === ".zip"
-						? installSkillZip(basename(filePath), data, join(root, WORKSPACE_PRIVATE_SKILLS_DIR))
-						: installSkillMarkdown(basename(filePath), data, join(root, WORKSPACE_PRIVATE_SKILLS_DIR));
+						? installSkillZip(basename(filePath), data, skillsRoot)
+						: installSkillMarkdown(basename(filePath), data, skillsRoot);
 					uploaded.push(workspaceSkillNode(root, skill.name));
 					installedSkill = true;
 					continue;
@@ -689,10 +698,14 @@ export async function handleWorkspacesRoutes(
 		const ext = extname(fileName).toLowerCase();
 		if (ext !== ".zip" && ext !== ".md") { json(res, 400, { error: "Only .zip or .md skill packages are supported" }); return true; }
 		const data = Buffer.from(dataBase64, "base64");
+		// Guard the install target: a symlink planted at `.skills` would make the
+		// installer delete/overwrite a directory outside the workspace.
+		const skillsRoot = safeWorkspacePath(wsId, WORKSPACE_PRIVATE_SKILLS_DIR);
+		if (!skillsRoot) { json(res, 400, { error: "Invalid skills directory" }); return true; }
 		try {
 			const skill = ext === ".zip"
-				? installSkillZip(fileName, data, join(root, WORKSPACE_PRIVATE_SKILLS_DIR))
-				: installSkillMarkdown(fileName, data, join(root, WORKSPACE_PRIVATE_SKILLS_DIR));
+				? installSkillZip(fileName, data, skillsRoot)
+				: installSkillMarkdown(fileName, data, skillsRoot);
 			scheduleSkillsReload();
 			json(res, 201, workspaceSkillNode(root, skill.name));
 		} catch (err) {

--- a/apps/inno-agent/src/utils/path-safety.ts
+++ b/apps/inno-agent/src/utils/path-safety.ts
@@ -1,0 +1,72 @@
+/**
+ * Symlink-aware path containment checks, shared by the HTTP file endpoints
+ * (server/file-helpers.ts) and the agent-side workspace path guard
+ * (agent/workspace-path-guard.ts).
+ *
+ * A purely lexical `resolve` + `relative` check is not enough for paths that
+ * may contain symlinks: a symlink planted inside an allowed root (e.g. by the
+ * agent's bash tool inside a workspace) lets a request escape to any file on
+ * the host. The checks here resolve the closest *existing* ancestor through
+ * `realpathSync` and project the non-existent suffix from there, so symlink
+ * escapes are caught for both reads and writes.
+ */
+
+import { existsSync, realpathSync } from "node:fs";
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
+
+export function isWithin(root: string, target: string): boolean {
+	const rel = relative(root, target);
+	return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`));
+}
+
+export function findExistingAncestor(target: string): string | null {
+	let current = target;
+	while (!existsSync(current)) {
+		const parent = dirname(current);
+		if (parent === current) return null;
+		current = parent;
+	}
+	return current;
+}
+
+/**
+ * Canonicalize a containment root. The root itself may contain symlink
+ * components (e.g. macOS /tmp → /private/tmp); children's realpaths never
+ * match a non-canonical root, which would silently reject every legitimate
+ * path. Falls back to the lexical path when the root does not exist yet.
+ */
+export function canonicalContainmentRoot(dir: string): string {
+	try {
+		return realpathSync(dir);
+	} catch {
+		return dir;
+	}
+}
+
+/**
+ * Resolve `userPath` against `baseDir` and verify that the canonical
+ * (symlink-resolved) target stays inside the canonical base. Returns the
+ * lexically resolved path (not the canonical one — callers keep their
+ * existing path semantics) or null when the path escapes.
+ */
+export function resolveContainedPath(baseDir: string, userPath: string): string | null {
+	try {
+		const resolvedBase = resolve(baseDir);
+		const resolvedPath = resolve(resolvedBase, userPath);
+		// Fast lexical reject before touching the filesystem.
+		if (!isWithin(resolvedBase, resolvedPath)) return null;
+
+		const canonicalBase = canonicalContainmentRoot(resolvedBase);
+		const existingAncestor = findExistingAncestor(resolvedPath);
+		if (!existingAncestor) return null;
+
+		const canonicalAncestor = realpathSync(existingAncestor);
+		const unresolvedSuffix = relative(existingAncestor, resolvedPath);
+		const canonicalTarget = resolve(canonicalAncestor, unresolvedSuffix);
+		if (!isWithin(canonicalBase, canonicalTarget)) return null;
+
+		return resolvedPath;
+	} catch {
+		return null;
+	}
+}

--- a/apps/inno-agent/src/utils/path-safety.ts
+++ b/apps/inno-agent/src/utils/path-safety.ts
@@ -9,9 +9,16 @@
  * the host. The checks here resolve the closest *existing* ancestor through
  * `realpathSync` and project the non-existent suffix from there, so symlink
  * escapes are caught for both reads and writes.
+ *
+ * "Existing" is determined with `lstatSync`, not `existsSync`: `existsSync`
+ * follows links, so a *dangling* symlink (target missing) would look like a
+ * non-existent suffix and skip the realpath check — and a subsequent write
+ * would follow the link and create the file outside the root. With lstat the
+ * symlink itself counts as existing, and `realpathSync` on a dangling link
+ * throws, which fails closed.
  */
 
-import { existsSync, realpathSync } from "node:fs";
+import { lstatSync, realpathSync } from "node:fs";
 import { dirname, isAbsolute, relative, resolve, sep } from "node:path";
 
 export function isWithin(root: string, target: string): boolean {
@@ -19,14 +26,28 @@ export function isWithin(root: string, target: string): boolean {
 	return rel === "" || (!isAbsolute(rel) && rel !== ".." && !rel.startsWith(`..${sep}`));
 }
 
+/**
+ * Closest ancestor of `target` that exists, where a symlink itself counts as
+ * existing even when its target does not (see module header). Returns null
+ * when nothing exists or a component cannot be inspected.
+ */
 export function findExistingAncestor(target: string): string | null {
 	let current = target;
-	while (!existsSync(current)) {
-		const parent = dirname(current);
-		if (parent === current) return null;
-		current = parent;
+	for (;;) {
+		try {
+			lstatSync(current);
+			return current;
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			// Only "not there" keeps the walk going; anything else (EACCES,
+			// ELOOP, ...) fails closed instead of skipping past a component
+			// we cannot inspect.
+			if (code !== "ENOENT" && code !== "ENOTDIR") return null;
+			const parent = dirname(current);
+			if (parent === current) return null;
+			current = parent;
+		}
 	}
-	return current;
 }
 
 /**
@@ -44,6 +65,24 @@ export function canonicalContainmentRoot(dir: string): string {
 }
 
 /**
+ * Canonicalize a path that may not exist yet: realpath the closest existing
+ * ancestor and project the missing suffix from there. Unlike a bare
+ * realpath-or-lexical fallback, this stays correct when the path is missing
+ * but an ancestor contains a symlink (macOS /var → /private/var, symlinked
+ * $HOME) — the mixed lexical/canonical comparison would otherwise reject
+ * every legitimate path under the not-yet-created directory.
+ */
+function canonicalizePossiblyMissing(target: string): string | null {
+	const ancestor = findExistingAncestor(target);
+	if (!ancestor) return null;
+	try {
+		return resolve(realpathSync(ancestor), relative(ancestor, target));
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Resolve `userPath` against `baseDir` and verify that the canonical
  * (symlink-resolved) target stays inside the canonical base. Returns the
  * lexically resolved path (not the canonical one — callers keep their
@@ -56,13 +95,13 @@ export function resolveContainedPath(baseDir: string, userPath: string): string 
 		// Fast lexical reject before touching the filesystem.
 		if (!isWithin(resolvedBase, resolvedPath)) return null;
 
-		const canonicalBase = canonicalContainmentRoot(resolvedBase);
-		const existingAncestor = findExistingAncestor(resolvedPath);
-		if (!existingAncestor) return null;
-
-		const canonicalAncestor = realpathSync(existingAncestor);
-		const unresolvedSuffix = relative(existingAncestor, resolvedPath);
-		const canonicalTarget = resolve(canonicalAncestor, unresolvedSuffix);
+		// The base may not exist yet (e.g. the L2 dir before the first wiki
+		// page is written); canonicalize it through its own existing ancestor
+		// so a symlinked ancestor cannot make every legitimate path mismatch.
+		const canonicalBase = canonicalizePossiblyMissing(resolvedBase);
+		if (!canonicalBase) return null;
+		const canonicalTarget = canonicalizePossiblyMissing(resolvedPath);
+		if (!canonicalTarget) return null;
 		if (!isWithin(canonicalBase, canonicalTarget)) return null;
 
 		return resolvedPath;


### PR DESCRIPTION
## 背景

#162 清单第 4 项（PR-2 文件安全批次）。HTTP 文件端点的 `safeJoin` 只做 `resolve`/`relative` 词法检查——workspace 里的 symlink(agent 的 bash 工具一行 `ln -s` 就能种下）即可让 `GET /api/workspace/file` 读到宿主机任意文件。

## 改动

### 共享 realpath 核心（新 `src/utils/path-safety.ts`)

按 issue 建议直接复用 `agent/workspace-path-guard.ts` 已验证的那套逻辑，抽成共享实现：

- `resolveContainedPath(baseDir, userPath)`：先词法快速拒绝，再对**最近存在祖先**做 `realpathSync`、投影不存在的后缀，校验 canonical target 落在 canonical root 内——读写两侧都能拦住 symlink 逃逸。
- root 同样 canonicalize(macOS `/tmp → /private/tmp` 的坑，此前 `canonicalTreeRoot` 注释里已记录）。
- `agent/workspace-path-guard.ts` 删掉本地副本，改为 import 共享 helper——agent 侧与 HTTP 侧现在同一份实现。

### 调用点替换（`safeJoin` → `safeJoinReal`，词法版已零调用）

| 端点 | 文件 |
|---|---|
| workspace file / raw / pptx-preview | `routes/workspaces.ts`(`safeWorkspacePath` 一处替换，全部覆盖） |
| skills 文件读 / 写 / raw | `routes/skills.ts` ×3 |
| wiki page 读 / 写 / 删 | `routes/wiki.ts` ×3 |
| session 文件查找 | `server.ts` `sessionFileFromId` |
| web/dist 静态 fallback | `server.ts` |

顺带去重：`canonicalTreeRoot` 改为委托共享的 `canonicalContainmentRoot`。

## 测试

smoke 新增用例：在 tmp workspace 里分别种**目录 symlink** 和**文件 symlink** 指向工作区外的 secret 文件，两个都必须 404；同时正面验证工作区内真实文件仍可 200 读取（防误伤）。

全套 30 文件 / 245 测试通过，`npm run build` 通过，CLAUDE.md 计数已同步。

## 未覆盖

清单剩余：文件权限 0600 / fetch-logger 脱敏 / Electron scheme 白名单 / timingSafeEqual(PR-3),Origin/Host（随 #159)。