### PR TITLE
fix: secret file permissions, LLM log redaction, Electron/bridge hardening (#162)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,10 @@ INNO_DATA_DIR=./runtime/data
 INNO_SKILLS_DIR=./runtime/skills
 INNO_WORKSPACE_DIR=./workspace
 INNO_PORT=3000
+
+# Log verbosity for the file logger (default: info)
+# LOG_LEVEL=info
+# Include truncated LLM request/response bodies in the log (privacy-sensitive:
+# prompts, learner profile and model output end up in log/server-*.log).
+# Default off — only metadata (URL, status, timing, body sizes) is logged.
+# LOG_LLM_BODY=0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~30 files (245 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~32 files (254 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 
@@ -195,7 +195,7 @@ The Electron main process (`electron/main.js`) spawns the server as a child proc
 
 ### LLM Fetch Logger (`src/utils/fetch-logger.ts`)
 
-Wraps `globalThis.fetch` at startup to intercept and log all LLM provider API calls (OpenAI-style `/chat/completions`, Anthropic `/messages`, PI proxy `/api/stream`). Each request gets a correlation ID (`seq/unixTimestamp`), logs the request body (truncated to 8000 chars), and logs the response with status, elapsed time, and body (truncated to 4000 chars). Installed via `installFetchLogger()` in both `server.ts` and `cli.ts`.
+Wraps `globalThis.fetch` at startup to intercept and log all LLM provider API calls (OpenAI-style `/chat/completions`, Anthropic `/messages`, PI proxy `/api/stream`). Each request gets a correlation ID (`seq/unixTimestamp`). By default only metadata is logged (URL, status, elapsed time, body sizes) — request/response bodies (truncated to 8000/4000 chars) are included only when `LOG_LLM_BODY=1` is set, since they contain prompts, learner data and model output. Installed via `installFetchLogger()` in both `server.ts` and `cli.ts`.
 
 ### Proxy Bypass (`src/utils/proxy-bypass.ts`)
 

--- a/apps/inno-agent/src/channels/bridge/bridge-server.test.ts
+++ b/apps/inno-agent/src/channels/bridge/bridge-server.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { ChannelRegistry } from "../channel.js";
+import type { PersonalChannelDispatcher } from "../personal-dispatcher.js";
+import { handleBridgeMessage, type BridgeServerOptions } from "./bridge-server.js";
+
+/**
+ * Auth tests for the bridge message endpoint (issue #162: the bearer token
+ * comparison must be constant-time and reject prefix/near-miss tokens).
+ */
+
+function makeOpts(): BridgeServerOptions {
+	return {
+		token: "secret-token",
+		// Auth runs before registry/dispatcher are touched, so the cheapest
+		// stubs that prove "auth passed" are enough: an unregistered channel
+		// surfaces as 400, distinct from the 401 auth failure.
+		channelRegistry: { get: () => undefined } as unknown as ChannelRegistry,
+		dispatcher: { handle: async () => {} } as unknown as PersonalChannelDispatcher,
+	};
+}
+
+const VALID_BODY = { channel: "qq", messageId: "m1", text: "hi" };
+
+describe("handleBridgeMessage auth", () => {
+	it("rejects a missing Authorization header", () => {
+		expect(handleBridgeMessage(makeOpts(), undefined, VALID_BODY).status).toBe(401);
+	});
+
+	it("rejects a wrong token", () => {
+		expect(handleBridgeMessage(makeOpts(), "Bearer wrong-token", VALID_BODY).status).toBe(401);
+	});
+
+	it("rejects prefix and extended near-miss tokens", () => {
+		expect(handleBridgeMessage(makeOpts(), "Bearer secret-toke", VALID_BODY).status).toBe(401);
+		expect(handleBridgeMessage(makeOpts(), "Bearer secret-tokenX", VALID_BODY).status).toBe(401);
+	});
+
+	it("rejects a non-Bearer scheme", () => {
+		expect(handleBridgeMessage(makeOpts(), "secret-token", VALID_BODY).status).toBe(401);
+	});
+
+	it("accepts the exact token (falls through to channel validation)", () => {
+		const result = handleBridgeMessage(makeOpts(), "Bearer secret-token", VALID_BODY);
+		// 400 "not registered" proves the request passed authentication.
+		expect(result.status).toBe(400);
+		expect(result.body.error).toContain("not registered");
+	});
+});

--- a/apps/inno-agent/src/channels/bridge/bridge-server.ts
+++ b/apps/inno-agent/src/channels/bridge/bridge-server.ts
@@ -2,6 +2,7 @@ import type { BridgeMessageBody, BridgeMessageResponse } from "./types.js";
 import type { IncomingMessage, ChannelName } from "../types.js";
 import type { PersonalChannelDispatcher } from "../personal-dispatcher.js";
 import type { ChannelRegistry } from "../channel.js";
+import { timingSafeEqual } from "node:crypto";
 import { logger } from "../../logger.js";
 
 const VALID_BRIDGE_CHANNELS = new Set<string>(["qq", "wechat"]);
@@ -12,12 +13,20 @@ export interface BridgeServerOptions {
 	dispatcher: PersonalChannelDispatcher;
 }
 
+/** Constant-time bearer-token check (the token guards message injection). */
+function bearerTokenMatches(authHeader: string | undefined, token: string): boolean {
+	if (!authHeader) return false;
+	const expected = Buffer.from(`Bearer ${token}`, "utf-8");
+	const actual = Buffer.from(authHeader, "utf-8");
+	return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
 export function handleBridgeMessage(
 	opts: BridgeServerOptions,
 	authHeader: string | undefined,
 	body: unknown,
 ): { status: number; body: BridgeMessageResponse } {
-	if (!authHeader || authHeader !== `Bearer ${opts.token}`) {
+	if (!bearerTokenMatches(authHeader, opts.token)) {
 		return { status: 401, body: { ok: false, error: "Unauthorized" } };
 	}
 

--- a/apps/inno-agent/src/channels/wechat/ilink-client.ts
+++ b/apps/inno-agent/src/channels/wechat/ilink-client.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { chmodSync, readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { randomBytes } from "node:crypto";
 import { logger } from "../../logger.js";
@@ -95,7 +95,13 @@ export class ILinkClient {
 			updates_buf: this.updatesBuf,
 			...extra,
 		};
-		writeFileSync(this.tokenFilePath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+		// 0o600: this file carries the live bot token.
+		writeFileSync(this.tokenFilePath, JSON.stringify(data, null, 2) + "\n", { encoding: "utf-8", mode: 0o600 });
+		try {
+			chmodSync(this.tokenFilePath, 0o600);
+		} catch {
+			// permissions are best-effort (Windows)
+		}
 	}
 
 	private buildHeaders(): Record<string, string> {

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "node:fs";
+import { chmodSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { RuntimePaths } from "./runtime.js";
 import { DEFAULT_SCHEDULER_TIMEZONE } from "./scheduler/cron-utils.js";
@@ -388,6 +388,14 @@ export function loadConfig(configPathOrDir: string): InnoConfig {
 		: join(configPathOrDir, "config.json");
 	try {
 		const raw = readFileSync(configPath, "utf-8");
+		// Best-effort permission fix-up for configs written before saveConfig
+		// started enforcing 0o600 — a config that is never re-saved would
+		// otherwise stay world-readable forever.
+		try {
+			chmodSync(configPath, 0o600);
+		} catch {
+			// read-only FS / Windows — permissions are best-effort
+		}
 		return normalizeConfig(JSON.parse(raw) as LegacyInnoConfig);
 	} catch (error) {
 		throw new Error(
@@ -403,7 +411,8 @@ export function saveConfig(configPathOrDir: string, config: InnoConfig): InnoCon
 	const normalized = normalizeConfig(config);
 	// Atomic write (tmp + rename): a crash mid-write must not leave a truncated
 	// config.json — the server hot-rewrites this file on every model switch.
-	writeJson(configPath, normalized);
+	// 0o600: the file carries plaintext provider API keys and the bridge token.
+	writeJson(configPath, normalized, { mode: 0o600 });
 	return normalized;
 }
 

--- a/apps/inno-agent/src/mcp/mcp-config-store.ts
+++ b/apps/inno-agent/src/mcp/mcp-config-store.ts
@@ -17,7 +17,7 @@
  *   6. <workspaceDir>/.pi/mcp.json   (project Pi override, highest)
  * Later sources override earlier ones by server name.
  */
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import type { RuntimePaths } from "../runtime.js";
@@ -150,8 +150,14 @@ export function writeManagedMcpConfig(paths: RuntimePaths, config: McpConfigFile
 	const configPath = getManagedMcpConfigPath(paths);
 	mkdirSync(dirname(configPath), { recursive: true });
 	const tmp = `${configPath}.tmp-${process.pid}`;
-	writeFileSync(tmp, `${JSON.stringify(config, null, 2)}\n`, "utf-8");
+	// 0o600: server entries commonly carry API keys / bearer tokens in env.
+	writeFileSync(tmp, `${JSON.stringify(config, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
 	renameSync(tmp, configPath);
+	try {
+		chmodSync(configPath, 0o600);
+	} catch {
+		// permissions are best-effort (Windows)
+	}
 }
 
 const SERVER_NAME_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;

--- a/apps/inno-agent/src/storage/file-store.test.ts
+++ b/apps/inno-agent/src/storage/file-store.test.ts
@@ -1,8 +1,8 @@
-import { mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { appendJsonl, readJsonl, readJsonlTail } from "./file-store.js";
+import { appendJsonl, readJson, readJsonl, readJsonlTail, writeJson } from "./file-store.js";
 
 let dir: string;
 
@@ -79,5 +79,26 @@ describe("readJsonlTail", () => {
 		const file = join(dir, "mixed.jsonl");
 		writeFileSync(file, '{"n":1}\nnot json\n{"n":2}\n', "utf-8");
 		expect(readJsonlTail<{ n: number }>(file, 1024).map((r) => r.n)).toEqual([1, 2]);
+	});
+});
+
+describe("writeJson mode option", () => {
+	it.skipIf(process.platform === "win32")("writes secret files with 0o600 and fixes pre-existing 0644 files", () => {
+		const file = join(dir, "secret.json");
+
+		writeJson(file, { key: "v1" }, { mode: 0o600 });
+		expect(statSync(file).mode & 0o777).toBe(0o600);
+
+		// Simulate a file written before the mode option existed.
+		writeFileSync(file, "{}", "utf-8");
+		chmodSync(file, 0o644);
+		writeJson(file, { key: "v2" }, { mode: 0o600 });
+		expect(statSync(file).mode & 0o777).toBe(0o600);
+	});
+
+	it("leaves permissions alone when no mode is given", () => {
+		const file = join(dir, "plain.json");
+		writeJson(file, { a: 1 });
+		expect(readJson(file, null)).toEqual({ a: 1 });
 	});
 });

--- a/apps/inno-agent/src/storage/file-store.ts
+++ b/apps/inno-agent/src/storage/file-store.ts
@@ -1,4 +1,4 @@
-import { closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, renameSync, statSync, writeFileSync, appendFileSync } from "node:fs";
+import { chmodSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync, renameSync, statSync, writeFileSync, appendFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { logger } from "../logger.js";
 
@@ -27,12 +27,25 @@ export function readJson<T>(filePath: string, defaultValue: T): T {
 
 /**
  * Write a JSON file atomically (write to .tmp then rename).
+ *
+ * `options.mode` (e.g. 0o600 for files containing secrets) is applied to the
+ * final file — including pre-existing files left over from before the option
+ * was introduced, whose permissions are corrected in place.
  */
-export function writeJson<T>(filePath: string, data: T): void {
+export function writeJson<T>(filePath: string, data: T, options?: { mode?: number }): void {
 	ensureDir(dirname(filePath));
 	const tmp = filePath + ".tmp";
-	writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n", "utf-8");
+	writeFileSync(tmp, JSON.stringify(data, null, 2) + "\n", { encoding: "utf-8", ...(options?.mode !== undefined ? { mode: options.mode } : {}) });
 	renameSync(tmp, filePath);
+	if (options?.mode !== undefined) {
+		// rename only helps if the tmp file got the right mode at creation;
+		// chmod unconditionally so old 0644 files are fixed on next write too.
+		try {
+			chmodSync(filePath, options.mode);
+		} catch (err) {
+			logger.warn({ err, filePath }, "failed to chmod file");
+		}
+	}
 }
 
 /**

--- a/apps/inno-agent/src/utils/fetch-logger.test.ts
+++ b/apps/inno-agent/src/utils/fetch-logger.test.ts
@@ -1,0 +1,100 @@
+import { createServer, type Server } from "node:http";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AddressInfo } from "node:net";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Privacy tests for the LLM fetch logger (issue #162): by default, request
+ * and response bodies must NOT be written to the log file — only metadata.
+ * LOG_LLM_BODY=1 opts back into (truncated) body logging.
+ *
+ * The logger resolves its log directory lazily from INNO_DATA_DIR on each
+ * write, so pointing that env var at a tmp dir captures this file's output.
+ * installFetchLogger wraps globalThis.fetch for the whole test process, so
+ * every fetch below goes through the wrapper.
+ */
+
+const SECRET_MARKER = "sk-super-secret-prompt-content";
+
+let dataDir: string;
+let server: Server;
+let baseUrl: string;
+
+function readLog(): string {
+	const logDir = join(dataDir, "log");
+	if (!existsSync(logDir)) return "";
+	return readdirSync(logDir)
+		.filter((f) => f.startsWith("server-"))
+		.map((f) => readFileSync(join(logDir, f), "utf-8"))
+		.join("");
+}
+
+async function waitForLog(predicate: (log: string) => boolean): Promise<string> {
+	const deadline = Date.now() + 5_000;
+	while (Date.now() < deadline) {
+		const log = readLog();
+		if (predicate(log)) return log;
+		await new Promise((r) => setTimeout(r, 50));
+	}
+	return readLog();
+}
+
+beforeAll(async () => {
+	dataDir = mkdtempSync(join(tmpdir(), "inno-fetchlog-"));
+	process.env.INNO_DATA_DIR = dataDir;
+	delete process.env.LOG_LLM_BODY;
+
+	server = createServer((req, res) => {
+		req.resume();
+		req.on("end", () => {
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end(JSON.stringify({ ok: true, echo: SECRET_MARKER }));
+		});
+	});
+	await new Promise<void>((resolveListen) => server.listen(0, "127.0.0.1", resolveListen));
+	baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+	const { installFetchLogger } = await import("./fetch-logger.js");
+	installFetchLogger();
+});
+
+afterAll(async () => {
+	await new Promise<void>((resolveClose) => server.close(() => resolveClose()));
+	rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe("fetch logger privacy", () => {
+	it("logs metadata only by default — no request/response bodies", async () => {
+		await fetch(`${baseUrl}/v1/chat/completions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({ messages: [{ role: "user", content: SECRET_MARKER }] }),
+		});
+
+		const log = await waitForLog((l) => l.includes("RESP"));
+		expect(log).toContain("REQ →");
+		expect(log).toContain("RESP ← 200");
+		expect(log).not.toContain(SECRET_MARKER);
+		// Quoted field names — requestBodyBytes/responseBodyBytes are allowed.
+		expect(log).not.toContain('"requestBody"');
+		expect(log).not.toContain('"responseBody"');
+	});
+
+	it("logs truncated bodies when LOG_LLM_BODY=1", async () => {
+		process.env.LOG_LLM_BODY = "1";
+		try {
+			await fetch(`${baseUrl}/v1/chat/completions`, {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({ messages: [{ role: "user", content: SECRET_MARKER }] }),
+			});
+
+			const log = await waitForLog((l) => (l.match(/RESP ←/g) ?? []).length >= 2);
+			expect(log).toContain(SECRET_MARKER);
+		} finally {
+			delete process.env.LOG_LLM_BODY;
+		}
+	});
+});

--- a/apps/inno-agent/src/utils/fetch-logger.ts
+++ b/apps/inno-agent/src/utils/fetch-logger.ts
@@ -3,12 +3,17 @@
  *
  * Installed once at startup via {@link installFetchLogger}. It wraps
  * `globalThis.fetch` so that any SDK (OpenAI, Anthropic, etc.) that uses
- * `fetch` under the hood will have its request URL and body logged through
+ * `fetch` under the hood will have its request URL and timing logged through
  * the shared Pino logger.
  *
  * Every LLM request gets a unique {@code seq/timestamp} identifier so that
  * request and response log lines can be correlated even when concurrent
  * calls produce interleaved output.
+ *
+ * Privacy: by default only metadata (URL, status, elapsed time, body sizes)
+ * is logged. Request/response bodies — which contain the system prompt,
+ * learner profile, user messages and model output — are only logged when
+ * LOG_LLM_BODY=1 is set explicitly.
  */
 
 import { logger } from "../logger.js";
@@ -25,6 +30,18 @@ const MAX_BODY_LENGTH = 8000;
 
 /** Maximum characters of the response body to log. */
 const MAX_RESPONSE_BODY_LENGTH = 4000;
+
+/**
+ * Body logging is opt-in: request bodies contain the system prompt, learner
+ * profile, user messages and uploaded document contents, and response bodies
+ * contain model output — all of it private learning data that should not sit
+ * in `log/server-*.log` by default. Set LOG_LLM_BODY=1 (or "true") to include
+ * truncated bodies when actively debugging a provider issue. Read dynamically
+ * so the toggle works without a restart (and stays testable).
+ */
+function shouldLogBodies(): boolean {
+	return /^(1|true|yes)$/i.test(process.env.LOG_LLM_BODY ?? "");
+}
 
 type FetchFn = typeof globalThis.fetch;
 
@@ -57,14 +74,16 @@ export function installFetchLogger(): void {
     const startTime = isLlmCall ? Date.now() : 0;
 
     if (isLlmCall) {
-      let bodyStr = extractBodyString(init?.body);
-      if (bodyStr.length > MAX_BODY_LENGTH) {
-        bodyStr = bodyStr.slice(0, MAX_BODY_LENGTH) + "...[truncated]";
+      const bodyStr = extractBodyString(init?.body);
+      // Default: metadata only (see shouldLogBodies). bodyBytes keeps size
+      // observability without persisting the content itself.
+      const fields: Record<string, unknown> = { reqId, url, requestBodyBytes: bodyStr.length };
+      if (shouldLogBodies()) {
+        fields.requestBody = bodyStr.length > MAX_BODY_LENGTH
+          ? bodyStr.slice(0, MAX_BODY_LENGTH) + "...[truncated]"
+          : bodyStr;
       }
-      logger.info(
-        { reqId, url, requestBody: bodyStr },
-        `[LLM ${reqId}] REQ → POST ${url}`,
-      );
+      logger.info(fields, `[LLM ${reqId}] REQ → POST ${url}`);
     }
 
     let response: Awaited<ReturnType<FetchFn>>;
@@ -159,24 +178,37 @@ async function logResponse(
   const status = response.status;
   let bodyStr = "";
 
-  try {
-    // Clone so we can read the body without consuming it for the caller.
-    const cloned = response.clone();
-    bodyStr = await cloned.text();
-  } catch {
-    bodyStr = "[unable to read response body]";
-  }
+  if (shouldLogBodies()) {
+    try {
+      // Clone so we can read the body without consuming it for the caller.
+      const cloned = response.clone();
+      bodyStr = await cloned.text();
+    } catch {
+      bodyStr = "[unable to read response body]";
+    }
 
-  if (bodyStr.length > MAX_RESPONSE_BODY_LENGTH) {
-    bodyStr = bodyStr.slice(0, MAX_RESPONSE_BODY_LENGTH) + "...[truncated]";
+    if (bodyStr.length > MAX_RESPONSE_BODY_LENGTH) {
+      bodyStr = bodyStr.slice(0, MAX_RESPONSE_BODY_LENGTH) + "...[truncated]";
+    }
+  } else {
+    // Content-Length keeps response-size observability without reading
+    // (and persisting) the body itself.
+    bodyStr = "";
   }
 
   const level = status >= 400 ? "warn" : "info";
   const elapsed = elapsedMs >= 1000
     ? `${(elapsedMs / 1000).toFixed(1)}s`
     : `${elapsedMs}ms`;
+  const fields: Record<string, unknown> = { reqId, url, status, elapsedMs };
+  if (shouldLogBodies()) {
+    fields.responseBody = bodyStr;
+  } else {
+    const contentLength = response.headers.get("content-length");
+    if (contentLength) fields.responseBodyBytes = Number.parseInt(contentLength, 10);
+  }
   logger[level](
-    { reqId, url, status, elapsedMs, responseBody: bodyStr },
+    fields,
     `[LLM ${reqId}] RESP ← ${status} (${elapsed})`,
   );
 }

--- a/electron/main.js
+++ b/electron/main.js
@@ -54,7 +54,7 @@ function ensureConfig() {
     subagents: { enabled: false },
     ui: { theme: "light", closeBehavior: "ask" },
   };
-  writeFileSync(configPath, JSON.stringify(defaults, null, 2) + "\n");
+  writeFileSync(configPath, JSON.stringify(defaults, null, 2) + "\n", { mode: 0o600 });
 }
 
 // ── 全局状态 ──────────────────────────────────────────────────────────────────
@@ -233,7 +233,16 @@ function openMainWindow() {
   });
   mainWindow.on("closed", () => { mainWindow = null; });
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    // Only http(s) may leave the app — file://, smb:// and custom schemes
+    // handed to shell.openExternal can trigger OS-level handlers (issue #162).
+    try {
+      const protocol = new URL(url).protocol;
+      if (protocol === "https:" || protocol === "http:") {
+        shell.openExternal(url);
+      }
+    } catch {
+      // unparseable URL — deny
+    }
     return { action: "deny" };
   });
 }


### PR DESCRIPTION
## 背景

#162 清单的 PR-3 批次（第 3、5、6、7 项），四个独立小改合并。

## 改动

### 1. 密钥文件 0600（第 3 项）

- `writeJson` 新增 `mode` 选项，rename 后无条件 `chmodSync`——覆盖老版本写下的 0644 存量文件。
- 落点：`config.json`(`saveConfig`，含明文 provider key + bridge token)、`wechat-token.json`(iLink bot token)、`mcp.json`(env 里常带 API key，顺手纳入）、Electron 首启默认配置。
- `loadConfig` 读取时 best-effort chmod——从不触发保存的老配置也能被修正。

### 2. fetch-logger 脱敏（第 5 项）

- 默认只记 metadata:url、status、elapsedMs、`requestBodyBytes`/`responseBodyBytes`。
- body（含 system prompt、学习者画像、用户消息、模型输出）改为 `LOG_LLM_BODY=1` 显式开启，截断逻辑保留；开关动态读取，无需重启。
- `.env.example` 与 CLAUDE.md 对应描述已同步。

### 3. Electron openExternal scheme 白名单（第 6 项）

`setWindowOpenHandler` 只放行 `https?:`,`file://`/`smb://`/自定义 scheme 一律 deny。

### 4. bridge token 常量时间比较（第 7 项）

`bridge-server.ts` 改为 `crypto.timingSafeEqual`（先比长度），前缀/扩展近似 token 一律 401。

## 测试

- `file-store.test.ts` +2:0600 落盘 + 存量 0644 修正（win32 skip)。
- 新 `bridge-server.test.ts` ×5：缺 header / 错 token / 前缀 / 超长 / 非 Bearer 全 401，精确 token 穿透到 channel 校验。
- 新 `fetch-logger.test.ts` ×2：真实起本地 HTTP server + 包装后的 fetch，断言默认日志**不含** marker 与 body 字段，开 flag 后**含**。

全套 **32 文件 / 254 测试**通过，`npm run build` 通过。

## 未覆盖

#162 仅剩第 8 项（Origin/Host 校验），按分析随 #159 的 token 方案一并落地。