### PR TITLE
fix(web): 修复 Skills 浏览器的过期请求状态覆盖问题

### DIFF
--- a/apps/inno-agent/web/src/stores/skills-store.test.ts
+++ b/apps/inno-agent/web/src/stores/skills-store.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	getSkillTree: vi.fn(),
+	getSkillFile: vi.fn(),
+	inlineSkillHtml: vi.fn(),
+	deleteSkill: vi.fn(),
+}));
+
+vi.mock("../api/skills.js", () => ({
+	getSkillTree: mocks.getSkillTree,
+	getSkillFile: mocks.getSkillFile,
+	inlineSkillHtml: mocks.inlineSkillHtml,
+	deleteSkill: mocks.deleteSkill,
+	listSkills: vi.fn(),
+	reloadSkills: vi.fn(),
+	updateSkill: vi.fn(),
+	uploadSkill: vi.fn(),
+	saveSkillFile: vi.fn(),
+	listSkillLibrary: vi.fn(),
+	importSkillFromLibrary: vi.fn(),
+}));
+
+import { SkillsStoreImpl } from "./skills-store.js";
+import type { WorkspaceFileDetail, WorkspaceTreeNode } from "../types/workspace.js";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+	return { promise, resolve, reject };
+}
+
+function node(path: string): WorkspaceTreeNode {
+	return { name: path.split("/").at(-1) ?? path, path, type: "file" };
+}
+
+function file(path: string): WorkspaceFileDetail {
+	return {
+		path,
+		name: path.split("/").at(-1) ?? path,
+		kind: "text",
+		mimeType: "text/plain",
+		size: 1,
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		content: path,
+	};
+}
+
+function skill(name: string) {
+	return {
+		name,
+		description: "",
+		enabled: true,
+		loaded: true,
+		filePath: `/skills/${name}`,
+		size: 0,
+		updatedAt: "2026-01-01T00:00:00.000Z",
+		diagnostics: [],
+	};
+}
+
+describe("SkillsStore request ownership", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mocks.inlineSkillHtml.mockImplementation(async (_name: string, content: string) => content);
+	});
+
+	it("does not let a stale tree failure clear a newer skill selection", async () => {
+		const stale = deferred<{ children: WorkspaceTreeNode[] }>();
+		mocks.getSkillTree.mockImplementation((name: string) => name === "old-skill" ? stale.promise : Promise.resolve({ children: [node("new.md")] }));
+		const store = new SkillsStoreImpl();
+
+		const oldRequest = store.selectSkill("old-skill");
+		await Promise.resolve();
+		await store.selectSkill("new-skill");
+		expect(store.skillTree?.[0]?.path).toBe("new.md");
+
+		stale.reject(new Error("old request failed"));
+		await oldRequest;
+		expect(store.selectedSkill).toBe("new-skill");
+		expect(store.skillTree?.[0]?.path).toBe("new.md");
+	});
+
+	it("does not let a stale file response overwrite the latest selection", async () => {
+		const stale = deferred<WorkspaceFileDetail>();
+		mocks.getSkillFile.mockImplementation((_name: string, path: string) => path === "old.md" ? stale.promise : Promise.resolve(file("new.md")));
+		const store = new SkillsStoreImpl();
+		store.selectedSkill = "skill";
+
+		const oldRequest = store.selectFile("old.md");
+		await Promise.resolve();
+		await store.selectFile("new.md");
+		expect(store.currentFile?.path).toBe("new.md");
+
+		stale.resolve(file("old.md"));
+		await oldRequest;
+		expect(store.currentFile?.path).toBe("new.md");
+	});
+
+	it("cancels pending requests when removing the selected skill", async () => {
+		const stale = deferred<{ children: WorkspaceTreeNode[] }>();
+		mocks.getSkillTree.mockReturnValue(stale.promise);
+		const store = new SkillsStoreImpl();
+		store.skills = [skill("skill")];
+
+		const request = store.selectSkill("skill");
+		await Promise.resolve();
+		await store.remove("skill");
+		expect(store.isLoadingTree).toBe(false);
+
+		stale.resolve({ children: [node("stale.md")] });
+		await request;
+		expect(store.selectedSkill).toBeNull();
+		expect(store.skillTree).toBeNull();
+	});
+});

--- a/apps/inno-agent/web/src/stores/skills-store.ts
+++ b/apps/inno-agent/web/src/stores/skills-store.ts
@@ -7,7 +7,7 @@ interface SkillsStoreEvents {
 	change: void;
 }
 
