### PR TITLE
feat(notes): 添加笔记元数据与内置模板

### DIFF
--- a/apps/inno-agent/note-templates/blank.md
+++ b/apps/inno-agent/note-templates/blank.md
@@ -1,0 +1,9 @@
+---
+label: 空白笔记
+labelEn: Blank note
+description: 从标题开始自由书写
+descriptionEn: Start with a simple title
+hidden: true
+---
+
+# 未命名笔记

--- a/apps/inno-agent/note-templates/common.md
+++ b/apps/inno-agent/note-templates/common.md
@@ -1,0 +1,44 @@
+---
+label: 通用总结
+labelEn: AI summary
+description: 提炼要点、待办与关联笔记
+descriptionEn: Capture takeaways, actions, and related notes
+tags: 总结
+tagsEn: summary
+title: AI Summary
+titleEn: AI Summary
+---
+# AI Summary
+
+## TL;DR
+
+一句话总结
+
+---
+
+## Key Points
+
+- 核心观点1
+- 核心观点2
+- 核心观点3
+
+---
+
+## Action Items
+
+- [ ]
+- [ ]
+- [ ]
+
+---
+
+## Related Notes
+
+- [[相关笔记1]]
+- [[相关笔记2]]
+
+---
+
+## Open Questions
+
+-

--- a/apps/inno-agent/note-templates/daily-note.md
+++ b/apps/inno-agent/note-templates/daily-note.md
@@ -1,0 +1,39 @@
+---
+label: 每日笔记
+labelEn: Daily note
+description: 记录每日计划、完成与学习
+descriptionEn: Track daily plans, progress, and learning
+tags: 每日笔记
+tagsEn: daily-note
+title: 每日笔记
+titleEn: Daily note
+---
+# 每日笔记
+
+## 基本信息
+
+- 日期：
+- 记录人：
+
+## 今日计划
+
+- [ ]
+- [ ]
+- [ ]
+
+## 今日完成
+
+- [x]
+- [x]
+
+## 学习记录
+
+-
+
+## 遇到的问题
+
+-
+
+## 明日计划
+
+-

--- a/apps/inno-agent/note-templates/meeting-minutes.md
+++ b/apps/inno-agent/note-templates/meeting-minutes.md
@@ -1,0 +1,51 @@
+---
+label: 会议纪要
+labelEn: Meeting minutes
+description: 议题、讨论与行动项
+descriptionEn: Agenda, notes, and action items
+tags: 会议纪要
+tagsEn: meeting
+title: 会议名称
+titleEn: Meeting name
+---
+
+# 会议名称
+
+## 会议信息
+
+- 时间：
+- 地点：
+- 主持人：
+- 参会人员：
+
+## 会议目标
+
+本次会议希望解决的问题：
+
+## 讨论内容
+
+### 议题1
+
+- 讨论：
+- 结论：
+
+### 议题2
+
+- 讨论：
+- 结论：
+
+## 决策事项
+
+1.
+2.
+3.
+
+## Action Items
+
+| 任务 | 负责人 | 截止时间 |
+|--------|--------|--------|
+| | | |
+
+## 待跟进问题
+
+-

--- a/apps/inno-agent/note-templates/reading-notes.md
+++ b/apps/inno-agent/note-templates/reading-notes.md
@@ -1,0 +1,44 @@
+---
+label: 读书笔记
+labelEn: Reading notes
+description: 摘录观点、理解与可实践内容
+descriptionEn: Capture ideas, reflections, and actionable insights
+tags: 读书笔记
+tagsEn: reading-notes
+title: 文章标题
+titleEn: Article title
+---
+
+# 文章标题
+
+来源：
+
+作者：
+
+时间：
+
+---
+
+## 核心观点
+
+1.
+2.
+3.
+
+---
+
+## 重要摘录
+
+>
+
+---
+
+## 我的理解
+
+-
+
+---
+
+## 可实践内容
+
+-

--- a/apps/inno-agent/note-templates/study-notes.md
+++ b/apps/inno-agent/note-templates/study-notes.md
@@ -1,0 +1,34 @@
+---
+label: 学习笔记
+labelEn: Study notes
+description: 记录课程要点与总结
+descriptionEn: Capture course notes and summaries
+tags: 学习笔记
+tagsEn: study-notes
+title: 学习主题
+titleEn: Study topic
+---
+
+# 学习主题
+
+## 关键词
+
+-
+-
+-
+
+---
+
+## 笔记区
+
+记录课程内容
+
+记录知识点
+
+记录案例
+
+---
+
+## 总结
+
+一句话总结本次学习内容

