### PR TITLE
feat: loopback 默认绑定 + 可选 API token + Origin 校验 (#159)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ INNO_DATA_DIR=./runtime/data
 INNO_SKILLS_DIR=./runtime/skills
 INNO_WORKSPACE_DIR=./workspace
 INNO_PORT=3000
+# Bind address — default 127.0.0.1 (loopback only). Set 0.0.0.0 for
+# LAN/remote access, and configure server.token in config.json in that case.
+# INNO_HOST=127.0.0.1
 
 # Log verbosity for the file logger (default: info)
 # LOG_LEVEL=info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~32 files (254 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~33 files (263 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 
@@ -158,6 +158,7 @@ Precedence: CLI flag → env var → `~/.inno-agent/...`.
 | `--skills` / `--skills-dir` | `INNO_SKILLS_DIR` | `<home>/skills` |
 | `--workspace` / `--workspace-dir` | `INNO_WORKSPACE_DIR` | invocation CWD |
 | `--port` | `INNO_PORT` (via config) | `3000` |
+| `--host` | `INNO_HOST` | `127.0.0.1` |
 
 Derived paths inside `dataDir`: `learner/`, `sessions/`, `jobs/`, `l2/`, `l3/`, `channels/`, `preset-cache/`. `applyRuntimeEnvironment` re-exports the resolved paths back into `process.env` plus `PI_CODING_AGENT_SESSION_DIR` so PI SDK code picks them up. It also sets `PI_CODING_AGENT_DIR` to `configDir` so pi-sandbox reads `sandbox.json` from the config directory.
 
@@ -252,7 +253,7 @@ Three layers, all file-backed under `dataDir`:
 
 ### HTTP server (`src/server.ts`)
 
-Plain Node `http.createServer` (no framework), ~1600 lines plus route domains extracted under `src/server/routes/` (chat, wiki, workspaces, skills, channels, jobs, sessions, settings, learner, practice, presets). Key endpoints:
+Plain Node `http.createServer` (no framework), ~1800 lines plus route domains extracted under `src/server/routes/` (chat, wiki, workspaces, skills, channels, jobs, sessions, settings, learner, practice, presets). Binds to `127.0.0.1` by default (`--host` / `INNO_HOST` / `server.host` to change; Docker sets `INNO_HOST=0.0.0.0`). Two request gates apply to all `/api/*` and the terminal WS upgrade: (1) when present, the `Origin` header's host must match the request `Host` (CSRF / DNS-rebinding defense); (2) when `server.token` is set, a Bearer token (or `?token=` query, stripped before routing) is required — `/health` and `/api/bridge/messages` (own bridge token) are exempt, and the served index.html gets the token injected as `window.__INNO_API_TOKEN__` for the web UI. Both host and token are peeked from config.json at startup (restart-only). Key endpoints:
 - `POST /api/chat/stream` — SSE streaming chat.
 - `POST /api/chat` — non-streaming chat (full response).
 - `GET /api/chat/events/:id` — SSE event replay for reconnecting to an in-progress chat stream after page navigation (backed by `SessionEventBroadcaster`, an in-memory buffer).
@@ -371,7 +372,7 @@ Separate Dockerfile for building the custom base image. Based on `node:22-bookwo
 
 ### User-facing config (`<configDir>/config.json`)
 
-Template: `config.example.json` at repo root. Declares `defaultProvider`, `defaultModel`, a `providers` map (each with `baseUrl`, `api` ∈ {`openai-completions`, `anthropic-messages`}, `apiKey`, `models[]`), optional `server.port`, optional `channels.*` blocks, optional `bridge.token`, optional `subagents.enabled`, optional `contentHub`, `memory`, `simpleMode`, and `ui` sections. The server hot-rewrites this file when the user switches model via the UI.
+Template: `config.example.json` at repo root. Declares `defaultProvider`, `defaultModel`, a `providers` map (each with `baseUrl`, `api` ∈ {`openai-completions`, `anthropic-messages`}, `apiKey`, `models[]`), optional `server.port` / `server.host` (loopback default) / `server.token` (optional API Bearer auth), optional `channels.*` blocks, optional `bridge.token`, optional `subagents.enabled`, optional `contentHub`, `memory`, `simpleMode`, and `ui` sections. The server hot-rewrites this file when the user switches model via the UI.
 
 Model config supports `reasoning` (boolean), `input` (modality array, e.g. `["text", "image"]`), `contextWindow`, and `maxTokens` per model entry. Provider config supports `authHeader` (boolean) and `bypassProxy` (boolean) fields.
 
@@ -381,7 +382,7 @@ Full config.json structure (see `config.example.json`):
   "defaultProvider": "innospark",
   "defaultModel": "claude-sonnet-4-6",
   "providers": { /* ... */ },
-  "server": { "port": 3000 },
+  "server": { "port": 3000, "host": "127.0.0.1", "token": "" },
   "channels": {
     "feishu": { "enabled": false, "personalOnly": true, "allowedUserIds": [] },
     "wechat": { "enabled": false, "mode": "bridge", "allowedUserIds": [], "sidecarBaseUrl": "http://127.0.0.1:4319" }

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,8 @@ ENV NODE_ENV=production \
     INNO_DATA_DIR=/var/lib/inno-agent/data \
     INNO_SKILLS_DIR=/var/lib/inno-agent/skills \
     INNO_WORKSPACE_DIR=/srv/inno-workspace \
-    INNO_PORT=3000
+    INNO_PORT=3000 \
+    INNO_HOST=0.0.0.0
 
 # Copy the FULL node_modules from build stage (no pruning).
 # npm prune --production is unreliable with workspaces: it can drop

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ General-purpose coding agents optimize for open-ended software engineering. Educ
 Inno Agent is a **personal** agent, and the architecture deliberately reflects that:
 
 - **One process, one active agent session.** A single in-memory prompt queue serializes all work; sessions, workspaces, and channels share it. Session switching swaps session files in place — there is no per-session agent pool.
-- **No multi-user concurrency, no horizontal scaling.** There is no auth model, no tenant isolation, and no sharded state. If you need a team deployment, run one instance per person.
+- **No multi-user concurrency, no horizontal scaling.** There is no auth model, no tenant isolation, and no sharded state. If you need a team deployment, run one instance per person. The HTTP server binds to `127.0.0.1` by default to match this threat model; if you deliberately expose it (`server.host` / `INNO_HOST`), set `server.token` too.
 - **Backpressure is a feature, not a bug.** When the queue is busy (e.g. another session's long turn or an unanswered question card), cross-session operations answer `409 session_busy` with blocker details instead of silently queueing for minutes — the UI surfaces this so you can finish or abort the blocking turn. See [issue #124](https://github.com/hhyqhh/inno-agent/issues/124) for the design discussion.
 
 These constraints keep the memory layers, scheduler, and channels simple enough to reason about — which matters more for a tool that watches how you learn than for one that serves a crowd.

--- a/apps/inno-agent/src/channels/bridge/bridge-server.ts
+++ b/apps/inno-agent/src/channels/bridge/bridge-server.ts
@@ -2,7 +2,7 @@ import type { BridgeMessageBody, BridgeMessageResponse } from "./types.js";
 import type { IncomingMessage, ChannelName } from "../types.js";
 import type { PersonalChannelDispatcher } from "../personal-dispatcher.js";
 import type { ChannelRegistry } from "../channel.js";
-import { timingSafeEqual } from "node:crypto";
+import { bearerTokenMatches } from "../../server/http-helpers.js";
 import { logger } from "../../logger.js";
 
 const VALID_BRIDGE_CHANNELS = new Set<string>(["qq", "wechat"]);
@@ -11,14 +11,6 @@ export interface BridgeServerOptions {
 	token: string;
 	channelRegistry: ChannelRegistry;
 	dispatcher: PersonalChannelDispatcher;
-}
-
-/** Constant-time bearer-token check (the token guards message injection). */
-function bearerTokenMatches(authHeader: string | undefined, token: string): boolean {
-	if (!authHeader) return false;
-	const expected = Buffer.from(`Bearer ${token}`, "utf-8");
-	const actual = Buffer.from(authHeader, "utf-8");
-	return actual.length === expected.length && timingSafeEqual(actual, expected);
 }
 
 export function handleBridgeMessage(

--- a/apps/inno-agent/src/config.ts
+++ b/apps/inno-agent/src/config.ts
@@ -160,6 +160,20 @@ export interface InnoConfig {
 	providers: Record<string, InnoProviderConfig>;
 	server?: {
 		port: number;
+		/**
+		 * Bind address. Defaults to 127.0.0.1 (loopback only) — the
+		 * single-user threat model does not include LAN attackers. Set
+		 * "0.0.0.0" explicitly (and pair it with `token`) for remote access.
+		 * Overridden by the --host flag / INNO_HOST env var.
+		 */
+		host?: string;
+		/**
+		 * Optional Bearer token. When set, every /api/* request and terminal
+		 * WebSocket upgrade must carry it (Authorization header or ?token=
+		 * query). The web UI receives it via an injected <script> in the
+		 * served index.html. Changes require a restart.
+		 */
+		token?: string;
 	};
 	feishu?: {
 		appId: string;
@@ -498,6 +512,28 @@ export function getConfiguredPort(config: InnoConfig, override?: number): number
 	const envPort = process.env.INNO_PORT ? Number.parseInt(process.env.INNO_PORT, 10) : undefined;
 	if (envPort && Number.isFinite(envPort)) return envPort;
 	return config.server?.port ?? 3000;
+}
+
+export const DEFAULT_SERVER_HOST = "127.0.0.1";
+
+/**
+ * Read server.host/server.token straight from the config file, without the
+ * full normalize/validate pipeline. server.ts needs these before (and
+ * independently of) the lazy bootstrap: host is required at listen() time
+ * and token must be known to inject into the served index.html even when no
+ * API call has triggered bootstrap yet. Both are restart-only settings.
+ */
+export function peekServerSecurity(configPath: string): { host?: string; token?: string } {
+	try {
+		const raw = JSON.parse(readFileSync(configPath, "utf-8")) as {
+			server?: { host?: unknown; token?: unknown };
+		};
+		const host = typeof raw.server?.host === "string" && raw.server.host.trim() ? raw.server.host.trim() : undefined;
+		const token = typeof raw.server?.token === "string" && raw.server.token ? raw.server.token : undefined;
+		return { host, token };
+	} catch {
+		return {};
+	}
 }
 
 /**

--- a/apps/inno-agent/src/runtime.ts
+++ b/apps/inno-agent/src/runtime.ts
@@ -24,6 +24,7 @@ export interface RuntimeCliOptions {
 	configDir?: string;
 	dataDir?: string;
 	home?: string;
+	host?: string;
 	port?: number;
 	sandbox?: boolean;
 	skillsDir?: string;
@@ -85,6 +86,8 @@ export function parseRuntimeArgs(args: string[]): ParsedRuntimeArgs {
 			options.dataDir = readValue(arg.startsWith("--data-dir") ? "--data-dir" : "--data");
 		} else if (arg === "--home" || arg.startsWith("--home=")) {
 			options.home = readValue("--home");
+		} else if (arg === "--host" || arg.startsWith("--host=")) {
+			options.host = readValue("--host");
 		} else if (arg === "--skills" || arg === "--skills-dir" || arg.startsWith("--skills=") || arg.startsWith("--skills-dir=")) {
 			options.skillsDir = readValue(arg.startsWith("--skills-dir") ? "--skills-dir" : "--skills");
 		} else if (arg === "--workspace" || arg === "--workspace-dir" || arg.startsWith("--workspace=") || arg.startsWith("--workspace-dir=")) {

--- a/apps/inno-agent/src/server-auth.smoke.test.ts
+++ b/apps/inno-agent/src/server-auth.smoke.test.ts
@@ -1,0 +1,206 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, Socket, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+/**
+ * Smoke tests for the optional server.token API auth (issue #159). Same
+ * spawn-a-real-server approach as server.smoke.test.ts, but with a config
+ * that sets server.host + server.token.
+ */
+
+const SERVER_ENTRY = resolve(import.meta.dirname, "server.ts");
+const REPO_ROOT = resolve(import.meta.dirname, "../../..");
+const SERVER_TOKEN = "test-server-token-abc123";
+
+let home: string;
+let workspace: string;
+let port: number;
+let child: ChildProcess;
+let childLog = "";
+let createdStubDist = false;
+
+async function getFreePort(): Promise<number> {
+	return new Promise((resolvePort, reject) => {
+		const srv = createServer();
+		srv.listen(0, "127.0.0.1", () => {
+			const freePort = (srv.address() as AddressInfo).port;
+			srv.close(() => resolvePort(freePort));
+		});
+		srv.on("error", reject);
+	});
+}
+
+function api(path: string, init?: RequestInit): Promise<Response> {
+	return fetch(`http://127.0.0.1:${port}${path}`, init);
+}
+
+function authed(path: string, init?: RequestInit): Promise<Response> {
+	return api(path, {
+		...init,
+		headers: { Authorization: `Bearer ${SERVER_TOKEN}`, ...init?.headers },
+	});
+}
+
+/** Raw HTTP upgrade request; resolves with the first response bytes ("" when the socket closes silently). */
+function rawUpgrade(path: string): Promise<string> {
+	return new Promise((resolveReq, rejectReq) => {
+		const socket = new Socket();
+		let data = "";
+		socket.connect(port, "127.0.0.1", () => {
+			socket.write(
+				`GET ${path} HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+			);
+		});
+		socket.on("data", (chunk) => {
+			data += chunk.toString();
+			socket.destroy();
+			resolveReq(data);
+		});
+		socket.on("close", () => resolveReq(data));
+		socket.on("error", rejectReq);
+		setTimeout(() => { socket.destroy(); resolveReq(data); }, 5_000);
+	});
+}
+
+beforeAll(async () => {
+	home = mkdtempSync(join(tmpdir(), "inno-auth-home-"));
+	workspace = mkdtempSync(join(tmpdir(), "inno-auth-ws-"));
+	mkdirSync(join(home, "config"), { recursive: true });
+	writeFileSync(
+		join(home, "config", "config.json"),
+		JSON.stringify({
+			defaultProvider: "dummy",
+			defaultModel: "dummy-model",
+			providers: {
+				dummy: {
+					baseUrl: "http://127.0.0.1:9",
+					apiKey: "sk-dummy",
+					api: "openai-completions",
+					models: [{ id: "dummy-model" }],
+				},
+			},
+			server: { port: 3000, host: "127.0.0.1", token: SERVER_TOKEN },
+		}),
+		"utf-8",
+	);
+
+	port = await getFreePort();
+
+	// CI runs tests before the frontend build, so web/dist may not exist.
+	// The index.html injection test needs one — stub it (and clean up only
+	// what we created).
+	const distDir = resolve(REPO_ROOT, "apps/inno-agent/web/dist");
+	if (!existsSync(join(distDir, "index.html"))) {
+		mkdirSync(distDir, { recursive: true });
+		writeFileSync(join(distDir, "index.html"), "<html><head><title>t</title></head><body></body></html>", "utf-8");
+		createdStubDist = true;
+	}
+
+	child = spawn(
+		process.execPath,
+		["--import", "tsx", SERVER_ENTRY, "--home", home, "--workspace", workspace, "--port", String(port)],
+		{ cwd: REPO_ROOT, stdio: ["ignore", "pipe", "pipe"] },
+	);
+	child.stdout?.on("data", (chunk) => (childLog += chunk));
+	child.stderr?.on("data", (chunk) => (childLog += chunk));
+
+	const deadline = Date.now() + 90_000;
+	let ready = false;
+	let exitCode: number | null = null;
+	child.on("exit", (code) => { exitCode = code; });
+	while (Date.now() < deadline) {
+		if (exitCode !== null) {
+			throw new Error(`server exited early with code ${exitCode}\n--- child log ---\n${childLog}`);
+		}
+		try {
+			const res = await api("/health");
+			if (res.status === 200) { ready = true; break; }
+		} catch {
+			// connection refused while starting
+		}
+		await new Promise((r) => setTimeout(r, 250));
+	}
+	if (!ready) {
+		throw new Error(`server did not become ready within 90s\n--- child log ---\n${childLog}`);
+	}
+}, 120_000);
+
+afterAll(async () => {
+	if (child && !child.killed) {
+		child.kill("SIGTERM");
+		await new Promise<void>((resolveDone) => {
+			const force = setTimeout(() => { child.kill("SIGKILL"); resolveDone(); }, 5_000);
+			child.on("exit", () => { clearTimeout(force); resolveDone(); });
+		});
+	}
+	rmSync(home, { recursive: true, force: true });
+	rmSync(workspace, { recursive: true, force: true });
+	if (createdStubDist) {
+		rmSync(resolve(REPO_ROOT, "apps/inno-agent/web/dist"), { recursive: true, force: true });
+	}
+}, 30_000);
+
+describe("server.token auth", () => {
+	it("GET /health stays open (Electron loading screen polls it)", async () => {
+		const res = await api("/health");
+		expect(res.status).toBe(200);
+	});
+
+	it("/api/* without a token returns 401", async () => {
+		expect((await api("/api/settings")).status).toBe(401);
+		expect((await api("/api/settings", { headers: { Authorization: "Bearer wrong" } })).status).toBe(401);
+	});
+
+	it("/api/* accepts the Bearer token and the ?token= query form", async () => {
+		expect((await authed("/api/settings")).status).toBe(200);
+		expect((await api(`/api/settings?token=${encodeURIComponent(SERVER_TOKEN)}`)).status).toBe(200);
+	}, 60_000 /* first authed call triggers lazy bootstrap */);
+
+	it("index.html carries the injected token for the web UI", async () => {
+		const res = await api("/");
+		expect(res.status).toBe(200);
+		const html = await res.text();
+		expect(html).toContain("window.__INNO_API_TOKEN__");
+		expect(html).toContain(SERVER_TOKEN);
+	});
+
+	it("/api/bridge/messages is not gated by the server token (it has its own)", async () => {
+		const res = await api("/api/bridge/messages", {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({}),
+		});
+		// 404 (no bridge configured) — not 401.
+		expect(res.status).toBe(404);
+	});
+
+	it("terminal WS upgrade without a token gets an HTTP 401; with a token it passes auth", async () => {
+		const denied = await rawUpgrade("/api/terminal/sessions/x/ws");
+		expect(denied).toContain("401");
+
+		// Auth passes here; the upgrade then fails downstream (no such
+		// terminal session) — the point is that it is NOT a 401.
+		const allowed = await rawUpgrade(`/api/terminal/sessions/x/ws?token=${encodeURIComponent(SERVER_TOKEN)}`);
+		expect(allowed).not.toContain("401");
+	});
+
+	it("WS upgrade with a mismatched Origin gets an HTTP 403", async () => {
+		const socket = new Socket();
+		const data = await new Promise<string>((resolveReq, rejectReq) => {
+			let buf = "";
+			socket.connect(port, "127.0.0.1", () => {
+				socket.write(
+					`GET /api/terminal/sessions/x/ws?token=${SERVER_TOKEN} HTTP/1.1\r\nHost: 127.0.0.1:${port}\r\nOrigin: http://evil.example\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\nSec-WebSocket-Version: 13\r\n\r\n`,
+				);
+			});
+			socket.on("data", (chunk) => { buf += chunk.toString(); socket.destroy(); resolveReq(buf); });
+			socket.on("close", () => resolveReq(buf));
+			socket.on("error", rejectReq);
+			setTimeout(() => { socket.destroy(); resolveReq(buf); }, 5_000);
+		});
+		expect(data).toContain("403");
+	});
+});