-class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
+export class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 	skills: SkillInfo[] = [];
 	isLoading = false;
 	isUploading = false;
@@ -30,6 +30,8 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 	libraryError: string | null = null;
 	/** Names currently being imported (for per-row spinners). */
 	importing = new Set<string>();
+	private treeRequestId = 0;
+	private fileRequestId = 0;
 
 	async load() {
 		this.isLoading = true;
@@ -71,9 +73,13 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 		await deleteSkill(name);
 		this.skills = this.skills.filter((item) => item.name !== name);
 		if (this.selectedSkill === name) {
+			this.treeRequestId++;
+			this.fileRequestId++;
 			this.selectedSkill = null;
 			this.skillTree = null;
 			this.currentFile = null;
+			this.isLoadingTree = false;
+			this.isLoadingFile = false;
 			this.isEditing = false;
 		}
 		this.emit("change", undefined);
@@ -133,48 +139,67 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 	/* --- File browsing --- */
 
 	async selectSkill(name: string) {
+		const requestId = ++this.treeRequestId;
+		this.fileRequestId++;
 		this.selectedSkill = name;
 		this.currentFile = null;
+		this.isLoadingFile = false;
 		this.isEditing = false;
 		this.isLoadingTree = true;
 		this.emit("change", undefined);
 		try {
 			const data = await getSkillTree(name);
-			if (this.selectedSkill === name) {
+			if (requestId === this.treeRequestId && this.selectedSkill === name) {
 				this.skillTree = data.children;
 			}
 		} catch {
-			this.skillTree = [];
+			if (requestId === this.treeRequestId && this.selectedSkill === name) {
+				this.skillTree = [];
+			}
 		} finally {
-			this.isLoadingTree = false;
-			this.emit("change", undefined);
+			if (requestId === this.treeRequestId && this.selectedSkill === name) {
+				this.isLoadingTree = false;
+				this.emit("change", undefined);
+			}
 		}
 	}
 
 	deselectSkill() {
+		this.treeRequestId++;
+		this.fileRequestId++;
 		this.selectedSkill = null;
 		this.skillTree = null;
 		this.currentFile = null;
+		this.isLoadingTree = false;
+		this.isLoadingFile = false;
 		this.isEditing = false;
 		this.emit("change", undefined);
 	}
 
 	async selectFile(path: string) {
-		if (!this.selectedSkill) return;
+		const skillName = this.selectedSkill;
+		if (!skillName) return;
+		const requestId = ++this.fileRequestId;
 		this.isEditing = false;
 		this.isLoadingFile = true;
 		this.emit("change", undefined);
 		try {
-			const file = await getSkillFile(this.selectedSkill, path);
+			const file = await getSkillFile(skillName, path);
+			if (requestId !== this.fileRequestId || this.selectedSkill !== skillName) return;
 			if (file && file.kind === "html" && file.content) {
-				file.content = await inlineSkillHtml(this.selectedSkill, file.content, file.path);
+				file.content = await inlineSkillHtml(skillName, file.content, file.path);
+				if (requestId !== this.fileRequestId || this.selectedSkill !== skillName) return;
 			}
 			this.currentFile = file;
 		} catch {
-			this.currentFile = null;
+			if (requestId === this.fileRequestId && this.selectedSkill === skillName) {
+				this.currentFile = null;
+			}
 		} finally {
-			this.isLoadingFile = false;
-			this.emit("change", undefined);
+			if (requestId === this.fileRequestId && this.selectedSkill === skillName) {
+				this.isLoadingFile = false;
+				this.emit("change", undefined);
+			}
 		}
 	}
 
@@ -187,17 +212,24 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 
 	/** Re-fetch the current file forcing text mode (for binary files the user wants to edit). */
 	async openAsText() {
-		if (!this.selectedSkill || !this.currentFile) return;
+		const skillName = this.selectedSkill;
+		const currentFile = this.currentFile;
+		if (!skillName || !currentFile) return;
+		const requestId = ++this.fileRequestId;
 		this.isLoadingFile = true;
 		this.emit("change", undefined);
 		try {
-			const file = await getSkillFile(this.selectedSkill, this.currentFile.path, true);
-			this.currentFile = file;
+			const file = await getSkillFile(skillName, currentFile.path, true);
+			if (requestId === this.fileRequestId && this.selectedSkill === skillName) {
+				this.currentFile = file;
+			}
 		} catch {
 			// keep current file on failure
 		} finally {
-			this.isLoadingFile = false;
-			this.emit("change", undefined);
+			if (requestId === this.fileRequestId && this.selectedSkill === skillName) {
+				this.isLoadingFile = false;
+				this.emit("change", undefined);
+			}
 		}
 	}
 
@@ -226,17 +258,25 @@ class SkillsStoreImpl extends EventEmitter<SkillsStoreEvents> {
 	}
 
 	async refreshTree() {
-		if (!this.selectedSkill) return;
+		const skillName = this.selectedSkill;
+		if (!skillName) return;
+		const requestId = ++this.treeRequestId;
 		this.isLoadingTree = true;
 		this.emit("change", undefined);
 		try {
-			const data = await getSkillTree(this.selectedSkill);
-			this.skillTree = data.children;
+			const data = await getSkillTree(skillName);
+			if (requestId === this.treeRequestId && this.selectedSkill === skillName) {
+				this.skillTree = data.children;
+			}
 		} catch {
-			this.skillTree = [];
+			if (requestId === this.treeRequestId && this.selectedSkill === skillName) {
+				this.skillTree = [];
+			}
 		} finally {
-			this.isLoadingTree = false;
-			this.emit("change", undefined);
+			if (requestId === this.treeRequestId && this.selectedSkill === skillName) {
+				this.isLoadingTree = false;
+				this.emit("change", undefined);
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 问题背景

Skills 面板中的目录和文件内容通过异步请求加载。用户快速切换 Skill、快速点击不同文件，或在请求尚未完成时返回列表/删除当前 Skill 时，旧请求仍可能在之后返回。
由于旧请求没有确认自己是否仍对应当前界面状态，其成功、失败和完成回调都可能继续修改 Store，导致较早请求污染较新的选择状态。

具体表现包括：
1. 用户先打开 Skill A，随后立即切换到 Skill B。
   - Skill B 的目录已成功加载。
   - 如果 Skill A 的旧目录请求之后失败，其 `catch` 会清空当前目录，其 `finally` 会错误关闭当前加载状态。
2. 用户在同一 Skill 中先打开 `old.md`，再立即打开 `new.md`。
   - `new.md` 先返回并正确显示。
   - `old.md` 的旧响应随后返回，会将当前文件重新覆盖为 `old.md`。
3. 用户在目录或文件请求进行中取消选择或删除当前 Skill。
   - 已失去上下文的请求仍可能尝试更新状态。
   - 加载状态可能无法正确重置。
## 修改内容
### 目录请求状态隔离
- 为 Skill 目录请求增加 `treeRequestId`。
- `selectSkill` 和 `refreshTree` 发起请求时递增请求 ID，并在响应、异常处理和结束处理时确认：
  - 请求 ID 仍是最新请求；
  - 当前选中的 Skill 仍与请求目标一致。
- 只有满足上述条件时，才允许更新目录数据、清空目录或关闭目录加载状态。
- `deselectSkill` 和删除当前 Skill 时递增请求 ID，使所有进行中的目录请求失效，并立即重置目录加载状态。
### 文件请求状态隔离
- 为文件内容请求增加 `fileRequestId`。
- `selectFile` 和 `openAsText` 发起请求时递增请求 ID，并保存当时的 Skill 名称和文件上下文。
- 只有最新请求且当前 Skill 未变化时，才允许更新 `currentFile`、清空文件内容或关闭文件加载状态。
- HTML 文件执行内容内联后会再次校验请求有效性，避免内联过程结束后将过期内容写回当前状态。
- 切换 Skill、取消选择或删除当前 Skill 时，使正在进行的文件请求失效，并重置文件加载状态。
### 回归测试
新增 `skills-store.test.ts`，覆盖以下场景：
- 旧 Skill 的目录请求失败后，不会清空新 Skill 的目录。
- 旧文件请求晚于新文件请求返回时，不会覆盖当前文件。
- 删除当前 Skill 时，进行中的目录请求不会恢复已删除的状态，也不会遗留加载状态。
## 当前结果
Skills 文件浏览状态现在遵循“最新请求优先”原则：
- 快速切换 Skill 不会被旧目录请求污染。
- 快速切换文件不会显示错误的旧文件。
- 请求进行中返回列表或删除 Skill 后，不会出现过期响应写回或加载状态卡住的问题。
## 验证结果
- `npm test`
  - 33 个测试文件通过
  - 256 个测试通过，1 个跳过
- `npm run build`
  - 构建通过
  - 仅保留既有的 Vite 大 chunk 和动态导入警告