--- a/apps/inno-agent/note-templates/tech-research.md
+++ b/apps/inno-agent/note-templates/tech-research.md
@@ -1,0 +1,48 @@
+---
+label: 技术调研
+labelEn: Tech research
+description: 对比方案、分析维度与结论
+descriptionEn: Compare options, analyze trade-offs, and conclude
+tags: 技术调研
+tagsEn: tech-research
+title: 调研主题
+titleEn: Research topic
+---
+
+# 调研主题
+
+## 调研目标
+
+为什么调研？
+
+---
+
+## 候选方案
+
+### 方案A
+
+优点：
+
+缺点：
+
+### 方案B
+
+优点：
+
+缺点：
+
+---
+
+## 对比分析
+
+| 维度 | A | B |
+|--------|--------|--------|
+| 功能 | | |
+| 成本 | | |
+| 性能 | | |
+
+---
+
+## 最终结论
+
+-

--- a/apps/inno-agent/note-templates/weekly-report.md
+++ b/apps/inno-agent/note-templates/weekly-report.md
@@ -1,0 +1,46 @@
+---
+label: 周报
+labelEn: Weekly report
+description: 本周成果、问题与下周计划
+descriptionEn: Weekly outcomes, issues, and next steps
+tags: 周报
+tagsEn: weekly-report
+title: 周报
+titleEn: Weekly report
+---
+
+# 第XX周工作总结
+
+## 本周完成
+
+### 项目A
+
+- 完成内容
+
+### 项目B
+
+- 完成内容
+
+---
+
+## 本周问题
+
+### 问题1
+
+原因：
+
+解决方案：
+
+---
+
+## 学习收获
+
+-
+
+---
+
+## 下周计划
+
+- [ ]
+- [ ]
+- [ ]

