### PR TITLE
fix: 统一 L2 路径并阻止工作区路径越界

### DIFF
--- a/apps/inno-agent/src/agent/workspace-path-guard.test.ts
+++ b/apps/inno-agent/src/agent/workspace-path-guard.test.ts
@@ -1,0 +1,72 @@
+import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { checkPathWithinRoot } from "./workspace-path-guard.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(prefix: string): string {
+	const dir = mkdtempSync(join(tmpdir(), prefix));
+	tempDirs.push(dir);
+	return dir;
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("workspace path containment", () => {
+	it("allows existing and new paths that stay inside the root", () => {
+		const root = makeTempDir("inno-path-root-");
+		mkdirSync(join(root, "nested"));
+		writeFileSync(join(root, "nested", "existing.txt"), "inside");
+
+		expect(checkPathWithinRoot(root, "nested/existing.txt")).toMatchObject({ allowed: true });
+		expect(checkPathWithinRoot(root, "nested/new.txt")).toMatchObject({ allowed: true });
+	});
+
+	it("rejects direct traversal and absolute paths outside the root", () => {
+		const root = makeTempDir("inno-path-root-");
+		const outside = makeTempDir("inno-path-outside-");
+		writeFileSync(join(outside, "existing.txt"), "outside");
+
+		expect(checkPathWithinRoot(root, "../escape.txt")).toMatchObject({
+			allowed: false,
+			reason: "outside_workspace",
+		});
+		expect(checkPathWithinRoot(root, join(outside, "existing.txt"))).toMatchObject({
+			allowed: false,
+			reason: "outside_workspace",
+		});
+	});
+
+	it("rejects existing and new paths reached through an escaping directory link", () => {
+		const root = makeTempDir("inno-path-root-");
+		const outside = makeTempDir("inno-path-outside-");
+		writeFileSync(join(outside, "existing.txt"), "outside");
+		symlinkSync(outside, join(root, "link"), process.platform === "win32" ? "junction" : "dir");
+
+		expect(checkPathWithinRoot(root, "link/existing.txt")).toMatchObject({
+			allowed: false,
+			reason: "outside_workspace",
+		});
+		expect(checkPathWithinRoot(root, "link/new.txt")).toMatchObject({
+			allowed: false,
+			reason: "outside_workspace",
+		});
+	});
+
+	it("rejects paths through a dangling link before its outside target exists", () => {
+		const root = makeTempDir("inno-path-root-");
+		const outside = makeTempDir("inno-path-outside-");
+		const missingTarget = join(outside, "not-created");
+		symlinkSync(missingTarget, join(root, "dangling"), process.platform === "win32" ? "junction" : "dir");
+
+		expect(checkPathWithinRoot(root, "dangling/new.txt")).toMatchObject({
+			allowed: false,
+			reason: "invalid_path",
+		});
+	});
+});

