### PR TITLE
feat(notes): 提供笔记本后端 API

### DIFF
--- a/apps/inno-agent/note-templates/blank.md
+++ b/apps/inno-agent/note-templates/blank.md
@@ -1,0 +1,9 @@
+---
+label: 空白笔记
+labelEn: Blank note
+description: 从标题开始自由书写
+descriptionEn: Start with a simple title
+hidden: true
+---
+
+# 未命名笔记

--- a/apps/inno-agent/note-templates/common.md
+++ b/apps/inno-agent/note-templates/common.md
@@ -1,0 +1,44 @@
+---
+label: 通用总结
+labelEn: AI summary
+description: 提炼要点、待办与关联笔记
+descriptionEn: Capture takeaways, actions, and related notes
+tags: 总结
+tagsEn: summary
+title: AI Summary
+titleEn: AI Summary
+---
+# AI Summary
+
+## TL;DR
+
+一句话总结
+
+---
+
+## Key Points
+
+- 核心观点1
+- 核心观点2
+- 核心观点3
+
+---
+
+## Action Items
+
+- [ ]
+- [ ]
+- [ ]
+
+---
+
+## Related Notes
+
+- [[相关笔记1]]
+- [[相关笔记2]]
+
+---
+
+## Open Questions
+
+-

--- a/apps/inno-agent/note-templates/daily-note.md
+++ b/apps/inno-agent/note-templates/daily-note.md
@@ -1,0 +1,39 @@
+---
+label: 每日笔记
+labelEn: Daily note
+description: 记录每日计划、完成与学习
+descriptionEn: Track daily plans, progress, and learning
+tags: 每日笔记
+tagsEn: daily-note
+title: 每日笔记
+titleEn: Daily note
+---
+# 每日笔记
+
+## 基本信息
+
+- 日期：
+- 记录人：
+
+## 今日计划
+
+- [ ]
+- [ ]
+- [ ]
+
+## 今日完成
+
+- [x]
+- [x]
+
+## 学习记录
+
+-
+
+## 遇到的问题
+
+-
+
+## 明日计划
+
+-

--- a/apps/inno-agent/note-templates/meeting-minutes.md
+++ b/apps/inno-agent/note-templates/meeting-minutes.md
@@ -1,0 +1,51 @@
+---
+label: 会议纪要
+labelEn: Meeting minutes
+description: 议题、讨论与行动项
+descriptionEn: Agenda, notes, and action items
+tags: 会议纪要
+tagsEn: meeting
+title: 会议名称
+titleEn: Meeting name
+---
+
+# 会议名称
+
+## 会议信息
+
+- 时间：
+- 地点：
+- 主持人：
+- 参会人员：
+
+## 会议目标
+
+本次会议希望解决的问题：
+
+## 讨论内容
+
+### 议题1
+
+- 讨论：
+- 结论：
+
+### 议题2
+
+- 讨论：
+- 结论：
+
+## 决策事项
+
+1.
+2.
+3.
+
+## Action Items
+
+| 任务 | 负责人 | 截止时间 |
+|--------|--------|--------|
+| | | |
+
+## 待跟进问题
+
+-

--- a/apps/inno-agent/note-templates/reading-notes.md
+++ b/apps/inno-agent/note-templates/reading-notes.md
@@ -1,0 +1,44 @@
+---
+label: 读书笔记
+labelEn: Reading notes
+description: 摘录观点、理解与可实践内容
+descriptionEn: Capture ideas, reflections, and actionable insights
+tags: 读书笔记
+tagsEn: reading-notes
+title: 文章标题
+titleEn: Article title
+---
+
+# 文章标题
+
+来源：
+
+作者：
+
+时间：
+
+---
+
+## 核心观点
+
+1.
+2.
+3.
+
+---
+
+## 重要摘录
+
+>
+
+---
+
+## 我的理解
+
+-
+
+---
+
+## 可实践内容
+
+-

--- a/apps/inno-agent/note-templates/study-notes.md
+++ b/apps/inno-agent/note-templates/study-notes.md
@@ -1,0 +1,34 @@
+---
+label: 学习笔记
+labelEn: Study notes
+description: 记录课程要点与总结
+descriptionEn: Capture course notes and summaries
+tags: 学习笔记
+tagsEn: study-notes
+title: 学习主题
+titleEn: Study topic
+---
+
+# 学习主题
+
+## 关键词
+
+-
+-
+-
+
+---
+
+## 笔记区
+
+记录课程内容
+
+记录知识点
+
+记录案例
+
+---
+
+## 总结
+
+一句话总结本次学习内容

--- a/apps/inno-agent/note-templates/tech-research.md
+++ b/apps/inno-agent/note-templates/tech-research.md
@@ -1,0 +1,48 @@
+---
+label: 技术调研
+labelEn: Tech research
+description: 对比方案、分析维度与结论
+descriptionEn: Compare options, analyze trade-offs, and conclude
+tags: 技术调研
+tagsEn: tech-research
+title: 调研主题
+titleEn: Research topic
+---
+
+# 调研主题
+
+## 调研目标
+
+为什么调研？
+
+---
+
+## 候选方案
+
+### 方案A
+
+优点：
+
+缺点：
+
+### 方案B
+
+优点：
+
+缺点：
+
+---
+
+## 对比分析
+
+| 维度 | A | B |
+|--------|--------|--------|
+| 功能 | | |
+| 成本 | | |
+| 性能 | | |
+
+---
+
+## 最终结论
+
+-

--- a/apps/inno-agent/note-templates/weekly-report.md
+++ b/apps/inno-agent/note-templates/weekly-report.md
@@ -1,0 +1,46 @@
+---
+label: 周报
+labelEn: Weekly report
+description: 本周成果、问题与下周计划
+descriptionEn: Weekly outcomes, issues, and next steps
+tags: 周报
+tagsEn: weekly-report
+title: 周报
+titleEn: Weekly report
+---
+
+# 第XX周工作总结
+
+## 本周完成
+
+### 项目A
+
+- 完成内容
+
+### 项目B
+
+- 完成内容
+
+---
+
+## 本周问题
+
+### 问题1
+
+原因：
+
+解决方案：
+
+---
+
+## 学习收获
+
+-
+
+---
+
+## 下周计划
+
+- [ ]
+- [ ]
+- [ ]

--- a/apps/inno-agent/src/memory/l2/manifest-store.ts
+++ b/apps/inno-agent/src/memory/l2/manifest-store.ts
@@ -60,3 +60,8 @@ export function findManifestByTitle(l2DataDir: string, title: string): ManifestE
 export function findManifestByHash(l2DataDir: string, contentHash: string): ManifestEntry | undefined {
 	return readManifest(l2DataDir).find((e) => e.contentHash === contentHash);
 }
+
+export function findManifestByRawPath(l2DataDir: string, rawPath: string): ManifestEntry | undefined {
+	const normalized = rawPath.replace(/\\/g, "/");
+	return readManifest(l2DataDir).find((e) => e.rawPath.replace(/\\/g, "/") === normalized);
+}