--- a/apps/inno-agent/src/server.smoke.test.ts
+++ b/apps/inno-agent/src/server.smoke.test.ts
@@ -453,6 +453,34 @@ describe("server smoke", () => {
 		expect(((await res.json()) as { error: string }).error).toContain("Invalid JSON");
 	});
 
+	it("binds to loopback by default (issue #159)", async () => {
+		expect(childLog).toContain(`listening on http://127.0.0.1:${port}`);
+	});
+
+	it("rejects cross-origin browser requests (Origin ≠ Host) with 403", async () => {
+		// A page on evil.example driving localhost:3000 — drive-by CSRF /
+		// DNS-rebinding defense (issues #159 / #162).
+		const evilPost = await fetch(`http://127.0.0.1:${port}/api/chat`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Origin: "http://evil.example" },
+			body: JSON.stringify({}),
+		});
+		expect(evilPost.status).toBe(403);
+
+		const evilGet = await fetch(`http://127.0.0.1:${port}/api/settings`, {
+			headers: { Origin: "http://evil.example" },
+		});
+		expect(evilGet.status).toBe(403);
+
+		// Same-origin Origin header (as the real UI sends) passes the check.
+		const sameOrigin = await fetch(`http://127.0.0.1:${port}/api/chat`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Origin: `http://127.0.0.1:${port}` },
+			body: JSON.stringify({}),
+		});
+		expect(sameOrigin.status).toBe(400); // passes Origin check, fails validation
+	});
+
 	it("POST with an oversized declared Content-Length returns 413 and survives to serve the next request", async () => {
 		// Send headers only — the server must reject from the declared length
 		// without consuming a single body byte. (issue #162: readBody had no cap)

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -8,7 +8,7 @@ import { cpSync, existsSync, readFileSync, readdirSync, realpathSync, rmSync, st
 import { tmpdir } from "node:os";
 import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
 import { EnvHttpProxyAgent, setGlobalDispatcher } from "undici";
-import { loadConfig, normalizeContentHubConfig, type InnoConfig, type InnoContentHubConfig } from "./config.js";
+import { loadConfig, normalizeContentHubConfig, peekServerSecurity, DEFAULT_SERVER_HOST, type InnoConfig, type InnoContentHubConfig } from "./config.js";
 import { installFetchLogger } from "./utils/fetch-logger.js";
 import { canonicalContainmentRoot, isWithin } from "./utils/path-safety.js";
 import { applyProviderProxyBypass } from "./utils/proxy-bypass.js";
@@ -35,7 +35,7 @@ import type { PersonalBridgeChannelConfig } from "./config.js";
 import { JobStore } from "./scheduler/job-store.js";
 import { seedManagedMcpConfig } from "./mcp/mcp-config-store.js";
 import { CronScheduler } from "./scheduler/cron-scheduler.js";
-import { HttpError, json } from "./server/http-helpers.js";
+import { HttpError, json, originMatchesHost, requestTokenMatches } from "./server/http-helpers.js";
 import {
 	safeJoinReal,
 	slugifySkillName,
@@ -92,6 +92,21 @@ applyRuntimeEnvironment(paths);
 const port = parsed.options.port
 	?? (process.env.INNO_PORT ? Number.parseInt(process.env.INNO_PORT, 10) : undefined)
 	?? 3000;
+
+// Host and API token are peeked from the raw config file (no bootstrap):
+// host is needed at listen() time, and the token must be known before the
+// first API call so the served index.html can carry it to the web UI.
+// Both are restart-only settings.
+//
+// Host defaults to loopback — the single-user threat model does not include
+// LAN attackers (issue #159). Remote access requires an explicit
+// server.host / --host / INNO_HOST plus a server.token.
+const serverSecurity = peekServerSecurity(paths.configPath);
+const host = parsed.options.host
+	?? (process.env.INNO_HOST?.trim() || undefined)
+	?? serverSecurity.host
+	?? DEFAULT_SERVER_HOST;
+const serverToken = serverSecurity.token ?? null;
 
 // Config is loaded on first API request, not at startup.
 let config!: InnoConfig;
@@ -479,6 +494,39 @@ function serveStatic(req: HttpReq, res: ServerResponse, filePath: string, sendBo
 		res.end(sendBody ? content : undefined);
 		return true;
 	} catch (err) {
+		return false;
+	}
+}
+
+/**
+ * Serve the SPA index.html, injecting the configured API token as a
+ * `window.__INNO_API_TOKEN__` bootstrap script so the web UI can
+ * authenticate its API/WS calls. Static assets stay unauthenticated (they
+ * carry no sensitive data); only /api/* and the terminal WS are gated.
+ * The token is restart-only, so the injected page is cached per process.
+ */
+let indexHtmlCache: Buffer | null = null;
+
+function serveIndexHtml(res: ServerResponse, sendBody = true): boolean {
+	try {
+		if (!indexHtmlCache) {
+			const filePath = join(webDistDir, "index.html");
+			if (!existsSync(filePath)) return false;
+			let html = readFileSync(filePath, "utf-8");
+			if (serverToken) {
+				const tag = `<script>window.__INNO_API_TOKEN__=${JSON.stringify(serverToken)};</script>`;
+				html = html.includes("</head>") ? html.replace("</head>", `${tag}</head>`) : tag + html;
+			}
+			indexHtmlCache = Buffer.from(html, "utf-8");
+		}
+		res.writeHead(200, {
+			"Content-Type": "text/html; charset=utf-8",
+			"Content-Length": indexHtmlCache.length,
+			"Cache-Control": "no-cache",
+		});
+		res.end(sendBody ? indexHtmlCache : undefined);
+		return true;
+	} catch {
 		return false;
 	}
 }
@@ -1375,8 +1423,24 @@ async function runQueueOpWithTimeout<T>(
 }
 
 const server = createServer(async (req, res) => {
-	const url = req.url ?? "/";
+	let url = req.url ?? "/";
 	const method = req.method ?? "GET";
+
+	// The API token may arrive as ?token= (browser WebSocket upgrades and
+	// <img>/iframe URLs can't set headers). Strip it before routing so
+	// exact-path route matching is unaffected.
+	if (url.includes("token=")) {
+		try {
+			const parsed = new URL(url, "http://localhost");
+			if (parsed.searchParams.has("token")) {
+				parsed.searchParams.delete("token");
+				const qs = parsed.searchParams.toString();
+				url = parsed.pathname + (qs ? `?${qs}` : "");
+			}
+		} catch {
+			// leave url as-is; route matching will 404
+		}
+	}
 
 	try {
 		// --- Health check (no bootstrap needed) ---
@@ -1390,6 +1454,22 @@ const server = createServer(async (req, res) => {
 		// Static files and SPA fallback skip this so no directories are
 		// created until the user actually interacts with the web UI.
 		if (url.startsWith("/api/")) {
+			// Cross-origin defense (issue #159 / #162): a browser page on
+			// another origin must not drive this API — neither via simple
+			// cross-site POSTs nor via DNS rebinding. Non-browser clients
+			// (curl, sidecars) carry no Origin header and are unaffected.
+			if (!originMatchesHost(req)) {
+				json(res, 403, { error: "Forbidden: cross-origin request" });
+				return;
+			}
+			// Optional Bearer auth (server.token). /api/bridge/messages is
+			// exempt — sidecars authenticate with the separate bridge token.
+			if (serverToken
+				&& url.split("?")[0] !== "/api/bridge/messages"
+				&& !requestTokenMatches(req, serverToken)) {
+				json(res, 401, { error: "Unauthorized" });
+				return;
+			}
 			await ensureBootstrapped();
 		}
 
@@ -1478,12 +1558,13 @@ const server = createServer(async (req, res) => {
 			const urlPath = decodeURIComponent(url.split("?")[0]);
 			const staticPath = safeJoinReal(webDistDir, urlPath.replace(/^\/+/, ""));
 			const sendBody = method === "GET";
-			// Try exact file in web/dist
-			if (staticPath && serveStatic(req, res, staticPath, sendBody, webDistDir)) return;
+			// index.html always goes through serveIndexHtml (never the exact-file
+			// path) so the API token injection can't be bypassed.
+			if (staticPath && basename(staticPath) !== "index.html" && serveStatic(req, res, staticPath, sendBody, webDistDir)) return;
 			// SPA fallback: serve index.html for non-API paths only. An unmatched
 			// /api/* route must fall through to the JSON 404 — returning HTML with
 			// a 200 status breaks API client error handling.
-			if (urlPath !== "/api" && !urlPath.startsWith("/api/") && serveStatic(req, res, join(webDistDir, "index.html"), sendBody, webDistDir)) return;
+			if (urlPath !== "/api" && !urlPath.startsWith("/api/") && serveIndexHtml(res, sendBody)) return;
 		}
 
 		// --- 404 ---
@@ -1522,6 +1603,20 @@ const wss = new WebSocketServer({ noServer: true });
 server.on("upgrade", (req, socket, head) => {
 	const url = req.url ?? "";
 		if (!bootstrapped) { socket.destroy(); return; }
+	// Same policy as the HTTP API: Origin must match Host when present, and
+	// the optional server token (carried as ?token= — browser WebSocket
+	// connections cannot set headers) must match. Reject with a real HTTP
+	// status (not just a dropped socket) so failures are debuggable.
+	if (!originMatchesHost(req)) {
+		socket.write("HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n");
+		socket.destroy();
+		return;
+	}
+	if (serverToken && !requestTokenMatches(req, serverToken)) {
+		socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+		socket.destroy();
+		return;
+	}
 	const m = /^\/api\/terminal\/sessions\/([^/?]+)\/ws$/.exec(url.split("?")[0]);
 	if (!m) {
 		socket.destroy();
@@ -1646,7 +1741,15 @@ installProcessFallbacks({
 	},
 });
 
-server.listen(port, () => {
-	console.log(`[inno-server] listening on http://localhost:${port}`);
+server.listen(port, host, () => {
+	console.log(`[inno-server] listening on http://${host}:${port}`);
 	console.log(`[inno-server] config: ${paths.configPath}`);
+	const isLoopback = host === "127.0.0.1" || host === "localhost" || host === "::1";
+	if (!isLoopback) {
+		const msg = serverToken
+			? `[inno-server] bound to ${host} — reachable beyond this machine; server.token auth is ON`
+			: `[inno-server] WARNING: bound to ${host} — every API (including the terminal WebSocket) is reachable by anyone who can reach this address. Set server.token in config.json.`;
+		console.warn(msg);
+		logger.warn({ host, tokenConfigured: !!serverToken }, msg);
+	}
 });

--- a/apps/inno-agent/src/server/http-helpers.ts
+++ b/apps/inno-agent/src/server/http-helpers.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import { timingSafeEqual } from "node:crypto";
 
 /**
  * Shared HTTP helpers for the server route domains.
@@ -84,6 +85,58 @@ export function json(res: ServerResponse, status: number, data: unknown): void {
 		"Content-Length": Buffer.byteLength(body),
 	});
 	res.end(body);
+}
+
+/** Constant-time `Authorization: Bearer <token>` check. */
+export function bearerTokenMatches(authHeader: string | undefined, token: string): boolean {
+	if (!authHeader) return false;
+	const expected = Buffer.from(`Bearer ${token}`, "utf-8");
+	const actual = Buffer.from(authHeader, "utf-8");
+	return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+/**
+ * Extract the API token from a request: the Authorization header, or the
+ * `?token=` query parameter (browser WebSocket connections cannot set
+ * headers, so the terminal WS carries it in the URL).
+ */
+export function requestToken(req: HttpReq): string | null {
+	const auth = req.headers.authorization;
+	if (auth?.startsWith("Bearer ")) return auth.slice("Bearer ".length);
+	try {
+		const url = new URL(req.url ?? "/", "http://localhost");
+		return url.searchParams.get("token");
+	} catch {
+		return null;
+	}
+}
+
+/** Constant-time check of a request against the configured server token. */
+export function requestTokenMatches(req: HttpReq, token: string): boolean {
+	const presented = requestToken(req);
+	if (presented === null) return false;
+	const expected = Buffer.from(token, "utf-8");
+	const actual = Buffer.from(presented, "utf-8");
+	return actual.length === expected.length && timingSafeEqual(actual, expected);
+}
+
+/**
+ * Cross-origin defense for the loopback-bound server: when a request carries
+ * an Origin header (i.e. it comes from a browser page), the Origin's host
+ * must match the request's Host header. This blocks cross-site form POSTs
+ * (drive-by CSRF against localhost) and DNS-rebinding reads, while leaving
+ * non-browser clients (curl, sidecars — no Origin header) untouched.
+ */
+export function originMatchesHost(req: HttpReq): boolean {
+	const origin = req.headers.origin;
+	if (!origin) return true;
+	const host = req.headers.host;
+	if (!host) return false;
+	try {
+		return new URL(origin).host === host;
+	} catch {
+		return false;
+	}
 }
 
 /**

--- a/apps/inno-agent/web/src/api/client.ts
+++ b/apps/inno-agent/web/src/api/client.ts
@@ -12,9 +12,41 @@ export class ApiError extends Error {
 
 const BASE_URL = ""; // Same origin — Vite proxy in dev
 
+/**
+ * API token injected by the server into index.html when `server.token` is
+ * configured (see serveIndexHtml in server.ts). Undefined in the default
+ * loopback deployment, where no auth is required.
+ */
+declare global {
+	interface Window {
+		__INNO_API_TOKEN__?: string;
+	}
+}
+
+export function apiToken(): string | undefined {
+	return typeof window !== "undefined" ? window.__INNO_API_TOKEN__ : undefined;
+}
+
+function authHeaders(): Record<string, string> {
+	const token = apiToken();
+	return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * Append the API token as a query parameter for contexts that cannot set
+ * headers — <img> tags and direct fetches of /api/* file URLs (workspace
+ * raw, skill raw, office previews). Non-API URLs (blob:, data:, external)
+ * are returned untouched.
+ */
+export function withApiToken(url: string): string {
+	const token = apiToken();
+	if (!token || !url.startsWith("/api/") || /[?&]token=/.test(url)) return url;
+	return `${url}${url.includes("?") ? "&" : "?"}token=${encodeURIComponent(token)}`;
+}
+
 export async function apiFetch<T>(path: string, options?: RequestInit): Promise<T> {
 	const res = await fetch(`${BASE_URL}${path}`, {
-		headers: { "Content-Type": "application/json", ...options?.headers },
+		headers: { "Content-Type": "application/json", ...authHeaders(), ...options?.headers },
 		...options,
 	});
 	if (!res.ok) {
@@ -100,7 +132,7 @@ export async function* streamSSE<T>(url: string, body: unknown, signal?: AbortSi
 	try {
 		res = await fetch(url, {
 			method: "POST",
-			headers: { "Content-Type": "application/json" },
+			headers: { "Content-Type": "application/json", ...authHeaders() },
 			body: JSON.stringify(body),
 			signal,
 		});
@@ -122,7 +154,7 @@ export async function* streamSSE<T>(url: string, body: unknown, signal?: AbortSi
 export async function* streamSSEGet<T>(url: string, signal?: AbortSignal, options: { allowNotFound?: boolean } = {}): AsyncGenerator<T> {
 	let res: Response;
 	try {
-		res = await fetch(url, { method: "GET", signal });
+		res = await fetch(url, { method: "GET", headers: { ...authHeaders() }, signal });
 	} catch (err) {
 		if (signal?.aborted) return;
 		throw err;

--- a/apps/inno-agent/web/src/api/skills.ts
+++ b/apps/inno-agent/web/src/api/skills.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "./client.js";
+import { apiFetch, withApiToken } from "./client.js";
 import type { SkillInfo, SkillLibraryItem } from "../types/skills.js";
 import type { WorkspaceTreeNode, WorkspaceFileDetail } from "../types/workspace.js";
 
@@ -82,7 +82,7 @@ export async function saveSkillFile(name: string, path: string, content: string)
 }
 
 export function skillRawUrl(name: string, path: string): string {
-	return `/api/skills/${encodeURIComponent(name)}/raw?path=${encodeURIComponent(path)}`;
+	return withApiToken(`/api/skills/${encodeURIComponent(name)}/raw?path=${encodeURIComponent(path)}`);
 }
 
 // ---- HTML resource inlining for srcdoc previews ----

--- a/apps/inno-agent/web/src/api/terminal.ts
+++ b/apps/inno-agent/web/src/api/terminal.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "./client.js";
+import { apiFetch, apiToken } from "./client.js";
 import type { RunRecord, TerminalSessionInfo } from "../types/terminal.js";
 
 export async function createTerminalSession(input: {
@@ -19,7 +19,11 @@ export async function closeTerminalSession(id: string): Promise<void> {
 
 export function terminalWsUrl(id: string): string {
 	const proto = location.protocol === "https:" ? "wss:" : "ws:";
-	return `${proto}//${location.host}/api/terminal/sessions/${encodeURIComponent(id)}/ws`;
+	// Browser WebSocket connections can't set headers — the server accepts the
+	// token as a query parameter on the upgrade request instead.
+	const token = apiToken();
+	const query = token ? `?token=${encodeURIComponent(token)}` : "";
+	return `${proto}//${location.host}/api/terminal/sessions/${encodeURIComponent(id)}/ws${query}`;
 }
 
 export async function listRuns(sessionId: string, limit = 20): Promise<RunRecord[]> {

--- a/apps/inno-agent/web/src/api/workspace.ts
+++ b/apps/inno-agent/web/src/api/workspace.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from "./client.js";
+import { apiFetch, withApiToken } from "./client.js";
 import type { PptxPreviewResult, WorkspaceFileDetail, WorkspaceTree, WorkspaceTreeNode } from "../types/workspace.js";
 
 function qs(workspaceId?: string): string {
@@ -75,7 +75,7 @@ export function workspaceFileUrl(path: string, workspaceId?: string, download = 
 	const params = new URLSearchParams({ path });
 	if (workspaceId) params.set("workspaceId", workspaceId);
 	if (download) params.set("download", "1");
-	return `/api/workspace/raw?${params.toString()}`;
+	return withApiToken(`/api/workspace/raw?${params.toString()}`);
 }
 
 /** Build the URL that zips and downloads a workspace folder (empty path → whole workspace). */
@@ -84,7 +84,7 @@ export function workspaceFolderZipUrl(path: string, workspaceId?: string): strin
 	if (path) params.set("path", path);
 	if (workspaceId) params.set("workspaceId", workspaceId);
 	const qs = params.toString();
-	return `/api/workspace/download-folder${qs ? `?${qs}` : ""}`;
+	return withApiToken(`/api/workspace/download-folder${qs ? `?${qs}` : ""}`);
 }
 
 /** Fetch a pptx rendered to per-slide SVG. */

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -4,6 +4,7 @@ import { Tree, type NodeRendererProps } from "react-arborist";
 import { RefreshCw, Upload, Trash2, ChevronLeft, File, FileText, FileType, Folder, FolderOpen, Globe, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Library, Download, Check, FileCode2, Search } from "lucide-react";
 import { skillsStore } from "../stores/skills-store.js";
 import { skillRawUrl } from '../api/skills.js';
+import { withApiToken } from '../api/client.js';
 import type { SkillInfo } from "../types/skills.js";
 import type { WorkspaceFileDetail, WorkspaceFileKind } from "../types/workspace.js";
 import { type ArboristNode, toArboristNodes } from "../types/workspace.js";
@@ -67,11 +68,11 @@ function FilePreview({ file, skillName, isLoading }: { file: WorkspaceFileDetail
 	if (isLoading) return <div className="flex h-full items-center justify-center text-sm text-[var(--inno-text-muted)]">{t("preview.loadingFile", "Loading...")}</div>;
 	if (file.kind === "markdown") return <div className="h-full overflow-y-auto p-5"><markdown-artifact content={normalizeMarkdownMath(file.content ?? "")} /></div>;
 	if (file.kind === "html") return <SkillHtmlPreview file={file} />;
-	if (file.kind === "pdf") return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" src={file.url ?? skillRawUrl(skillName, file.path)} title={file.name} />;
+	if (file.kind === "pdf") return <iframe className="h-full w-full border-0 bg-[var(--inno-surface)]" src={withApiToken(file.url ?? skillRawUrl(skillName, file.path))} title={file.name} />;
 	if (file.kind === "image") {
 		return (
 			<div className="flex h-full items-center justify-center overflow-auto bg-[var(--inno-surface-muted)] p-4">
-				<img className="max-h-full max-w-full object-contain" src={file.url ?? skillRawUrl(skillName, file.path)} alt={file.name} />
+				<img className="max-h-full max-w-full object-contain" src={withApiToken(file.url ?? skillRawUrl(skillName, file.path))} alt={file.name} />
 			</div>
 		);
 	}

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -4,6 +4,7 @@ import { Tree, type NodeRendererProps, type TreeApi, type CreateHandler, type Re
 import { RefreshCw, FileText, FileType, Globe, File, FolderOpen, Folder, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Sparkles, Download, FileCode2, Presentation, FileSpreadsheet, Copy, Check, ListChecks, Trash2 } from "lucide-react";
 import { workspaceStore, type StreamingWorkspacePreview } from "../stores/workspace-store.js";
 import { workspaceFileUrl, workspaceFolderZipUrl, triggerDownload } from "../api/workspace.js";
+import { withApiToken } from "../api/client.js";
 import { workspacesStore } from "../stores/workspaces-store.js";
 import { sessionsStore } from "../stores/sessions-store.js";
 import { settingsStore } from "../stores/settings-store.js";
@@ -237,7 +238,7 @@ function OfficePreview({ file }: { file: WorkspaceFileDetail }) {
 		setLoading(true);
 		setError("");
 		setData(null);
-		fetch(file.previewUrl)
+		fetch(withApiToken(file.previewUrl))
 			.then(async (res) => {
 				if (!res.ok) {
 					const body = await res.json().catch(() => ({}));
@@ -252,7 +253,7 @@ function OfficePreview({ file }: { file: WorkspaceFileDetail }) {
 	}, [file.previewUrl, file.path, t]);
 
 	const downloadOriginal = useCallback(() => {
-		if (file.url) triggerDownload(`${file.url}${file.url.includes("?") ? "&" : "?"}download=1`);
+		if (file.url) triggerDownload(`${withApiToken(file.url)}${file.url.includes("?") ? "&" : "?"}download=1`);
 	}, [file.url]);
 
 	if (loading) {
@@ -323,7 +324,7 @@ function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: bo
 		// Default to fit-width so the PDF fills the preview panel horizontally.
 		// `view=FitH` (PDF Open Params) + `zoom=page-width` covers Chromium and Firefox.
 		// Users can still zoom in/out further via the native PDF viewer toolbar.
-		const baseUrl = file.url ?? "";
+		const baseUrl = withApiToken(file.url ?? "");
 		const pdfUrl = baseUrl
 			? `${baseUrl}${baseUrl.includes("#") ? "&" : "#"}view=FitH&zoom=page-width`
 			: "";
@@ -332,7 +333,7 @@ function Preview({ file, isLoading }: { file: WorkspaceFileDetail; isLoading: bo
 	if (file.kind === "image") {
 		return (
 			<div className="flex h-full items-center justify-center overflow-auto bg-[var(--inno-surface-muted)] p-4">
-				<img className="max-h-full max-w-full object-contain" src={file.url ?? ""} alt={file.name} />
+				<img className="max-h-full max-w-full object-contain" src={withApiToken(file.url ?? "")} alt={file.name} />
 			</div>
 		);
 	}

--- a/apps/inno-agent/web/src/react/office/DocxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/DocxPreview.tsx
@@ -4,6 +4,7 @@ import { Download } from "lucide-react";
 import { renderAsync } from "docx-preview";
 import type { WorkspaceFileDetail } from "../../types/workspace.js";
 import { triggerDownload } from "../../api/workspace.js";
+import { withApiToken } from "../../api/client.js";
 
 /**
  * Render a .docx into an HTML container with formatting preserved, via
@@ -29,7 +30,7 @@ export default function DocxPreview({ file }: { file: WorkspaceFileDetail }) {
 		if (container) container.innerHTML = "";
 		(async () => {
 			try {
-				const res = await fetch(file.url as string);
+				const res = await fetch(withApiToken(file.url as string));
 				if (!res.ok) throw new Error(res.statusText);
 				const buf = await res.arrayBuffer();
 				if (cancelled || !containerRef.current) return;
@@ -59,7 +60,7 @@ export default function DocxPreview({ file }: { file: WorkspaceFileDetail }) {
 	}, [file.url, t]);
 
 	const downloadOriginal = () => {
-		if (file.url) triggerDownload(`${file.url}${file.url.includes("?") ? "&" : "?"}download=1`);
+		if (file.url) triggerDownload(`${withApiToken(file.url)}${file.url.includes("?") ? "&" : "?"}download=1`);
 	};
 
 	return (

--- a/apps/inno-agent/web/src/react/office/PptxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/PptxPreview.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Download } from "lucide-react";
 import type { PptxPreviewResult, PptxSlide, WorkspaceFileDetail } from "../../types/workspace.js";
 import { triggerDownload } from "../../api/workspace.js";
+import { withApiToken } from "../../api/client.js";
 import { Spinner } from "../ui/Spinner.js";
 
 /**
@@ -27,7 +28,7 @@ export default function PptxPreview({ file }: { file: WorkspaceFileDetail }) {
 		setLoading(true);
 		setError("");
 		setSlides([]);
-		fetch(file.previewUrl)
+		fetch(withApiToken(file.previewUrl))
 			.then(async (res) => {
 				if (!res.ok) {
 					const body = await res.json().catch(() => ({}));
@@ -46,7 +47,7 @@ export default function PptxPreview({ file }: { file: WorkspaceFileDetail }) {
 	}, [file.previewUrl, t]);
 
 	const downloadOriginal = () => {
-		if (file.url) triggerDownload(`${file.url}${file.url.includes("?") ? "&" : "?"}download=1`);
+		if (file.url) triggerDownload(`${withApiToken(file.url)}${file.url.includes("?") ? "&" : "?"}download=1`);
 	};
 
 	if (loading) {

--- a/apps/inno-agent/web/src/react/office/XlsxPreview.tsx
+++ b/apps/inno-agent/web/src/react/office/XlsxPreview.tsx
@@ -4,6 +4,7 @@ import { Download } from "lucide-react";
 import * as XLSX from "xlsx";
 import type { WorkspaceFileDetail } from "../../types/workspace.js";
 import { triggerDownload } from "../../api/workspace.js";
+import { withApiToken } from "../../api/client.js";
 
 /** Cap rendered rows per sheet to avoid blowing up the DOM on huge sheets. */
 const MAX_ROWS = 2000;
@@ -35,7 +36,7 @@ export default function XlsxPreview({ file }: { file: WorkspaceFileDetail }) {
 		setActive(0);
 		(async () => {
 			try {
-				const res = await fetch(file.url as string);
+				const res = await fetch(withApiToken(file.url as string));
 				if (!res.ok) throw new Error(res.statusText);
 				const buf = await res.arrayBuffer();
 				if (cancelled) return;
@@ -90,7 +91,7 @@ export default function XlsxPreview({ file }: { file: WorkspaceFileDetail }) {
 	}, [tableHtml]);
 
 	const downloadOriginal = () => {
-		if (file.url) triggerDownload(`${file.url}${file.url.includes("?") ? "&" : "?"}download=1`);
+		if (file.url) triggerDownload(`${withApiToken(file.url)}${file.url.includes("?") ? "&" : "?"}download=1`);
 	};
 
 	if (loading) {

--- a/config.example.json
+++ b/config.example.json
@@ -21,7 +21,11 @@
 		}
 	},
 	"server": {
-		"port": 3000
+		"port": 3000,
+		"_comment_host": "Bind address. Default 127.0.0.1 (loopback only). Set 0.0.0.0 for LAN/remote access — pair it with token.",
+		"host": "127.0.0.1",
+		"_comment_token": "Optional Bearer token. When set, all /api/* requests and the terminal WebSocket require it. Recommended when host is not loopback. Restart to apply.",
+		"token": ""
 	},
 	"channels": {
 		"feishu": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,10 @@ services:
       INNO_SKILLS_DIR: /var/lib/inno-agent/skills
       INNO_WORKSPACE_DIR: /srv/inno-workspace
       INNO_PORT: 3000
+      # The server defaults to loopback-only binding; inside a container it
+      # must listen on all interfaces for the published port to work.
+      # Consider also setting server.token in config.json (see config.example.json).
+      INNO_HOST: 0.0.0.0
     volumes:
       - ./runtime/config:/etc/inno-agent
       - ./runtime/data:/var/lib/inno-agent/data


### PR DESCRIPTION
## 背景

实现 #159（含 #162 剩余的第 8 项 Origin/Host 校验）。不引入多用户认证体系，只让部署默认值与单用户威胁模型自洽。

## 改动

### 1. 默认绑回环（建议 1 + 4）

- `server.listen(port)` → `server.listen(port, host)`；host 解析优先级：`--host` flag > `INNO_HOST` env > `config.json server.host` > `127.0.0.1`。
- 启动日志打印**真实**绑定地址（原来绑 `0.0.0.0` 却打印 localhost，有误导）。
- 绑定非回环地址时：无 token → console + log 双路醒目告警；有 token → 提示 auth 已开。
- **Docker**:`Dockerfile` / `docker-compose.yml` 显式 `INNO_HOST=0.0.0.0`（容器内必须监听全部接口，端口映射才能工作），compose 里注释建议配 token。

### 2. 可选 `server.token`（建议 2)

- 设置后所有 `/api/*` 与终端 WS 升级要求 `Authorization: Bearer`（常量时间比较，与 bridge token 共用 `http-helpers` 的 helper)。
- 豁免：`/health`（Electron loading 轮询）、`/api/bridge/messages`(sidecar 用独立 bridge token)。
- **前端免配置**:index.html 注入 `window.__INNO_API_TOKEN__`,`apiFetch`/SSE 自动带 header；浏览器 WS 与 `<img>`/iframe/下载等无法设 header 的场景走 `?token=`(`withApiToken()` 统一收口，服务端路由前剥离该参数，不影响精确路径匹配）。
- host/token 均为启动时从 config.json  peek(**restart-only**，改完需重启）。

### 3. Origin 校验（建议 3 + #162 第 8 项）

- `/api/*` 全方法 + WS 升级：请求带 `Origin` 头时，其 host 必须等于请求 `Host`——挡掉跨域 form POST(drive-by CSRF）与 DNS rebinding 读取；无 Origin 的非浏览器客户端（curl、sidecar）不受影响。
- WS 拒绝时回真实 HTTP 401/403 状态行（不再是静默断 socket），可调试性 + 可测试性。

## 测试

- 新 `server-auth.smoke.test.ts`（独立 spawn,config 带 token):/health 开放、无 token/错 token 401、Bearer 与 `?token=` 两种形式 200、bridge 端点豁免、index.html 注入、WS 无 token 401 / 有 token 通过 / Origin 不符 403。dist 缺失时（CI 先测后 build）自动 stub index.html 并清理。
- 主 smoke +3：默认绑定 127.0.0.1 日志断言、evil Origin POST/GET 403、同源 Origin 放行。
- 全套 **33 文件 / 263 测试**绿；`npm run build` 绿。
- `CLAUDE.md`（运行时表、server 配置、安全门禁说明、测试计数）、`README` Non-goals、`config.example.json`、`.env.example` 已同步。

## 行为变化注意

1. **局域网访问旧部署会断**：升级后默认只监听回环。需要远程访问的用户必须显式设 `server.host`（建议同时设 `server.token`)。
2. Vite dev(:5173 代理）与 Electron 默认路径均不受影响。