--- a/apps/inno-agent/src/agent/workspace-path-guard.ts
+++ b/apps/inno-agent/src/agent/workspace-path-guard.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -30,12 +30,44 @@ function isWithin(root: string, target: string): boolean {
 
 function findExistingAncestor(target: string): string | null {
 	let current = target;
-	while (!existsSync(current)) {
+	while (true) {
+		try {
+			lstatSync(current);
+			return current;
+		} catch (err) {
+			const code = (err as NodeJS.ErrnoException).code;
+			if (code !== "ENOENT" && code !== "ENOTDIR") throw err;
+		}
 		const parent = dirname(current);
 		if (parent === current) return null;
 		current = parent;
 	}
-	return current;
+}
+
+/** Resolve a path while ensuring existing symlinks cannot escape the root. */
+export function checkPathWithinRoot(rootDir: string, requestedPath: string): WorkspacePathCheck {
+	try {
+		const canonicalRoot = realpathSync(rootDir);
+		const resolvedPath = resolve(rootDir, requestedPath);
+		const existingAncestor = findExistingAncestor(resolvedPath);
+		if (!existingAncestor) {
+			return { allowed: false, resolvedPath, reason: "invalid_path" };
+		}
+
+		const canonicalAncestor = realpathSync(existingAncestor);
+		const unresolvedSuffix = relative(existingAncestor, resolvedPath);
+		const canonicalTarget = resolve(canonicalAncestor, unresolvedSuffix);
+		if (!isWithin(canonicalRoot, canonicalTarget)) {
+			return { allowed: false, resolvedPath, reason: "outside_workspace" };
+		}
+
+		return { allowed: true, resolvedPath };
+	} catch {
+		return {
+			allowed: false,
+			reason: existsSync(rootDir) ? "invalid_path" : "workspace_unavailable",
+		};
+	}
 }
 
 /**
@@ -46,21 +78,7 @@ export function checkWorkspaceMutationPath(workspaceDir: string, requestedPath: 
 	if (!requestedPath.trim()) return { allowed: false, reason: "invalid_path" };
 
 	try {
-		const workspaceRoot = realpathSync(workspaceDir);
-		const resolvedPath = resolve(workspaceDir, normalizeToolPath(requestedPath));
-		const existingAncestor = findExistingAncestor(resolvedPath);
-		if (!existingAncestor) {
-			return { allowed: false, resolvedPath, reason: "invalid_path" };
-		}
-
-		const canonicalAncestor = realpathSync(existingAncestor);
-		const unresolvedSuffix = relative(existingAncestor, resolvedPath);
-		const canonicalTarget = resolve(canonicalAncestor, unresolvedSuffix);
-		if (!isWithin(workspaceRoot, canonicalTarget)) {
-			return { allowed: false, resolvedPath, reason: "outside_workspace" };
-		}
-
-		return { allowed: true, resolvedPath };
+		return checkPathWithinRoot(workspaceDir, normalizeToolPath(requestedPath));
 	} catch {
 		return {
 			allowed: false,

--- a/apps/inno-agent/src/memory/l2/l2-indexer.ts
+++ b/apps/inno-agent/src/memory/l2/l2-indexer.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
 import { readText, fileExists } from "../../storage/file-store.js";
 import { parseFrontmatter } from "./wiki-maintainer.js";
 import type { L2IndexStore, L2PageDoc } from "./l2-index-store.js";
+import { joinL2Path, normalizeL2Path } from "./l2-path.js";
 
 const WIKI_SUBDIRS = ["sources", "entities", "concepts", "analysis"] as const;
 
@@ -33,6 +34,7 @@ function inferTypeFromPath(wikiPath: string): string {
  * written (false when the file is missing/empty or unchanged since last index).
  */
 export function indexPage(store: L2IndexStore, l2DataDir: string, wikiPath: string): boolean {
+	wikiPath = normalizeL2Path(wikiPath);
 	const abs = join(l2DataDir, wikiPath);
 	if (!fileExists(abs)) return false;
 	const content = readText(abs);
@@ -81,7 +83,7 @@ export function indexAllPages(store: L2IndexStore, l2DataDir: string): { indexed
 			continue;
 		}
 		for (const f of files) {
-			const wikiPath = join("wiki", sub, f);
+			const wikiPath = joinL2Path("wiki", sub, f);
 			present.add(wikiPath);
 			if (indexPage(store, l2DataDir, wikiPath)) indexed++;
 		}
@@ -97,5 +99,5 @@ export function indexAllPages(store: L2IndexStore, l2DataDir: string): { indexed
 }
 
 export function removePageFromIndex(store: L2IndexStore, wikiPath: string): void {
-	store.deletePage(wikiPath);
+	store.deletePage(normalizeL2Path(wikiPath));
 }

--- a/apps/inno-agent/src/memory/l2/l2-lint.ts
+++ b/apps/inno-agent/src/memory/l2/l2-lint.ts
@@ -7,6 +7,7 @@ import { readManifest } from "./manifest-store.js";
 import type { WikiPageFrontmatter, WikiPageType } from "./types.js";
 import { buildAliasIndex, extractOutgoingLinks } from "./wiki-links.js";
 import { parseFrontmatter } from "./wiki-maintainer.js";
+import { joinL2Path, normalizeL2Path } from "./l2-path.js";
 
 const PAGE_DIRS = ["sources", "entities", "concepts", "analysis"] as const;
 const REQUIRED_FIELDS = ["title", "created", "type", "tags", "sources", "source_ids", "updated", "status", "confidence"] as const;
@@ -52,10 +53,6 @@ interface PageRecord {
 	rawFrontmatter: Record<string, unknown> | null;
 }
 
-function normalizePath(value: string): string {
-	return value.replace(/\\/g, "/");
-}
-
 function fileExistsWithin(root: string, relativePath: string): boolean {
 	const absoluteRoot = resolve(root);
 	const target = resolve(absoluteRoot, relativePath);
@@ -65,7 +62,7 @@ function fileExistsWithin(root: string, relativePath: string): boolean {
 }
 
 function finding(code: L2LintCode, severity: L2LintSeverity, path: string, message: string): L2LintFinding {
-	return { code, severity, path: normalizePath(path), message };
+	return { code, severity, path: normalizeL2Path(path), message };
 }
 
 function wikiPagePaths(l2DataDir: string): string[] {
@@ -74,7 +71,7 @@ function wikiPagePaths(l2DataDir: string): string[] {
 		const absolute = join(l2DataDir, "wiki", directory);
 		if (!fileExists(absolute)) continue;
 		for (const file of readdirSync(absolute).filter((candidate) => candidate.endsWith(".md")).sort()) {
-			paths.push(join("wiki", directory, file));
+			paths.push(joinL2Path("wiki", directory, file));
 		}
 	}
 	return paths;
@@ -147,7 +144,7 @@ function indexedWikiPaths(l2DataDir: string): Set<string> {
 	const paths = new Set<string>();
 	const pattern = /`(wiki[\\/](?:sources|entities|concepts|analysis)[\\/][^`]+\.md)`/g;
 	let match: RegExpExecArray | null;
-	while ((match = pattern.exec(index)) !== null) paths.add(normalizePath(match[1]));
+	while ((match = pattern.exec(index)) !== null) paths.add(normalizeL2Path(match[1]));
 	return paths;
 }
 
@@ -157,7 +154,7 @@ export function runL2Lint(l2DataDir: string): L2LintReport {
 	const manifest = readManifest(l2DataDir);
 	const manifestIds = new Set(manifest.map((entry) => entry.id));
 	const pagePaths = wikiPagePaths(l2DataDir);
-	const actualPagePaths = new Set(pagePaths.map(normalizePath));
+	const actualPagePaths = new Set(pagePaths.map(normalizeL2Path));
 	const pages = pagePaths.map((path) => readPage(l2DataDir, path, findings));
 
 	const alias = buildAliasIndex(pages);

--- a/apps/inno-agent/src/memory/l2/l2-path.ts
+++ b/apps/inno-agent/src/memory/l2/l2-path.ts
@@ -1,0 +1,10 @@
+import { posix } from "node:path";
+
+/** L2 paths are persisted identifiers, so they always use POSIX separators. */
+export function normalizeL2Path(value: string): string {
+	return value.replace(/\\/g, "/");
+}
+
+export function joinL2Path(...segments: string[]): string {
+	return posix.join(...segments.map(normalizeL2Path));
+}

--- a/apps/inno-agent/src/memory/l2/l2-tools.test.ts
+++ b/apps/inno-agent/src/memory/l2/l2-tools.test.ts
@@ -14,7 +14,7 @@ vi.mock("./document-parser.js", async (importOriginal) => {
 import type { L2Memory } from "./l2-memory.js";
 import { createL2Tools } from "./l2-tools.js";
 import { runL2Lint } from "./l2-lint.js";
-import { upsertManifest, readManifest } from "./manifest-store.js";
+import { upsertManifest, readManifest, removeWikiPathFromManifest } from "./manifest-store.js";
 import { writeText } from "../../storage/file-store.js";
 
 const tempDirs: string[] = [];
@@ -81,6 +81,9 @@ describe("l2_archive", () => {
 		const entries = readManifest(root);
 		expect(entries).toHaveLength(1);
 		expect(entries[0].status).toBe("indexed");
+		expect(entries[0].rawPath).not.toContain("\\");
+		expect(entries[0].extractedPath).not.toContain("\\");
+		expect(entries[0].wikiPages.every((pagePath) => !pagePath.includes("\\"))).toBe(true);
 		expect(readFileSync(join(root, entries[0].rawPath), "utf8")).toContain("间隔重复");
 		expect(readFileSync(join(root, entries[0].extractedPath!), "utf8")).toContain("间隔重复");
 		expect(entries[0].wikiPages.length).toBeGreaterThan(0);
@@ -96,6 +99,34 @@ describe("l2_archive", () => {
 
 		expect(readManifest(root)).toHaveLength(1);
 		expect(duplicate.details).toMatchObject({ duplicate: true });
+	});
+
+	it("normalizes legacy Windows paths when reading and updating the manifest", () => {
+		const root = makeTempDir();
+		const legacyEntry = {
+			id: "legacy",
+			title: "Legacy",
+			sourceType: "markdown" as const,
+			rawPath: "raw\\uploads\\source.md",
+			extractedPath: "extracted\\source.md",
+			wikiPages: ["wiki\\concepts\\legacy.md"],
+			tags: [],
+			contentHash: "legacy-hash",
+			status: "indexed" as const,
+			source: { origin: "user_upload" as const },
+			createdAt: "2026-01-01T00:00:00.000Z",
+			updatedAt: "2026-01-01T00:00:00.000Z",
+		};
+		writeText(join(root, "manifest.jsonl"), `${JSON.stringify(legacyEntry)}\n`);
+
+		expect(readManifest(root)[0]).toMatchObject({
+			rawPath: "raw/uploads/source.md",
+			extractedPath: "extracted/source.md",
+			wikiPages: ["wiki/concepts/legacy.md"],
+		});
+		expect(removeWikiPathFromManifest(root, "wiki\\concepts\\legacy.md")).toBe(true);
+		expect(readManifest(root)[0].wikiPages).toEqual([]);
+		expect(readFileSync(join(root, "manifest.jsonl"), "utf8")).not.toContain("\\");
 	});
 
 	it("discovers a linked concept near the end of a long source without a model", async () => {

--- a/apps/inno-agent/src/memory/l2/manifest-store.ts
+++ b/apps/inno-agent/src/memory/l2/manifest-store.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path";
 import { appendJsonl, readJsonl, writeText } from "../../storage/file-store.js";
 import type { ManifestEntry } from "./types.js";
+import { normalizeL2Path } from "./l2-path.js";
 
 const MANIFEST_FILE = "manifest.jsonl";
 
@@ -9,21 +10,31 @@ function getManifestPath(l2DataDir: string): string {
 }
 
 export function appendManifest(l2DataDir: string, entry: ManifestEntry): void {
-	appendJsonl(getManifestPath(l2DataDir), entry);
+	appendJsonl(getManifestPath(l2DataDir), normalizeManifestPaths(entry));
 }
 
 /** Insert a manifest entry or atomically replace the existing record with the same id. */
 export function upsertManifest(l2DataDir: string, entry: ManifestEntry): void {
 	const entries = readManifest(l2DataDir);
 	const index = entries.findIndex((candidate) => candidate.id === entry.id);
-	if (index >= 0) entries[index] = entry;
-	else entries.push(entry);
+	const normalizedEntry = normalizeManifestPaths(entry);
+	if (index >= 0) entries[index] = normalizedEntry;
+	else entries.push(normalizedEntry);
 	const lines = entries.map((candidate) => JSON.stringify(candidate)).join("\n");
 	writeText(getManifestPath(l2DataDir), lines ? `${lines}\n` : "");
 }
 
 export function readManifest(l2DataDir: string): ManifestEntry[] {
-	return readJsonl<ManifestEntry>(getManifestPath(l2DataDir));
+	return readJsonl<ManifestEntry>(getManifestPath(l2DataDir)).map(normalizeManifestPaths);
+}
+
+function normalizeManifestPaths(entry: ManifestEntry): ManifestEntry {
+	return {
+		...entry,
+		rawPath: normalizeL2Path(entry.rawPath),
+		extractedPath: entry.extractedPath === undefined ? undefined : normalizeL2Path(entry.extractedPath),
+		wikiPages: entry.wikiPages.map(normalizeL2Path),
+	};
 }
 
 /**
@@ -34,10 +45,11 @@ export function readManifest(l2DataDir: string): ManifestEntry[] {
  */
 export function removeWikiPathFromManifest(l2DataDir: string, wikiPath: string): boolean {
 	const entries = readManifest(l2DataDir);
+	const normalizedPath = normalizeL2Path(wikiPath);
 	let changed = false;
 	for (const entry of entries) {
-		if (entry.wikiPages.includes(wikiPath)) {
-			entry.wikiPages = entry.wikiPages.filter((p) => p !== wikiPath);
+		if (entry.wikiPages.includes(normalizedPath)) {
+			entry.wikiPages = entry.wikiPages.filter((p) => p !== normalizedPath);
 			changed = true;
 		}
 	}

--- a/apps/inno-agent/src/memory/l2/raw-store.ts
+++ b/apps/inno-agent/src/memory/l2/raw-store.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { copyFileSync } from "node:fs";
 import { ensureDir, writeText } from "../../storage/file-store.js";
 import type { RawSourceType } from "./types.js";
+import { joinL2Path } from "./l2-path.js";
 
 /** Map source type to subdirectory under raw/. */
 const TYPE_DIR_MAP: Record<RawSourceType, string> = {
@@ -55,7 +56,7 @@ export function saveRaw(
 	ensureDir(dir);
 	const filename = generateFilename(title, sourceType);
 	writeText(join(dir, filename), rawFrontmatter(content, sourceType, sourceUrl) + content);
-	return join("raw", subdir, filename);
+	return joinL2Path("raw", subdir, filename);
 }
 
 /**
@@ -81,5 +82,5 @@ export function saveRawFile(
 	const ext = extname(originalFilePath);
 	const filename = `${date}-${slug}-${randomUUID().slice(0, 6)}${ext}`;
 	copyFileSync(originalFilePath, join(dir, filename));
-	return join("raw", subdir, filename);
+	return joinL2Path("raw", subdir, filename);
 }

--- a/apps/inno-agent/src/memory/l2/source-converter.ts
+++ b/apps/inno-agent/src/memory/l2/source-converter.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { ensureDir, writeText } from "../../storage/file-store.js";
 import type { RawSourceType } from "./types.js";
 import { logger } from "../../logger.js";
+import { joinL2Path } from "./l2-path.js";
 
 /**
  * Convert raw content to extracted markdown and save to data/l2/extracted/.
@@ -24,7 +25,7 @@ export function convertToExtracted(
 		.slice(0, 50);
 	const filename = `${slug}-${randomUUID().slice(0, 6)}.md`;
 	writeText(join(dir, filename), markdown);
-	return join("extracted", filename);
+	return joinL2Path("extracted", filename);
 }
 
 function convertContent(content: string, sourceType: RawSourceType): string {

--- a/apps/inno-agent/src/memory/l2/wiki-graph.test.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-graph.test.ts
@@ -14,9 +14,9 @@ afterEach(() => {
 });
 
 function writePage(root: string, name: string, title: string, sourceId: string, body: string): string {
-	const path = join("wiki", "concepts", `${name}.md`);
+	const path = `wiki/concepts/${name}.md`;
 	writeText(
-		join(root, path),
+		join(root, "wiki", "concepts", `${name}.md`),
 		`${serializeFrontmatter({
 			title,
 			created: "2026-07-30",

--- a/apps/inno-agent/src/memory/l2/wiki-graph.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-graph.ts
@@ -26,6 +26,7 @@ const louvainDetailed = (louvainImport as unknown as { detailed: LouvainDetailed
 import { readText, fileExists } from "../../storage/file-store.js";
 import { parseFrontmatter } from "./wiki-maintainer.js";
 import { buildAliasIndex, extractOutgoingLinks, normalizeWikiLink, stripParenthetical } from "./wiki-links.js";
+import { joinL2Path } from "./l2-path.js";
 
 const WIKI_SUBDIRS = ["sources", "entities", "concepts", "analysis"] as const;
 
@@ -39,7 +40,7 @@ const MIN_COMMUNITY_SIZE = 3;
  * "connects everything" super-node AND inflate the degree of exactly the nodes
  * it ranks — a feedback loop. It is therefore excluded from the graph.
  */
-export const OVERVIEW_PATH = join("wiki", "analysis", "overview.md");
+export const OVERVIEW_PATH = joinL2Path("wiki", "analysis", "overview.md");
 
 export interface WikiGraphNode {
 	id: string;
@@ -128,7 +129,7 @@ function readAllPages(l2DataDir: string): PageRecord[] {
 		}
 		for (const file of files) {
 			if (!file.endsWith(".md")) continue;
-			const wikiPath = join("wiki", sub, file);
+			const wikiPath = joinL2Path("wiki", sub, file);
 			if (wikiPath === OVERVIEW_PATH) continue;
 			const { frontmatter, body } = parseFrontmatter(readText(join(l2DataDir, wikiPath)));
 			if (!frontmatter) continue;

--- a/apps/inno-agent/src/memory/l2/wiki-linker.test.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-linker.test.ts
@@ -131,6 +131,7 @@ describe("L2 wiki link maintenance", () => {
 		const source = entry();
 		const summary = "## 关键概念\n\n- [[Shared Memory]]";
 		const sourcePath = createSourcePage(root, source, summary, source.extractedPath);
+		const legacySourcePath = sourcePath.replace(/\//g, "\\");
 		writeText(
 			join(root, "wiki", "concepts", "shared-memory.md"),
 			`${serializeFrontmatter({
@@ -143,7 +144,7 @@ describe("L2 wiki link maintenance", () => {
 				updated: "2026-07-29",
 				status: "draft",
 				confidence: "medium",
-			})}\n# Shared Memory\n\n## 定义\n\n旧定义。\n`,
+			})}\n# Shared Memory\n\n## 定义\n\n旧定义。\n\n## 相关资料\n\n- [[旧资料]] — \`${legacySourcePath}\`\n`,
 		);
 
 		completeMock
@@ -172,7 +173,11 @@ describe("L2 wiki link maintenance", () => {
 		expect(result.pages).toEqual(["wiki/concepts/shared-memory.md"]);
 		expect(result.created).toEqual([]);
 		expect(result.updated).toEqual(["wiki/concepts/shared-memory.md"]);
-		expect(readFileSync(join(root, "wiki", "concepts", "shared-memory.md"), "utf8")).toContain(source.id);
+		const updatedPage = readFileSync(join(root, "wiki", "concepts", "shared-memory.md"), "utf8");
+		expect(updatedPage).toContain(source.id);
+		const updatedBody = parseFrontmatter(updatedPage).body;
+		expect(updatedBody).toContain(legacySourcePath);
+		expect(updatedBody).not.toContain(`\`${sourcePath}\``);
 		expect(() => readFileSync(join(root, "wiki", "entities", "shared-memory.md"), "utf8")).toThrow();
 	});
 });

--- a/apps/inno-agent/src/memory/l2/wiki-linker.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-linker.ts
@@ -12,6 +12,7 @@ import { parseFrontmatter, serializeFrontmatter } from "./wiki-maintainer.js";
 import { splitSemanticChunks } from "./semantic-chunker.js";
 import { buildAliasIndex, normalizeWikiLink } from "./wiki-links.js";
 import { logger } from "../../logger.js";
+import { joinL2Path } from "./l2-path.js";
 
 type LinkablePageType = Extract<WikiPageType, "entity" | "concept">;
 
@@ -270,7 +271,7 @@ function pageDirForType(type: LinkablePageType): string {
 }
 
 function relativePagePath(type: LinkablePageType, filename: string): string {
-	return join("wiki", pageDirForType(type), filename);
+	return joinL2Path("wiki", pageDirForType(type), filename);
 }
 
 function findExistingPage(l2DataDir: string, item: LinkedItem): string {
@@ -332,7 +333,7 @@ function readAllWikiPageAliases(l2DataDir: string): { title: string; path: strin
 		if (!existsSync(dir)) continue;
 		for (const file of readdirSync(dir)) {
 			if (!file.endsWith(".md")) continue;
-			const path = join("wiki", dirName, file);
+			const path = joinL2Path("wiki", dirName, file);
 			const { frontmatter } = parseFrontmatter(readText(join(l2DataDir, path)));
 			pages.push({ title: frontmatter?.title || basename(file, extname(file)), path });
 		}
@@ -454,7 +455,8 @@ function updateFrontmatterReference(content: string, entry: ManifestEntry, sourc
 }
 
 function addReferenceIfMissing(content: string, entry: ManifestEntry, sourcePagePath: string): string | null {
-	const bodyAlreadyReferencesSource = content.includes(sourcePagePath);
+	const legacyWindowsPath = sourcePagePath.replace(/\//g, "\\");
+	const bodyAlreadyReferencesSource = content.includes(sourcePagePath) || content.includes(legacyWindowsPath);
 	const metadataUpdate = updateFrontmatterReference(content, entry, sourcePagePath);
 	content = metadataUpdate.content;
 	let changed = metadataUpdate.changed;

--- a/apps/inno-agent/src/memory/l2/wiki-links.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-links.ts
@@ -30,7 +30,7 @@ export function stripParenthetical(s: string): string {
 
 /** Filename stem of a wiki-relative path (no dir, no `.md`). */
 export function pageStem(path: string): string {
-	return (path.split("/").pop() ?? path).replace(/\.md$/, "");
+	return (path.replace(/\\/g, "/").split("/").pop() ?? path).replace(/\.md$/, "");
 }
 
 /** Extract raw `[[link]]` targets (alias part stripped) from a page body. */

--- a/apps/inno-agent/src/memory/l2/wiki-maintainer.test.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-maintainer.test.ts
@@ -62,6 +62,26 @@ describe("L2 wiki maintenance", () => {
 		expect(parsed.body).toBe("正文");
 	});
 
+	it("serializes Windows source paths with portable separators", () => {
+		const frontmatter: WikiPageFrontmatter = {
+			title: "Portable source",
+			created: "2026-07-30",
+			type: "analysis",
+			tags: [],
+			sources: ["workspace\\reports\\result.md"],
+			source_ids: [],
+			updated: "2026-07-30",
+			status: "draft",
+			confidence: "medium",
+		};
+
+		const serialized = serializeFrontmatter(frontmatter);
+		expect(serialized).not.toContain("\\");
+		expect(parseFrontmatter(`${serialized}\nBody`).frontmatter?.sources).toEqual([
+			"workspace/reports/result.md",
+		]);
+	});
+
 	it("creates navigation and schema files without user setup", () => {
 		const root = makeTempDir();
 		ensureL2Directories(root);

--- a/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
@@ -10,6 +10,7 @@ import type {
 	ManifestEntry,
 } from "./types.js";
 import { logger } from "../../logger.js";
+import { joinL2Path, normalizeL2Path } from "./l2-path.js";
 
 const L2_SCHEMA_VERSION = "1.0";
 
@@ -42,7 +43,7 @@ export function serializeFrontmatter(fm: WikiPageFrontmatter): string {
 		created: fm.created || fm.updated,
 		type: fm.type,
 		tags: fm.tags,
-		sources: fm.sources,
+		sources: fm.sources.map(normalizeL2Path),
 		source_ids: fm.source_ids,
 		updated: fm.updated,
 		status: fm.status,
@@ -92,7 +93,7 @@ export function parseFrontmatter(content: string): { frontmatter: WikiPageFrontm
 			created: asString(raw.created) || asString(raw.updated),
 			type: (raw.type as WikiPageType) ?? "source-summary",
 			tags: asStringArray(raw.tags),
-			sources: asStringArray(raw.sources),
+			sources: asStringArray(raw.sources).map(normalizeL2Path),
 			source_ids: asStringArray(raw.source_ids),
 			updated: asString(raw.updated),
 			status: (raw.status as WikiPageStatus) ?? "draft",
@@ -288,7 +289,7 @@ export function createSourcePage(
 	const ref = extractedPath ? `\n## 来源\n\n完整提取文本: \`${extractedPath}\`\n` : "";
 	const body = `\n# ${entry.title}\n\n${summaryBody}\n${ref}`;
 	writeText(join(dir, filename), serializeFrontmatter(fm) + body);
-	return join("wiki", "sources", filename);
+	return joinL2Path("wiki", "sources", filename);
 }
 
 // ============================================================================
@@ -423,7 +424,7 @@ function listWikiPagesForIndex(
 	const fallbackTitleByPath = new Map<string, string>();
 	for (const entry of entries) {
 		for (const wikiPath of entry.wikiPages) {
-			fallbackTitleByPath.set(wikiPath, entry.title);
+			fallbackTitleByPath.set(normalizeL2Path(wikiPath), entry.title);
 		}
 	}
 	for (const type of ["source-summary", "entity", "concept", "analysis"] as WikiPageType[]) {
@@ -431,7 +432,7 @@ function listWikiPagesForIndex(
 		if (!fileExists(dir)) continue;
 		const files = readDirectoryMdFiles(dir);
 		for (const file of files) {
-			const wikiPath = join("wiki", TYPE_DIR_MAP[type], file);
+			const wikiPath = joinL2Path("wiki", TYPE_DIR_MAP[type], file);
 			items.push(readWikiPageIndexItem(l2DataDir, fallbackTitleByPath.get(wikiPath) ?? file.replace(/\.md$/, ""), wikiPath));
 		}
 	}

--- a/apps/inno-agent/src/memory/l2/wiki-query.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-query.ts
@@ -4,6 +4,7 @@ import { readManifest } from "./manifest-store.js";
 import type { ManifestEntry } from "./types.js";
 import type { L2Memory } from "./l2-memory.js";
 import type { L2SearchResult } from "./l2-search.js";
+import { normalizeL2Path } from "./l2-path.js";
 
 export interface WikiQueryHit {
 	path: string;
@@ -32,7 +33,7 @@ export function readIndex(l2DataDir: string): string {
  * Read a specific wiki page by relative path.
  */
 export function readWikiPage(l2DataDir: string, relativePath: string): string | null {
-	const absPath = join(l2DataDir, relativePath);
+	const absPath = join(l2DataDir, normalizeL2Path(relativePath));
 	if (!fileExists(absPath)) return null;
 	return readText(absPath);
 }

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -70,6 +70,8 @@ import { DEFAULT_WORKSPACE_ID, TEMP_WORKSPACE_ID, WorkspaceRegistry } from "./wo
 import { listPresets, listRemotePresets, ensurePresetCached, instantiatePreset } from "./presets/preset-store.js";
 import { createContentSource, type RemoteContentSource } from "./content-source/index.js";
 import { mapWithConcurrency } from "./content-source/types.js";
+import { joinL2Path, normalizeL2Path } from "./memory/l2/l2-path.js";
+import { checkPathWithinRoot } from "./agent/workspace-path-guard.js";
 import { RunRecordStore } from "./terminal/run-record-store.js";
 import { TerminalSessionManager } from "./terminal/terminal-session-manager.js";
 import type { ClientTerminalEvent, ServerTerminalEvent } from "./terminal/terminal-types.js";
@@ -812,11 +814,8 @@ function serveStatic(req: HttpReq, res: ServerResponse, filePath: string, sendBo
 // ---------------------------------------------------------------------------
 
 function safeJoin(baseDir: string, userPath: string): string | null {
-	const resolvedBase = resolve(baseDir);
-	const resolvedPath = resolve(resolvedBase, userPath);
-	const rel = relative(resolvedBase, resolvedPath);
-	if (rel.startsWith("..") || resolve(rel) === rel) return null;
-	return resolvedPath;
+	const result = checkPathWithinRoot(baseDir, userPath);
+	return result.allowed ? result.resolvedPath ?? null : null;
 }
 
 function safeWorkspacePath(workspaceId: string | null | undefined, userPath: string): string | null {
@@ -1823,7 +1822,7 @@ function listWikiPagePaths(): string[] {
 		if (!existsSync(dir)) continue;
 		for (const file of readdirSync(dir)) {
 			if (file.endsWith(".md")) {
-				paths.push(join("wiki", dirName, file));
+				paths.push(joinL2Path("wiki", dirName, file));
 			}
 		}
 	}
@@ -3428,11 +3427,12 @@ const server = createServer(async (req, res) => {
 
 		if (method === "GET" && url.startsWith("/api/wiki/page?")) {
 			const params = new URL(url, "http://localhost").searchParams;
-			const path = params.get("path");
-			if (!path) {
+			const requestedPath = params.get("path");
+			if (!requestedPath) {
 				json(res, 400, { error: "Missing path parameter" });
 				return;
 			}
+			const path = normalizeL2Path(requestedPath);
 			const fullPath = safeJoin(l2DataDir, path);
 			if (!fullPath) {
 				json(res, 400, { error: "Invalid wiki path" });
@@ -3449,12 +3449,13 @@ const server = createServer(async (req, res) => {
 
 		if (method === "PUT" && url === "/api/wiki/page") {
 			const body = (await readBody(req)) as Record<string, unknown>;
-			const path = body.path as string | undefined;
+			const requestedPath = body.path as string | undefined;
 			const content = body.content as string | undefined;
-			if (!path || content === undefined) {
+			if (!requestedPath || content === undefined) {
 				json(res, 400, { error: "Missing path or content" });
 				return;
 			}
+			const path = normalizeL2Path(requestedPath);
 			const fullPath = safeJoin(l2DataDir, path);
 			if (!fullPath) {
 				json(res, 400, { error: "Invalid wiki path" });
@@ -3468,11 +3469,12 @@ const server = createServer(async (req, res) => {
 
 		if (method === "DELETE" && url.startsWith("/api/wiki/page?")) {
 			const params = new URL(url, "http://localhost").searchParams;
-			const path = params.get("path");
-			if (!path) {
+			const requestedPath = params.get("path");
+			if (!requestedPath) {
 				json(res, 400, { error: "Missing path parameter" });
 				return;
 			}
+			const path = normalizeL2Path(requestedPath);
 			const fullPath = safeJoin(l2DataDir, path);
 			if (!fullPath) {
 				json(res, 400, { error: "Invalid wiki path" });
@@ -4214,7 +4216,7 @@ const server = createServer(async (req, res) => {
 			const ws = workspaceRegistry.getWorkspace(record.workspaceId);
 
 			const now = new Date().toISOString();
-			const wikiRelPath = join("wiki", "analysis", `run-${record.id}.md`);
+			const wikiRelPath = joinL2Path("wiki", "analysis", `run-${record.id}.md`);
 			const fullPath = join(l2DataDir, wikiRelPath);
 			if (existsSync(fullPath)) {
 				json(res, 409, { error: "Run already archived", path: wikiRelPath });
@@ -4295,7 +4297,7 @@ const server = createServer(async (req, res) => {
 			const outputPath = join(dir, outputName);
 			const data = Buffer.from(dataBase64, "base64");
 			writeFileSync(outputPath, data);
-			const rawPath = join("raw", "uploads", outputName);
+			const rawPath = joinL2Path("raw", "uploads", outputName);
 			json(res, 201, {
 				fileName,
 				mimeType,

--- a/apps/inno-agent/web/vite.config.ts
+++ b/apps/inno-agent/web/vite.config.ts
@@ -1,7 +1,7 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { cpSync, existsSync, mkdirSync, readFileSync, readdirSync, statSync, symlinkSync, writeFileSync } from "node:fs";
-import { basename, extname, join, resolve } from "node:path";
+import { basename, extname, join, posix, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { brotliCompressSync, constants as zlibConstants, gzipSync } from "node:zlib";
 import { defineConfig, type Plugin, type ResolvedConfig } from "vite";
@@ -196,7 +196,7 @@ export default defineConfig({
 								fileName,
 								mimeType,
 								size: data.length,
-								rawPath: join("raw", "uploads", outputName),
+								rawPath: posix.join("raw", "uploads", outputName),
 							}));
 						} catch (err) {
 							res.statusCode = 500;


### PR DESCRIPTION
## 概述

- 在所有平台上统一使用 POSIX `/` 分隔符保存 L2 逻辑路径。
- 兼容 manifest、frontmatter、Wiki 链接及 SQLite 索引中的旧版 Windows 路径。
- 加强工作区路径校验，防止通过符号链接或目录联接越界访问文件。
- 为以上问题补充回归测试。

## 问题背景

L2 逻辑路径此前通过 `node:path.join()` 构建，在 Windows 上会产生反斜杠路径。部分模块仅按 `/` 解析路径，进而导致 Wiki 图谱丢失边、Overview 无法生成，以及 API 返回的路径格式不一致。

工作区文件接口此前仅进行字符串层面的路径校验。攻击者可以利用符号链接或目录联接，使看似位于工作区内的路径实际指向工作区外部。

## 主要改动

- 新增统一的 L2 路径标准化和 POSIX 路径拼接方法。
- 读取和索引已有数据时，自动兼容旧版 Windows 路径。
- 将标准化路径应用于 Wiki graph、linker、query、archive、manifest、raw upload 和开发环境上传流程。
- 通过规范化后的真实文件系统路径检查工作区边界。
- 拒绝符号链接、目录联接、悬空链接、`..` 路径穿越及外部绝对路径。
- 在服务端工作区文件接口中统一复用安全路径校验。
- 补充 Windows 路径和工作区越界场景的回归测试。

## 验证结果

- `npm test`：18 个测试文件、107 个测试全部通过
- `npm run build`：通过
- `npx tsc --noEmit -p apps/inno-agent/web/tsconfig.json`：通过
- `npx tsc --noEmit -p apps/showcase/tsconfig.json`：通过
- `git diff --check`：通过