--- a/apps/inno-agent/src/memory/l2/note-attachments-service.ts
+++ b/apps/inno-agent/src/memory/l2/note-attachments-service.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { readJson, writeJson, readText } from "../../storage/file-store.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
+import { parseNoteFrontmatter } from "./note-frontmatter.js";
+import { sanitizeUploadedFileName, uploadExtension } from "./upload-file-utils.js";
+
+export type NoteAttachmentStatus = "uploaded" | "extracting" | "extracted" | "indexed" | "error";
+
+export interface NoteAttachmentRecord {
+	id: string;
+	noteRawPath: string;
+	noteId: string;
+	fileName: string;
+	mimeType: string;
+	size: number;
+	filePath: string;
+	status: NoteAttachmentStatus;
+	createdAt: string;
+	updatedAt: string;
+}
+
+const INDEX_FILE = "note-attachments.json";
+
+function attachmentsIndexPath(l2DataDir: string): string {
+	return join(l2DataDir, INDEX_FILE);
+}
+
+function readAttachmentIndex(l2DataDir: string): NoteAttachmentRecord[] {
+	return readJson<NoteAttachmentRecord[]>(attachmentsIndexPath(l2DataDir), []);
+}
+
+function writeAttachmentIndex(l2DataDir: string, records: NoteAttachmentRecord[]): void {
+	writeJson(attachmentsIndexPath(l2DataDir), records);
+}
+
+function normalizeNoteRawPath(rawPath: string): string {
+	return rawPath.replace(/\\/g, "/");
+}
+
+export function listNoteAttachments(l2DataDir: string, noteRawPath: string): NoteAttachmentRecord[] {
+	const normalizedPath = normalizeNoteRawPath(noteRawPath);
+	return readAttachmentIndex(l2DataDir)
+		.filter((record) => normalizeNoteRawPath(record.noteRawPath) === normalizedPath)
+		.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function uploadNoteAttachment(
+	l2DataDir: string,
+	noteRawPath: string,
+	options: { fileName: string; mimeType: string; dataBase64: string },
+): NoteAttachmentRecord {
+	const normalizedPath = normalizeNoteRawPath(noteRawPath);
+	const noteRelativePath = normalizedPath.slice("raw/notes/".length);
+	if (
+		!normalizedPath.startsWith("raw/notes/")
+		|| noteRelativePath.includes("/")
+		|| !noteRelativePath.toLowerCase().endsWith(".md")
+	) {
+		throw new Error("Invalid note path");
+	}
+
+	const notePath = resolveContainedPath(join(l2DataDir, "raw", "notes"), noteRelativePath);
+	if (!notePath) throw new Error("Invalid note path");
+	const { frontmatter } = parseNoteFrontmatter(readText(notePath));
+	if (!frontmatter?.note_id) {
+		throw new Error("Invalid note file");
+	}
+	const noteId = frontmatter.note_id.trim();
+	if (!/^note_[A-Za-z0-9_-]+$/.test(noteId)) {
+		throw new Error("Invalid note id");
+	}
+	const attachmentId = `att_${randomUUID().slice(0, 8)}`;
+	const safeName = sanitizeUploadedFileName(options.fileName, "attachment");
+	const ext = uploadExtension(safeName, options.mimeType);
+	const base = basename(safeName, ext).slice(0, 80) || "attachment";
+	const storedName = `${attachmentId}-${base}${ext}`;
+	const attachmentsRoot = join(l2DataDir, "raw", "notes", "attachments");
+	const attachmentDir = resolveContainedPath(attachmentsRoot, noteId);
+	if (!attachmentDir) throw new Error("Invalid attachment path");
+	mkdirSync(attachmentDir, { recursive: true });
+	const absPath = resolveContainedPath(attachmentDir, storedName);
+	if (!absPath) throw new Error("Invalid attachment path");
+	const data = Buffer.from(options.dataBase64, "base64");
+	writeFileSync(absPath, data);
+
+	const now = new Date().toISOString();
+	const record: NoteAttachmentRecord = {
+		id: attachmentId,
+		noteRawPath: normalizedPath,
+		noteId,
+		fileName: options.fileName,
+		mimeType: options.mimeType,
+		size: data.length,
+		filePath: join("raw/notes/attachments", noteId, storedName).replace(/\\/g, "/"),
+		status: "uploaded",
+		createdAt: now,
+		updatedAt: now,
+	};
+
+	const records = readAttachmentIndex(l2DataDir);
+	records.push(record);
+	writeAttachmentIndex(l2DataDir, records);
+	return record;
+}
+
+export function deleteNoteAttachment(l2DataDir: string, attachmentId: string): NoteAttachmentRecord {
+	const records = readAttachmentIndex(l2DataDir);
+	const index = records.findIndex((record) => record.id === attachmentId);
+	if (index < 0) {
+		throw new Error("Attachment not found");
+	}
+
+	const removed = records[index];
+	const normalizedFilePath = removed.filePath.replace(/\\/g, "/");
+	const attachmentPrefix = "raw/notes/attachments/";
+	if (!normalizedFilePath.startsWith(attachmentPrefix)) {
+		throw new Error("Invalid attachment path");
+	}
+	const absPath = resolveContainedPath(
+		join(l2DataDir, "raw", "notes", "attachments"),
+		normalizedFilePath.slice(attachmentPrefix.length),
+	);
+	if (!absPath) throw new Error("Invalid attachment path");
+
+	records.splice(index, 1);
+	writeAttachmentIndex(l2DataDir, records);
+
+	if (existsSync(absPath)) {
+		unlinkSync(absPath);
+	}
+	return removed;
+}
+
+export function findNoteAttachment(l2DataDir: string, attachmentId: string): NoteAttachmentRecord | undefined {
+	return readAttachmentIndex(l2DataDir).find((record) => record.id === attachmentId);
+}

--- a/apps/inno-agent/src/memory/l2/note-frontmatter.ts
+++ b/apps/inno-agent/src/memory/l2/note-frontmatter.ts
@@ -1,0 +1,171 @@
+export type NoteStatus = "draft" | "indexed" | "outdated" | "error";
+
+export interface NoteFrontmatter {
+	note_id: string;
+	title: string;
+	tags: string[];
+	record_date: string;
+	status: NoteStatus;
+	source_id?: string;
+	created: string;
+	updated: string;
+}
+
+const FRONTMATTER_PATTERN = /^(?:\uFEFF)?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/;
+
+function parseScalar(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+		try {
+			return JSON.parse(trimmed) as string;
+		} catch {
+			return trimmed.slice(1, -1);
+		}
+	}
+	return trimmed;
+}
+
+function parseTagList(value: string): string[] {
+	const trimmed = value.trim();
+	if (!trimmed) return [];
+	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		return trimmed
+			.slice(1, -1)
+			.split(",")
+			.map((tag) => parseScalar(tag.trim()))
+			.filter(Boolean);
+	}
+	return trimmed
+		.split(/[,，;；、|]/)
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
+export function getTodayRecordDate(): string {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+export function recordDateFromIso(isoString: string | undefined): string {
+	if (!isoString) return getTodayRecordDate();
+	const date = new Date(isoString);
+	if (Number.isNaN(date.getTime())) return getTodayRecordDate();
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+function normalizeRecordDateValue(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) return "";
+	if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+	const slashMatch = trimmed.match(/^(\d{4})[/.](\d{1,2})[/.](\d{1,2})$/);
+	if (slashMatch) {
+		return `${slashMatch[1]}-${slashMatch[2].padStart(2, "0")}-${slashMatch[3].padStart(2, "0")}`;
+	}
+	const parsed = new Date(trimmed);
+	if (!Number.isNaN(parsed.getTime())) return recordDateFromIso(parsed.toISOString());
+	return "";
+}
+
+export function parseNoteFrontmatter(content: string): { frontmatter: NoteFrontmatter | null; body: string } {
+	const match = content.match(FRONTMATTER_PATTERN);
+	if (!match) return { frontmatter: null, body: content };
+
+	const yamlBlock = match[1];
+	const body = match[2];
+	const fm: Record<string, unknown> = {};
+	let currentKey = "";
+	let currentArray: string[] = [];
+
+	for (const line of yamlBlock.split("\n")) {
+		const kvMatch = line.match(/^(\w+):\s*(.*)$/);
+		if (kvMatch) {
+			if (currentKey && currentArray.length > 0) {
+				fm[currentKey] = currentArray;
+				currentArray = [];
+			}
+			currentKey = kvMatch[1];
+			const value = kvMatch[2].trim();
+			if (value.startsWith("[") && value.endsWith("]")) {
+				fm[currentKey] = parseTagList(value);
+				currentKey = "";
+			} else if (value === "") {
+				// array items follow
+			} else {
+				fm[currentKey] = value;
+				currentKey = "";
+			}
+		} else {
+			const itemMatch = line.match(/^\s+-\s+(.+)$/);
+			if (itemMatch) {
+				currentArray.push(parseScalar(itemMatch[1]));
+			}
+		}
+	}
+	if (currentKey && currentArray.length > 0) {
+		fm[currentKey] = currentArray;
+	}
+
+	const status = fm.status as string;
+	const validStatus: NoteStatus =
+		status === "indexed" || status === "outdated" || status === "error" ? status : "draft";
+	const created = parseScalar(String(fm.created ?? ""));
+	const recordDateRaw = parseScalar(String(fm.record_date ?? fm.recordDate ?? ""));
+
+	return {
+		frontmatter: {
+			note_id: parseScalar(String(fm.note_id ?? "")),
+			title: parseScalar(String(fm.title ?? "")),
+			tags: Array.isArray(fm.tags) ? (fm.tags as string[]) : parseTagList(String(fm.tags ?? "")),
+			record_date: normalizeRecordDateValue(recordDateRaw) || recordDateFromIso(created),
+			status: validStatus,
+			source_id: fm.source_id ? parseScalar(String(fm.source_id)) : undefined,
+			created,
+			updated: parseScalar(String(fm.updated ?? "")),
+		},
+		body,
+	};
+}
+
+function yamlQuote(value: string): string {
+	if (/[:\[\]{},#&*!|>'"%@`\n]/.test(value) || value.trim() !== value || value === "") {
+		return JSON.stringify(value);
+	}
+	return value;
+}
+
+export function serializeNoteFile(frontmatter: NoteFrontmatter, body: string): string {
+	const lines = [
+		"---",
+		`note_id: ${yamlQuote(frontmatter.note_id)}`,
+		`title: ${yamlQuote(frontmatter.title)}`,
+	];
+	if (frontmatter.tags.length > 0) {
+		lines.push("tags:");
+		for (const tag of frontmatter.tags) {
+			lines.push(`  - ${yamlQuote(tag)}`);
+		}
+	} else {
+		lines.push("tags: []");
+	}
+	lines.push(`record_date: ${yamlQuote(frontmatter.record_date)}`);
+	lines.push(`status: ${frontmatter.status}`);
+	if (frontmatter.source_id) {
+		lines.push(`source_id: ${yamlQuote(frontmatter.source_id)}`);
+	}
+	lines.push(`created: ${yamlQuote(frontmatter.created)}`);
+	lines.push(`updated: ${yamlQuote(frontmatter.updated)}`);
+	lines.push("---");
+	const trimmedBody = body.replace(/^\n/, "");
+	return `${lines.join("\n")}\n${trimmedBody}`;
+}
+
+export function extractNoteTitle(body: string, fallback: string): string {
+	const match = body.match(/^#\s+(.+)$/m);
+	return match?.[1]?.trim() || fallback;
+}

--- a/apps/inno-agent/src/memory/l2/note-templates.ts
+++ b/apps/inno-agent/src/memory/l2/note-templates.ts
@@ -1,0 +1,100 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+export interface NoteTemplateDefinition {
+	id: string;
+	label: string;
+	labelEn: string;
+	description: string;
+	descriptionEn: string;
+	tags: string[];
+	body: string;
+	defaultTitle: string;
+	hidden: boolean;
+}
+
+function readAttribute(lines: string[], keys: string[]): string {
+	for (const line of lines) {
+		const match = line.match(/^(\w+):\s*(.*)$/);
+		if (!match) continue;
+		if (keys.includes(match[1])) return match[2].trim();
+	}
+	return "";
+}
+
+function parseTagList(value: string): string[] {
+	if (!value.trim()) return [];
+	return value
+		.split(/[,，;；、|]/)
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
+function extractFirstHeading(body: string): string | null {
+	const match = body.match(/^#\s+(.+)$/m);
+	return match?.[1]?.trim() ?? null;
+}
+
+function loadTemplateFile(codeDir: string, fileName: string): NoteTemplateDefinition | null {
+	const absPath = join(codeDir, "note-templates", fileName);
+	if (!existsSync(absPath)) return null;
+	const raw = readFileSync(absPath, "utf8");
+	const match = raw.match(/^(?:\uFEFF)?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/);
+	if (!match) return null;
+
+	const metaLines = match[1].split("\n");
+	const body = match[2];
+	const id = basename(fileName, ".md");
+	const heading = extractFirstHeading(body);
+	const label = readAttribute(metaLines, ["label"]) || heading || id;
+	const labelEn = readAttribute(metaLines, ["labelEn", "label_en"]) || label;
+	const description = readAttribute(metaLines, ["description", "desc"]);
+	const descriptionEn = readAttribute(metaLines, ["descriptionEn", "description_en"]) || description;
+	const tags = parseTagList(readAttribute(metaLines, ["tags", "tag"]));
+	const defaultTitle = readAttribute(metaLines, ["title"]) || heading || label;
+	const hidden = readAttribute(metaLines, ["hidden"]).toLowerCase() === "true";
+
+	return { id, label, labelEn, description, descriptionEn, tags, body, defaultTitle, hidden };
+}
+
+export function listNoteTemplates(codeDir: string): NoteTemplateDefinition[] {
+	const dir = join(codeDir, "note-templates");
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir)
+		.filter((name) => name.endsWith(".md"))
+		.map((name) => loadTemplateFile(codeDir, name))
+		.filter((item): item is NoteTemplateDefinition => item !== null)
+		.sort((a, b) => a.label.localeCompare(b.label, "zh"));
+}
+
+export function getNoteTemplate(codeDir: string, templateId: string): NoteTemplateDefinition | undefined {
+	return listNoteTemplates(codeDir).find((item) => item.id === templateId);
+}
+
+export function resolveNoteTemplateContent(
+	codeDir: string,
+	options: { templateId?: string; title?: string; tags?: string[]; content?: string },
+): { title: string; tags: string[]; body: string } {
+	if (options.content?.trim()) {
+		return {
+			title: options.title?.trim() || "未命名笔记",
+			tags: options.tags ?? [],
+			body: options.content,
+		};
+	}
+
+	const template = options.templateId ? getNoteTemplate(codeDir, options.templateId) : getNoteTemplate(codeDir, "blank");
+	if (template) {
+		return {
+			title: options.title?.trim() || template.defaultTitle,
+			tags: options.tags ?? template.tags,
+			body: template.body,
+		};
+	}
+
+	return {
+		title: options.title?.trim() || "未命名笔记",
+		tags: options.tags ?? [],
+		body: "# 未命名笔记\n\n",
+	};
+}

--- a/apps/inno-agent/src/memory/l2/notes-service.ts
+++ b/apps/inno-agent/src/memory/l2/notes-service.ts
@@ -1,0 +1,273 @@
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { readText, writeText } from "../../storage/file-store.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
+import { findManifestByRawPath, readManifest } from "./manifest-store.js";
+import {
+	extractNoteTitle,
+	getTodayRecordDate,
+	parseNoteFrontmatter,
+	recordDateFromIso,
+	serializeNoteFile,
+	type NoteFrontmatter,
+	type NoteStatus,
+} from "./note-frontmatter.js";
+import { resolveNoteTemplateContent } from "./note-templates.js";
+import { inferNotebookType, primaryWikiPath, scanOrphans } from "./sources-service.js";
+import type { ManifestEntry, ManifestStatus, RawSourceType } from "./types.js";
+import { ensureL2Directories } from "./wiki-maintainer.js";
+import { logger } from "../../logger.js";
+import { listNoteAttachments, type NoteAttachmentRecord } from "./note-attachments-service.js";
+
+export type NotebookItemKind = "markdown" | "orphan" | "archived";
+export type NotebookType = "conversation" | "file" | "note";
+export type NotebookItemStatus = NoteStatus | ManifestStatus | "uploaded";
+
+export interface NoteSummaryDto {
+	noteId: string;
+	rawPath: string;
+	title: string;
+	tags: string[];
+	notebookType: NotebookType;
+	contentType: RawSourceType;
+	status: NotebookItemStatus;
+	kind: NotebookItemKind;
+	wikiPagePath?: string;
+	wikiPages?: string[];
+	origin?: ManifestEntry["source"]["origin"];
+	extractedPath?: string;
+	size?: number;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface NoteContentDto {
+	rawPath: string;
+	noteId: string;
+	title: string;
+	tags: string[];
+	recordDate: string;
+	status: NoteStatus;
+	sourceId?: string;
+	content: string;
+	attachments: NoteAttachmentRecord[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface NotesListResponse {
+	notes: NoteSummaryDto[];
+}
+
+function noteFileName(title: string, noteId: string): string {
+	const slug = title
+		.toLowerCase()
+		.replace(/[^a-z0-9\u4e00-\u9fff]+/g, "-")
+		.replace(/^-|-$/g, "")
+		.slice(0, 40);
+	return `${slug || "note"}-${noteId.slice(-8)}.md`;
+}
+
+function readNoteFile(l2DataDir: string, rawPath: string): { absPath: string; frontmatter: NoteFrontmatter; body: string } {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	const noteRelativePath = normalizedPath.slice("raw/notes/".length);
+	if (
+		!normalizedPath.startsWith("raw/notes/")
+		|| noteRelativePath.includes("/")
+		|| !noteRelativePath.toLowerCase().endsWith(".md")
+	) {
+		throw new Error("Invalid note path");
+	}
+	const absPath = resolveContainedPath(join(l2DataDir, "raw", "notes"), noteRelativePath);
+	if (!absPath) throw new Error("Invalid note path");
+	const content = readText(absPath);
+	const { frontmatter, body } = parseNoteFrontmatter(content);
+	if (!frontmatter?.note_id) {
+		throw new Error("Invalid note file: missing note_id frontmatter");
+	}
+	return { absPath, frontmatter, body };
+}
+
+function noteSummaryFromFile(l2DataDir: string, rawPath: string): NoteSummaryDto | null {
+	try {
+		const { frontmatter, body } = readNoteFile(l2DataDir, rawPath);
+		const manifest = findManifestByRawPath(l2DataDir, rawPath);
+		if (manifest?.status === "indexed") {
+			return null;
+		}
+		const title = frontmatter.title || extractNoteTitle(body, basename(rawPath, ".md"));
+		return {
+			noteId: frontmatter.note_id,
+			rawPath,
+			title,
+			tags: frontmatter.tags,
+			notebookType: "note",
+			contentType: "markdown",
+			status: frontmatter.status,
+			kind: "markdown",
+			wikiPagePath: manifest ? primaryWikiPath(manifest.wikiPages) : undefined,
+			wikiPages: manifest?.wikiPages,
+			origin: "user_upload",
+			createdAt: frontmatter.created || statSync(join(l2DataDir, rawPath)).mtime.toISOString(),
+			updatedAt: frontmatter.updated || frontmatter.created || statSync(join(l2DataDir, rawPath)).mtime.toISOString(),
+		};
+	} catch (err) {
+		logger.warn({ err, rawPath }, "failed to read note file");
+		return null;
+	}
+}
+
+function manifestToNoteSummary(entry: ManifestEntry): NoteSummaryDto {
+	const rawPath = entry.rawPath.replace(/\\/g, "/");
+	return {
+		noteId: entry.id,
+		rawPath,
+		title: entry.title,
+		tags: entry.tags,
+		notebookType: inferNotebookType(rawPath),
+		contentType: entry.sourceType,
+		status: entry.status,
+		kind: "archived",
+		wikiPagePath: primaryWikiPath(entry.wikiPages),
+		wikiPages: entry.wikiPages,
+		origin: entry.source.origin,
+		extractedPath: entry.extractedPath,
+		createdAt: entry.createdAt,
+		updatedAt: entry.updatedAt,
+	};
+}
+
+function orphanToNoteSummary(orphan: ReturnType<typeof scanOrphans>[number]): NoteSummaryDto {
+	return {
+		noteId: `orphan_${createHash("sha256").update(orphan.rawPath).digest("hex").slice(0, 8)}`,
+		rawPath: orphan.rawPath,
+		title: orphan.fileName,
+		tags: [],
+		notebookType: "file",
+		contentType: orphan.sourceType,
+		status: "uploaded",
+		kind: "orphan",
+		size: orphan.size,
+		origin: "user_upload",
+		createdAt: orphan.modifiedAt,
+		updatedAt: orphan.modifiedAt,
+	};
+}
+
+export function listL2Notes(
+	l2DataDir: string,
+	options: {
+		notebookType?: NotebookType;
+		status?: string;
+	} = {},
+): NotesListResponse {
+	ensureL2Directories(l2DataDir);
+	const entries = readManifest(l2DataDir);
+	const indexedRawPaths = new Set(entries.map((e) => e.rawPath.replace(/\\/g, "/")));
+	const notes: NoteSummaryDto[] = [];
+
+	for (const entry of entries) {
+		const summary = manifestToNoteSummary(entry);
+		if (options.notebookType && summary.notebookType !== options.notebookType) continue;
+		if (options.status && summary.status !== options.status) continue;
+		notes.push(summary);
+	}
+
+	const notesDir = join(l2DataDir, "raw", "notes");
+	if (existsSync(notesDir)) {
+		for (const name of readdirSync(notesDir)) {
+			if (!name.endsWith(".md")) continue;
+			const rawPath = join("raw/notes", name).replace(/\\/g, "/");
+			const summary = noteSummaryFromFile(l2DataDir, rawPath);
+			if (!summary) continue;
+			if (options.notebookType && summary.notebookType !== options.notebookType) continue;
+			if (options.status && summary.status !== options.status) continue;
+			notes.push(summary);
+		}
+	}
+
+	for (const orphan of scanOrphans(l2DataDir, indexedRawPaths)) {
+		const summary = orphanToNoteSummary(orphan);
+		if (options.notebookType && summary.notebookType !== options.notebookType) continue;
+		if (options.status && summary.status !== options.status) continue;
+		notes.push(summary);
+	}
+
+	notes.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+	return { notes };
+}
+
+export function readNoteContent(l2DataDir: string, rawPath: string): NoteContentDto {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	if (!normalizedPath.startsWith("raw/notes/")) {
+		throw new Error("Invalid note path");
+	}
+	const { frontmatter, body } = readNoteFile(l2DataDir, normalizedPath);
+	const title = frontmatter.title || extractNoteTitle(body, basename(normalizedPath, ".md"));
+	return {
+		rawPath: normalizedPath,
+		noteId: frontmatter.note_id,
+		title,
+		tags: frontmatter.tags,
+		recordDate: frontmatter.record_date,
+		status: frontmatter.status,
+		sourceId: frontmatter.source_id,
+		content: body,
+		attachments: listNoteAttachments(l2DataDir, normalizedPath),
+		createdAt: frontmatter.created,
+		updatedAt: frontmatter.updated,
+	};
+}
+
+export function createL2Note(
+	l2DataDir: string,
+	codeDir: string,
+	options: {
+		title?: string;
+		templateId?: string;
+		tags?: string[];
+		content?: string;
+	},
+): { rawPath: string; status: NoteStatus; noteId: string; title: string } {
+	ensureL2Directories(l2DataDir);
+	const { title, tags, body } = resolveNoteTemplateContent(codeDir, options);
+	const noteId = `note_${randomUUID().slice(0, 8)}`;
+	const now = new Date().toISOString();
+	const fileName = noteFileName(title, noteId);
+	const rawPath = join("raw/notes", fileName).replace(/\\/g, "/");
+	const frontmatter: NoteFrontmatter = {
+		note_id: noteId,
+		title,
+		tags,
+		record_date: getTodayRecordDate(),
+		status: "draft",
+		created: now,
+		updated: now,
+	};
+	writeText(join(l2DataDir, rawPath), serializeNoteFile(frontmatter, body));
+	return { rawPath, status: "draft", noteId, title };
+}
+
+export function saveL2NoteContent(
+	l2DataDir: string,
+	rawPath: string,
+	options: { title: string; tags?: string[]; recordDate?: string; content: string },
+): { rawPath: string; status: NoteStatus } {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	const { absPath, frontmatter, body: _oldBody } = readNoteFile(l2DataDir, normalizedPath);
+	const wasIndexed = frontmatter.status === "indexed" || Boolean(frontmatter.source_id);
+	const nextStatus: NoteStatus = wasIndexed ? "outdated" : "draft";
+	const now = new Date().toISOString();
+	const nextFrontmatter: NoteFrontmatter = {
+		...frontmatter,
+		title: options.title.trim() || frontmatter.title,
+		tags: options.tags ?? frontmatter.tags,
+		record_date: options.recordDate?.trim() || frontmatter.record_date || recordDateFromIso(frontmatter.created),
+		status: nextStatus,
+		updated: now,
+	};
+	writeText(absPath, serializeNoteFile(nextFrontmatter, options.content));
+	return { rawPath: normalizedPath, status: nextStatus };
+}

--- a/apps/inno-agent/src/memory/l2/sources-service.ts
+++ b/apps/inno-agent/src/memory/l2/sources-service.ts
@@ -1,0 +1,140 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+
+import { readText } from "../../storage/file-store.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
+import { readManifest } from "./manifest-store.js";
+import { ensureL2Directories } from "./wiki-maintainer.js";
+import type { ManifestEntry, ManifestStatus, RawSourceType } from "./types.js";
+import { logger } from "../../logger.js";
+
+export interface SourceSummaryDto {
+	sourceId: string;
+	title: string;
+	notebookType: "conversation" | "file" | "note";
+	sourceType: RawSourceType;
+	rawPath: string;
+	extractedPath?: string;
+	primaryWikiPath?: string;
+	wikiPages: string[];
+	tags: string[];
+	status: ManifestStatus;
+	origin: ManifestEntry["source"]["origin"];
+	originUrl?: string;
+	sessionId?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface OrphanRawFileDto {
+	rawPath: string;
+	fileName: string;
+	sourceType: RawSourceType;
+	size: number;
+	modifiedAt: string;
+	isMarkdown: boolean;
+	pipelineStatus: "uploaded";
+}
+
+export interface SourcesListResponse {
+	sources: SourceSummaryDto[];
+	orphans: OrphanRawFileDto[];
+}
+
+const RAW_SCAN_DIRS = ["raw/uploads", "raw/conversations"] as const;
+
+function inferSourceType(fileName: string): RawSourceType {
+	const ext = extname(fileName).toLowerCase();
+	if (ext === ".pdf") return "pdf";
+	if (ext === ".doc" || ext === ".docx") return "word";
+	if ([".png", ".jpg", ".jpeg", ".gif", ".webp", ".tiff"].includes(ext)) return "image";
+	if (ext === ".md") return "markdown";
+	return "text";
+}
+
+export function inferNotebookType(rawPath: string): "conversation" | "file" | "note" {
+	if (rawPath.startsWith("raw/conversations/")) return "conversation";
+	if (rawPath.startsWith("raw/notes/")) return "note";
+	return "file";
+}
+
+export function primaryWikiPath(wikiPages: string[]): string | undefined {
+	return wikiPages.find((p) => p.includes("wiki/sources/")) ?? wikiPages[0];
+}
+
+function entryToSummary(entry: ManifestEntry): SourceSummaryDto {
+	const rawPath = entry.rawPath.replace(/\\/g, "/");
+	return {
+		sourceId: entry.id,
+		title: entry.title,
+		notebookType: inferNotebookType(rawPath),
+		sourceType: entry.sourceType,
+		rawPath,
+		extractedPath: entry.extractedPath,
+		primaryWikiPath: primaryWikiPath(entry.wikiPages),
+		wikiPages: entry.wikiPages,
+		tags: entry.tags,
+		status: entry.status,
+		origin: entry.source.origin,
+		originUrl: entry.source.url,
+		sessionId: entry.source.sessionId,
+		createdAt: entry.createdAt,
+		updatedAt: entry.updatedAt,
+	};
+}
+
+export function scanOrphans(l2DataDir: string, indexedRawPaths: Set<string>): OrphanRawFileDto[] {
+	const orphans: OrphanRawFileDto[] = [];
+	for (const relDir of RAW_SCAN_DIRS) {
+		const absDir = join(l2DataDir, relDir);
+		if (!existsSync(absDir)) continue;
+		for (const name of readdirSync(absDir)) {
+			const relPath = join(relDir, name).replace(/\\/g, "/");
+			if (indexedRawPaths.has(relPath)) continue;
+			const absPath = join(l2DataDir, relPath);
+			try {
+				const stat = statSync(absPath);
+				if (!stat.isFile()) continue;
+				const ext = extname(name).toLowerCase();
+				orphans.push({
+					rawPath: relPath,
+					fileName: name,
+					sourceType: inferSourceType(name),
+					size: stat.size,
+					modifiedAt: stat.mtime.toISOString(),
+					isMarkdown: ext === ".md" || ext === ".txt",
+					pipelineStatus: "uploaded",
+				});
+			} catch (err) {
+				logger.warn({ err, relPath }, "failed to stat orphan raw file");
+			}
+		}
+	}
+	orphans.sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt));
+	return orphans;
+}
+
+export function listL2Sources(l2DataDir: string): SourcesListResponse {
+	ensureL2Directories(l2DataDir);
+	const entries = readManifest(l2DataDir);
+	const indexedRawPaths = new Set(entries.map((e) => e.rawPath.replace(/\\/g, "/")));
+	return {
+		sources: entries.map(entryToSummary).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+		orphans: scanOrphans(l2DataDir, indexedRawPaths),
+	};
+}
+
+export function readRawTextPreview(l2DataDir: string, rawPath: string, maxChars = 12000): string {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	const sourceType = inferSourceType(basename(normalizedPath));
+	if (sourceType === "pdf" || sourceType === "word" || sourceType === "image") {
+		return "";
+	}
+	if (!normalizedPath.startsWith("raw/") || normalizedPath === "raw/") {
+		throw new Error("Invalid raw path");
+	}
+	const absPath = resolveContainedPath(join(l2DataDir, "raw"), normalizedPath.slice("raw/".length));
+	if (!absPath) throw new Error("Invalid raw path");
+	const text = readText(absPath);
+	return text.length > maxChars ? `${text.slice(0, maxChars)}\n\n...(已截断)` : text;
+}

--- a/apps/inno-agent/src/memory/l2/upload-file-utils.ts
+++ b/apps/inno-agent/src/memory/l2/upload-file-utils.ts
@@ -1,0 +1,30 @@
+import { extname } from "node:path";
+
+const MIME_EXTENSIONS: Readonly<Record<string, string>> = {
+	"application/pdf": ".pdf",
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+	"application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+	"image/bmp": ".bmp",
+	"image/gif": ".gif",
+	"image/jpeg": ".jpg",
+	"image/png": ".png",
+	"image/tiff": ".tiff",
+	"image/webp": ".webp",
+	"text/markdown": ".md",
+	"text/plain": ".txt",
+};
+
+export function sanitizeUploadedFileName(name: string, fallback: string): string {
+	const cleaned = name
+		.replace(/[/\\?%*:|"<>]/g, "-")
+		.replace(/\s+/g, " ")
+		.trim();
+	return cleaned || fallback;
+}
+
+export function uploadExtension(fileName: string, mimeType: string): string {
+	const extension = extname(fileName).toLowerCase();
+	if (/^\.[a-z0-9]{1,10}$/.test(extension)) return extension;
+	return MIME_EXTENSIONS[mimeType.trim().toLowerCase()] ?? ".bin";
+}

--- a/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
@@ -437,6 +437,7 @@ export function appendLog(l2DataDir: string, action: string, title: string, deta
 export function ensureL2Directories(l2DataDir: string): void {
 	const dirs = [
 		"raw/uploads",
+		"raw/notes",
 		"raw/web",
 		"raw/conversations",
 		"raw/research",

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -48,6 +48,7 @@ import { handleWorkspacesRoutes } from "./server/routes/workspaces.js";
 import { handleSessionsRoutes } from "./server/routes/sessions.js";
 import { handleLearnerRoutes } from "./server/routes/learner.js";
 import { handleWikiRoutes } from "./server/routes/wiki.js";
+import { handleNotebookRoutes } from "./server/routes/notebook.js";
 import { handlePresetsRoutes } from "./server/routes/presets.js";
 import { handlePracticeRoutes } from "./server/routes/practice.js";
 import { handleChatRoutes } from "./server/routes/chat.js";
@@ -1435,6 +1436,12 @@ const server = createServer(async (req, res) => {
 
 		// --- Wiki + L2 raw upload API (extracted to server/routes/wiki.ts) ---
 		if (await handleWikiRoutes(req, res, method, url, { l2DataDir })) return;
+
+		// --- L2 Notebook API (extracted to server/routes/notebook.ts) ---
+		if (await handleNotebookRoutes(req, res, method, url, {
+			l2DataDir,
+			codeDir: paths.codeDir,
+		})) return;
 
 		// --- Learner profile API (extracted to server/routes/learner.ts) ---
 		if (await handleLearnerRoutes(req, res, method, url, { paths })) return;

--- a/apps/inno-agent/src/server/routes/notebook.ts
+++ b/apps/inno-agent/src/server/routes/notebook.ts
@@ -1,0 +1,323 @@
+import { createReadStream, existsSync, statSync } from "node:fs";
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import { basename, extname, join } from "node:path";
+
+import {
+	deleteNoteAttachment,
+	listNoteAttachments,
+	uploadNoteAttachment,
+} from "../../memory/l2/note-attachments-service.js";
+import {
+	createL2Note,
+	listL2Notes,
+	readNoteContent,
+	saveL2NoteContent,
+} from "../../memory/l2/notes-service.js";
+import { listNoteTemplates } from "../../memory/l2/note-templates.js";
+import { listL2Sources, readRawTextPreview } from "../../memory/l2/sources-service.js";
+import { logger } from "../../logger.js";
+import { safeJoinReal } from "../file-helpers.js";
+import { json, matchRoute, readBody, UPLOAD_MAX_BODY_BYTES } from "../http-helpers.js";
+
+export interface NotebookRouteContext {
+	l2DataDir: string;
+	codeDir: string;
+}
+
+interface ResolvedL2Path {
+	fullPath: string;
+	rawPath: string;
+}
+
+function resolveRawPath(l2DataDir: string, userPath: string): ResolvedL2Path | null {
+	const rawPath = userPath.replace(/\\/g, "/");
+	if (!rawPath.startsWith("raw/") || rawPath === "raw/") return null;
+	const fullPath = safeJoinReal(join(l2DataDir, "raw"), rawPath.slice("raw/".length));
+	return fullPath ? { fullPath, rawPath } : null;
+}
+
+function resolveNotePath(l2DataDir: string, userPath: string): ResolvedL2Path | null {
+	const rawPath = userPath.replace(/\\/g, "/");
+	if (!rawPath.startsWith("raw/notes/") || rawPath === "raw/notes/") return null;
+	const relativePath = rawPath.slice("raw/notes/".length);
+	if (relativePath.includes("/") || !relativePath.toLowerCase().endsWith(".md")) return null;
+	const fullPath = safeJoinReal(join(l2DataDir, "raw", "notes"), relativePath);
+	return fullPath ? { fullPath, rawPath } : null;
+}
+
+function isFile(filePath: string): boolean {
+	try {
+		return existsSync(filePath) && statSync(filePath).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+	return err instanceof Error ? err.message : fallback;
+}
+
+function rawFileMime(filePath: string): string {
+	const ext = extname(filePath).toLowerCase();
+	if (ext === ".pdf") return "application/pdf";
+	if (ext === ".png") return "image/png";
+	if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+	return "application/octet-stream";
+}
+
+/** Handle Notebook notes, sources, raw previews, and note attachments. */
+export async function handleNotebookRoutes(
+	req: HttpReq,
+	res: ServerResponse,
+	method: string,
+	url: string,
+	ctx: NotebookRouteContext,
+): Promise<boolean> {
+	const { l2DataDir, codeDir } = ctx;
+
+	if (method === "GET" && url === "/api/l2/sources") {
+		try {
+			json(res, 200, listL2Sources(l2DataDir));
+		} catch (err) {
+			logger.warn({ err }, "failed to list L2 sources");
+			json(res, 500, { error: "Failed to list sources" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/l2/raw/content?")) {
+		const rawPath = new URL(url, "http://localhost").searchParams.get("path");
+		if (!rawPath) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const resolved = resolveRawPath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid raw path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Raw file not found" });
+			return true;
+		}
+		try {
+			json(res, 200, {
+				path: resolved.rawPath,
+				content: readRawTextPreview(l2DataDir, resolved.rawPath),
+			});
+		} catch (err) {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to read raw content");
+			json(res, 500, { error: "Failed to read raw content" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/l2/raw/file?")) {
+		const rawPath = new URL(url, "http://localhost").searchParams.get("path");
+		if (!rawPath) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const resolved = resolveRawPath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid raw path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Raw file not found" });
+			return true;
+		}
+		const name = basename(resolved.fullPath);
+		const mimeType = rawFileMime(resolved.fullPath);
+		const disposition = mimeType === "application/octet-stream" ? "attachment" : "inline";
+		const asciiName = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+		const fileSize = statSync(resolved.fullPath).size;
+		const stream = createReadStream(resolved.fullPath);
+		stream.on("error", (err) => {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to stream raw file");
+			if (!res.headersSent) json(res, 500, { error: "Failed to read raw file" });
+			else res.destroy(err);
+		});
+		res.writeHead(200, {
+			"Content-Type": mimeType,
+			"Content-Disposition": `${disposition}; filename="${asciiName}"; filename*=UTF-8''${encodeURIComponent(name)}`,
+			"Content-Length": fileSize,
+			"X-Content-Type-Options": "nosniff",
+		});
+		stream.pipe(res);
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/l2/notes/content?")) {
+		const rawPath = new URL(url, "http://localhost").searchParams.get("path");
+		if (!rawPath) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const resolved = resolveNotePath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid note path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Note not found" });
+			return true;
+		}
+		try {
+			json(res, 200, readNoteContent(l2DataDir, resolved.rawPath));
+		} catch (err) {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to read note content");
+			json(res, 500, { error: errorMessage(err, "Failed to read note") });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url === "/api/l2/notes/templates") {
+		try {
+			json(res, 200, { templates: listNoteTemplates(codeDir) });
+		} catch (err) {
+			logger.warn({ err }, "failed to list note templates");
+			json(res, 500, { error: "Failed to list templates" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && (url === "/api/l2/notes" || url.startsWith("/api/l2/notes?"))) {
+		const params = new URL(url, "http://localhost").searchParams;
+		const status = params.get("status") ?? undefined;
+		const notebookType = params.get("notebookType") ?? undefined;
+		const validNotebookTypes = new Set(["conversation", "file", "note"]);
+		try {
+			json(res, 200, listL2Notes(l2DataDir, {
+				status,
+				notebookType:
+					notebookType && validNotebookTypes.has(notebookType)
+						? (notebookType as "conversation" | "file" | "note")
+						: undefined,
+			}));
+		} catch (err) {
+			logger.warn({ err }, "failed to list L2 notes");
+			json(res, 500, { error: "Failed to list notes" });
+		}
+		return true;
+	}
+
+	if (method === "POST" && url === "/api/l2/notes") {
+		const body = (await readBody(req)) as Record<string, unknown>;
+		const title = typeof body.title === "string" ? body.title.trim() : undefined;
+		const templateId = typeof body.templateId === "string" ? body.templateId.trim() : undefined;
+		const content = typeof body.content === "string" ? body.content : undefined;
+		const tags = Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === "string") : undefined;
+		try {
+			json(res, 201, createL2Note(l2DataDir, codeDir, { title, templateId, tags, content }));
+		} catch (err) {
+			logger.warn({ err }, "failed to create note");
+			json(res, 500, { error: errorMessage(err, "Create note failed") });
+		}
+		return true;
+	}
+
+	if (method === "PUT" && url === "/api/l2/notes/content") {
+		const body = (await readBody(req)) as Record<string, unknown>;
+		const rawPath = typeof body.rawPath === "string" ? body.rawPath.trim() : "";
+		const title = typeof body.title === "string" ? body.title.trim() : "";
+		const hasContent = typeof body.content === "string";
+		const content = hasContent ? (body.content as string) : "";
+		const tags = Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === "string") : undefined;
+		const recordDate = typeof body.recordDate === "string" ? body.recordDate.trim() : undefined;
+		if (!rawPath || !title || !hasContent) {
+			json(res, 400, { error: "Missing rawPath, title, or content" });
+			return true;
+		}
+		const resolved = resolveNotePath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid note path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Note not found" });
+			return true;
+		}
+		try {
+			json(res, 200, saveL2NoteContent(l2DataDir, resolved.rawPath, { title, tags, recordDate, content }));
+		} catch (err) {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to save note");
+			json(res, 500, { error: errorMessage(err, "Save note failed") });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/l2/notes/attachments?")) {
+		const rawPath = new URL(url, "http://localhost").searchParams.get("path");
+		if (!rawPath) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const resolved = resolveNotePath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid note path" });
+			return true;
+		}
+		try {
+			json(res, 200, { attachments: listNoteAttachments(l2DataDir, resolved.rawPath) });
+		} catch (err) {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to list note attachments");
+			json(res, 500, { error: errorMessage(err, "Failed to list attachments") });
+		}
+		return true;
+	}
+
+	if (method === "POST" && url === "/api/l2/notes/attachments") {
+		const body = (await readBody(req, { maxBytes: UPLOAD_MAX_BODY_BYTES })) as Record<string, unknown>;
+		const noteRawPath = typeof body.noteRawPath === "string" ? body.noteRawPath.trim() : "";
+		const fileName = typeof body.fileName === "string" ? body.fileName.trim() : "";
+		const mimeType = typeof body.mimeType === "string" ? body.mimeType : "application/octet-stream";
+		const dataBase64 = typeof body.dataBase64 === "string" ? body.dataBase64 : "";
+		if (!noteRawPath || !fileName || !dataBase64) {
+			json(res, 400, { error: "Missing noteRawPath, fileName, or dataBase64" });
+			return true;
+		}
+		const resolved = resolveNotePath(l2DataDir, noteRawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid note path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Note not found" });
+			return true;
+		}
+		try {
+			const attachment = uploadNoteAttachment(l2DataDir, resolved.rawPath, { fileName, mimeType, dataBase64 });
+			json(res, 201, {
+				attachmentId: attachment.id,
+				filePath: attachment.filePath,
+				status: attachment.status,
+				attachment,
+			});
+		} catch (err) {
+			logger.warn({ err, noteRawPath: resolved.rawPath }, "failed to upload note attachment");
+			json(res, 500, { error: errorMessage(err, "Upload attachment failed") });
+		}
+		return true;
+	}
+
+	const deleteAttachmentMatch = matchRoute("DELETE", method, url, "/api/l2/notes/attachments/:attachmentId");
+	if (deleteAttachmentMatch) {
+		const attachmentId = deleteAttachmentMatch.attachmentId.trim();
+		if (!attachmentId) {
+			json(res, 400, { error: "Missing attachment id" });
+			return true;
+		}
+		try {
+			const removed = deleteNoteAttachment(l2DataDir, attachmentId);
+			json(res, 200, { attachmentId: removed.id });
+		} catch (err) {
+			logger.warn({ err, attachmentId }, "failed to delete note attachment");
+			const message = errorMessage(err, "Delete attachment failed");
+			json(res, message.includes("not found") ? 404 : 500, { error: message });
+		}
+		return true;
+	}
+
+	return false;
+}

--- a/apps/inno-agent/src/server/routes/wiki.ts
+++ b/apps/inno-agent/src/server/routes/wiki.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
 import { existsSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { basename, extname, join } from "node:path";
+import { basename, join } from "node:path";
 import { wikiPathJoin } from "../../memory/l2/wiki-paths.js";
+import { sanitizeUploadedFileName, uploadExtension } from "../../memory/l2/upload-file-utils.js";
 import { logger } from "../../logger.js";
 import { getL2Memory } from "../../memory/l2/l2-memory.js";
 import { readManifest, removeWikiPathFromManifest } from "../../memory/l2/manifest-store.js";
@@ -46,27 +48,6 @@ function manifestSourceIdByWikiPath(l2DataDir: string): Map<string, string> {
 		}
 	}
 	return map;
-}
-
-function sanitizeUploadName(name: string): string {
-	const cleaned = name
-		.replace(/[/\\?%*:|"<>]/g, "-")
-		.replace(/\s+/g, " ")
-		.trim();
-	return cleaned || "upload";
-}
-
-function uploadExtension(fileName: string, mimeType: string): string {
-	const ext = extname(fileName);
-	if (ext) return ext;
-	if (mimeType === "application/pdf") return ".pdf";
-	if (mimeType.includes("wordprocessingml")) return ".docx";
-	if (mimeType.includes("spreadsheetml")) return ".xlsx";
-	if (mimeType.includes("presentationml")) return ".pptx";
-	if (mimeType === "text/markdown") return ".md";
-	if (mimeType.startsWith("image/")) return `.${mimeType.slice("image/".length).replace("jpeg", "jpg")}`;
-	if (mimeType.startsWith("text/")) return ".txt";
-	return ".bin";
 }
 
 /**
@@ -222,14 +203,18 @@ export async function handleWikiRoutes(
 		const dir = join(l2DataDir, "raw", "uploads");
 		ensureDir(dir);
 		const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-		const safeName = sanitizeUploadName(fileName);
+		const safeName = sanitizeUploadedFileName(fileName, "upload");
 		const ext = uploadExtension(safeName, mimeType);
 		const base = basename(safeName, ext).slice(0, 80) || "upload";
-		const outputName = `${timestamp}-${base}${ext}`;
-		const outputPath = join(dir, outputName);
+		const outputName = `${timestamp}-${randomUUID().slice(0, 8)}-${base}${ext}`;
+		const outputPath = safeJoinReal(dir, outputName);
+		if (!outputPath) {
+			json(res, 400, { error: "Invalid upload path" });
+			return true;
+		}
 		const data = Buffer.from(dataBase64, "base64");
 		writeFileSync(outputPath, data);
-		const rawPath = join("raw", "uploads", outputName);
+		const rawPath = join("raw", "uploads", outputName).replace(/\\/g, "/");
 		json(res, 201, {
 			fileName,
 			mimeType,

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 			"electron/**/*",
 			"apps/inno-agent/dist/**/*",
 			"apps/inno-agent/web/dist/**/*",
+			"apps/inno-agent/note-templates/**/*",
 			"apps/inno-agent/presets/**/*",
 			"apps/inno-agent/scripts/**/*",
 			"node_modules/**/*",


### PR DESCRIPTION
## 依赖关系

- 本 PR 依赖 #178。
- #178 合并后，会将本分支重新变基到最新 `main`，以便只显示本层 API 差异。

## 改动内容

- 新增独立的 Notebook HTTP 路由模块并接入服务端入口。
- 提供资料列表、文本预览和受控文件读取接口。
- 提供笔记模板、笔记列表、笔记内容读取、创建和保存接口。
- 提供笔记附件的列出、上传和删除接口。
- 复用统一的上传文件安全处理，收紧原始资料上传的文件名、MIME 类型和目标路径校验。

## 改动原因

上一层 PR 只提供后端服务，本 PR 负责将这些能力暴露为独立 HTTP API。路由层单独提交后，可以集中审查请求校验、上传大小限制、路径边界和响应行为，而不混入前端代码。

## 影响范围

本 PR 新增后端 API，但暂不修改前端界面。后续前端数据层 PR 会调用这些接口。

## 验证情况

- `git diff --check` 检查通过。
- 后端 TypeScript 检查仅保留仓库原有的 `@tavily/core` 依赖缺失及其派生的隐式 `any` 错误；本 PR 涉及文件没有新增类型错误。