--- a/apps/inno-agent/src/memory/l2/note-frontmatter.ts
+++ b/apps/inno-agent/src/memory/l2/note-frontmatter.ts
@@ -1,0 +1,171 @@
+export type NoteStatus = "draft" | "indexed" | "outdated" | "error";
+
+export interface NoteFrontmatter {
+	note_id: string;
+	title: string;
+	tags: string[];
+	record_date: string;
+	status: NoteStatus;
+	source_id?: string;
+	created: string;
+	updated: string;
+}
+
+const FRONTMATTER_PATTERN = /^(?:\uFEFF)?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/;
+
+function parseScalar(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+		try {
+			return JSON.parse(trimmed) as string;
+		} catch {
+			return trimmed.slice(1, -1);
+		}
+	}
+	return trimmed;
+}
+
+function parseTagList(value: string): string[] {
+	const trimmed = value.trim();
+	if (!trimmed) return [];
+	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		return trimmed
+			.slice(1, -1)
+			.split(",")
+			.map((tag) => parseScalar(tag.trim()))
+			.filter(Boolean);
+	}
+	return trimmed
+		.split(/[,，;；、|]/)
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
+export function getTodayRecordDate(): string {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+export function recordDateFromIso(isoString: string | undefined): string {
+	if (!isoString) return getTodayRecordDate();
+	const date = new Date(isoString);
+	if (Number.isNaN(date.getTime())) return getTodayRecordDate();
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+function normalizeRecordDateValue(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) return "";
+	if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+	const slashMatch = trimmed.match(/^(\d{4})[/.](\d{1,2})[/.](\d{1,2})$/);
+	if (slashMatch) {
+		return `${slashMatch[1]}-${slashMatch[2].padStart(2, "0")}-${slashMatch[3].padStart(2, "0")}`;
+	}
+	const parsed = new Date(trimmed);
+	if (!Number.isNaN(parsed.getTime())) return recordDateFromIso(parsed.toISOString());
+	return "";
+}
+
+export function parseNoteFrontmatter(content: string): { frontmatter: NoteFrontmatter | null; body: string } {
+	const match = content.match(FRONTMATTER_PATTERN);
+	if (!match) return { frontmatter: null, body: content };
+
+	const yamlBlock = match[1];
+	const body = match[2];
+	const fm: Record<string, unknown> = {};
+	let currentKey = "";
+	let currentArray: string[] = [];
+
+	for (const line of yamlBlock.split("\n")) {
+		const kvMatch = line.match(/^(\w+):\s*(.*)$/);
+		if (kvMatch) {
+			if (currentKey && currentArray.length > 0) {
+				fm[currentKey] = currentArray;
+				currentArray = [];
+			}
+			currentKey = kvMatch[1];
+			const value = kvMatch[2].trim();
+			if (value.startsWith("[") && value.endsWith("]")) {
+				fm[currentKey] = parseTagList(value);
+				currentKey = "";
+			} else if (value === "") {
+				// array items follow
+			} else {
+				fm[currentKey] = value;
+				currentKey = "";
+			}
+		} else {
+			const itemMatch = line.match(/^\s+-\s+(.+)$/);
+			if (itemMatch) {
+				currentArray.push(parseScalar(itemMatch[1]));
+			}
+		}
+	}
+	if (currentKey && currentArray.length > 0) {
+		fm[currentKey] = currentArray;
+	}
+
+	const status = fm.status as string;
+	const validStatus: NoteStatus =
+		status === "indexed" || status === "outdated" || status === "error" ? status : "draft";
+	const created = parseScalar(String(fm.created ?? ""));
+	const recordDateRaw = parseScalar(String(fm.record_date ?? fm.recordDate ?? ""));
+
+	return {
+		frontmatter: {
+			note_id: parseScalar(String(fm.note_id ?? "")),
+			title: parseScalar(String(fm.title ?? "")),
+			tags: Array.isArray(fm.tags) ? (fm.tags as string[]) : parseTagList(String(fm.tags ?? "")),
+			record_date: normalizeRecordDateValue(recordDateRaw) || recordDateFromIso(created),
+			status: validStatus,
+			source_id: fm.source_id ? parseScalar(String(fm.source_id)) : undefined,
+			created,
+			updated: parseScalar(String(fm.updated ?? "")),
+		},
+		body,
+	};
+}
+
+function yamlQuote(value: string): string {
+	if (/[:\[\]{},#&*!|>'"%@`\n]/.test(value) || value.trim() !== value || value === "") {
+		return JSON.stringify(value);
+	}
+	return value;
+}
+
+export function serializeNoteFile(frontmatter: NoteFrontmatter, body: string): string {
+	const lines = [
+		"---",
+		`note_id: ${yamlQuote(frontmatter.note_id)}`,
+		`title: ${yamlQuote(frontmatter.title)}`,
+	];
+	if (frontmatter.tags.length > 0) {
+		lines.push("tags:");
+		for (const tag of frontmatter.tags) {
+			lines.push(`  - ${yamlQuote(tag)}`);
+		}
+	} else {
+		lines.push("tags: []");
+	}
+	lines.push(`record_date: ${yamlQuote(frontmatter.record_date)}`);
+	lines.push(`status: ${frontmatter.status}`);
+	if (frontmatter.source_id) {
+		lines.push(`source_id: ${yamlQuote(frontmatter.source_id)}`);
+	}
+	lines.push(`created: ${yamlQuote(frontmatter.created)}`);
+	lines.push(`updated: ${yamlQuote(frontmatter.updated)}`);
+	lines.push("---");
+	const trimmedBody = body.replace(/^\n/, "");
+	return `${lines.join("\n")}\n${trimmedBody}`;
+}
+
+export function extractNoteTitle(body: string, fallback: string): string {
+	const match = body.match(/^#\s+(.+)$/m);
+	return match?.[1]?.trim() || fallback;
+}

--- a/apps/inno-agent/src/memory/l2/note-templates.ts
+++ b/apps/inno-agent/src/memory/l2/note-templates.ts
@@ -1,0 +1,100 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+export interface NoteTemplateDefinition {
+	id: string;
+	label: string;
+	labelEn: string;
+	description: string;
+	descriptionEn: string;
+	tags: string[];
+	body: string;
+	defaultTitle: string;
+	hidden: boolean;
+}
+
+function readAttribute(lines: string[], keys: string[]): string {
+	for (const line of lines) {
+		const match = line.match(/^(\w+):\s*(.*)$/);
+		if (!match) continue;
+		if (keys.includes(match[1])) return match[2].trim();
+	}
+	return "";
+}
+
+function parseTagList(value: string): string[] {
+	if (!value.trim()) return [];
+	return value
+		.split(/[,，;；、|]/)
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
+function extractFirstHeading(body: string): string | null {
+	const match = body.match(/^#\s+(.+)$/m);
+	return match?.[1]?.trim() ?? null;
+}
+
+function loadTemplateFile(codeDir: string, fileName: string): NoteTemplateDefinition | null {
+	const absPath = join(codeDir, "note-templates", fileName);
+	if (!existsSync(absPath)) return null;
+	const raw = readFileSync(absPath, "utf8");
+	const match = raw.match(/^(?:\uFEFF)?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/);
+	if (!match) return null;
+
+	const metaLines = match[1].split("\n");
+	const body = match[2];
+	const id = basename(fileName, ".md");
+	const heading = extractFirstHeading(body);
+	const label = readAttribute(metaLines, ["label"]) || heading || id;
+	const labelEn = readAttribute(metaLines, ["labelEn", "label_en"]) || label;
+	const description = readAttribute(metaLines, ["description", "desc"]);
+	const descriptionEn = readAttribute(metaLines, ["descriptionEn", "description_en"]) || description;
+	const tags = parseTagList(readAttribute(metaLines, ["tags", "tag"]));
+	const defaultTitle = readAttribute(metaLines, ["title"]) || heading || label;
+	const hidden = readAttribute(metaLines, ["hidden"]).toLowerCase() === "true";
+
+	return { id, label, labelEn, description, descriptionEn, tags, body, defaultTitle, hidden };
+}
+
+export function listNoteTemplates(codeDir: string): NoteTemplateDefinition[] {
+	const dir = join(codeDir, "note-templates");
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir)
+		.filter((name) => name.endsWith(".md"))
+		.map((name) => loadTemplateFile(codeDir, name))
+		.filter((item): item is NoteTemplateDefinition => item !== null)
+		.sort((a, b) => a.label.localeCompare(b.label, "zh"));
+}
+
+export function getNoteTemplate(codeDir: string, templateId: string): NoteTemplateDefinition | undefined {
+	return listNoteTemplates(codeDir).find((item) => item.id === templateId);
+}
+
+export function resolveNoteTemplateContent(
+	codeDir: string,
+	options: { templateId?: string; title?: string; tags?: string[]; content?: string },
+): { title: string; tags: string[]; body: string } {
+	if (options.content?.trim()) {
+		return {
+			title: options.title?.trim() || "未命名笔记",
+			tags: options.tags ?? [],
+			body: options.content,
+		};
+	}
+
+	const template = options.templateId ? getNoteTemplate(codeDir, options.templateId) : getNoteTemplate(codeDir, "blank");
+	if (template) {
+		return {
+			title: options.title?.trim() || template.defaultTitle,
+			tags: options.tags ?? template.tags,
+			body: template.body,
+		};
+	}
+
+	return {
+		title: options.title?.trim() || "未命名笔记",
+		tags: options.tags ?? [],
+		body: "# 未命名笔记\n\n",
+	};
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 			"electron/**/*",
 			"apps/inno-agent/dist/**/*",
 			"apps/inno-agent/web/dist/**/*",
+			"apps/inno-agent/note-templates/**/*",
 			"apps/inno-agent/presets/**/*",
 			"apps/inno-agent/scripts/**/*",
 			"node_modules/**/*",


### PR DESCRIPTION
## 改动内容

- 新增兼容 CRLF 换行的笔记 Frontmatter 解析与序列化工具。
- 新增 8 个内置 Markdown 笔记模板，覆盖常见学习与记录场景。
- 将内置模板目录加入桌面应用打包文件。

## 改动原因

这部分是后续笔记本 API 和前端功能共同依赖的数据格式基础。单独提交后，可以在不混入服务端路由或前端代码的情况下，集中审查笔记结构和内置模板内容。

## 影响范围

本 PR 暂不直接提供新的 UI 或 API。后续堆叠 PR 会在创建和编辑笔记时复用这些工具与模板。

## 验证情况

- 已通过 `listNoteTemplates` 成功加载全部 8 个内置模板。
- `git diff --check` 检查通过。
- 后端全量 TypeScript 检查仅保留仓库原有的 `@tavily/core` 依赖缺失及其派生的隐式 `any` 错误；本 PR 涉及的文件没有新增类型错误。
