### PR TITLE
feat(notes): 添加笔记本前端数据层与属性编辑

### DIFF
--- a/apps/inno-agent/note-templates/blank.md
+++ b/apps/inno-agent/note-templates/blank.md
@@ -1,0 +1,9 @@
+---
+label: 空白笔记
+labelEn: Blank note
+description: 从标题开始自由书写
+descriptionEn: Start with a simple title
+hidden: true
+---
+
+# 未命名笔记

--- a/apps/inno-agent/note-templates/common.md
+++ b/apps/inno-agent/note-templates/common.md
@@ -1,0 +1,44 @@
+---
+label: 通用总结
+labelEn: AI summary
+description: 提炼要点、待办与关联笔记
+descriptionEn: Capture takeaways, actions, and related notes
+tags: 总结
+tagsEn: summary
+title: AI Summary
+titleEn: AI Summary
+---
+# AI Summary
+
+## TL;DR
+
+一句话总结
+
+---
+
+## Key Points
+
+- 核心观点1
+- 核心观点2
+- 核心观点3
+
+---
+
+## Action Items
+
+- [ ]
+- [ ]
+- [ ]
+
+---
+
+## Related Notes
+
+- [[相关笔记1]]
+- [[相关笔记2]]
+
+---
+
+## Open Questions
+
+-

--- a/apps/inno-agent/note-templates/daily-note.md
+++ b/apps/inno-agent/note-templates/daily-note.md
@@ -1,0 +1,39 @@
+---
+label: 每日笔记
+labelEn: Daily note
+description: 记录每日计划、完成与学习
+descriptionEn: Track daily plans, progress, and learning
+tags: 每日笔记
+tagsEn: daily-note
+title: 每日笔记
+titleEn: Daily note
+---
+# 每日笔记
+
+## 基本信息
+
+- 日期：
+- 记录人：
+
+## 今日计划
+
+- [ ]
+- [ ]
+- [ ]
+
+## 今日完成
+
+- [x]
+- [x]
+
+## 学习记录
+
+-
+
+## 遇到的问题
+
+-
+
+## 明日计划
+
+-

--- a/apps/inno-agent/note-templates/meeting-minutes.md
+++ b/apps/inno-agent/note-templates/meeting-minutes.md
@@ -1,0 +1,51 @@
+---
+label: 会议纪要
+labelEn: Meeting minutes
+description: 议题、讨论与行动项
+descriptionEn: Agenda, notes, and action items
+tags: 会议纪要
+tagsEn: meeting
+title: 会议名称
+titleEn: Meeting name
+---
+
+# 会议名称
+
+## 会议信息
+
+- 时间：
+- 地点：
+- 主持人：
+- 参会人员：
+
+## 会议目标
+
+本次会议希望解决的问题：
+
+## 讨论内容
+
+### 议题1
+
+- 讨论：
+- 结论：
+
+### 议题2
+
+- 讨论：
+- 结论：
+
+## 决策事项
+
+1.
+2.
+3.
+
+## Action Items
+
+| 任务 | 负责人 | 截止时间 |
+|--------|--------|--------|
+| | | |
+
+## 待跟进问题
+
+-

--- a/apps/inno-agent/note-templates/reading-notes.md
+++ b/apps/inno-agent/note-templates/reading-notes.md
@@ -1,0 +1,44 @@
+---
+label: 读书笔记
+labelEn: Reading notes
+description: 摘录观点、理解与可实践内容
+descriptionEn: Capture ideas, reflections, and actionable insights
+tags: 读书笔记
+tagsEn: reading-notes
+title: 文章标题
+titleEn: Article title
+---
+
+# 文章标题
+
+来源：
+
+作者：
+
+时间：
+
+---
+
+## 核心观点
+
+1.
+2.
+3.
+
+---
+
+## 重要摘录
+
+>
+
+---
+
+## 我的理解
+
+-
+
+---
+
+## 可实践内容
+
+-

--- a/apps/inno-agent/note-templates/study-notes.md
+++ b/apps/inno-agent/note-templates/study-notes.md
@@ -1,0 +1,34 @@
+---
+label: 学习笔记
+labelEn: Study notes
+description: 记录课程要点与总结
+descriptionEn: Capture course notes and summaries
+tags: 学习笔记
+tagsEn: study-notes
+title: 学习主题
+titleEn: Study topic
+---
+
+# 学习主题
+
+## 关键词
+
+-
+-
+-
+
+---
+
+## 笔记区
+
+记录课程内容
+
+记录知识点
+
+记录案例
+
+---
+
+## 总结
+
+一句话总结本次学习内容

--- a/apps/inno-agent/note-templates/tech-research.md
+++ b/apps/inno-agent/note-templates/tech-research.md
@@ -1,0 +1,48 @@
+---
+label: 技术调研
+labelEn: Tech research
+description: 对比方案、分析维度与结论
+descriptionEn: Compare options, analyze trade-offs, and conclude
+tags: 技术调研
+tagsEn: tech-research
+title: 调研主题
+titleEn: Research topic
+---
+
+# 调研主题
+
+## 调研目标
+
+为什么调研？
+
+---
+
+## 候选方案
+
+### 方案A
+
+优点：
+
+缺点：
+
+### 方案B
+
+优点：
+
+缺点：
+
+---
+
+## 对比分析
+
+| 维度 | A | B |
+|--------|--------|--------|
+| 功能 | | |
+| 成本 | | |
+| 性能 | | |
+
+---
+
+## 最终结论
+
+-

--- a/apps/inno-agent/note-templates/weekly-report.md
+++ b/apps/inno-agent/note-templates/weekly-report.md
@@ -1,0 +1,46 @@
+---
+label: 周报
+labelEn: Weekly report
+description: 本周成果、问题与下周计划
+descriptionEn: Weekly outcomes, issues, and next steps
+tags: 周报
+tagsEn: weekly-report
+title: 周报
+titleEn: Weekly report
+---
+
+# 第XX周工作总结
+
+## 本周完成
+
+### 项目A
+
+- 完成内容
+
+### 项目B
+
+- 完成内容
+
+---
+
+## 本周问题
+
+### 问题1
+
+原因：
+
+解决方案：
+
+---
+
+## 学习收获
+
+-
+
+---
+
+## 下周计划
+
+- [ ]
+- [ ]
+- [ ]

--- a/apps/inno-agent/src/memory/l2/l2-archive-service.test.ts
+++ b/apps/inno-agent/src/memory/l2/l2-archive-service.test.ts
@@ -1,0 +1,138 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { writeText } from "../../storage/file-store.js";
+import { ArchiveReplacementRequiredError, archiveL2Source } from "./l2-archive-service.js";
+import type { L2Memory } from "./l2-memory.js";
+import { createL2Tools } from "./l2-tools.js";
+import { readManifest } from "./manifest-store.js";
+import { ensureL2Directories } from "./wiki-maintainer.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "inno-l2-archive-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function fakeMemory(root: string): L2Memory {
+	return {
+		dataDir: root,
+		indexPageByPath: vi.fn().mockResolvedValue(undefined),
+		removePage: vi.fn().mockResolvedValue(undefined),
+	} as unknown as L2Memory;
+}
+
+function deferred<T>() {
+	let resolvePromise!: (value: T) => void;
+	let rejectPromise!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolve, reject) => {
+		resolvePromise = resolve;
+		rejectPromise = reject;
+	});
+	return { promise, resolve: resolvePromise, reject: rejectPromise };
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("archiveL2Source", () => {
+	it("archives an existing raw file without replacing its path", async () => {
+		const root = makeTempDir();
+		ensureL2Directories(root);
+		const rawPath = "raw/uploads/existing.md";
+		writeText(join(root, rawPath), "正文包含 [[共享归档]] 概念。");
+		const memory = fakeMemory(root);
+
+		const result = await archiveL2Source(
+			root,
+			{
+				title: "已有文件",
+				source: { kind: "existing", rawPath, sourceType: "markdown" },
+				dedupeBy: "rawPath",
+			},
+			{ memory },
+		);
+
+		expect(result).toMatchObject({ rawPath, status: "indexed", duplicate: false });
+		expect(readManifest(root)).toHaveLength(1);
+		expect(readFileSync(join(root, rawPath), "utf8")).toContain("共享归档");
+		expect(memory.indexPageByPath).toHaveBeenCalled();
+	});
+
+	it("serializes direct and agent-tool archives for the same directory", async () => {
+		const root = makeTempDir();
+		const firstIndex = deferred<void>();
+		const memory = fakeMemory(root);
+		vi.mocked(memory.indexPageByPath)
+			.mockImplementationOnce(() => firstIndex.promise)
+			.mockResolvedValue(undefined);
+
+		const first = archiveL2Source(
+			root,
+			{ title: "直接归档", source: { kind: "content", content: "第一篇正文", sourceType: "markdown" } },
+			{ memory },
+		);
+		await vi.waitFor(() => expect(memory.indexPageByPath).toHaveBeenCalledTimes(1));
+
+		const tool = createL2Tools(root, undefined, memory)[0];
+		const second = (tool.execute as (...args: any[]) => Promise<any>)(
+			"call-tool",
+			{ title: "工具归档", content: "第二篇正文", sourceType: "markdown" },
+			undefined,
+			undefined,
+			{ model: undefined, modelRegistry: undefined },
+		);
+		await Promise.resolve();
+		expect(readManifest(root)).toHaveLength(1);
+
+		firstIndex.resolve();
+		await Promise.all([first, second]);
+		expect(readManifest(root).map((entry) => entry.title)).toEqual(["直接归档", "工具归档"]);
+	});
+
+	it("rejects changed raw-path content until replacement support is stacked", async () => {
+		const root = makeTempDir();
+		const rawPath = "raw/uploads/mutable.md";
+		ensureL2Directories(root);
+		writeText(join(root, rawPath), "第一版正文");
+		await archiveL2Source(
+			root,
+			{
+				title: "可更新资料",
+				source: { kind: "existing", rawPath, sourceType: "markdown" },
+				dedupeBy: "rawPath",
+			},
+			{ memory: fakeMemory(root) },
+		);
+		writeText(join(root, rawPath), "第二版正文");
+
+		await expect(archiveL2Source(
+			root,
+			{
+				title: "可更新资料",
+				source: { kind: "existing", rawPath, sourceType: "markdown" },
+				dedupeBy: "rawPath",
+			},
+			{ memory: fakeMemory(root) },
+		)).rejects.toBeInstanceOf(ArchiveReplacementRequiredError);
+	});
+
+	it("preserves content-mode force semantics", async () => {
+		const root = makeTempDir();
+		const request = {
+			title: "强制归档",
+			source: { kind: "content" as const, content: "相同正文", sourceType: "markdown" as const },
+		};
+		const first = await archiveL2Source(root, request, { memory: fakeMemory(root) });
+		const second = await archiveL2Source(root, { ...request, force: true }, { memory: fakeMemory(root) });
+
+		expect(second.id).not.toBe(first.id);
+		expect(readManifest(root)).toHaveLength(2);
+	});
+
+});

--- a/apps/inno-agent/src/memory/l2/l2-archive-service.test.ts
+++ b/apps/inno-agent/src/memory/l2/l2-archive-service.test.ts
@@ -1,14 +1,15 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { writeText } from "../../storage/file-store.js";
-import { ArchiveReplacementRequiredError, archiveL2Source } from "./l2-archive-service.js";
+import { archiveL2Source } from "./l2-archive-service.js";
+import { runL2Lint } from "./l2-lint.js";
 import type { L2Memory } from "./l2-memory.js";
 import { createL2Tools } from "./l2-tools.js";
 import { readManifest } from "./manifest-store.js";
-import { ensureL2Directories } from "./wiki-maintainer.js";
+import { ensureL2Directories, parseFrontmatter, serializeFrontmatter } from "./wiki-maintainer.js";
 
 const tempDirs: string[] = [];
 
@@ -95,31 +96,138 @@ describe("archiveL2Source", () => {
 		expect(readManifest(root).map((entry) => entry.title)).toEqual(["直接归档", "工具归档"]);
 	});
 
-	it("rejects changed raw-path content until replacement support is stacked", async () => {
+	it("replaces stale linked-page provenance when existing content changes", async () => {
 		const root = makeTempDir();
-		const rawPath = "raw/uploads/mutable.md";
 		ensureL2Directories(root);
-		writeText(join(root, rawPath), "第一版正文");
-		await archiveL2Source(
+		const rawPath = "raw/uploads/mutable.md";
+		writeText(join(root, rawPath), "正文包含 [[旧概念]]。");
+		const memory = fakeMemory(root);
+		const first = await archiveL2Source(
 			root,
 			{
 				title: "可更新资料",
+				source: { kind: "existing", rawPath, sourceType: "markdown" },
+				dedupeBy: "rawPath",
+			},
+			{ memory },
+		);
+		const oldLinkedPage = first.linkedPages[0];
+		expect(existsSync(join(root, oldLinkedPage))).toBe(true);
+		writeText(
+			join(root, oldLinkedPage),
+			`${readFileSync(join(root, oldLinkedPage), "utf8").trimEnd()}\n\n## 用户补充\n\n这段手工内容必须可恢复。\n`,
+		);
+
+		writeText(join(root, rawPath), "正文改为 [[新概念]]。");
+		const second = await archiveL2Source(
+			root,
+			{
+				title: "可更新资料",
+				source: { kind: "existing", rawPath, sourceType: "markdown" },
+				dedupeBy: "rawPath",
+			},
+			{ memory },
+		);
+
+		expect(second).toMatchObject({ id: first.id, rawPath, duplicate: false });
+		expect(second.wikiPagePath).toBe(first.wikiPagePath);
+		expect(second.linkedPages).not.toContain(oldLinkedPage);
+		expect(existsSync(join(root, oldLinkedPage))).toBe(true);
+		expect(readFileSync(join(root, oldLinkedPage), "utf8")).toContain("旧页面内容已备份");
+		const backups = readdirSync(join(root, "wiki", "orphans"));
+		expect(backups).toHaveLength(1);
+		expect(readFileSync(join(root, "wiki", "orphans", backups[0]), "utf8")).toContain("这段手工内容必须可恢复");
+		expect(memory.indexPageByPath).toHaveBeenCalledWith(oldLinkedPage);
+		expect(readManifest(root)).toHaveLength(1);
+		expect(runL2Lint(root).findings.filter((finding) =>
+			finding.code === "missing_source_file" || finding.code === "dangling_link"
+		)).toEqual([]);
+	});
+
+	it("keeps the source-summary path stable when a source title changes", async () => {
+		const root = makeTempDir();
+		const memory = fakeMemory(root);
+		const content = "正文包含 [[稳定概念]]。";
+		const first = await archiveL2Source(
+			root,
+			{ title: "旧标题", source: { kind: "content", content, sourceType: "markdown" } },
+			{ memory },
+		);
+		const linkedPath = first.linkedPages[0];
+		const linkedBefore = readFileSync(join(root, linkedPath), "utf8");
+		const parsed = parseFrontmatter(linkedBefore);
+		expect(parsed.frontmatter).not.toBeNull();
+		parsed.frontmatter!.contested = true;
+		parsed.frontmatter!.contradictions = [first.id];
+		writeText(
+			join(root, linkedPath),
+			`${serializeFrontmatter(parsed.frontmatter!)}\n${parsed.body.trimEnd()}\n\n## 争议\n\n- 测试争议（来源 [[旧标题]] \`${first.id}\`）\n`,
+		);
+		const second = await archiveL2Source(
+			root,
+			{
+				title: "新标题",
+				source: { kind: "existing", rawPath: first.rawPath, sourceType: "markdown", content },
+				dedupeBy: "rawPath",
+				force: true,
+			},
+			{ memory },
+		);
+
+		expect(second.id).toBe(first.id);
+		expect(second.wikiPagePath).toBe(first.wikiPagePath);
+		const linkedContent = readFileSync(join(root, second.linkedPages[0]), "utf8");
+		expect(linkedContent).toContain(`[[新标题]] — \`${second.wikiPagePath}\``);
+		expect(linkedContent).not.toContain("[[旧标题]]");
+		expect(runL2Lint(root).findings.filter((finding) =>
+			finding.code === "missing_source_file" || finding.code === "dangling_link"
+		)).toEqual([]);
+	});
+
+	it("reconciles the semantic index after an interrupted cleanup", async () => {
+		const root = makeTempDir();
+		const rawPath = "raw/uploads/retry.md";
+		ensureL2Directories(root);
+		writeText(join(root, rawPath), "第一版 [[旧重试概念]]");
+		const first = await archiveL2Source(
+			root,
+			{
+				title: "可重试资料",
 				source: { kind: "existing", rawPath, sourceType: "markdown" },
 				dedupeBy: "rawPath",
 			},
 			{ memory: fakeMemory(root) },
 		);
-		writeText(join(root, rawPath), "第二版正文");
+		const oldLinkedPage = first.linkedPages[0];
+		writeText(join(root, rawPath), "第二版 [[新重试概念]]");
 
+		const failingMemory = fakeMemory(root);
+		vi.mocked(failingMemory.indexPageByPath).mockImplementation(async (path) => {
+			if (path === oldLinkedPage) throw new Error("simulated index interruption");
+		});
 		await expect(archiveL2Source(
 			root,
 			{
-				title: "可更新资料",
+				title: "可重试资料",
 				source: { kind: "existing", rawPath, sourceType: "markdown" },
 				dedupeBy: "rawPath",
 			},
-			{ memory: fakeMemory(root) },
-		)).rejects.toBeInstanceOf(ArchiveReplacementRequiredError);
+			{ memory: failingMemory },
+		)).rejects.toThrow("simulated index interruption");
+		expect(readManifest(root)[0].status).toBe("error");
+
+		const retryMemory = fakeMemory(root);
+		await archiveL2Source(
+			root,
+			{
+				title: "可重试资料",
+				source: { kind: "existing", rawPath, sourceType: "markdown" },
+				dedupeBy: "rawPath",
+			},
+			{ memory: retryMemory },
+		);
+		expect(retryMemory.indexPageByPath).toHaveBeenCalledWith(oldLinkedPage);
+		expect(readManifest(root)[0].status).toBe("indexed");
 	});
 
 	it("preserves content-mode force semantics", async () => {
@@ -134,5 +242,4 @@ describe("archiveL2Source", () => {
 		expect(second.id).not.toBe(first.id);
 		expect(readManifest(root)).toHaveLength(2);
 	});
-
 });

--- a/apps/inno-agent/src/memory/l2/l2-archive-service.ts
+++ b/apps/inno-agent/src/memory/l2/l2-archive-service.ts
@@ -1,0 +1,328 @@
+import { createHash, randomUUID } from "node:crypto";
+import { join, resolve } from "node:path";
+import type { Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+
+import { logger } from "../../logger.js";
+import { fileExists, readText } from "../../storage/file-store.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
+import { DocumentParseError, parseDocument } from "./document-parser.js";
+import { getL2Memory, type L2Memory } from "./l2-memory.js";
+import { findManifestByHash, findManifestByRawPath, readManifest, upsertManifest } from "./manifest-store.js";
+import { regenerateOverview } from "./overview.js";
+import { saveRaw, saveRawFile } from "./raw-store.js";
+import { convertToExtracted } from "./source-converter.js";
+import { summarizeContent } from "./summarizer.js";
+import type { ManifestEntry, RawSourceType } from "./types.js";
+import {
+	appendLog,
+	createSourcePage,
+	ensureL2Directories,
+	readMaintenanceContext,
+	rebuildIndex,
+} from "./wiki-maintainer.js";
+import { maintainLinkedWikiPages } from "./wiki-linker.js";
+
+type FileSourceType = Extract<RawSourceType, "pdf" | "word" | "image">;
+
+export type ArchiveL2Source =
+	| { kind: "content"; content: string; sourceType: RawSourceType }
+	| { kind: "file"; filePath: string; sourceType: FileSourceType }
+	| { kind: "existing"; rawPath: string; sourceType: RawSourceType; content?: string };
+
+export interface ArchiveL2Request {
+	title: string;
+	source: ArchiveL2Source;
+	tags?: string[];
+	origin?: ManifestEntry["source"]["origin"];
+	url?: string;
+	sessionId?: string;
+	force?: boolean;
+	dedupeBy?: "content" | "rawPath";
+	createExtracted?: boolean;
+	plainSummaryFallback?: boolean;
+	preferredId?: string;
+	createdAt?: string;
+	logLabel?: string;
+	onIndexed?: (result: ArchiveL2Result) => void | Promise<void>;
+}
+
+export interface ArchiveL2Runtime {
+	model?: Model<any>;
+	modelRegistry?: ModelRegistry;
+	memory?: L2Memory;
+}
+
+export interface ArchiveL2Result {
+	id: string;
+	noteId: string;
+	sourceId: string;
+	title: string;
+	rawPath: string;
+	extractedPath?: string;
+	wikiPagePath: string;
+	wikiPages: string[];
+	linkedPages: string[];
+	tags: string[];
+	contentHash: string;
+	status: "indexed";
+	duplicate: boolean;
+	createdCount: number;
+	updatedCount: number;
+}
+
+export class ArchiveSourceReadError extends Error {
+	constructor(
+		message: string,
+		readonly code: DocumentParseError["code"] | "READ_ERROR",
+		options?: ErrorOptions,
+	) {
+		super(message, options);
+		this.name = "ArchiveSourceReadError";
+	}
+}
+
+export class ArchiveReplacementRequiredError extends Error {
+	constructor(readonly rawPath: string) {
+		super(`Re-archiving changed content is not enabled for ${rawPath}`);
+		this.name = "ArchiveReplacementRequiredError";
+	}
+}
+
+const archiveQueueTails = new Map<string, Promise<void>>();
+
+function enqueueArchive<T>(l2DataDir: string, task: () => Promise<T>): Promise<T> {
+	const queueKey = resolve(l2DataDir);
+	const previous = archiveQueueTails.get(queueKey) ?? Promise.resolve();
+	const run = previous.then(task, task);
+	const tail = run.then(
+		() => undefined,
+		() => undefined,
+	);
+	archiveQueueTails.set(queueKey, tail);
+	return run.finally(() => {
+		if (archiveQueueTails.get(queueKey) === tail) archiveQueueTails.delete(queueKey);
+	});
+}
+
+function normalizeRawPath(rawPath: string): string {
+	return rawPath.replace(/\\/g, "/");
+}
+
+function resolveExistingRawFile(l2DataDir: string, rawPath: string): { rawPath: string; fullPath: string } {
+	const normalized = normalizeRawPath(rawPath);
+	if (!normalized.startsWith("raw/") || normalized === "raw/") {
+		throw new ArchiveSourceReadError("Invalid raw path", "READ_ERROR");
+	}
+	const fullPath = resolveContainedPath(join(l2DataDir, "raw"), normalized.slice("raw/".length));
+	if (!fullPath || !fileExists(fullPath)) {
+		throw new ArchiveSourceReadError(`Raw file not found: ${normalized}`, "FILE_NOT_FOUND");
+	}
+	return { rawPath: normalized, fullPath };
+}
+
+function reusableStoredFile(l2DataDir: string, storedPath: string | undefined, rootName: string): string | undefined {
+	if (!storedPath) return undefined;
+	const normalized = normalizeRawPath(storedPath);
+	const prefix = `${rootName}/`;
+	if (!normalized.startsWith(prefix) || normalized === prefix) return undefined;
+	const fullPath = resolveContainedPath(join(l2DataDir, rootName), normalized.slice(prefix.length));
+	return fullPath && fileExists(fullPath) ? normalized : undefined;
+}
+
+async function resolveArchiveContent(
+	l2DataDir: string,
+	source: ArchiveL2Source,
+): Promise<{ content: string; requestedRawPath?: string; sourceFilePath?: string }> {
+	try {
+		if (source.kind === "content") return { content: source.content };
+		if (source.kind === "file") {
+			const parsed = await parseDocument(source.filePath);
+			return { content: parsed.text, sourceFilePath: source.filePath };
+		}
+
+		const existing = resolveExistingRawFile(l2DataDir, source.rawPath);
+		if (source.content !== undefined) {
+			return { content: source.content, requestedRawPath: existing.rawPath };
+		}
+		if (source.sourceType === "pdf" || source.sourceType === "word" || source.sourceType === "image") {
+			const parsed = await parseDocument(existing.fullPath);
+			return { content: parsed.text, requestedRawPath: existing.rawPath };
+		}
+		return { content: readText(existing.fullPath), requestedRawPath: existing.rawPath };
+	} catch (err) {
+		if (err instanceof ArchiveSourceReadError) throw err;
+		if (err instanceof DocumentParseError) {
+			throw new ArchiveSourceReadError(err.message, err.code, { cause: err });
+		}
+		throw new ArchiveSourceReadError(err instanceof Error ? err.message : String(err), "READ_ERROR", {
+			cause: err,
+		});
+	}
+}
+
+function resultFromEntry(
+	entry: ManifestEntry,
+	duplicate: boolean,
+	counts: { created: number; updated: number } = { created: 0, updated: 0 },
+): ArchiveL2Result {
+	return {
+		id: entry.id,
+		noteId: entry.id,
+		sourceId: entry.id,
+		title: entry.title,
+		rawPath: normalizeRawPath(entry.rawPath),
+		extractedPath: entry.extractedPath,
+		wikiPagePath: entry.wikiPages[0] ?? "",
+		wikiPages: entry.wikiPages,
+		linkedPages: entry.wikiPages.slice(1),
+		tags: entry.tags,
+		contentHash: entry.contentHash,
+		status: "indexed",
+		duplicate,
+		createdCount: counts.created,
+		updatedCount: counts.updated,
+	};
+}
+
+export function archiveL2Source(
+	l2DataDir: string,
+	request: ArchiveL2Request,
+	runtime: ArchiveL2Runtime = {},
+): Promise<ArchiveL2Result> {
+	return enqueueArchive(l2DataDir, async () => {
+		ensureL2Directories(l2DataDir);
+		const resolvedSource = await resolveArchiveContent(l2DataDir, request.source);
+		const content = resolvedSource.content;
+		if (!content.trim()) {
+			throw new ArchiveSourceReadError("无法从资料中提取有效文本", "EMPTY_RESULT");
+		}
+
+		const contentHash = createHash("sha256").update(content).digest("hex").slice(0, 16);
+		const existingByPath = resolvedSource.requestedRawPath
+			? findManifestByRawPath(l2DataDir, resolvedSource.requestedRawPath)
+			: undefined;
+		const existingByHash = findManifestByHash(l2DataDir, contentHash);
+		const dedupeByRawPath = request.dedupeBy === "rawPath";
+		const existing = dedupeByRawPath
+			? existingByPath
+			: (request.force ? undefined : existingByHash);
+		const duplicateMatches = !dedupeByRawPath || existing?.contentHash === contentHash;
+		if (existing?.status === "indexed" && !request.force && duplicateMatches) {
+			const duplicateResult = resultFromEntry(existing, true);
+			await request.onIndexed?.(duplicateResult);
+			return duplicateResult;
+		}
+		if (dedupeByRawPath && existing?.status === "indexed") {
+			throw new ArchiveReplacementRequiredError(resolvedSource.requestedRawPath ?? existing.rawPath);
+		}
+
+		const reusableRawPath = reusableStoredFile(l2DataDir, existing?.rawPath, "raw");
+		const rawPath = resolvedSource.requestedRawPath
+			?? reusableRawPath
+			?? normalizeRawPath(resolvedSource.sourceFilePath
+				? saveRawFile(l2DataDir, request.title, resolvedSource.sourceFilePath, request.source.sourceType)
+				: saveRaw(l2DataDir, request.title, content, request.source.sourceType, request.url));
+
+		const createExtracted = request.createExtracted !== false;
+		const reusableExtractedPath = existing?.contentHash === contentHash
+			? reusableStoredFile(l2DataDir, existing.extractedPath, "extracted")
+			: undefined;
+		const extractedPath = createExtracted
+			? (reusableExtractedPath ?? convertToExtracted(l2DataDir, request.title, content, request.source.sourceType))
+			: undefined;
+
+		const now = new Date().toISOString();
+		const sourceUrl = request.url ?? existing?.source.url;
+		const sourceSessionId = request.sessionId ?? existing?.source.sessionId;
+		const previousWikiPages = existing?.wikiPages ?? [];
+		const entry: ManifestEntry = {
+			...existing,
+			id: existing?.id ?? request.preferredId ?? `l2src_${randomUUID().slice(0, 8)}`,
+			title: request.title,
+			sourceType: request.source.sourceType,
+			rawPath,
+			extractedPath,
+			wikiPages: previousWikiPages,
+			tags: request.tags ?? existing?.tags ?? [],
+			contentHash,
+			status: "extracted",
+			source: {
+				origin: request.origin
+					?? existing?.source.origin
+					?? (request.source.sourceType === "conversation" ? "conversation" : "user_upload"),
+				...(sourceUrl && { url: sourceUrl }),
+				...(sourceSessionId && { sessionId: sourceSessionId }),
+			},
+			createdAt: existing?.createdAt ?? request.createdAt ?? now,
+			updatedAt: now,
+		};
+		upsertManifest(l2DataDir, entry);
+
+		const maintenanceContext = readMaintenanceContext(l2DataDir);
+		let linkMaintenance: Awaited<ReturnType<typeof maintainLinkedWikiPages>>;
+		try {
+			const summaryContent = extractedPath ? readText(join(l2DataDir, extractedPath)) : content;
+			let summaryBody = request.plainSummaryFallback ? content : `## 摘要\n\n${summaryContent}`;
+			if (runtime.model && runtime.modelRegistry) {
+				const summary = await summarizeContent(runtime.model, runtime.modelRegistry, request.title, summaryContent);
+				if (summary) summaryBody = summary;
+			}
+
+			const wikiPagePath = createSourcePage(l2DataDir, entry, summaryBody, extractedPath);
+			linkMaintenance = await maintainLinkedWikiPages(
+				l2DataDir,
+				entry,
+				wikiPagePath,
+				summaryBody,
+				runtime.model,
+				runtime.modelRegistry,
+			);
+			if (linkMaintenance.sourcePageBody !== summaryBody) {
+				createSourcePage(l2DataDir, entry, linkMaintenance.sourcePageBody, extractedPath);
+			}
+			const nextWikiPages = [wikiPagePath, ...linkMaintenance.pages];
+			const memory = runtime.memory ?? getL2Memory(l2DataDir);
+			for (const wikiPath of nextWikiPages) await memory.indexPageByPath(wikiPath);
+
+			entry.wikiPages = nextWikiPages;
+			entry.status = "indexed";
+			entry.updatedAt = new Date().toISOString();
+			upsertManifest(l2DataDir, entry);
+			rebuildIndex(l2DataDir, readManifest(l2DataDir));
+			try {
+				const overviewPath = await regenerateOverview(l2DataDir, runtime.model, runtime.modelRegistry);
+				if (overviewPath) await memory.indexPageByPath(overviewPath);
+			} catch (err) {
+				logger.warn({ err }, "L2 archive overview regeneration failed");
+			}
+		} catch (err) {
+			entry.status = "error";
+			entry.updatedAt = new Date().toISOString();
+			upsertManifest(l2DataDir, entry);
+			throw err;
+		}
+
+		const result = resultFromEntry(entry, false, {
+			created: linkMaintenance.created.length,
+			updated: linkMaintenance.updated.length,
+		});
+		await request.onIndexed?.(result);
+		appendLog(
+			l2DataDir,
+			"ingest",
+			request.title,
+			[
+				`- ID: ${entry.id}`,
+				`- 类型: ${entry.sourceType}`,
+				`- 原始文件: ${rawPath}`,
+				...(extractedPath ? [`- 提取文本: ${extractedPath}`] : []),
+				`- Source 页面: ${result.wikiPagePath}`,
+				`- concepts/entities: 新建 ${linkMaintenance.created.length}, 更新 ${linkMaintenance.updated.length}, 不变 ${linkMaintenance.unchanged.length}, 争议 ${linkMaintenance.contested.length}`,
+				...(request.logLabel ? [`- 调用来源: ${request.logLabel}`] : []),
+				`- 维护前上下文: schema ${maintenanceContext.schema.length} chars, index ${maintenanceContext.index.length} chars, recent log ${maintenanceContext.recentLog.length} chars`,
+			].join("\n"),
+		);
+		return result;
+	});
+}

--- a/apps/inno-agent/src/memory/l2/l2-archive-service.ts
+++ b/apps/inno-agent/src/memory/l2/l2-archive-service.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import { unlinkSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { Model } from "@earendil-works/pi-ai";
 import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
@@ -21,7 +22,7 @@ import {
 	readMaintenanceContext,
 	rebuildIndex,
 } from "./wiki-maintainer.js";
-import { maintainLinkedWikiPages } from "./wiki-linker.js";
+import { maintainLinkedWikiPages, reconcileLinkedWikiSource } from "./wiki-linker.js";
 
 type FileSourceType = Extract<RawSourceType, "pdf" | "word" | "image">;
 
@@ -82,13 +83,6 @@ export class ArchiveSourceReadError extends Error {
 	}
 }
 
-export class ArchiveReplacementRequiredError extends Error {
-	constructor(readonly rawPath: string) {
-		super(`Re-archiving changed content is not enabled for ${rawPath}`);
-		this.name = "ArchiveReplacementRequiredError";
-	}
-}
-
 const archiveQueueTails = new Map<string, Promise<void>>();
 
 function enqueueArchive<T>(l2DataDir: string, task: () => Promise<T>): Promise<T> {
@@ -128,6 +122,13 @@ function reusableStoredFile(l2DataDir: string, storedPath: string | undefined, r
 	if (!normalized.startsWith(prefix) || normalized === prefix) return undefined;
 	const fullPath = resolveContainedPath(join(l2DataDir, rootName), normalized.slice(prefix.length));
 	return fullPath && fileExists(fullPath) ? normalized : undefined;
+}
+
+function resolveWikiSourceFile(l2DataDir: string, wikiPath: string): string | undefined {
+	const normalized = normalizeRawPath(wikiPath);
+	const prefix = "wiki/sources/";
+	if (!normalized.startsWith(prefix) || normalized === prefix) return undefined;
+	return resolveContainedPath(join(l2DataDir, "wiki", "sources"), normalized.slice(prefix.length)) ?? undefined;
 }
 
 async function resolveArchiveContent(
@@ -213,10 +214,6 @@ export function archiveL2Source(
 			await request.onIndexed?.(duplicateResult);
 			return duplicateResult;
 		}
-		if (dedupeByRawPath && existing?.status === "indexed") {
-			throw new ArchiveReplacementRequiredError(resolvedSource.requestedRawPath ?? existing.rawPath);
-		}
-
 		const reusableRawPath = reusableStoredFile(l2DataDir, existing?.rawPath, "raw");
 		const rawPath = resolvedSource.requestedRawPath
 			?? reusableRawPath
@@ -236,6 +233,8 @@ export function archiveL2Source(
 		const sourceUrl = request.url ?? existing?.source.url;
 		const sourceSessionId = request.sessionId ?? existing?.source.sessionId;
 		const previousWikiPages = existing?.wikiPages ?? [];
+		const previousSourcePages = previousWikiPages.filter((path) => path.startsWith("wiki/sources/"));
+		const preferredSourcePagePath = previousSourcePages[0];
 		const entry: ManifestEntry = {
 			...existing,
 			id: existing?.id ?? request.preferredId ?? `l2src_${randomUUID().slice(0, 8)}`,
@@ -269,7 +268,13 @@ export function archiveL2Source(
 				if (summary) summaryBody = summary;
 			}
 
-			const wikiPagePath = createSourcePage(l2DataDir, entry, summaryBody, extractedPath);
+			const wikiPagePath = createSourcePage(
+				l2DataDir,
+				entry,
+				summaryBody,
+				extractedPath,
+				preferredSourcePagePath,
+			);
 			linkMaintenance = await maintainLinkedWikiPages(
 				l2DataDir,
 				entry,
@@ -279,10 +284,49 @@ export function archiveL2Source(
 				runtime.modelRegistry,
 			);
 			if (linkMaintenance.sourcePageBody !== summaryBody) {
-				createSourcePage(l2DataDir, entry, linkMaintenance.sourcePageBody, extractedPath);
+				createSourcePage(
+					l2DataDir,
+					entry,
+					linkMaintenance.sourcePageBody,
+					extractedPath,
+					wikiPagePath,
+				);
 			}
 			const nextWikiPages = [wikiPagePath, ...linkMaintenance.pages];
+			const staleSourcePages = previousSourcePages.filter((path) => path !== wikiPagePath);
+			entry.wikiPages = Array.from(new Set([...previousWikiPages, ...nextWikiPages]));
+			entry.updatedAt = new Date().toISOString();
+			upsertManifest(l2DataDir, entry);
+
 			const memory = runtime.memory ?? getL2Memory(l2DataDir);
+			const nextLinkedPages = new Set(linkMaintenance.pages);
+			const previousLinkedPages = previousWikiPages.filter(
+				(path) => path.startsWith("wiki/entities/") || path.startsWith("wiki/concepts/"),
+			);
+			for (const previousLinkedPath of previousLinkedPages) {
+				const reconciled = reconcileLinkedWikiSource(l2DataDir, previousLinkedPath, {
+					sourceId: entry.id,
+					previousSourcePagePaths: previousSourcePages,
+					currentSourcePagePath: wikiPagePath,
+					currentTitle: entry.title,
+					keepSource: nextLinkedPages.has(previousLinkedPath),
+				});
+				if (!nextLinkedPages.has(previousLinkedPath)) {
+					if (reconciled.exists) await memory.indexPageByPath(reconciled.path);
+					else await memory.removePage(reconciled.path);
+				}
+			}
+
+			const manifestsBeforeCleanup = readManifest(l2DataDir);
+			for (const staleWikiPath of staleSourcePages) {
+				const referencedByOtherSource = manifestsBeforeCleanup.some(
+					(candidate) => candidate.id !== entry.id && candidate.wikiPages.includes(staleWikiPath),
+				);
+				if (referencedByOtherSource) continue;
+				const staleFile = resolveWikiSourceFile(l2DataDir, staleWikiPath);
+				if (staleFile && fileExists(staleFile)) unlinkSync(staleFile);
+				await memory.removePage(staleWikiPath);
+			}
 			for (const wikiPath of nextWikiPages) await memory.indexPageByPath(wikiPath);
 
 			entry.wikiPages = nextWikiPages;

--- a/apps/inno-agent/src/memory/l2/l2-tools.ts
+++ b/apps/inno-agent/src/memory/l2/l2-tools.ts
@@ -1,47 +1,15 @@
 import { StringEnum } from "@earendil-works/pi-ai";
 import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { randomUUID, createHash } from "node:crypto";
-import { join, isAbsolute, resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 
 import type { ManifestEntry, RawSourceType } from "./types.js";
-import { saveRaw, saveRawFile } from "./raw-store.js";
-import { convertToExtracted } from "./source-converter.js";
-import { upsertManifest, readManifest, findManifestByHash } from "./manifest-store.js";
-import {
-	createSourcePage,
-	rebuildIndex,
-	appendLog,
-	ensureL2Directories,
-	readMaintenanceContext,
-} from "./wiki-maintainer.js";
 import { queryWikiHybridDetailed } from "./wiki-query.js";
-import { summarizeContent } from "./summarizer.js";
-import { maintainLinkedWikiPages } from "./wiki-linker.js";
-import { fileExists, readText } from "../../storage/file-store.js";
-import { parseDocument, DocumentParseError } from "./document-parser.js";
+import { appendLog, ensureL2Directories } from "./wiki-maintainer.js";
 import { getL2Memory, type L2Memory } from "./l2-memory.js";
-import { regenerateOverview } from "./overview.js";
 import { formatL2LintReport, runL2Lint } from "./l2-lint.js";
+import { archiveL2Source, ArchiveSourceReadError, type ArchiveL2Source } from "./l2-archive-service.js";
 import { logger } from "../../logger.js";
-
-// PI may dispatch several archive tool calls from one turn concurrently.
-const archiveQueueTails = new Map<string, Promise<void>>();
-
-function enqueueArchive<T>(l2DataDir: string, task: () => Promise<T>): Promise<T> {
-	const queueKey = resolve(l2DataDir);
-	const previous = archiveQueueTails.get(queueKey) ?? Promise.resolve();
-	const run = previous.then(task, task);
-	const tail = run.then(
-		() => undefined,
-		() => undefined,
-	);
-	archiveQueueTails.set(queueKey, tail);
-
-	return run.finally(() => {
-		if (archiveQueueTails.get(queueKey) === tail) archiveQueueTails.delete(queueKey);
-	});
-}
 
 /**
  * Create L2 Wiki memory tools for the Inno Agent.
@@ -91,40 +59,17 @@ export function createL2Tools(
 		}),
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
 			if (isEnabled && !isEnabled()) return l2DisabledResult();
-			return enqueueArchive(l2DataDir, async () => {
-			ensureL2Directories(l2DataDir);
-			const maintenanceContext = readMaintenanceContext(l2DataDir);
-
 			const sourceType = params.sourceType as RawSourceType;
 			const isFileType = sourceType === "pdf" || sourceType === "word" || sourceType === "image";
-
-			// Resolve content: either from params.content or by parsing a file
-			let content: string;
-			let resolvedFilePath: string | undefined;
-
+			let source: ArchiveL2Source;
 			if (isFileType && params.filePath) {
-				// File-based: parse with LiteParse
 				const workspaceDir = getActiveWorkspaceDir?.() || process.env.INNO_WORKSPACE_DIR || process.cwd();
-				resolvedFilePath = isAbsolute(params.filePath)
+				const resolvedFilePath = isAbsolute(params.filePath)
 					? params.filePath
 					: resolve(workspaceDir, params.filePath);
-
-				let parsed;
-				try {
-					parsed = await parseDocument(resolvedFilePath);
-				} catch (err) {
-					logger.warn({ err, filePath: resolvedFilePath }, "l2_archive: failed to parse document");
-					const msg = err instanceof DocumentParseError ? err.message : String(err);
-					return {
-						content: [{ type: "text" as const, text: `文件解析失败: ${msg}` }],
-						details: { error: err instanceof DocumentParseError ? err.code : "parse_error" },
-					};
-				}
-
-				content = parsed.text;
+				source = { kind: "file", filePath: resolvedFilePath, sourceType };
 			} else if (params.content) {
-				// Text-based: use content directly
-				content = params.content;
+				source = { kind: "content", content: params.content, sourceType };
 			} else {
 				return {
 					content: [{ type: "text" as const, text: "参数错误：必须提供 content（文本内容）或 filePath（文件路径）。" }],
@@ -132,151 +77,71 @@ export function createL2Tools(
 				};
 			}
 
-			const contentHash = createHash("sha256").update(content).digest("hex").slice(0, 16);
-
-				// Completed content is a duplicate. Incomplete records resume below.
-				const existing = !params.force ? findManifestByHash(l2DataDir, contentHash) : undefined;
-				if (existing?.status === "indexed") {
-						return {
+			try {
+				const result = await archiveL2Source(
+					l2DataDir,
+					{
+						title: params.title,
+						source,
+						tags: params.tags,
+						origin: params.origin as ManifestEntry["source"]["origin"] | undefined,
+						url: params.url,
+						sessionId: params.sessionId,
+						force: params.force,
+						dedupeBy: "content",
+						logLabel: "agent tool",
+					},
+					{ model: ctx.model, modelRegistry: ctx.modelRegistry, memory: l2Memory },
+				);
+				if (result.duplicate) {
+					return {
 						content: [
 							{
 								type: "text" as const,
 								text:
 									`该内容已归档，无需重复保存。\n\n` +
-									`- ID: ${existing.id}\n` +
-									`- 标题: ${existing.title}\n` +
-									`- Wiki 页面: ${existing.wikiPages.join(", ") || "无"}\n\n` +
+									`- ID: ${result.id}\n` +
+									`- 标题: ${result.title}\n` +
+									`- Wiki 页面: ${result.wikiPages.join(", ") || "无"}\n\n` +
 									`如需强制归档，请设置 force: true。`,
 							},
 						],
-						details: { id: existing.id, duplicate: true },
+						details: { id: result.id, duplicate: true },
 					};
 				}
 
-				const existingRawPath = existing?.rawPath && fileExists(join(l2DataDir, existing.rawPath))
-					? existing.rawPath
-					: undefined;
-				const rawPath = existingRawPath ?? (resolvedFilePath
-					? saveRawFile(l2DataDir, params.title, resolvedFilePath, sourceType)
-					: saveRaw(l2DataDir, params.title, content, sourceType, params.url));
-
-				const id = existing?.id ?? `l2src_${randomUUID().slice(0, 8)}`;
-				const tags = params.tags ?? [];
-
-				// Convert to extracted markdown
-				const existingExtractedPath = existing?.extractedPath && fileExists(join(l2DataDir, existing.extractedPath))
-					? existing.extractedPath
-					: undefined;
-				const extractedPath = existingExtractedPath
-					?? convertToExtracted(l2DataDir, params.title, content, sourceType);
-
-				// Persist the recoverable source record before model/page work begins.
-				const inferredOrigin = sourceType === "conversation" ? "conversation" : "user_upload";
-				const entry: ManifestEntry = {
-					...existing,
-					id,
-				title: params.title,
-				sourceType,
-				rawPath,
-				extractedPath,
-				wikiPages: [],
-				tags,
-				contentHash,
-				status: "extracted",
-				source: {
-					origin: (params.origin ?? inferredOrigin) as ManifestEntry["source"]["origin"],
-					...(params.url && { url: params.url }),
-					...(params.sessionId && { sessionId: params.sessionId }),
-				},
-					createdAt: existing?.createdAt ?? new Date().toISOString(),
-					updatedAt: new Date().toISOString(),
-				};
-				upsertManifest(l2DataDir, entry);
-
-				let wikiPagePath = "";
-				let linkMaintenance: Awaited<ReturnType<typeof maintainLinkedWikiPages>>;
-				try {
-					// Create wiki source page (with LLM summary)
-					const extractedContent = readText(join(l2DataDir, extractedPath));
-					let summaryBody = `## 摘要\n\n${extractedContent}`;
-					if (ctx.model) {
-						const summary = await summarizeContent(ctx.model, ctx.modelRegistry, params.title, extractedContent);
-						if (summary) summaryBody = summary;
-					}
-					wikiPagePath = createSourcePage(l2DataDir, entry, summaryBody, extractedPath);
-					linkMaintenance = await maintainLinkedWikiPages(
-						l2DataDir,
-						entry,
-						wikiPagePath,
-						summaryBody,
-						ctx.model,
-						ctx.modelRegistry,
-					);
-					if (linkMaintenance.sourcePageBody !== summaryBody) {
-						createSourcePage(l2DataDir, entry, linkMaintenance.sourcePageBody, extractedPath);
-					}
-					entry.wikiPages = [wikiPagePath, ...linkMaintenance.pages];
-					entry.status = "indexed";
-					entry.updatedAt = new Date().toISOString();
-					upsertManifest(l2DataDir, entry);
-
-					// Rebuild index
-					const allEntries = readManifest(l2DataDir);
-					rebuildIndex(l2DataDir, allEntries);
-
-					// Keep the retrieval index in sync with the touched pages.
-					for (const wikiPath of entry.wikiPages) {
-						await l2Memory.indexPageByPath(wikiPath);
-					}
-
-					// Regenerate the knowledge-base overview (best-effort; never fails archive).
-					try {
-						const overviewPath = await regenerateOverview(l2DataDir, ctx.model, ctx.modelRegistry);
-						if (overviewPath) await l2Memory.indexPageByPath(overviewPath);
-					} catch (err) {
-						logger.warn({ err }, "l2_archive: overview regeneration failed");
-					}
-				} catch (err) {
-					entry.status = "error";
-					entry.updatedAt = new Date().toISOString();
-					upsertManifest(l2DataDir, entry);
-					throw err;
-				}
-
-			// Append log
-			appendLog(
-				l2DataDir,
-				"ingest",
-				params.title,
-				[
-					`- ID: ${id}`,
-					`- 类型: ${sourceType}`,
-					`- 原始文件: ${rawPath}`,
-					`- 提取文本: ${extractedPath}`,
-					`- Source 页面: ${wikiPagePath}`,
-					`- concepts/entities: 新建 ${linkMaintenance.created.length}, 更新 ${linkMaintenance.updated.length}, 不变 ${linkMaintenance.unchanged.length}, 争议 ${linkMaintenance.contested.length}`,
-					`- 维护前上下文: schema ${maintenanceContext.schema.length} chars, index ${maintenanceContext.index.length} chars, recent log ${maintenanceContext.recentLog.length} chars`,
-				].join("\n"),
-			);
-
-			return {
-				content: [
-					{
-						type: "text" as const,
-						text:
-							`资料已归档到 L2 Wiki。\n\n` +
-							`- ID: ${id}\n` +
+				return {
+					content: [
+						{
+							type: "text" as const,
+							text:
+								`资料已归档到 L2 Wiki。\n\n` +
+							`- ID: ${result.id}\n` +
 							`- 标题: ${params.title}\n` +
-							`- 原始文件: ${rawPath}\n` +
-							`- Wiki 页面: ${wikiPagePath}\n` +
-							`- 自动维护: 新建 ${linkMaintenance.created.length} 个概念/实体页，更新 ${linkMaintenance.updated.length} 个\n` +
-							`- 标签: ${tags.join(", ") || "无"}\n\n` +
+							`- 原始文件: ${result.rawPath}\n` +
+							`- Wiki 页面: ${result.wikiPagePath}\n` +
+							`- 自动维护: 新建 ${result.createdCount} 个概念/实体页，更新 ${result.updatedCount} 个\n` +
+							`- 标签: ${result.tags.join(", ") || "无"}\n\n` +
 							`Wiki 索引已更新。`,
+						},
+					],
+					details: {
+						id: result.id,
+						rawPath: result.rawPath,
+						wikiPagePath: result.wikiPagePath,
+						linkedPages: result.linkedPages,
 					},
-				],
-				details: { id, rawPath, wikiPagePath, linkedPages: linkMaintenance.pages },
-			};
-			});
+				};
+			} catch (err) {
+				if (err instanceof ArchiveSourceReadError) {
+					logger.warn({ err }, "l2_archive: failed to read source");
+					return {
+						content: [{ type: "text" as const, text: `文件解析失败: ${err.message}` }],
+						details: { error: err.code === "READ_ERROR" ? "parse_error" : err.code },
+					};
+				}
+				throw err;
+			}
 		},
 	});
 

--- a/apps/inno-agent/src/memory/l2/manifest-store.ts
+++ b/apps/inno-agent/src/memory/l2/manifest-store.ts
@@ -60,3 +60,8 @@ export function findManifestByTitle(l2DataDir: string, title: string): ManifestE
 export function findManifestByHash(l2DataDir: string, contentHash: string): ManifestEntry | undefined {
 	return readManifest(l2DataDir).find((e) => e.contentHash === contentHash);
 }
+
+export function findManifestByRawPath(l2DataDir: string, rawPath: string): ManifestEntry | undefined {
+	const normalized = rawPath.replace(/\\/g, "/");
+	return readManifest(l2DataDir).find((e) => e.rawPath.replace(/\\/g, "/") === normalized);
+}

--- a/apps/inno-agent/src/memory/l2/note-attachments-service.ts
+++ b/apps/inno-agent/src/memory/l2/note-attachments-service.ts
@@ -1,0 +1,139 @@
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { readJson, writeJson, readText } from "../../storage/file-store.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
+import { parseNoteFrontmatter } from "./note-frontmatter.js";
+import { sanitizeUploadedFileName, uploadExtension } from "./upload-file-utils.js";
+
+export type NoteAttachmentStatus = "uploaded" | "extracting" | "extracted" | "indexed" | "error";
+
+export interface NoteAttachmentRecord {
+	id: string;
+	noteRawPath: string;
+	noteId: string;
+	fileName: string;
+	mimeType: string;
+	size: number;
+	filePath: string;
+	status: NoteAttachmentStatus;
+	createdAt: string;
+	updatedAt: string;
+}
+
+const INDEX_FILE = "note-attachments.json";
+
+function attachmentsIndexPath(l2DataDir: string): string {
+	return join(l2DataDir, INDEX_FILE);
+}
+
+function readAttachmentIndex(l2DataDir: string): NoteAttachmentRecord[] {
+	return readJson<NoteAttachmentRecord[]>(attachmentsIndexPath(l2DataDir), []);
+}
+
+function writeAttachmentIndex(l2DataDir: string, records: NoteAttachmentRecord[]): void {
+	writeJson(attachmentsIndexPath(l2DataDir), records);
+}
+
+function normalizeNoteRawPath(rawPath: string): string {
+	return rawPath.replace(/\\/g, "/");
+}
+
+export function listNoteAttachments(l2DataDir: string, noteRawPath: string): NoteAttachmentRecord[] {
+	const normalizedPath = normalizeNoteRawPath(noteRawPath);
+	return readAttachmentIndex(l2DataDir)
+		.filter((record) => normalizeNoteRawPath(record.noteRawPath) === normalizedPath)
+		.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function uploadNoteAttachment(
+	l2DataDir: string,
+	noteRawPath: string,
+	options: { fileName: string; mimeType: string; dataBase64: string },
+): NoteAttachmentRecord {
+	const normalizedPath = normalizeNoteRawPath(noteRawPath);
+	const noteRelativePath = normalizedPath.slice("raw/notes/".length);
+	if (
+		!normalizedPath.startsWith("raw/notes/")
+		|| noteRelativePath.includes("/")
+		|| !noteRelativePath.toLowerCase().endsWith(".md")
+	) {
+		throw new Error("Invalid note path");
+	}
+
+	const notePath = resolveContainedPath(join(l2DataDir, "raw", "notes"), noteRelativePath);
+	if (!notePath) throw new Error("Invalid note path");
+	const { frontmatter } = parseNoteFrontmatter(readText(notePath));
+	if (!frontmatter?.note_id) {
+		throw new Error("Invalid note file");
+	}
+	const noteId = frontmatter.note_id.trim();
+	if (!/^note_[A-Za-z0-9_-]+$/.test(noteId)) {
+		throw new Error("Invalid note id");
+	}
+	const attachmentId = `att_${randomUUID().slice(0, 8)}`;
+	const safeName = sanitizeUploadedFileName(options.fileName, "attachment");
+	const ext = uploadExtension(safeName, options.mimeType);
+	const base = basename(safeName, ext).slice(0, 80) || "attachment";
+	const storedName = `${attachmentId}-${base}${ext}`;
+	const attachmentsRoot = join(l2DataDir, "raw", "notes", "attachments");
+	const attachmentDir = resolveContainedPath(attachmentsRoot, noteId);
+	if (!attachmentDir) throw new Error("Invalid attachment path");
+	mkdirSync(attachmentDir, { recursive: true });
+	const absPath = resolveContainedPath(attachmentDir, storedName);
+	if (!absPath) throw new Error("Invalid attachment path");
+	const data = Buffer.from(options.dataBase64, "base64");
+	writeFileSync(absPath, data);
+
+	const now = new Date().toISOString();
+	const record: NoteAttachmentRecord = {
+		id: attachmentId,
+		noteRawPath: normalizedPath,
+		noteId,
+		fileName: options.fileName,
+		mimeType: options.mimeType,
+		size: data.length,
+		filePath: join("raw/notes/attachments", noteId, storedName).replace(/\\/g, "/"),
+		status: "uploaded",
+		createdAt: now,
+		updatedAt: now,
+	};
+
+	const records = readAttachmentIndex(l2DataDir);
+	records.push(record);
+	writeAttachmentIndex(l2DataDir, records);
+	return record;
+}
+
+export function deleteNoteAttachment(l2DataDir: string, attachmentId: string): NoteAttachmentRecord {
+	const records = readAttachmentIndex(l2DataDir);
+	const index = records.findIndex((record) => record.id === attachmentId);
+	if (index < 0) {
+		throw new Error("Attachment not found");
+	}
+
+	const removed = records[index];
+	const normalizedFilePath = removed.filePath.replace(/\\/g, "/");
+	const attachmentPrefix = "raw/notes/attachments/";
+	if (!normalizedFilePath.startsWith(attachmentPrefix)) {
+		throw new Error("Invalid attachment path");
+	}
+	const absPath = resolveContainedPath(
+		join(l2DataDir, "raw", "notes", "attachments"),
+		normalizedFilePath.slice(attachmentPrefix.length),
+	);
+	if (!absPath) throw new Error("Invalid attachment path");
+
+	records.splice(index, 1);
+	writeAttachmentIndex(l2DataDir, records);
+
+	if (existsSync(absPath)) {
+		unlinkSync(absPath);
+	}
+	return removed;
+}
+
+export function findNoteAttachment(l2DataDir: string, attachmentId: string): NoteAttachmentRecord | undefined {
+	return readAttachmentIndex(l2DataDir).find((record) => record.id === attachmentId);
+}

--- a/apps/inno-agent/src/memory/l2/note-frontmatter.ts
+++ b/apps/inno-agent/src/memory/l2/note-frontmatter.ts
@@ -1,0 +1,171 @@
+export type NoteStatus = "draft" | "indexed" | "outdated" | "error";
+
+export interface NoteFrontmatter {
+	note_id: string;
+	title: string;
+	tags: string[];
+	record_date: string;
+	status: NoteStatus;
+	source_id?: string;
+	created: string;
+	updated: string;
+}
+
+const FRONTMATTER_PATTERN = /^(?:\uFEFF)?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/;
+
+function parseScalar(value: string): string {
+	const trimmed = value.trim();
+	if (trimmed.startsWith("\"") && trimmed.endsWith("\"")) {
+		try {
+			return JSON.parse(trimmed) as string;
+		} catch {
+			return trimmed.slice(1, -1);
+		}
+	}
+	return trimmed;
+}
+
+function parseTagList(value: string): string[] {
+	const trimmed = value.trim();
+	if (!trimmed) return [];
+	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		return trimmed
+			.slice(1, -1)
+			.split(",")
+			.map((tag) => parseScalar(tag.trim()))
+			.filter(Boolean);
+	}
+	return trimmed
+		.split(/[,，;；、|]/)
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
+export function getTodayRecordDate(): string {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+export function recordDateFromIso(isoString: string | undefined): string {
+	if (!isoString) return getTodayRecordDate();
+	const date = new Date(isoString);
+	if (Number.isNaN(date.getTime())) return getTodayRecordDate();
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+function normalizeRecordDateValue(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) return "";
+	if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+	const slashMatch = trimmed.match(/^(\d{4})[/.](\d{1,2})[/.](\d{1,2})$/);
+	if (slashMatch) {
+		return `${slashMatch[1]}-${slashMatch[2].padStart(2, "0")}-${slashMatch[3].padStart(2, "0")}`;
+	}
+	const parsed = new Date(trimmed);
+	if (!Number.isNaN(parsed.getTime())) return recordDateFromIso(parsed.toISOString());
+	return "";
+}
+
+export function parseNoteFrontmatter(content: string): { frontmatter: NoteFrontmatter | null; body: string } {
+	const match = content.match(FRONTMATTER_PATTERN);
+	if (!match) return { frontmatter: null, body: content };
+
+	const yamlBlock = match[1];
+	const body = match[2];
+	const fm: Record<string, unknown> = {};
+	let currentKey = "";
+	let currentArray: string[] = [];
+
+	for (const line of yamlBlock.split("\n")) {
+		const kvMatch = line.match(/^(\w+):\s*(.*)$/);
+		if (kvMatch) {
+			if (currentKey && currentArray.length > 0) {
+				fm[currentKey] = currentArray;
+				currentArray = [];
+			}
+			currentKey = kvMatch[1];
+			const value = kvMatch[2].trim();
+			if (value.startsWith("[") && value.endsWith("]")) {
+				fm[currentKey] = parseTagList(value);
+				currentKey = "";
+			} else if (value === "") {
+				// array items follow
+			} else {
+				fm[currentKey] = value;
+				currentKey = "";
+			}
+		} else {
+			const itemMatch = line.match(/^\s+-\s+(.+)$/);
+			if (itemMatch) {
+				currentArray.push(parseScalar(itemMatch[1]));
+			}
+		}
+	}
+	if (currentKey && currentArray.length > 0) {
+		fm[currentKey] = currentArray;
+	}
+
+	const status = fm.status as string;
+	const validStatus: NoteStatus =
+		status === "indexed" || status === "outdated" || status === "error" ? status : "draft";
+	const created = parseScalar(String(fm.created ?? ""));
+	const recordDateRaw = parseScalar(String(fm.record_date ?? fm.recordDate ?? ""));
+
+	return {
+		frontmatter: {
+			note_id: parseScalar(String(fm.note_id ?? "")),
+			title: parseScalar(String(fm.title ?? "")),
+			tags: Array.isArray(fm.tags) ? (fm.tags as string[]) : parseTagList(String(fm.tags ?? "")),
+			record_date: normalizeRecordDateValue(recordDateRaw) || recordDateFromIso(created),
+			status: validStatus,
+			source_id: fm.source_id ? parseScalar(String(fm.source_id)) : undefined,
+			created,
+			updated: parseScalar(String(fm.updated ?? "")),
+		},
+		body,
+	};
+}
+
+function yamlQuote(value: string): string {
+	if (/[:\[\]{},#&*!|>'"%@`\n]/.test(value) || value.trim() !== value || value === "") {
+		return JSON.stringify(value);
+	}
+	return value;
+}
+
+export function serializeNoteFile(frontmatter: NoteFrontmatter, body: string): string {
+	const lines = [
+		"---",
+		`note_id: ${yamlQuote(frontmatter.note_id)}`,
+		`title: ${yamlQuote(frontmatter.title)}`,
+	];
+	if (frontmatter.tags.length > 0) {
+		lines.push("tags:");
+		for (const tag of frontmatter.tags) {
+			lines.push(`  - ${yamlQuote(tag)}`);
+		}
+	} else {
+		lines.push("tags: []");
+	}
+	lines.push(`record_date: ${yamlQuote(frontmatter.record_date)}`);
+	lines.push(`status: ${frontmatter.status}`);
+	if (frontmatter.source_id) {
+		lines.push(`source_id: ${yamlQuote(frontmatter.source_id)}`);
+	}
+	lines.push(`created: ${yamlQuote(frontmatter.created)}`);
+	lines.push(`updated: ${yamlQuote(frontmatter.updated)}`);
+	lines.push("---");
+	const trimmedBody = body.replace(/^\n/, "");
+	return `${lines.join("\n")}\n${trimmedBody}`;
+}
+
+export function extractNoteTitle(body: string, fallback: string): string {
+	const match = body.match(/^#\s+(.+)$/m);
+	return match?.[1]?.trim() || fallback;
+}

--- a/apps/inno-agent/src/memory/l2/note-templates.ts
+++ b/apps/inno-agent/src/memory/l2/note-templates.ts
@@ -1,0 +1,100 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+export interface NoteTemplateDefinition {
+	id: string;
+	label: string;
+	labelEn: string;
+	description: string;
+	descriptionEn: string;
+	tags: string[];
+	body: string;
+	defaultTitle: string;
+	hidden: boolean;
+}
+
+function readAttribute(lines: string[], keys: string[]): string {
+	for (const line of lines) {
+		const match = line.match(/^(\w+):\s*(.*)$/);
+		if (!match) continue;
+		if (keys.includes(match[1])) return match[2].trim();
+	}
+	return "";
+}
+
+function parseTagList(value: string): string[] {
+	if (!value.trim()) return [];
+	return value
+		.split(/[,，;；、|]/)
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
+function extractFirstHeading(body: string): string | null {
+	const match = body.match(/^#\s+(.+)$/m);
+	return match?.[1]?.trim() ?? null;
+}
+
+function loadTemplateFile(codeDir: string, fileName: string): NoteTemplateDefinition | null {
+	const absPath = join(codeDir, "note-templates", fileName);
+	if (!existsSync(absPath)) return null;
+	const raw = readFileSync(absPath, "utf8");
+	const match = raw.match(/^(?:\uFEFF)?---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?([\s\S]*)$/);
+	if (!match) return null;
+
+	const metaLines = match[1].split("\n");
+	const body = match[2];
+	const id = basename(fileName, ".md");
+	const heading = extractFirstHeading(body);
+	const label = readAttribute(metaLines, ["label"]) || heading || id;
+	const labelEn = readAttribute(metaLines, ["labelEn", "label_en"]) || label;
+	const description = readAttribute(metaLines, ["description", "desc"]);
+	const descriptionEn = readAttribute(metaLines, ["descriptionEn", "description_en"]) || description;
+	const tags = parseTagList(readAttribute(metaLines, ["tags", "tag"]));
+	const defaultTitle = readAttribute(metaLines, ["title"]) || heading || label;
+	const hidden = readAttribute(metaLines, ["hidden"]).toLowerCase() === "true";
+
+	return { id, label, labelEn, description, descriptionEn, tags, body, defaultTitle, hidden };
+}
+
+export function listNoteTemplates(codeDir: string): NoteTemplateDefinition[] {
+	const dir = join(codeDir, "note-templates");
+	if (!existsSync(dir)) return [];
+	return readdirSync(dir)
+		.filter((name) => name.endsWith(".md"))
+		.map((name) => loadTemplateFile(codeDir, name))
+		.filter((item): item is NoteTemplateDefinition => item !== null)
+		.sort((a, b) => a.label.localeCompare(b.label, "zh"));
+}
+
+export function getNoteTemplate(codeDir: string, templateId: string): NoteTemplateDefinition | undefined {
+	return listNoteTemplates(codeDir).find((item) => item.id === templateId);
+}
+
+export function resolveNoteTemplateContent(
+	codeDir: string,
+	options: { templateId?: string; title?: string; tags?: string[]; content?: string },
+): { title: string; tags: string[]; body: string } {
+	if (options.content?.trim()) {
+		return {
+			title: options.title?.trim() || "未命名笔记",
+			tags: options.tags ?? [],
+			body: options.content,
+		};
+	}
+
+	const template = options.templateId ? getNoteTemplate(codeDir, options.templateId) : getNoteTemplate(codeDir, "blank");
+	if (template) {
+		return {
+			title: options.title?.trim() || template.defaultTitle,
+			tags: options.tags ?? template.tags,
+			body: template.body,
+		};
+	}
+
+	return {
+		title: options.title?.trim() || "未命名笔记",
+		tags: options.tags ?? [],
+		body: "# 未命名笔记\n\n",
+	};
+}

--- a/apps/inno-agent/src/memory/l2/notes-archive-service.test.ts
+++ b/apps/inno-agent/src/memory/l2/notes-archive-service.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { L2Memory } from "./l2-memory.js";
+import {
+	archiveL2Note,
+	createL2Note,
+	listL2Notes,
+	readNoteContent,
+	saveL2NoteContent,
+} from "./notes-service.js";
+
+const tempDirs: string[] = [];
+
+function makeTempDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "inno-note-archive-"));
+	tempDirs.push(dir);
+	return dir;
+}
+
+function fakeMemory(root: string): L2Memory {
+	return {
+		dataDir: root,
+		indexPageByPath: vi.fn().mockResolvedValue(undefined),
+		removePage: vi.fn().mockResolvedValue(undefined),
+	} as unknown as L2Memory;
+}
+
+function deferred<T>() {
+	let resolvePromise!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromiseCallback) => {
+		resolvePromise = resolvePromiseCallback;
+	});
+	return { promise, resolve: resolvePromise };
+}
+
+afterEach(() => {
+	for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe("archiveL2Note", () => {
+	it("preserves edits made while a note is being archived", async () => {
+		const root = makeTempDir();
+		const created = createL2Note(root, resolve("apps/inno-agent"), {
+			title: "并发编辑",
+			content: "归档开始时的正文",
+		});
+		const firstIndex = deferred<void>();
+		const memory = fakeMemory(root);
+		vi.mocked(memory.indexPageByPath)
+			.mockImplementationOnce(() => firstIndex.promise)
+			.mockResolvedValue(undefined);
+
+		const archiving = archiveL2Note(root, created.rawPath, { memory });
+		await vi.waitFor(() => expect(memory.indexPageByPath).toHaveBeenCalledTimes(1));
+		saveL2NoteContent(root, created.rawPath, {
+			title: "并发编辑",
+			content: "归档期间保存的新正文",
+		});
+
+		firstIndex.resolve();
+		await archiving;
+		const current = readNoteContent(root, created.rawPath);
+		expect(current.content).toContain("归档期间保存的新正文");
+		expect(current.status).toBe("outdated");
+	});
+
+	it("keeps one editable item through archive, edit, and rearchive", async () => {
+		const root = makeTempDir();
+		const memory = fakeMemory(root);
+		const created = createL2Note(root, resolve("apps/inno-agent"), {
+			title: "生命周期",
+			content: "第一版 [[笔记流程]]",
+		});
+
+		await archiveL2Note(root, created.rawPath, { memory });
+		expect(listL2Notes(root).notes).toMatchObject([
+			{ rawPath: created.rawPath, kind: "markdown", status: "indexed" },
+		]);
+		saveL2NoteContent(root, created.rawPath, { title: "生命周期", content: "第二版 [[笔记流程]]" });
+		expect(listL2Notes(root).notes).toMatchObject([
+			{ rawPath: created.rawPath, kind: "markdown", status: "outdated" },
+		]);
+		await archiveL2Note(root, created.rawPath, { memory });
+		expect(listL2Notes(root).notes).toMatchObject([
+			{ rawPath: created.rawPath, kind: "markdown", status: "indexed" },
+		]);
+	});
+
+	it("leaves a concurrently archived note indexed", async () => {
+		const root = makeTempDir();
+		const memory = fakeMemory(root);
+		const created = createL2Note(root, resolve("apps/inno-agent"), {
+			title: "重复归档",
+			content: "不会被误标过期",
+		});
+
+		const results = await Promise.all([
+			archiveL2Note(root, created.rawPath, { memory }),
+			archiveL2Note(root, created.rawPath, { memory }),
+		]);
+		expect(results.map((result) => result.duplicate)).toEqual([false, true]);
+		expect(readNoteContent(root, created.rawPath).status).toBe("indexed");
+	});
+});

--- a/apps/inno-agent/src/memory/l2/notes-service.ts
+++ b/apps/inno-agent/src/memory/l2/notes-service.ts
@@ -1,0 +1,273 @@
+import { createHash, randomUUID } from "node:crypto";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, join } from "node:path";
+
+import { readText, writeText } from "../../storage/file-store.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
+import { findManifestByRawPath, readManifest } from "./manifest-store.js";
+import {
+	extractNoteTitle,
+	getTodayRecordDate,
+	parseNoteFrontmatter,
+	recordDateFromIso,
+	serializeNoteFile,
+	type NoteFrontmatter,
+	type NoteStatus,
+} from "./note-frontmatter.js";
+import { resolveNoteTemplateContent } from "./note-templates.js";
+import { inferNotebookType, primaryWikiPath, scanOrphans } from "./sources-service.js";
+import type { ManifestEntry, ManifestStatus, RawSourceType } from "./types.js";
+import { ensureL2Directories } from "./wiki-maintainer.js";
+import { logger } from "../../logger.js";
+import { listNoteAttachments, type NoteAttachmentRecord } from "./note-attachments-service.js";
+
+export type NotebookItemKind = "markdown" | "orphan" | "archived";
+export type NotebookType = "conversation" | "file" | "note";
+export type NotebookItemStatus = NoteStatus | ManifestStatus | "uploaded";
+
+export interface NoteSummaryDto {
+	noteId: string;
+	rawPath: string;
+	title: string;
+	tags: string[];
+	notebookType: NotebookType;
+	contentType: RawSourceType;
+	status: NotebookItemStatus;
+	kind: NotebookItemKind;
+	wikiPagePath?: string;
+	wikiPages?: string[];
+	origin?: ManifestEntry["source"]["origin"];
+	extractedPath?: string;
+	size?: number;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface NoteContentDto {
+	rawPath: string;
+	noteId: string;
+	title: string;
+	tags: string[];
+	recordDate: string;
+	status: NoteStatus;
+	sourceId?: string;
+	content: string;
+	attachments: NoteAttachmentRecord[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface NotesListResponse {
+	notes: NoteSummaryDto[];
+}
+
+function noteFileName(title: string, noteId: string): string {
+	const slug = title
+		.toLowerCase()
+		.replace(/[^a-z0-9\u4e00-\u9fff]+/g, "-")
+		.replace(/^-|-$/g, "")
+		.slice(0, 40);
+	return `${slug || "note"}-${noteId.slice(-8)}.md`;
+}
+
+function readNoteFile(l2DataDir: string, rawPath: string): { absPath: string; frontmatter: NoteFrontmatter; body: string } {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	const noteRelativePath = normalizedPath.slice("raw/notes/".length);
+	if (
+		!normalizedPath.startsWith("raw/notes/")
+		|| noteRelativePath.includes("/")
+		|| !noteRelativePath.toLowerCase().endsWith(".md")
+	) {
+		throw new Error("Invalid note path");
+	}
+	const absPath = resolveContainedPath(join(l2DataDir, "raw", "notes"), noteRelativePath);
+	if (!absPath) throw new Error("Invalid note path");
+	const content = readText(absPath);
+	const { frontmatter, body } = parseNoteFrontmatter(content);
+	if (!frontmatter?.note_id) {
+		throw new Error("Invalid note file: missing note_id frontmatter");
+	}
+	return { absPath, frontmatter, body };
+}
+
+function noteSummaryFromFile(l2DataDir: string, rawPath: string): NoteSummaryDto | null {
+	try {
+		const { frontmatter, body } = readNoteFile(l2DataDir, rawPath);
+		const manifest = findManifestByRawPath(l2DataDir, rawPath);
+		if (manifest?.status === "indexed") {
+			return null;
+		}
+		const title = frontmatter.title || extractNoteTitle(body, basename(rawPath, ".md"));
+		return {
+			noteId: frontmatter.note_id,
+			rawPath,
+			title,
+			tags: frontmatter.tags,
+			notebookType: "note",
+			contentType: "markdown",
+			status: frontmatter.status,
+			kind: "markdown",
+			wikiPagePath: manifest ? primaryWikiPath(manifest.wikiPages) : undefined,
+			wikiPages: manifest?.wikiPages,
+			origin: "user_upload",
+			createdAt: frontmatter.created || statSync(join(l2DataDir, rawPath)).mtime.toISOString(),
+			updatedAt: frontmatter.updated || frontmatter.created || statSync(join(l2DataDir, rawPath)).mtime.toISOString(),
+		};
+	} catch (err) {
+		logger.warn({ err, rawPath }, "failed to read note file");
+		return null;
+	}
+}
+
+function manifestToNoteSummary(entry: ManifestEntry): NoteSummaryDto {
+	const rawPath = entry.rawPath.replace(/\\/g, "/");
+	return {
+		noteId: entry.id,
+		rawPath,
+		title: entry.title,
+		tags: entry.tags,
+		notebookType: inferNotebookType(rawPath),
+		contentType: entry.sourceType,
+		status: entry.status,
+		kind: "archived",
+		wikiPagePath: primaryWikiPath(entry.wikiPages),
+		wikiPages: entry.wikiPages,
+		origin: entry.source.origin,
+		extractedPath: entry.extractedPath,
+		createdAt: entry.createdAt,
+		updatedAt: entry.updatedAt,
+	};
+}
+
+function orphanToNoteSummary(orphan: ReturnType<typeof scanOrphans>[number]): NoteSummaryDto {
+	return {
+		noteId: `orphan_${createHash("sha256").update(orphan.rawPath).digest("hex").slice(0, 8)}`,
+		rawPath: orphan.rawPath,
+		title: orphan.fileName,
+		tags: [],
+		notebookType: "file",
+		contentType: orphan.sourceType,
+		status: "uploaded",
+		kind: "orphan",
+		size: orphan.size,
+		origin: "user_upload",
+		createdAt: orphan.modifiedAt,
+		updatedAt: orphan.modifiedAt,
+	};
+}
+
+export function listL2Notes(
+	l2DataDir: string,
+	options: {
+		notebookType?: NotebookType;
+		status?: string;
+	} = {},
+): NotesListResponse {
+	ensureL2Directories(l2DataDir);
+	const entries = readManifest(l2DataDir);
+	const indexedRawPaths = new Set(entries.map((e) => e.rawPath.replace(/\\/g, "/")));
+	const notes: NoteSummaryDto[] = [];
+
+	for (const entry of entries) {
+		const summary = manifestToNoteSummary(entry);
+		if (options.notebookType && summary.notebookType !== options.notebookType) continue;
+		if (options.status && summary.status !== options.status) continue;
+		notes.push(summary);
+	}
+
+	const notesDir = join(l2DataDir, "raw", "notes");
+	if (existsSync(notesDir)) {
+		for (const name of readdirSync(notesDir)) {
+			if (!name.endsWith(".md")) continue;
+			const rawPath = join("raw/notes", name).replace(/\\/g, "/");
+			const summary = noteSummaryFromFile(l2DataDir, rawPath);
+			if (!summary) continue;
+			if (options.notebookType && summary.notebookType !== options.notebookType) continue;
+			if (options.status && summary.status !== options.status) continue;
+			notes.push(summary);
+		}
+	}
+
+	for (const orphan of scanOrphans(l2DataDir, indexedRawPaths)) {
+		const summary = orphanToNoteSummary(orphan);
+		if (options.notebookType && summary.notebookType !== options.notebookType) continue;
+		if (options.status && summary.status !== options.status) continue;
+		notes.push(summary);
+	}
+
+	notes.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+	return { notes };
+}
+
+export function readNoteContent(l2DataDir: string, rawPath: string): NoteContentDto {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	if (!normalizedPath.startsWith("raw/notes/")) {
+		throw new Error("Invalid note path");
+	}
+	const { frontmatter, body } = readNoteFile(l2DataDir, normalizedPath);
+	const title = frontmatter.title || extractNoteTitle(body, basename(normalizedPath, ".md"));
+	return {
+		rawPath: normalizedPath,
+		noteId: frontmatter.note_id,
+		title,
+		tags: frontmatter.tags,
+		recordDate: frontmatter.record_date,
+		status: frontmatter.status,
+		sourceId: frontmatter.source_id,
+		content: body,
+		attachments: listNoteAttachments(l2DataDir, normalizedPath),
+		createdAt: frontmatter.created,
+		updatedAt: frontmatter.updated,
+	};
+}
+
+export function createL2Note(
+	l2DataDir: string,
+	codeDir: string,
+	options: {
+		title?: string;
+		templateId?: string;
+		tags?: string[];
+		content?: string;
+	},
+): { rawPath: string; status: NoteStatus; noteId: string; title: string } {
+	ensureL2Directories(l2DataDir);
+	const { title, tags, body } = resolveNoteTemplateContent(codeDir, options);
+	const noteId = `note_${randomUUID().slice(0, 8)}`;
+	const now = new Date().toISOString();
+	const fileName = noteFileName(title, noteId);
+	const rawPath = join("raw/notes", fileName).replace(/\\/g, "/");
+	const frontmatter: NoteFrontmatter = {
+		note_id: noteId,
+		title,
+		tags,
+		record_date: getTodayRecordDate(),
+		status: "draft",
+		created: now,
+		updated: now,
+	};
+	writeText(join(l2DataDir, rawPath), serializeNoteFile(frontmatter, body));
+	return { rawPath, status: "draft", noteId, title };
+}
+
+export function saveL2NoteContent(
+	l2DataDir: string,
+	rawPath: string,
+	options: { title: string; tags?: string[]; recordDate?: string; content: string },
+): { rawPath: string; status: NoteStatus } {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	const { absPath, frontmatter, body: _oldBody } = readNoteFile(l2DataDir, normalizedPath);
+	const wasIndexed = frontmatter.status === "indexed" || Boolean(frontmatter.source_id);
+	const nextStatus: NoteStatus = wasIndexed ? "outdated" : "draft";
+	const now = new Date().toISOString();
+	const nextFrontmatter: NoteFrontmatter = {
+		...frontmatter,
+		title: options.title.trim() || frontmatter.title,
+		tags: options.tags ?? frontmatter.tags,
+		record_date: options.recordDate?.trim() || frontmatter.record_date || recordDateFromIso(frontmatter.created),
+		status: nextStatus,
+		updated: now,
+	};
+	writeText(absPath, serializeNoteFile(nextFrontmatter, options.content));
+	return { rawPath: normalizedPath, status: nextStatus };
+}

--- a/apps/inno-agent/src/memory/l2/notes-service.ts
+++ b/apps/inno-agent/src/memory/l2/notes-service.ts
@@ -1,10 +1,14 @@
 import { createHash, randomUUID } from "node:crypto";
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
+import type { Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 
 import { readText, writeText } from "../../storage/file-store.js";
 import { resolveContainedPath } from "../../utils/path-safety.js";
 import { findManifestByRawPath, readManifest } from "./manifest-store.js";
+import { archiveL2Source } from "./l2-archive-service.js";
+import type { L2Memory } from "./l2-memory.js";
 import {
 	extractNoteTitle,
 	getTodayRecordDate,
@@ -15,7 +19,13 @@ import {
 	type NoteStatus,
 } from "./note-frontmatter.js";
 import { resolveNoteTemplateContent } from "./note-templates.js";
-import { inferNotebookType, primaryWikiPath, scanOrphans } from "./sources-service.js";
+import {
+	archiveRawFile,
+	inferNotebookType,
+	primaryWikiPath,
+	scanOrphans,
+	type ArchiveRawResult,
+} from "./sources-service.js";
 import type { ManifestEntry, ManifestStatus, RawSourceType } from "./types.js";
 import { ensureL2Directories } from "./wiki-maintainer.js";
 import { logger } from "../../logger.js";
@@ -61,6 +71,14 @@ export interface NotesListResponse {
 	notes: NoteSummaryDto[];
 }
 
+interface ArchiveNotebookOptions {
+	title?: string;
+	tags?: string[];
+	model?: Model<any>;
+	modelRegistry?: ModelRegistry;
+	memory?: L2Memory;
+}
+
 function noteFileName(title: string, noteId: string): string {
 	const slug = title
 		.toLowerCase()
@@ -94,9 +112,6 @@ function noteSummaryFromFile(l2DataDir: string, rawPath: string): NoteSummaryDto
 	try {
 		const { frontmatter, body } = readNoteFile(l2DataDir, rawPath);
 		const manifest = findManifestByRawPath(l2DataDir, rawPath);
-		if (manifest?.status === "indexed") {
-			return null;
-		}
 		const title = frontmatter.title || extractNoteTitle(body, basename(rawPath, ".md"));
 		return {
 			noteId: frontmatter.note_id,
@@ -170,6 +185,7 @@ export function listL2Notes(
 
 	for (const entry of entries) {
 		const summary = manifestToNoteSummary(entry);
+		if (summary.notebookType === "note") continue;
 		if (options.notebookType && summary.notebookType !== options.notebookType) continue;
 		if (options.status && summary.status !== options.status) continue;
 		notes.push(summary);
@@ -197,6 +213,18 @@ export function listL2Notes(
 
 	notes.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
 	return { notes };
+}
+
+export function archiveL2NotebookItem(
+	l2DataDir: string,
+	rawPath: string,
+	options: ArchiveNotebookOptions,
+): Promise<ArchiveRawResult> {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	if (normalizedPath.startsWith("raw/notes/")) {
+		return archiveL2Note(l2DataDir, normalizedPath, options);
+	}
+	return archiveRawFile(l2DataDir, normalizedPath, options);
 }
 
 export function readNoteContent(l2DataDir: string, rawPath: string): NoteContentDto {
@@ -270,4 +298,60 @@ export function saveL2NoteContent(
 	};
 	writeText(absPath, serializeNoteFile(nextFrontmatter, options.content));
 	return { rawPath: normalizedPath, status: nextStatus };
+}
+
+export async function archiveL2Note(
+	l2DataDir: string,
+	rawPath: string,
+	options: ArchiveNotebookOptions,
+): Promise<ArchiveRawResult> {
+	ensureL2Directories(l2DataDir);
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	const snapshot = readNoteFile(l2DataDir, normalizedPath);
+	const archivedContent = snapshot.body.trim();
+	if (!archivedContent) throw new Error("笔记内容为空，无法归档");
+
+	const title = options.title?.trim()
+		|| snapshot.frontmatter.title
+		|| extractNoteTitle(snapshot.body, basename(normalizedPath, ".md"));
+	const tags = options.tags ?? snapshot.frontmatter.tags;
+
+	return archiveL2Source(
+		l2DataDir,
+		{
+			title,
+			source: {
+				kind: "existing",
+				rawPath: normalizedPath,
+				sourceType: "markdown",
+				content: archivedContent,
+			},
+			tags,
+			origin: "user_upload",
+			dedupeBy: "rawPath",
+			createExtracted: false,
+			plainSummaryFallback: true,
+			preferredId: snapshot.frontmatter.source_id,
+			createdAt: snapshot.frontmatter.created,
+			force: snapshot.frontmatter.status === "outdated",
+			logLabel: "notebook notes API",
+			onIndexed: (result) => {
+				const current = readNoteFile(l2DataDir, normalizedPath);
+				const currentHash = createHash("sha256").update(current.body.trim()).digest("hex").slice(0, 16);
+				const sameTags = current.frontmatter.tags.length === tags.length
+					&& current.frontmatter.tags.every((tag, index) => tag === tags[index]);
+				const unchanged = currentHash === result.contentHash
+					&& current.frontmatter.title === title
+					&& sameTags;
+				const nextFrontmatter: NoteFrontmatter = {
+					...current.frontmatter,
+					status: unchanged ? "indexed" : "outdated",
+					source_id: result.sourceId,
+					updated: new Date().toISOString(),
+				};
+				writeText(current.absPath, serializeNoteFile(nextFrontmatter, current.body));
+			},
+		},
+		{ model: options.model, modelRegistry: options.modelRegistry, memory: options.memory },
+	);
 }

--- a/apps/inno-agent/src/memory/l2/sources-service.ts
+++ b/apps/inno-agent/src/memory/l2/sources-service.ts
@@ -1,0 +1,140 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { basename, extname, join } from "node:path";
+
+import { readText } from "../../storage/file-store.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
+import { readManifest } from "./manifest-store.js";
+import { ensureL2Directories } from "./wiki-maintainer.js";
+import type { ManifestEntry, ManifestStatus, RawSourceType } from "./types.js";
+import { logger } from "../../logger.js";
+
+export interface SourceSummaryDto {
+	sourceId: string;
+	title: string;
+	notebookType: "conversation" | "file" | "note";
+	sourceType: RawSourceType;
+	rawPath: string;
+	extractedPath?: string;
+	primaryWikiPath?: string;
+	wikiPages: string[];
+	tags: string[];
+	status: ManifestStatus;
+	origin: ManifestEntry["source"]["origin"];
+	originUrl?: string;
+	sessionId?: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface OrphanRawFileDto {
+	rawPath: string;
+	fileName: string;
+	sourceType: RawSourceType;
+	size: number;
+	modifiedAt: string;
+	isMarkdown: boolean;
+	pipelineStatus: "uploaded";
+}
+
+export interface SourcesListResponse {
+	sources: SourceSummaryDto[];
+	orphans: OrphanRawFileDto[];
+}
+
+const RAW_SCAN_DIRS = ["raw/uploads", "raw/conversations"] as const;
+
+function inferSourceType(fileName: string): RawSourceType {
+	const ext = extname(fileName).toLowerCase();
+	if (ext === ".pdf") return "pdf";
+	if (ext === ".doc" || ext === ".docx") return "word";
+	if ([".png", ".jpg", ".jpeg", ".gif", ".webp", ".tiff"].includes(ext)) return "image";
+	if (ext === ".md") return "markdown";
+	return "text";
+}
+
+export function inferNotebookType(rawPath: string): "conversation" | "file" | "note" {
+	if (rawPath.startsWith("raw/conversations/")) return "conversation";
+	if (rawPath.startsWith("raw/notes/")) return "note";
+	return "file";
+}
+
+export function primaryWikiPath(wikiPages: string[]): string | undefined {
+	return wikiPages.find((p) => p.includes("wiki/sources/")) ?? wikiPages[0];
+}
+
+function entryToSummary(entry: ManifestEntry): SourceSummaryDto {
+	const rawPath = entry.rawPath.replace(/\\/g, "/");
+	return {
+		sourceId: entry.id,
+		title: entry.title,
+		notebookType: inferNotebookType(rawPath),
+		sourceType: entry.sourceType,
+		rawPath,
+		extractedPath: entry.extractedPath,
+		primaryWikiPath: primaryWikiPath(entry.wikiPages),
+		wikiPages: entry.wikiPages,
+		tags: entry.tags,
+		status: entry.status,
+		origin: entry.source.origin,
+		originUrl: entry.source.url,
+		sessionId: entry.source.sessionId,
+		createdAt: entry.createdAt,
+		updatedAt: entry.updatedAt,
+	};
+}
+
+export function scanOrphans(l2DataDir: string, indexedRawPaths: Set<string>): OrphanRawFileDto[] {
+	const orphans: OrphanRawFileDto[] = [];
+	for (const relDir of RAW_SCAN_DIRS) {
+		const absDir = join(l2DataDir, relDir);
+		if (!existsSync(absDir)) continue;
+		for (const name of readdirSync(absDir)) {
+			const relPath = join(relDir, name).replace(/\\/g, "/");
+			if (indexedRawPaths.has(relPath)) continue;
+			const absPath = join(l2DataDir, relPath);
+			try {
+				const stat = statSync(absPath);
+				if (!stat.isFile()) continue;
+				const ext = extname(name).toLowerCase();
+				orphans.push({
+					rawPath: relPath,
+					fileName: name,
+					sourceType: inferSourceType(name),
+					size: stat.size,
+					modifiedAt: stat.mtime.toISOString(),
+					isMarkdown: ext === ".md" || ext === ".txt",
+					pipelineStatus: "uploaded",
+				});
+			} catch (err) {
+				logger.warn({ err, relPath }, "failed to stat orphan raw file");
+			}
+		}
+	}
+	orphans.sort((a, b) => b.modifiedAt.localeCompare(a.modifiedAt));
+	return orphans;
+}
+
+export function listL2Sources(l2DataDir: string): SourcesListResponse {
+	ensureL2Directories(l2DataDir);
+	const entries = readManifest(l2DataDir);
+	const indexedRawPaths = new Set(entries.map((e) => e.rawPath.replace(/\\/g, "/")));
+	return {
+		sources: entries.map(entryToSummary).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
+		orphans: scanOrphans(l2DataDir, indexedRawPaths),
+	};
+}
+
+export function readRawTextPreview(l2DataDir: string, rawPath: string, maxChars = 12000): string {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	const sourceType = inferSourceType(basename(normalizedPath));
+	if (sourceType === "pdf" || sourceType === "word" || sourceType === "image") {
+		return "";
+	}
+	if (!normalizedPath.startsWith("raw/") || normalizedPath === "raw/") {
+		throw new Error("Invalid raw path");
+	}
+	const absPath = resolveContainedPath(join(l2DataDir, "raw"), normalizedPath.slice("raw/".length));
+	if (!absPath) throw new Error("Invalid raw path");
+	const text = readText(absPath);
+	return text.length > maxChars ? `${text.slice(0, maxChars)}\n\n...(已截断)` : text;
+}

--- a/apps/inno-agent/src/memory/l2/sources-service.ts
+++ b/apps/inno-agent/src/memory/l2/sources-service.ts
@@ -1,8 +1,12 @@
 import { existsSync, readdirSync, statSync } from "node:fs";
 import { basename, extname, join } from "node:path";
+import type { Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 
 import { readText } from "../../storage/file-store.js";
 import { resolveContainedPath } from "../../utils/path-safety.js";
+import { archiveL2Source, type ArchiveL2Result } from "./l2-archive-service.js";
+import type { L2Memory } from "./l2-memory.js";
 import { readManifest } from "./manifest-store.js";
 import { ensureL2Directories } from "./wiki-maintainer.js";
 import type { ManifestEntry, ManifestStatus, RawSourceType } from "./types.js";
@@ -40,6 +44,8 @@ export interface SourcesListResponse {
 	sources: SourceSummaryDto[];
 	orphans: OrphanRawFileDto[];
 }
+
+export type ArchiveRawResult = ArchiveL2Result;
 
 const RAW_SCAN_DIRS = ["raw/uploads", "raw/conversations"] as const;
 
@@ -122,6 +128,39 @@ export function listL2Sources(l2DataDir: string): SourcesListResponse {
 		sources: entries.map(entryToSummary).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)),
 		orphans: scanOrphans(l2DataDir, indexedRawPaths),
 	};
+}
+
+function defaultTitleFromPath(rawPath: string): string {
+	const name = basename(rawPath);
+	const extension = extname(name);
+	return name.slice(0, name.length - extension.length) || name;
+}
+
+export function archiveRawFile(
+	l2DataDir: string,
+	rawPath: string,
+	options: {
+		title?: string;
+		tags?: string[];
+		model?: Model<any>;
+		modelRegistry?: ModelRegistry;
+		memory?: L2Memory;
+	},
+): Promise<ArchiveRawResult> {
+	const normalizedPath = rawPath.replace(/\\/g, "/");
+	const sourceType = inferSourceType(basename(normalizedPath));
+	return archiveL2Source(
+		l2DataDir,
+		{
+			title: options.title?.trim() || defaultTitleFromPath(normalizedPath),
+			source: { kind: "existing", rawPath: normalizedPath, sourceType },
+			tags: options.tags,
+			origin: normalizedPath.startsWith("raw/conversations/") ? "conversation" : "user_upload",
+			dedupeBy: "rawPath",
+			logLabel: "notebook sources API",
+		},
+		{ model: options.model, modelRegistry: options.modelRegistry, memory: options.memory },
+	);
 }
 
 export function readRawTextPreview(l2DataDir: string, rawPath: string, maxChars = 12000): string {

--- a/apps/inno-agent/src/memory/l2/upload-file-utils.ts
+++ b/apps/inno-agent/src/memory/l2/upload-file-utils.ts
@@ -1,0 +1,30 @@
+import { extname } from "node:path";
+
+const MIME_EXTENSIONS: Readonly<Record<string, string>> = {
+	"application/pdf": ".pdf",
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+	"application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+	"application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+	"image/bmp": ".bmp",
+	"image/gif": ".gif",
+	"image/jpeg": ".jpg",
+	"image/png": ".png",
+	"image/tiff": ".tiff",
+	"image/webp": ".webp",
+	"text/markdown": ".md",
+	"text/plain": ".txt",
+};
+
+export function sanitizeUploadedFileName(name: string, fallback: string): string {
+	const cleaned = name
+		.replace(/[/\\?%*:|"<>]/g, "-")
+		.replace(/\s+/g, " ")
+		.trim();
+	return cleaned || fallback;
+}
+
+export function uploadExtension(fileName: string, mimeType: string): string {
+	const extension = extname(fileName).toLowerCase();
+	if (/^\.[a-z0-9]{1,10}$/.test(extension)) return extension;
+	return MIME_EXTENSIONS[mimeType.trim().toLowerCase()] ?? ".bin";
+}

--- a/apps/inno-agent/src/memory/l2/wiki-linker.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-linker.ts
@@ -13,6 +13,7 @@ import { parseFrontmatter, serializeFrontmatter } from "./wiki-maintainer.js";
 import { splitStructuralChunks } from "./structural-chunker.js";
 import { buildAliasIndex, normalizeWikiLink } from "./wiki-links.js";
 import { logger } from "../../logger.js";
+import { resolveContainedPath } from "../../utils/path-safety.js";
 
 type LinkablePageType = Extract<WikiPageType, "entity" | "concept">;
 
@@ -419,8 +420,30 @@ function addRelatedLinks(content: string, relatedTitles: string[]): string | nul
 	return `${content.trimEnd()}\n\n## 相关概念\n\n${bullets}\n`;
 }
 
-function referenceBullet(entry: ManifestEntry, sourcePagePath: string): string {
+function referenceBullet(entry: Pick<ManifestEntry, "title">, sourcePagePath: string): string {
 	return `- [[${entry.title}]] — \`${sourcePagePath}\``;
+}
+
+function refreshReferenceBullet(
+	content: string,
+	entry: Pick<ManifestEntry, "title">,
+	sourcePagePath: string,
+): { content: string; found: boolean; changed: boolean } {
+	const marker = `\`${sourcePagePath}\``;
+	const expected = referenceBullet(entry, sourcePagePath);
+	let found = false;
+	let changed = false;
+	const lines = content.split("\n").flatMap((line) => {
+		if (!line.trimStart().startsWith("- ") || !line.includes(marker)) return [line];
+		if (found) {
+			changed = true;
+			return [];
+		}
+		found = true;
+		if (line !== expected) changed = true;
+		return [expected];
+	});
+	return { content: lines.join("\n"), found, changed };
 }
 
 /**
@@ -455,12 +478,14 @@ function updateFrontmatterReference(content: string, entry: ManifestEntry, sourc
 }
 
 function addReferenceIfMissing(content: string, entry: ManifestEntry, sourcePagePath: string): string | null {
-	const bodyAlreadyReferencesSource = content.includes(sourcePagePath);
 	const metadataUpdate = updateFrontmatterReference(content, entry, sourcePagePath);
 	content = metadataUpdate.content;
 	let changed = metadataUpdate.changed;
 
-	if (bodyAlreadyReferencesSource) return changed ? content : null;
+	const refreshed = refreshReferenceBullet(content, entry, sourcePagePath);
+	content = refreshed.content;
+	changed ||= refreshed.changed;
+	if (refreshed.found) return changed ? content : null;
 
 	const bullet = referenceBullet(entry, sourcePagePath);
 	const sectionHeader = "\n## 相关资料";
@@ -474,6 +499,130 @@ function addReferenceIfMissing(content: string, entry: ManifestEntry, sourcePage
 		return `${before}\n${bullet}${after}`;
 	}
 	return `${content.trimEnd()}\n\n## 相关资料\n\n${bullet}\n`;
+}
+
+export interface ReconcileLinkedWikiSourceResult {
+	status: "unchanged" | "updated";
+	path: string;
+	exists: boolean;
+}
+
+/**
+ * Reconcile one source's provenance after re-archiving it. The helper only
+ * touches generated entity/concept pages and is idempotent so an interrupted
+ * archive can safely retry the cleanup.
+ */
+export function reconcileLinkedWikiSource(
+	l2DataDir: string,
+	wikiPath: string,
+	options: {
+		sourceId: string;
+		previousSourcePagePaths: string[];
+		currentSourcePagePath?: string;
+		currentTitle: string;
+		keepSource: boolean;
+	},
+): ReconcileLinkedWikiSourceResult {
+	const normalizedPath = wikiPath.replace(/\\/g, "/");
+	if (!normalizedPath.startsWith("wiki/entities/") && !normalizedPath.startsWith("wiki/concepts/")) {
+		return { status: "unchanged", path: normalizedPath, exists: false };
+	}
+	const absPath = resolveContainedPath(join(l2DataDir, "wiki"), normalizedPath.slice("wiki/".length));
+	if (!absPath || !existsSync(absPath)) return { status: "unchanged", path: normalizedPath, exists: false };
+
+	const original = readText(absPath);
+	const { frontmatter, body } = parseFrontmatter(original);
+	if (!frontmatter) return { status: "unchanged", path: normalizedPath, exists: true };
+
+	const previousPaths = new Set(options.previousSourcePagePaths.map((path) => path.replace(/\\/g, "/")));
+	const currentPath = options.currentSourcePagePath?.replace(/\\/g, "/");
+	const stalePaths = new Set(
+		[...previousPaths].filter((path) => !options.keepSource || path !== currentPath),
+	);
+	let changed = false;
+
+	const nextSources = frontmatter.sources.filter((path) => !stalePaths.has(path.replace(/\\/g, "/")));
+	if (nextSources.length !== frontmatter.sources.length) {
+		frontmatter.sources = nextSources;
+		changed = true;
+	}
+	if (options.keepSource && currentPath && !frontmatter.sources.includes(currentPath)) {
+		frontmatter.sources.push(currentPath);
+		changed = true;
+	}
+
+	if (options.keepSource) {
+		if (!frontmatter.source_ids.includes(options.sourceId)) {
+			frontmatter.source_ids.push(options.sourceId);
+			changed = true;
+		}
+	} else {
+		const nextSourceIds = frontmatter.source_ids.filter((id) => id !== options.sourceId);
+		if (nextSourceIds.length !== frontmatter.source_ids.length) {
+			frontmatter.source_ids = nextSourceIds;
+			changed = true;
+		}
+		const nextContradictions = (frontmatter.contradictions ?? []).filter((id) => id !== options.sourceId);
+		if (nextContradictions.length !== (frontmatter.contradictions ?? []).length) {
+			frontmatter.contradictions = nextContradictions;
+			changed = true;
+		}
+		if (nextContradictions.length === 0 && frontmatter.contested) {
+			frontmatter.contested = false;
+			changed = true;
+		}
+	}
+
+	let nextBody = body;
+	const sourceIdMarker = `\`${options.sourceId}\``;
+	const filteredLines = nextBody.split("\n").filter((line) => {
+		if (!line.trimStart().startsWith("- ")) return true;
+		if ([...stalePaths].some((path) => line.includes(`\`${path}\``))) return false;
+		if (!options.keepSource && line.includes(sourceIdMarker)) return false;
+		return true;
+	});
+	if (filteredLines.length !== nextBody.split("\n").length) {
+		nextBody = filteredLines.join("\n");
+		changed = true;
+	}
+
+	if (options.keepSource && currentPath) {
+		const entry = { title: options.currentTitle };
+		const refreshed = refreshReferenceBullet(nextBody, entry, currentPath);
+		nextBody = refreshed.content;
+		changed ||= refreshed.changed;
+		const refreshedContradictions = nextBody.split("\n").map((line) => {
+			if (!line.trimStart().startsWith("- ") || !line.includes(sourceIdMarker)) return line;
+			return line.replace(/（来源 \[\[[^\]]+\]\] /, `（来源 [[${options.currentTitle}]] `);
+		});
+		const refreshedBody = refreshedContradictions.join("\n");
+		if (refreshedBody !== nextBody) {
+			nextBody = refreshedBody;
+			changed = true;
+		}
+	}
+
+	const hasProvenance = frontmatter.source_ids.length > 0 || frontmatter.sources.length > 0;
+	if (!options.keepSource && !hasProvenance && changed) {
+		const backupHash = createHash("sha256").update(original).digest("hex").slice(0, 10);
+		const orphanDir = join(l2DataDir, "wiki", "orphans");
+		ensureDir(orphanDir);
+		const backupPath = wikiPathJoin(
+			"wiki",
+			"orphans",
+			`${basename(normalizedPath, ".md")}-${backupHash}.md`,
+		);
+		writeText(join(l2DataDir, backupPath), original);
+		frontmatter.status = "outdated";
+		frontmatter.confidence = "low";
+		frontmatter.contested = false;
+		frontmatter.contradictions = [];
+		nextBody = `# ${frontmatter.title}\n\n## 状态\n\n> 原始来源已更新；旧页面内容已备份到 \`${backupPath}\`，请重新确认。\n`;
+	}
+	if (!changed) return { status: "unchanged", path: normalizedPath, exists: true };
+	frontmatter.updated = new Date().toISOString().slice(0, 10);
+	writeText(absPath, `${serializeFrontmatter(frontmatter)}\n${nextBody}`);
+	return { status: "updated", path: normalizedPath, exists: true };
 }
 
 function upsertLinkedPage(

--- a/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
@@ -437,6 +437,7 @@ export function appendLog(l2DataDir: string, action: string, title: string, deta
 export function ensureL2Directories(l2DataDir: string): void {
 	const dirs = [
 		"raw/uploads",
+		"raw/notes",
 		"raw/web",
 		"raw/conversations",
 		"raw/research",

--- a/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
+++ b/apps/inno-agent/src/memory/l2/wiki-maintainer.ts
@@ -301,7 +301,15 @@ export function readMaintenanceContext(l2DataDir: string): { schema: string; ind
 // Source summary page
 // ============================================================================
 
-function sourcePageFilename(title: string, id: string): string {
+function sourcePageFilename(title: string, id: string, preferredWikiPath?: string): string {
+	const normalizedPreferredPath = preferredWikiPath?.replace(/\\/g, "/");
+	const preferredPrefix = "wiki/sources/";
+	if (normalizedPreferredPath?.startsWith(preferredPrefix)) {
+		const preferredName = normalizedPreferredPath.slice(preferredPrefix.length);
+		if (preferredName && !preferredName.includes("/") && preferredName.toLowerCase().endsWith(".md")) {
+			return preferredName;
+		}
+	}
 	const slug = title
 		.toLowerCase()
 		.replace(/[^a-z0-9\u4e00-\u9fff]+/g, "-")
@@ -321,10 +329,11 @@ export function createSourcePage(
 	entry: ManifestEntry,
 	summaryBody: string,
 	extractedPath?: string,
+	preferredWikiPath?: string,
 ): string {
 	const dir = join(l2DataDir, "wiki", "sources");
 	ensureDir(dir);
-	const filename = sourcePageFilename(entry.title, entry.id);
+	const filename = sourcePageFilename(entry.title, entry.id, preferredWikiPath);
 	const fm: WikiPageFrontmatter = {
 		title: entry.title,
 		created: new Date().toISOString().slice(0, 10),

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1441,6 +1441,10 @@ const server = createServer(async (req, res) => {
 		if (await handleNotebookRoutes(req, res, method, url, {
 			l2DataDir,
 			codeDir: paths.codeDir,
+			getArchiveRuntime: () => {
+				const session = getSession();
+				return { model: session.model, modelRegistry: session.modelRegistry };
+			},
 		})) return;
 
 		// --- Learner profile API (extracted to server/routes/learner.ts) ---

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -48,6 +48,7 @@ import { handleWorkspacesRoutes } from "./server/routes/workspaces.js";
 import { handleSessionsRoutes } from "./server/routes/sessions.js";
 import { handleLearnerRoutes } from "./server/routes/learner.js";
 import { handleWikiRoutes } from "./server/routes/wiki.js";
+import { handleNotebookRoutes } from "./server/routes/notebook.js";
 import { handlePresetsRoutes } from "./server/routes/presets.js";
 import { handlePracticeRoutes } from "./server/routes/practice.js";
 import { handleChatRoutes } from "./server/routes/chat.js";
@@ -1435,6 +1436,12 @@ const server = createServer(async (req, res) => {
 
 		// --- Wiki + L2 raw upload API (extracted to server/routes/wiki.ts) ---
 		if (await handleWikiRoutes(req, res, method, url, { l2DataDir })) return;
+
+		// --- L2 Notebook API (extracted to server/routes/notebook.ts) ---
+		if (await handleNotebookRoutes(req, res, method, url, {
+			l2DataDir,
+			codeDir: paths.codeDir,
+		})) return;
 
 		// --- Learner profile API (extracted to server/routes/learner.ts) ---
 		if (await handleLearnerRoutes(req, res, method, url, { paths })) return;

--- a/apps/inno-agent/src/server/routes/notebook.ts
+++ b/apps/inno-agent/src/server/routes/notebook.ts
@@ -1,0 +1,323 @@
+import { createReadStream, existsSync, statSync } from "node:fs";
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import { basename, extname, join } from "node:path";
+
+import {
+	deleteNoteAttachment,
+	listNoteAttachments,
+	uploadNoteAttachment,
+} from "../../memory/l2/note-attachments-service.js";
+import {
+	createL2Note,
+	listL2Notes,
+	readNoteContent,
+	saveL2NoteContent,
+} from "../../memory/l2/notes-service.js";
+import { listNoteTemplates } from "../../memory/l2/note-templates.js";
+import { listL2Sources, readRawTextPreview } from "../../memory/l2/sources-service.js";
+import { logger } from "../../logger.js";
+import { safeJoinReal } from "../file-helpers.js";
+import { json, matchRoute, readBody, UPLOAD_MAX_BODY_BYTES } from "../http-helpers.js";
+
+export interface NotebookRouteContext {
+	l2DataDir: string;
+	codeDir: string;
+}
+
+interface ResolvedL2Path {
+	fullPath: string;
+	rawPath: string;
+}
+
+function resolveRawPath(l2DataDir: string, userPath: string): ResolvedL2Path | null {
+	const rawPath = userPath.replace(/\\/g, "/");
+	if (!rawPath.startsWith("raw/") || rawPath === "raw/") return null;
+	const fullPath = safeJoinReal(join(l2DataDir, "raw"), rawPath.slice("raw/".length));
+	return fullPath ? { fullPath, rawPath } : null;
+}
+
+function resolveNotePath(l2DataDir: string, userPath: string): ResolvedL2Path | null {
+	const rawPath = userPath.replace(/\\/g, "/");
+	if (!rawPath.startsWith("raw/notes/") || rawPath === "raw/notes/") return null;
+	const relativePath = rawPath.slice("raw/notes/".length);
+	if (relativePath.includes("/") || !relativePath.toLowerCase().endsWith(".md")) return null;
+	const fullPath = safeJoinReal(join(l2DataDir, "raw", "notes"), relativePath);
+	return fullPath ? { fullPath, rawPath } : null;
+}
+
+function isFile(filePath: string): boolean {
+	try {
+		return existsSync(filePath) && statSync(filePath).isFile();
+	} catch {
+		return false;
+	}
+}
+
+function errorMessage(err: unknown, fallback: string): string {
+	return err instanceof Error ? err.message : fallback;
+}
+
+function rawFileMime(filePath: string): string {
+	const ext = extname(filePath).toLowerCase();
+	if (ext === ".pdf") return "application/pdf";
+	if (ext === ".png") return "image/png";
+	if (ext === ".jpg" || ext === ".jpeg") return "image/jpeg";
+	return "application/octet-stream";
+}
+
+/** Handle Notebook notes, sources, raw previews, and note attachments. */
+export async function handleNotebookRoutes(
+	req: HttpReq,
+	res: ServerResponse,
+	method: string,
+	url: string,
+	ctx: NotebookRouteContext,
+): Promise<boolean> {
+	const { l2DataDir, codeDir } = ctx;
+
+	if (method === "GET" && url === "/api/l2/sources") {
+		try {
+			json(res, 200, listL2Sources(l2DataDir));
+		} catch (err) {
+			logger.warn({ err }, "failed to list L2 sources");
+			json(res, 500, { error: "Failed to list sources" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/l2/raw/content?")) {
+		const rawPath = new URL(url, "http://localhost").searchParams.get("path");
+		if (!rawPath) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const resolved = resolveRawPath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid raw path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Raw file not found" });
+			return true;
+		}
+		try {
+			json(res, 200, {
+				path: resolved.rawPath,
+				content: readRawTextPreview(l2DataDir, resolved.rawPath),
+			});
+		} catch (err) {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to read raw content");
+			json(res, 500, { error: "Failed to read raw content" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/l2/raw/file?")) {
+		const rawPath = new URL(url, "http://localhost").searchParams.get("path");
+		if (!rawPath) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const resolved = resolveRawPath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid raw path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Raw file not found" });
+			return true;
+		}
+		const name = basename(resolved.fullPath);
+		const mimeType = rawFileMime(resolved.fullPath);
+		const disposition = mimeType === "application/octet-stream" ? "attachment" : "inline";
+		const asciiName = name.replace(/[^\x20-\x7e]/g, "_").replace(/["\\]/g, "_");
+		const fileSize = statSync(resolved.fullPath).size;
+		const stream = createReadStream(resolved.fullPath);
+		stream.on("error", (err) => {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to stream raw file");
+			if (!res.headersSent) json(res, 500, { error: "Failed to read raw file" });
+			else res.destroy(err);
+		});
+		res.writeHead(200, {
+			"Content-Type": mimeType,
+			"Content-Disposition": `${disposition}; filename="${asciiName}"; filename*=UTF-8''${encodeURIComponent(name)}`,
+			"Content-Length": fileSize,
+			"X-Content-Type-Options": "nosniff",
+		});
+		stream.pipe(res);
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/l2/notes/content?")) {
+		const rawPath = new URL(url, "http://localhost").searchParams.get("path");
+		if (!rawPath) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const resolved = resolveNotePath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid note path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Note not found" });
+			return true;
+		}
+		try {
+			json(res, 200, readNoteContent(l2DataDir, resolved.rawPath));
+		} catch (err) {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to read note content");
+			json(res, 500, { error: errorMessage(err, "Failed to read note") });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url === "/api/l2/notes/templates") {
+		try {
+			json(res, 200, { templates: listNoteTemplates(codeDir) });
+		} catch (err) {
+			logger.warn({ err }, "failed to list note templates");
+			json(res, 500, { error: "Failed to list templates" });
+		}
+		return true;
+	}
+
+	if (method === "GET" && (url === "/api/l2/notes" || url.startsWith("/api/l2/notes?"))) {
+		const params = new URL(url, "http://localhost").searchParams;
+		const status = params.get("status") ?? undefined;
+		const notebookType = params.get("notebookType") ?? undefined;
+		const validNotebookTypes = new Set(["conversation", "file", "note"]);
+		try {
+			json(res, 200, listL2Notes(l2DataDir, {
+				status,
+				notebookType:
+					notebookType && validNotebookTypes.has(notebookType)
+						? (notebookType as "conversation" | "file" | "note")
+						: undefined,
+			}));
+		} catch (err) {
+			logger.warn({ err }, "failed to list L2 notes");
+			json(res, 500, { error: "Failed to list notes" });
+		}
+		return true;
+	}
+
+	if (method === "POST" && url === "/api/l2/notes") {
+		const body = (await readBody(req)) as Record<string, unknown>;
+		const title = typeof body.title === "string" ? body.title.trim() : undefined;
+		const templateId = typeof body.templateId === "string" ? body.templateId.trim() : undefined;
+		const content = typeof body.content === "string" ? body.content : undefined;
+		const tags = Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === "string") : undefined;
+		try {
+			json(res, 201, createL2Note(l2DataDir, codeDir, { title, templateId, tags, content }));
+		} catch (err) {
+			logger.warn({ err }, "failed to create note");
+			json(res, 500, { error: errorMessage(err, "Create note failed") });
+		}
+		return true;
+	}
+
+	if (method === "PUT" && url === "/api/l2/notes/content") {
+		const body = (await readBody(req)) as Record<string, unknown>;
+		const rawPath = typeof body.rawPath === "string" ? body.rawPath.trim() : "";
+		const title = typeof body.title === "string" ? body.title.trim() : "";
+		const hasContent = typeof body.content === "string";
+		const content = hasContent ? (body.content as string) : "";
+		const tags = Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === "string") : undefined;
+		const recordDate = typeof body.recordDate === "string" ? body.recordDate.trim() : undefined;
+		if (!rawPath || !title || !hasContent) {
+			json(res, 400, { error: "Missing rawPath, title, or content" });
+			return true;
+		}
+		const resolved = resolveNotePath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid note path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Note not found" });
+			return true;
+		}
+		try {
+			json(res, 200, saveL2NoteContent(l2DataDir, resolved.rawPath, { title, tags, recordDate, content }));
+		} catch (err) {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to save note");
+			json(res, 500, { error: errorMessage(err, "Save note failed") });
+		}
+		return true;
+	}
+
+	if (method === "GET" && url.startsWith("/api/l2/notes/attachments?")) {
+		const rawPath = new URL(url, "http://localhost").searchParams.get("path");
+		if (!rawPath) {
+			json(res, 400, { error: "Missing path parameter" });
+			return true;
+		}
+		const resolved = resolveNotePath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid note path" });
+			return true;
+		}
+		try {
+			json(res, 200, { attachments: listNoteAttachments(l2DataDir, resolved.rawPath) });
+		} catch (err) {
+			logger.warn({ err, rawPath: resolved.rawPath }, "failed to list note attachments");
+			json(res, 500, { error: errorMessage(err, "Failed to list attachments") });
+		}
+		return true;
+	}
+
+	if (method === "POST" && url === "/api/l2/notes/attachments") {
+		const body = (await readBody(req, { maxBytes: UPLOAD_MAX_BODY_BYTES })) as Record<string, unknown>;
+		const noteRawPath = typeof body.noteRawPath === "string" ? body.noteRawPath.trim() : "";
+		const fileName = typeof body.fileName === "string" ? body.fileName.trim() : "";
+		const mimeType = typeof body.mimeType === "string" ? body.mimeType : "application/octet-stream";
+		const dataBase64 = typeof body.dataBase64 === "string" ? body.dataBase64 : "";
+		if (!noteRawPath || !fileName || !dataBase64) {
+			json(res, 400, { error: "Missing noteRawPath, fileName, or dataBase64" });
+			return true;
+		}
+		const resolved = resolveNotePath(l2DataDir, noteRawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid note path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Note not found" });
+			return true;
+		}
+		try {
+			const attachment = uploadNoteAttachment(l2DataDir, resolved.rawPath, { fileName, mimeType, dataBase64 });
+			json(res, 201, {
+				attachmentId: attachment.id,
+				filePath: attachment.filePath,
+				status: attachment.status,
+				attachment,
+			});
+		} catch (err) {
+			logger.warn({ err, noteRawPath: resolved.rawPath }, "failed to upload note attachment");
+			json(res, 500, { error: errorMessage(err, "Upload attachment failed") });
+		}
+		return true;
+	}
+
+	const deleteAttachmentMatch = matchRoute("DELETE", method, url, "/api/l2/notes/attachments/:attachmentId");
+	if (deleteAttachmentMatch) {
+		const attachmentId = deleteAttachmentMatch.attachmentId.trim();
+		if (!attachmentId) {
+			json(res, 400, { error: "Missing attachment id" });
+			return true;
+		}
+		try {
+			const removed = deleteNoteAttachment(l2DataDir, attachmentId);
+			json(res, 200, { attachmentId: removed.id });
+		} catch (err) {
+			logger.warn({ err, attachmentId }, "failed to delete note attachment");
+			const message = errorMessage(err, "Delete attachment failed");
+			json(res, message.includes("not found") ? 404 : 500, { error: message });
+		}
+		return true;
+	}
+
+	return false;
+}

--- a/apps/inno-agent/src/server/routes/notebook.ts
+++ b/apps/inno-agent/src/server/routes/notebook.ts
@@ -1,3 +1,5 @@
+import type { Model } from "@earendil-works/pi-ai";
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { createReadStream, existsSync, statSync } from "node:fs";
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
 import { basename, extname, join } from "node:path";
@@ -8,6 +10,7 @@ import {
 	uploadNoteAttachment,
 } from "../../memory/l2/note-attachments-service.js";
 import {
+	archiveL2NotebookItem,
 	createL2Note,
 	listL2Notes,
 	readNoteContent,
@@ -15,6 +18,7 @@ import {
 } from "../../memory/l2/notes-service.js";
 import { listNoteTemplates } from "../../memory/l2/note-templates.js";
 import { listL2Sources, readRawTextPreview } from "../../memory/l2/sources-service.js";
+import type { L2Memory } from "../../memory/l2/l2-memory.js";
 import { logger } from "../../logger.js";
 import { safeJoinReal } from "../file-helpers.js";
 import { json, matchRoute, readBody, UPLOAD_MAX_BODY_BYTES } from "../http-helpers.js";
@@ -22,6 +26,7 @@ import { json, matchRoute, readBody, UPLOAD_MAX_BODY_BYTES } from "../http-helpe
 export interface NotebookRouteContext {
 	l2DataDir: string;
 	codeDir: string;
+	getArchiveRuntime: () => { model?: Model<any>; modelRegistry?: ModelRegistry; memory?: L2Memory };
 }
 
 interface ResolvedL2Path {
@@ -315,6 +320,42 @@ export async function handleNotebookRoutes(
 			logger.warn({ err, attachmentId }, "failed to delete note attachment");
 			const message = errorMessage(err, "Delete attachment failed");
 			json(res, message.includes("not found") ? 404 : 500, { error: message });
+		}
+		return true;
+	}
+
+	if (method === "POST" && (url === "/api/l2/notes/archive" || url === "/api/l2/sources/archive")) {
+		const body = (await readBody(req)) as Record<string, unknown>;
+		const rawPath = typeof body.rawPath === "string" ? body.rawPath.trim() : "";
+		const title = typeof body.title === "string" ? body.title.trim() : undefined;
+		const tags = Array.isArray(body.tags) ? body.tags.filter((tag): tag is string => typeof tag === "string") : undefined;
+		if (!rawPath) {
+			json(res, 400, { error: "Missing rawPath" });
+			return true;
+		}
+		const resolved = resolveRawPath(l2DataDir, rawPath);
+		if (!resolved) {
+			json(res, 400, { error: "Invalid raw path" });
+			return true;
+		}
+		if (!isFile(resolved.fullPath)) {
+			json(res, 404, { error: "Raw file not found" });
+			return true;
+		}
+		try {
+			const runtime = ctx.getArchiveRuntime();
+			const result = await archiveL2NotebookItem(l2DataDir, resolved.rawPath, {
+				title,
+				tags,
+				model: runtime.model,
+				modelRegistry: runtime.modelRegistry,
+				memory: runtime.memory,
+			});
+			json(res, 201, result);
+		} catch (err) {
+			const isNoteRoute = url === "/api/l2/notes/archive";
+			logger.warn({ err, rawPath: resolved.rawPath }, isNoteRoute ? "failed to archive note" : "failed to archive raw file");
+			json(res, 500, { error: errorMessage(err, isNoteRoute ? "Archive note failed" : "Archive failed") });
 		}
 		return true;
 	}

--- a/apps/inno-agent/src/server/routes/wiki.ts
+++ b/apps/inno-agent/src/server/routes/wiki.ts
@@ -1,7 +1,9 @@
+import { randomUUID } from "node:crypto";
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
 import { existsSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { basename, extname, join } from "node:path";
+import { basename, join } from "node:path";
 import { wikiPathJoin } from "../../memory/l2/wiki-paths.js";
+import { sanitizeUploadedFileName, uploadExtension } from "../../memory/l2/upload-file-utils.js";
 import { logger } from "../../logger.js";
 import { getL2Memory } from "../../memory/l2/l2-memory.js";
 import { readManifest, removeWikiPathFromManifest } from "../../memory/l2/manifest-store.js";
@@ -46,27 +48,6 @@ function manifestSourceIdByWikiPath(l2DataDir: string): Map<string, string> {
 		}
 	}
 	return map;
-}
-
-function sanitizeUploadName(name: string): string {
-	const cleaned = name
-		.replace(/[/\\?%*:|"<>]/g, "-")
-		.replace(/\s+/g, " ")
-		.trim();
-	return cleaned || "upload";
-}
-
-function uploadExtension(fileName: string, mimeType: string): string {
-	const ext = extname(fileName);
-	if (ext) return ext;
-	if (mimeType === "application/pdf") return ".pdf";
-	if (mimeType.includes("wordprocessingml")) return ".docx";
-	if (mimeType.includes("spreadsheetml")) return ".xlsx";
-	if (mimeType.includes("presentationml")) return ".pptx";
-	if (mimeType === "text/markdown") return ".md";
-	if (mimeType.startsWith("image/")) return `.${mimeType.slice("image/".length).replace("jpeg", "jpg")}`;
-	if (mimeType.startsWith("text/")) return ".txt";
-	return ".bin";
 }
 
 /**
@@ -222,14 +203,18 @@ export async function handleWikiRoutes(
 		const dir = join(l2DataDir, "raw", "uploads");
 		ensureDir(dir);
 		const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-		const safeName = sanitizeUploadName(fileName);
+		const safeName = sanitizeUploadedFileName(fileName, "upload");
 		const ext = uploadExtension(safeName, mimeType);
 		const base = basename(safeName, ext).slice(0, 80) || "upload";
-		const outputName = `${timestamp}-${base}${ext}`;
-		const outputPath = join(dir, outputName);
+		const outputName = `${timestamp}-${randomUUID().slice(0, 8)}-${base}${ext}`;
+		const outputPath = safeJoinReal(dir, outputName);
+		if (!outputPath) {
+			json(res, 400, { error: "Invalid upload path" });
+			return true;
+		}
 		const data = Buffer.from(dataBase64, "base64");
 		writeFileSync(outputPath, data);
-		const rawPath = join("raw", "uploads", outputName);
+		const rawPath = join("raw", "uploads", outputName).replace(/\\/g, "/");
 		json(res, 201, {
 			fileName,
 			mimeType,

--- a/apps/inno-agent/web/src/api/notes.ts
+++ b/apps/inno-agent/web/src/api/notes.ts
@@ -1,0 +1,105 @@
+import { apiFetch } from "./client.js";
+import type {
+	ArchiveNoteResult,
+	CreateNoteResult,
+	NoteAttachment,
+	NoteContent,
+	NotesListResponse,
+	SaveNoteResult,
+	UploadNoteAttachmentResult,
+	UploadNoteFileResult,
+} from "../types/notes.js";
+import { arrayBufferToBase64, uploadRawFile } from "./uploads.js";
+
+export function l2RawFileUrl(rawPath: string): string {
+	return `/api/l2/raw/file?path=${encodeURIComponent(rawPath)}`;
+}
+
+export async function listNotes(options?: {
+	status?: string;
+	notebookType?: string;
+}): Promise<NotesListResponse> {
+	const params = new URLSearchParams();
+	if (options?.status) params.set("status", options.status);
+	if (options?.notebookType) params.set("notebookType", options.notebookType);
+	const query = params.toString();
+	return apiFetch<NotesListResponse>(`/api/l2/notes${query ? `?${query}` : ""}`);
+}
+
+export async function fetchNoteContent(rawPath: string): Promise<NoteContent> {
+	return apiFetch<NoteContent>(`/api/l2/notes/content?path=${encodeURIComponent(rawPath)}`);
+}
+
+export async function fetchRawContent(rawPath: string): Promise<string> {
+	const data = await apiFetch<{ path: string; content: string }>(
+		`/api/l2/raw/content?path=${encodeURIComponent(rawPath)}`,
+	);
+	return data.content;
+}
+
+export async function createNote(options: {
+	title?: string;
+	templateId?: string;
+	tags?: string[];
+	content?: string;
+}): Promise<CreateNoteResult> {
+	const result = await apiFetch<CreateNoteResult>("/api/l2/notes", {
+		method: "POST",
+		body: JSON.stringify(options),
+	});
+	return { ...result, notebookType: "note" };
+}
+
+export async function saveNoteContent(options: {
+	rawPath: string;
+	title: string;
+	tags?: string[];
+	recordDate?: string;
+	content: string;
+}): Promise<SaveNoteResult> {
+	return apiFetch<SaveNoteResult>("/api/l2/notes/content", {
+		method: "PUT",
+		body: JSON.stringify(options),
+	});
+}
+
+export async function archiveNote(
+	rawPath: string,
+	options: { title?: string; tags?: string[] } = {},
+): Promise<ArchiveNoteResult> {
+	return apiFetch<ArchiveNoteResult>("/api/l2/notes/archive", {
+		method: "POST",
+		body: JSON.stringify({ rawPath, ...options }),
+	});
+}
+
+export async function uploadNoteFile(file: File): Promise<UploadNoteFileResult> {
+	const uploaded = await uploadRawFile(file);
+	return { ...uploaded, notebookType: "file", status: "uploaded" };
+}
+
+export async function listNoteAttachments(rawPath: string): Promise<NoteAttachment[]> {
+	const data = await apiFetch<{ attachments: NoteAttachment[] }>(
+		`/api/l2/notes/attachments?path=${encodeURIComponent(rawPath)}`,
+	);
+	return data.attachments;
+}
+
+export async function uploadNoteAttachment(rawPath: string, file: File): Promise<UploadNoteAttachmentResult> {
+	const dataBase64 = arrayBufferToBase64(await file.arrayBuffer());
+	return apiFetch<UploadNoteAttachmentResult>("/api/l2/notes/attachments", {
+		method: "POST",
+		body: JSON.stringify({
+			noteRawPath: rawPath,
+			fileName: file.name,
+			mimeType: file.type || "application/octet-stream",
+			dataBase64,
+		}),
+	});
+}
+
+export async function deleteNoteAttachment(attachmentId: string): Promise<{ attachmentId: string }> {
+	return apiFetch<{ attachmentId: string }>(`/api/l2/notes/attachments/${encodeURIComponent(attachmentId)}`, {
+		method: "DELETE",
+	});
+}

--- a/apps/inno-agent/web/src/lib/build-note-from-template.ts
+++ b/apps/inno-agent/web/src/lib/build-note-from-template.ts
@@ -1,0 +1,24 @@
+import {
+	getDefaultNoteTemplate,
+	getNoteTemplate,
+	getVisibleNoteTemplates,
+	NOTE_TEMPLATES,
+	type NoteTemplateId,
+	type NoteTemplateMeta,
+} from "./note-template-loader.js";
+
+export type { NoteTemplateId, NoteTemplateMeta };
+export { getVisibleNoteTemplates, NOTE_TEMPLATES };
+
+export function buildNoteFromTemplate(templateId: NoteTemplateId): {
+	title: string;
+	tags: string[];
+	body: string;
+} {
+	const template = getNoteTemplate(templateId) ?? getDefaultNoteTemplate();
+	return {
+		title: template.defaultTitle || template.label,
+		tags: template.tags,
+		body: template.body,
+	};
+}

--- a/apps/inno-agent/web/src/lib/note-frontmatter.ts
+++ b/apps/inno-agent/web/src/lib/note-frontmatter.ts
@@ -1,0 +1,124 @@
+export interface ParsedNoteFrontmatter {
+	attributes: { key: string; value: string }[];
+	body: string;
+	hasFrontmatter: boolean;
+}
+
+const FRONTMATTER_PATTERN = /^(?:\uFEFF)?---\n([\s\S]*?)\n---\n?([\s\S]*)$/;
+
+export function parseNoteFrontmatter(markdown: string): ParsedNoteFrontmatter {
+	const match = markdown.match(FRONTMATTER_PATTERN);
+	if (!match) {
+		return { attributes: [], body: markdown, hasFrontmatter: false };
+	}
+
+	const attributes: { key: string; value: string }[] = [];
+	for (const line of match[1].split("\n")) {
+		const property = line.match(/^(\w+):\s*(.*)$/);
+		if (!property) continue;
+		attributes.push({ key: property[1], value: property[2] });
+	}
+
+	return { attributes, body: match[2], hasFrontmatter: true };
+}
+
+export function getFrontmatterAttribute(
+	parsed: ParsedNoteFrontmatter,
+	keys: string[],
+): { key: string; value: string } | undefined {
+	for (const key of keys) {
+		const found = parsed.attributes.find((item) => item.key === key);
+		if (found) return found;
+	}
+	return undefined;
+}
+
+export function parseTagList(value: string): string[] {
+	const trimmed = value.trim();
+	if (!trimmed) return [];
+	if (trimmed.startsWith("[") && trimmed.endsWith("]")) {
+		return trimmed
+			.slice(1, -1)
+			.split(",")
+			.map((tag) => tag.trim().replace(/^["']|["']$/g, ""))
+			.filter(Boolean);
+	}
+	return trimmed
+		.split(/[,，;；、|]/)
+		.map((tag) => tag.trim())
+		.filter(Boolean);
+}
+
+export function serializeTagList(tags: string[]): string {
+	return tags.map((tag) => tag.trim()).filter(Boolean).join(", ");
+}
+
+export function getTodayRecordDate(): string {
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+export function normalizeRecordDateValue(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) return "";
+	if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+	const slashMatch = trimmed.match(/^(\d{4})[/.](\d{1,2})[/.](\d{1,2})$/);
+	if (slashMatch) {
+		return `${slashMatch[1]}-${slashMatch[2].padStart(2, "0")}-${slashMatch[3].padStart(2, "0")}`;
+	}
+	const parsed = new Date(trimmed);
+	if (!Number.isNaN(parsed.getTime())) {
+		return getTodayRecordDateFromDate(parsed);
+	}
+	return "";
+}
+
+export function getTodayRecordDateFromDate(date: Date): string {
+	const year = date.getFullYear();
+	const month = String(date.getMonth() + 1).padStart(2, "0");
+	const day = String(date.getDate()).padStart(2, "0");
+	return `${year}-${month}-${day}`;
+}
+
+export function parseRecordDate(value: string): Date | null {
+	const normalized = normalizeRecordDateValue(value);
+	const match = normalized.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+	if (!match) return null;
+	const year = Number(match[1]);
+	const month = Number(match[2]) - 1;
+	const day = Number(match[3]);
+	const date = new Date(year, month, day);
+	if (date.getFullYear() !== year || date.getMonth() !== month || date.getDate() !== day) {
+		return null;
+	}
+	return date;
+}
+
+export function toRecordDateString(date: Date): string {
+	return getTodayRecordDateFromDate(date);
+}
+
+export function formatRecordDateDisplay(value: string, language: "zh" | "en"): string {
+	const date = parseRecordDate(value);
+	if (!date) {
+		return language === "en" ? "Select date" : "选择日期";
+	}
+	if (language === "en") {
+		return date.toLocaleDateString("en-US", {
+			weekday: "short",
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+		});
+	}
+	const weekdayLabels = ["周日", "周一", "周二", "周三", "周四", "周五", "周六"];
+	return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日 ${weekdayLabels[date.getDay()]}`;
+}
+
+export function extractNoteTitle(body: string, fallback: string): string {
+	const match = body.match(/^#\s+(.+)$/m);
+	return match?.[1]?.trim() || fallback;
+}

--- a/apps/inno-agent/web/src/lib/note-template-loader.ts
+++ b/apps/inno-agent/web/src/lib/note-template-loader.ts
@@ -1,0 +1,84 @@
+import i18n from "../i18n/index.js";
+import { getFrontmatterAttribute, parseNoteFrontmatter, parseTagList } from "./note-frontmatter.js";
+
+export type NoteTemplateId = string;
+
+export interface NoteTemplateMeta {
+	id: NoteTemplateId;
+	label: string;
+	description: string;
+	tags: string[];
+	body: string;
+	hidden: boolean;
+	defaultTitle: string;
+}
+
+const templateModules = import.meta.glob("../../../note-templates/*.md", {
+	query: "?raw",
+	import: "default",
+	eager: true,
+}) as Record<string, string>;
+
+function templateIdFromPath(path: string): string {
+	return path.match(/\/([^/]+)\.md$/)?.[1] ?? "template";
+}
+
+function readAttribute(attributes: { key: string; value: string }[], keys: string[]): string {
+	return getFrontmatterAttribute({ attributes, body: "", hasFrontmatter: true }, keys)?.value.trim() ?? "";
+}
+
+function extractFirstHeading(body: string): string | null {
+	const match = body.match(/^#\s+(.+)$/m);
+	return match?.[1]?.trim() ?? null;
+}
+
+function humanizeTemplateId(id: string): string {
+	return id.replace(/-/g, " ");
+}
+
+function loadNoteTemplates(): NoteTemplateMeta[] {
+	const language = i18n.language.startsWith("en") ? "en" : "zh";
+	return Object.entries(templateModules)
+		.map(([path, raw]) => {
+			const id = templateIdFromPath(path);
+			const parsed = parseNoteFrontmatter(raw);
+			const body = parsed.hasFrontmatter ? parsed.body : raw;
+			const attributes = parsed.attributes;
+			const heading = extractFirstHeading(body);
+			const labelZh = readAttribute(attributes, ["label"]) || heading || humanizeTemplateId(id);
+			const labelEn = readAttribute(attributes, ["labelEn", "label_en"]) || labelZh;
+			const descriptionZh = readAttribute(attributes, ["description", "desc"]);
+			const descriptionEn = readAttribute(attributes, ["descriptionEn", "description_en"]) || descriptionZh;
+			const tagsZh = parseTagList(readAttribute(attributes, ["tags", "tag"]));
+			const tagsEn = parseTagList(readAttribute(attributes, ["tagsEn", "tags_en", "tagEn"]));
+			const resolvedTagsEn = tagsEn.length > 0 ? tagsEn : tagsZh;
+			const titleZh = readAttribute(attributes, ["title"]) || heading || labelZh;
+			const titleEn = readAttribute(attributes, ["titleEn", "title_en"]) || titleZh;
+			const hidden = readAttribute(attributes, ["hidden"]).toLowerCase() === "true";
+
+			return {
+				id,
+				label: language === "en" ? labelEn : labelZh,
+				description: language === "en" ? descriptionEn : descriptionZh,
+				tags: language === "en" ? resolvedTagsEn : tagsZh,
+				body,
+				hidden,
+				defaultTitle: language === "en" ? titleEn : titleZh,
+			};
+		})
+		.sort((left, right) => left.label.localeCompare(right.label, language === "en" ? "en" : "zh"));
+}
+
+export const NOTE_TEMPLATES = loadNoteTemplates();
+
+export function getNoteTemplate(templateId: NoteTemplateId): NoteTemplateMeta | undefined {
+	return NOTE_TEMPLATES.find((template) => template.id === templateId);
+}
+
+export function getVisibleNoteTemplates(): NoteTemplateMeta[] {
+	return NOTE_TEMPLATES.filter((template) => !template.hidden);
+}
+
+export function getDefaultNoteTemplate(): NoteTemplateMeta {
+	return getNoteTemplate("blank") ?? NOTE_TEMPLATES[0];
+}

--- a/apps/inno-agent/web/src/react/notebook/NoteProperties.tsx
+++ b/apps/inno-agent/web/src/react/notebook/NoteProperties.tsx
@@ -1,0 +1,207 @@
+import { ChevronRight, CalendarDays, Hash, Tag, Type, X } from "lucide-react";
+import { useEffect, useState, type KeyboardEvent } from "react";
+import { useTranslation } from "react-i18next";
+import { formatRecordDateDisplay, parseTagList } from "../../lib/note-frontmatter.js";
+import { RecordDatePropertyEditor } from "./RecordDatePropertyEditor.js";
+
+export interface NotePropertiesProps {
+	title: string;
+	tags: string[];
+	recordDate: string;
+	readOnly?: boolean;
+	editorKey?: string;
+	onTitleChange: (title: string) => void;
+	onTagsChange: (tags: string[]) => void;
+	onRecordDateChange: (recordDate: string) => void;
+}
+function TagPill({
+	tag,
+	readOnly,
+	uiLanguage,
+	onRemove,
+}: {
+	tag: string;
+	readOnly: boolean;
+	uiLanguage: "zh" | "en";
+	onRemove?: () => void;
+}) {
+	return (
+		<span className="inno-note-property-tag-pill">
+			<Hash size={11} aria-hidden="true" />
+			<span className="inno-note-property-tag-text">{tag}</span>
+			{!readOnly && onRemove ? (
+				<button
+					type="button"
+					className="inno-note-property-tag-remove"
+					onClick={onRemove}
+					aria-label={uiLanguage === "en" ? `Remove tag ${tag}` : `移除标签 ${tag}`}
+				>
+					<X size={12} />
+				</button>
+			) : null}
+		</span>
+	);
+}
+
+function TagsPropertyEditor({
+	value,
+	readOnly,
+	uiLanguage,
+	onChange,
+}: {
+	value: string[];
+	readOnly: boolean;
+	uiLanguage: "zh" | "en";
+	onChange: (tags: string[]) => void;
+}) {
+	const { t } = useTranslation();
+	const tags = value;
+	const [draft, setDraft] = useState("");
+
+	function commitDraft(raw: string) {
+		const nextTags = parseTagList(raw).filter((tag) => !tags.includes(tag));
+		if (nextTags.length === 0) {
+			setDraft("");
+			return;
+		}
+		onChange([...tags, ...nextTags]);
+		setDraft("");
+	}
+
+	function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+		if (event.key === "Enter" || event.key === "," || event.key === "，" || event.key === ";" || event.key === "；") {
+			event.preventDefault();
+			commitDraft(draft);
+		} else if (event.key === "Backspace" && draft.length === 0 && tags.length > 0) {
+			onChange(tags.slice(0, -1));
+		}
+	}
+
+	return (
+		<div className="inno-note-property-tags">
+			{tags.map((tag) => (
+				<TagPill
+					key={tag}
+					tag={tag}
+					readOnly={readOnly}
+					uiLanguage={uiLanguage}
+					onRemove={() => onChange(tags.filter((entry) => entry !== tag))}
+				/>
+			))}
+			{!readOnly ? (
+				<input
+					className="inno-note-property-tag-input"
+					value={draft}
+					placeholder={t("notes.properties.addTag")}
+					aria-label={t("notes.properties.addTag")}
+					onChange={(event) => setDraft(event.currentTarget.value)}
+					onKeyDown={handleKeyDown}
+					onBlur={() => commitDraft(draft)}
+				/>
+			) : null}
+		</div>
+	);
+}
+
+export function NoteProperties({
+	title,
+	tags,
+	recordDate,
+	readOnly = false,
+	editorKey,
+	onTitleChange,
+	onTagsChange,
+	onRecordDateChange,
+}: NotePropertiesProps) {
+	const { t, i18n } = useTranslation();
+	const uiLanguage = i18n.language.startsWith("zh") ? "zh" : "en";
+	const [expanded, setExpanded] = useState(false);
+	const propertyCount = 3;
+	useEffect(() => {
+		setExpanded(false);
+	}, [editorKey]);
+
+	return (
+		<section
+			className={`inno-note-properties ${expanded ? "expanded" : "collapsed"}`}
+			aria-label={t("notes.properties.heading")}
+		>
+			<div className="inno-note-properties-header">
+				<button
+					type="button"
+					className="inno-note-properties-toggle"
+					aria-expanded={expanded}
+					onClick={() => setExpanded((current) => !current)}
+				>
+					<ChevronRight size={15} aria-hidden="true" className="inno-note-properties-chevron" />
+					<span className="inno-note-properties-heading">{t("notes.properties.heading")}</span>
+					<span className="inno-note-properties-count">{propertyCount}</span>
+				</button>
+				{!expanded ? (
+					<div className="inno-note-properties-preview" aria-hidden="true">
+						{recordDate ? (
+							<span className="inno-note-properties-date-preview">
+								<CalendarDays size={12} />
+								{formatRecordDateDisplay(recordDate, uiLanguage)}
+							</span>
+						) : null}
+						{tags.slice(0, 4).map((tag) => (
+							<TagPill key={tag} tag={tag} readOnly uiLanguage={uiLanguage} />
+						))}
+						{tags.length > 4 ? (
+							<span className="inno-note-properties-more">+{tags.length - 4}</span>
+						) : null}
+					</div>
+				) : null}
+			</div>
+			{expanded ? (
+				<div className="inno-note-properties-body">
+					<div className="inno-note-property-row">
+						<div className="inno-note-property-label">
+							<Type size={14} aria-hidden="true" />
+							<span>{t("notes.properties.title")}</span>
+						</div>
+						<div className="inno-note-property-value">
+							<input
+								className="inno-note-property-inline-input"
+								value={title}
+								readOnly={readOnly}
+								placeholder={t("notes.titlePlaceholder") ?? ""}
+								aria-label={t("notes.properties.title")}
+								onChange={(event) => onTitleChange(event.currentTarget.value)}
+							/>
+						</div>
+					</div>
+					<div className="inno-note-property-row">
+						<div className="inno-note-property-label">
+							<CalendarDays size={14} aria-hidden="true" />
+							<span>{t("notes.properties.recordDateKey")}</span>
+						</div>
+						<div className="inno-note-property-value">
+							<RecordDatePropertyEditor
+								value={recordDate}
+								readOnly={readOnly}
+								uiLanguage={uiLanguage}
+								onChange={onRecordDateChange}
+							/>
+						</div>
+					</div>
+					<div className="inno-note-property-row">
+						<div className="inno-note-property-label">
+							<Tag size={14} aria-hidden="true" />
+							<span>{t("notes.properties.tags")}</span>
+						</div>
+						<div className="inno-note-property-value">
+							<TagsPropertyEditor
+								value={tags}
+								readOnly={readOnly}
+								uiLanguage={uiLanguage}
+								onChange={onTagsChange}
+							/>
+						</div>
+					</div>
+				</div>
+			) : null}
+		</section>
+	);
+}

--- a/apps/inno-agent/web/src/react/notebook/RecordDatePropertyEditor.tsx
+++ b/apps/inno-agent/web/src/react/notebook/RecordDatePropertyEditor.tsx
@@ -1,0 +1,261 @@
+import { CalendarDays, ChevronLeft, ChevronRight } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import {
+	formatRecordDateDisplay,
+	getTodayRecordDate,
+	normalizeRecordDateValue,
+	parseRecordDate,
+	toRecordDateString,
+} from "../../lib/note-frontmatter.js";
+
+const WEEKDAY_LABELS = {
+	zh: ["日", "一", "二", "三", "四", "五", "六"],
+	en: ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+} as const;
+
+const DATE_POPOVER_WIDTH = 280;
+const DATE_POPOVER_ESTIMATED_HEIGHT = 340;
+
+function formatCalendarMonth(year: number, month: number, uiLanguage: "zh" | "en"): string {
+	if (uiLanguage === "en") {
+		return new Date(year, month, 1).toLocaleDateString("en-US", { month: "long", year: "numeric" });
+	}
+	return `${year}年${month + 1}月`;
+}
+
+export interface RecordDatePropertyEditorProps {
+	value: string;
+	readOnly?: boolean;
+	uiLanguage: "zh" | "en";
+	onChange: (nextValue: string) => void;
+}
+
+export function RecordDatePropertyEditor({
+	value,
+	readOnly = false,
+	uiLanguage,
+	onChange,
+}: RecordDatePropertyEditorProps) {
+	const { t } = useTranslation();
+	const containerRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLButtonElement>(null);
+	const popoverRef = useRef<HTMLDivElement>(null);
+	const [open, setOpen] = useState(false);
+	const [popoverStyle, setPopoverStyle] = useState<CSSProperties>({});
+	const normalizedValue = normalizeRecordDateValue(value);
+	const selectedDate = parseRecordDate(normalizedValue);
+	const todayValue = getTodayRecordDate();
+	const todayDate = parseRecordDate(todayValue)!;
+	const [viewYear, setViewYear] = useState(selectedDate?.getFullYear() ?? todayDate.getFullYear());
+	const [viewMonth, setViewMonth] = useState(selectedDate?.getMonth() ?? todayDate.getMonth());
+
+	const updatePopoverPosition = useCallback(() => {
+		const trigger = triggerRef.current;
+		if (!trigger) return;
+		const rect = trigger.getBoundingClientRect();
+		const width = Math.min(DATE_POPOVER_WIDTH, Math.max(rect.width, 240));
+		let left = rect.left;
+		let top = rect.bottom + 6;
+		if (left + width > window.innerWidth - 12) {
+			left = Math.max(12, window.innerWidth - width - 12);
+		}
+		if (top + DATE_POPOVER_ESTIMATED_HEIGHT > window.innerHeight - 12) {
+			top = Math.max(12, rect.top - DATE_POPOVER_ESTIMATED_HEIGHT - 6);
+		}
+		setPopoverStyle({ position: "fixed", top, left, width });
+	}, []);
+
+	useEffect(() => {
+		if (!selectedDate) return;
+		setViewYear(selectedDate.getFullYear());
+		setViewMonth(selectedDate.getMonth());
+	}, [normalizedValue]);
+
+	useEffect(() => {
+		if (!open) return;
+		updatePopoverPosition();
+
+		function handlePointerDown(event: PointerEvent) {
+			const target = event.target;
+			if (!(target instanceof Node)) return;
+			if (containerRef.current?.contains(target) || popoverRef.current?.contains(target)) return;
+			setOpen(false);
+		}
+
+		function handleKeyDown(event: globalThis.KeyboardEvent) {
+			if (event.key === "Escape") setOpen(false);
+		}
+
+		window.addEventListener("resize", updatePopoverPosition);
+		window.addEventListener("scroll", updatePopoverPosition, true);
+		document.addEventListener("pointerdown", handlePointerDown, true);
+		document.addEventListener("keydown", handleKeyDown);
+		return () => {
+			window.removeEventListener("resize", updatePopoverPosition);
+			window.removeEventListener("scroll", updatePopoverPosition, true);
+			document.removeEventListener("pointerdown", handlePointerDown, true);
+			document.removeEventListener("keydown", handleKeyDown);
+		};
+	}, [open, updatePopoverPosition]);
+
+	const calendarCells = useMemo(() => {
+		const firstWeekday = new Date(viewYear, viewMonth, 1).getDay();
+		const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+		const cells: Array<{ date: Date; muted: boolean }> = [];
+		for (let index = 0; index < firstWeekday; index += 1) {
+			const day = new Date(viewYear, viewMonth, index - firstWeekday + 1);
+			cells.push({ date: day, muted: true });
+		}
+		for (let day = 1; day <= daysInMonth; day += 1) {
+			cells.push({ date: new Date(viewYear, viewMonth, day), muted: false });
+		}
+		while (cells.length % 7 !== 0) {
+			const nextDay = cells.length - firstWeekday - daysInMonth + 1;
+			cells.push({ date: new Date(viewYear, viewMonth + 1, nextDay), muted: true });
+		}
+		return cells;
+	}, [viewMonth, viewYear]);
+
+	function selectDate(date: Date) {
+		onChange(toRecordDateString(date));
+		setOpen(false);
+	}
+
+	function goToPreviousMonth() {
+		if (viewMonth === 0) {
+			setViewYear((current) => current - 1);
+			setViewMonth(11);
+			return;
+		}
+		setViewMonth((current) => current - 1);
+	}
+
+	function goToNextMonth() {
+		if (viewMonth === 11) {
+			setViewYear((current) => current + 1);
+			setViewMonth(0);
+			return;
+		}
+		setViewMonth((current) => current + 1);
+	}
+
+	const displayText = formatRecordDateDisplay(normalizedValue, uiLanguage);
+	const selectedValue = selectedDate ? toRecordDateString(selectedDate) : "";
+
+	const popover =
+		open && !readOnly ? (
+			<div
+				ref={popoverRef}
+				className="inno-note-property-date-popover inno-note-property-date-popover-portal"
+				style={popoverStyle}
+				role="dialog"
+				aria-label={t("notes.properties.chooseDate")}
+				onPointerDown={(event) => event.stopPropagation()}
+			>
+				<div className="inno-note-property-date-popover-header">
+					<button
+						type="button"
+						className="inno-note-property-date-nav-button"
+						aria-label={t("notes.properties.previousMonth")}
+						onClick={goToPreviousMonth}
+					>
+						<ChevronLeft size={16} />
+					</button>
+					<span className="inno-note-property-date-month-label">
+						{formatCalendarMonth(viewYear, viewMonth, uiLanguage)}
+					</span>
+					<button
+						type="button"
+						className="inno-note-property-date-nav-button"
+						aria-label={t("notes.properties.nextMonth")}
+						onClick={goToNextMonth}
+					>
+						<ChevronRight size={16} />
+					</button>
+				</div>
+				<div className="inno-note-property-date-weekdays" aria-hidden="true">
+					{WEEKDAY_LABELS[uiLanguage].map((label) => (
+						<span key={label} className="inno-note-property-date-weekday">
+							{label}
+						</span>
+					))}
+				</div>
+				<div className="inno-note-property-date-grid">
+					{calendarCells.map(({ date, muted }, cellIndex) => {
+						const cellValue = toRecordDateString(date);
+						const isSelected = cellValue === selectedValue;
+						const isToday = cellValue === todayValue;
+						return (
+							<button
+								key={`${cellValue}-${cellIndex}`}
+								type="button"
+								className={[
+									"inno-note-property-date-day",
+									muted ? "muted" : "",
+									isSelected ? "selected" : "",
+									isToday ? "today" : "",
+								]
+									.filter(Boolean)
+									.join(" ")}
+								aria-label={formatRecordDateDisplay(cellValue, uiLanguage)}
+								aria-pressed={isSelected}
+								onClick={() => selectDate(date)}
+							>
+								{date.getDate()}
+							</button>
+						);
+					})}
+				</div>
+				<div className="inno-note-property-date-footer">
+					<button
+						type="button"
+						className="inno-note-property-date-today-button"
+						onClick={() => {
+							onChange(todayValue);
+							setViewYear(todayDate.getFullYear());
+							setViewMonth(todayDate.getMonth());
+							setOpen(false);
+						}}
+					>
+						{t("notes.properties.today")}
+					</button>
+				</div>
+			</div>
+		) : null;
+
+	return (
+		<div className={`inno-note-property-date-field ${open ? "open" : ""}`} ref={containerRef}>
+			<button
+				ref={triggerRef}
+				type="button"
+				className="inno-note-property-date-trigger"
+				disabled={readOnly}
+				aria-expanded={open}
+				aria-haspopup="dialog"
+				aria-label={t("notes.properties.recordDate")}
+				onClick={() => {
+					if (!readOnly) {
+						setOpen((current) => {
+							const nextOpen = !current;
+							if (nextOpen) {
+								requestAnimationFrame(() => updatePopoverPosition());
+							}
+							return nextOpen;
+						});
+					}
+				}}
+			>
+				<span className="inno-note-property-date-trigger-icon" aria-hidden="true">
+					<CalendarDays size={14} />
+				</span>
+				<span className="inno-note-property-date-trigger-text">{displayText}</span>
+				{!readOnly ? (
+					<ChevronRight size={14} aria-hidden="true" className="inno-note-property-date-trigger-chevron" />
+				) : null}
+			</button>
+			{popover ? createPortal(popover, document.body) : null}
+		</div>
+	);
+}

--- a/apps/inno-agent/web/src/stores/notes-store.ts
+++ b/apps/inno-agent/web/src/stores/notes-store.ts
@@ -1,0 +1,346 @@
+import { EventEmitter } from "./event-emitter.js";
+import { getTodayRecordDate } from "../lib/note-frontmatter.js";
+import {
+	archiveNote,
+	createNote,
+	deleteNoteAttachment,
+	fetchNoteContent,
+	fetchRawContent,
+	listNotes,
+	saveNoteContent,
+	uploadNoteAttachment,
+	uploadNoteFile,
+} from "../api/notes.js";
+import type { NoteAttachment, NoteContent, NoteListBox, NoteSummary } from "../types/notes.js";
+
+interface NotesStoreEvents {
+	change: void;
+}
+
+class NotesStoreImpl extends EventEmitter<NotesStoreEvents> {
+	notes: NoteSummary[] = [];
+	selected: NoteSummary | null = null;
+	editorContent = "";
+	editorTitle = "";
+	editorTags: string[] = [];
+	editorRecordDate = "";
+	attachments: NoteAttachment[] = [];
+	savedContent = "";
+	savedTitle = "";
+	savedTags: string[] = [];
+	savedRecordDate = "";
+	previewContent = "";
+	listBox: NoteListBox = "drafts";
+	searchQuery = "";
+	isLoading = false;
+	isLoadingContent = false;
+	isLoadingPreview = false;
+	isCreating = false;
+	isSaving = false;
+	isArchiving = false;
+	isUploading = false;
+	isUploadingAttachment = false;
+	deletingAttachmentId: string | null = null;
+	error: string | null = null;
+	notice: string | null = null;
+
+	get isDirty(): boolean {
+		if (!this.selected || this.selected.kind !== "markdown") return false;
+		return (
+			this.editorContent !== this.savedContent ||
+			this.editorTitle !== this.savedTitle ||
+			this.editorTags.join(",") !== this.savedTags.join(",") ||
+			this.editorRecordDate !== this.savedRecordDate
+		);
+	}
+
+	get filteredNotes(): NoteSummary[] {
+		const q = this.searchQuery.trim().toLowerCase();
+		const byBox = this.notes.filter((note) =>
+			this.listBox === "drafts"
+				? note.kind === "orphan" || (note.kind === "markdown" && note.status === "draft")
+				: note.kind === "archived" ||
+					(note.kind === "markdown" &&
+						(note.status === "indexed" || note.status === "outdated" || note.status === "error")),
+		);
+		if (!q) return byBox;
+		return byBox.filter(
+			(note) =>
+				note.title.toLowerCase().includes(q) ||
+				note.rawPath.toLowerCase().includes(q) ||
+				note.tags.some((tag) => tag.toLowerCase().includes(q)),
+		);
+	}
+
+	get draftCount(): number {
+		return this.notes.filter(
+			(note) => note.kind === "orphan" || (note.kind === "markdown" && note.status === "draft"),
+		).length;
+	}
+
+	get archivedCount(): number {
+		return this.notes.filter(
+			(note) =>
+				note.kind === "archived" ||
+				(note.kind === "markdown" &&
+					(note.status === "indexed" || note.status === "outdated" || note.status === "error")),
+		).length;
+	}
+
+	clearMessages() {
+		this.error = null;
+		this.notice = null;
+	}
+
+	setSearchQuery(query: string) {
+		this.searchQuery = query;
+		this.emit("change", undefined);
+	}
+
+	setListBox(listBox: NoteListBox) {
+		this.listBox = listBox;
+		this.emit("change", undefined);
+	}
+
+	updateEditorTitle(title: string) {
+		this.editorTitle = title;
+		this.emit("change", undefined);
+	}
+
+	updateEditorContent(content: string) {
+		this.editorContent = content;
+		this.emit("change", undefined);
+	}
+
+	updateEditorTags(tags: string[]) {
+		this.editorTags = tags;
+		this.emit("change", undefined);
+	}
+
+	updateEditorRecordDate(recordDate: string) {
+		this.editorRecordDate = recordDate;
+		this.emit("change", undefined);
+	}
+
+	async loadPreview(rawPath: string, contentType: string) {
+		if (contentType === "pdf" || contentType === "word" || contentType === "image") {
+			this.previewContent = "";
+			return;
+		}
+		this.isLoadingPreview = true;
+		this.emit("change", undefined);
+		try {
+			this.previewContent = await fetchRawContent(rawPath);
+		} catch {
+			this.previewContent = "";
+		} finally {
+			this.isLoadingPreview = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async loadAll(): Promise<void> {
+		this.isLoading = true;
+		this.clearMessages();
+		this.emit("change", undefined);
+		try {
+			const data = await listNotes();
+			this.notes = data.notes;
+			if (this.selected) {
+				const updated = this.notes.find((note) => note.rawPath === this.selected?.rawPath);
+				this.selected = updated ?? null;
+			}
+		} catch {
+			this.notes = [];
+			this.error = "loadFailed";
+		} finally {
+			this.isLoading = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async selectNote(note: NoteSummary): Promise<void> {
+		this.selected = note;
+		this.previewContent = "";
+		this.attachments = [];
+		this.clearMessages();
+		this.emit("change", undefined);
+
+		if (note.kind === "markdown") {
+			this.isLoadingContent = true;
+			this.emit("change", undefined);
+			try {
+				const detail: NoteContent = await fetchNoteContent(note.rawPath);
+				this.editorTitle = detail.title;
+				this.editorTags = detail.tags;
+				this.editorRecordDate = detail.recordDate || getTodayRecordDate();
+				this.editorContent = detail.content;
+				this.attachments = detail.attachments ?? [];
+				this.savedTitle = detail.title;
+				this.savedTags = [...detail.tags];
+				this.savedRecordDate = detail.recordDate || getTodayRecordDate();
+				this.savedContent = detail.content;
+				this.selected = { ...note, ...detail };
+			} catch {
+				this.error = "loadContentFailed";
+				this.editorContent = "";
+				this.attachments = [];
+			} finally {
+				this.isLoadingContent = false;
+				this.emit("change", undefined);
+			}
+			return;
+		}
+
+		await this.loadPreview(note.rawPath, note.contentType);
+	}
+
+	async createFromTemplate(templateId: string): Promise<void> {
+		this.isCreating = true;
+		this.clearMessages();
+		this.emit("change", undefined);
+		try {
+			const result = await createNote({ templateId });
+			this.notice = templateId === "blank" ? "created" : "createdFromTemplate";
+			this.listBox = "drafts";
+			await this.loadAll();
+			const created = this.notes.find((note) => note.rawPath === result.rawPath);
+			if (created) {
+				await this.selectNote(created);
+			}
+		} catch {
+			this.error = "createFailed";
+		} finally {
+			this.isCreating = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async uploadFiles(files: FileList | File[]): Promise<void> {
+		const list = Array.from(files);
+		if (list.length === 0) return;
+		this.isUploading = true;
+		this.clearMessages();
+		this.emit("change", undefined);
+		try {
+			for (const file of list) {
+				await uploadNoteFile(file);
+			}
+			this.notice = "uploaded";
+			this.listBox = "drafts";
+			await this.loadAll();
+		} catch {
+			this.error = "uploadFailed";
+		} finally {
+			this.isUploading = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async uploadAttachments(files: FileList | File[]): Promise<void> {
+		if (!this.selected || this.selected.kind !== "markdown") return;
+		const list = Array.from(files);
+		if (list.length === 0) return;
+		this.isUploadingAttachment = true;
+		this.clearMessages();
+		this.emit("change", undefined);
+		try {
+			for (const file of list) {
+				const result = await uploadNoteAttachment(this.selected.rawPath, file);
+				this.attachments = [result.attachment, ...this.attachments.filter((item) => item.id !== result.attachment.id)];
+			}
+			this.notice = "attachmentUploaded";
+		} catch {
+			this.error = "attachmentUploadFailed";
+		} finally {
+			this.isUploadingAttachment = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async deleteAttachment(attachmentId: string): Promise<void> {
+		if (!this.selected || this.selected.kind !== "markdown") return;
+		this.deletingAttachmentId = attachmentId;
+		this.clearMessages();
+		this.emit("change", undefined);
+		try {
+			await deleteNoteAttachment(attachmentId);
+			this.attachments = this.attachments.filter((item) => item.id !== attachmentId);
+			this.notice = "attachmentDeleted";
+		} catch {
+			this.error = "attachmentDeleteFailed";
+		} finally {
+			this.deletingAttachmentId = null;
+			this.emit("change", undefined);
+		}
+	}
+
+	async saveSelected(): Promise<boolean> {
+		if (!this.selected || this.selected.kind !== "markdown" || !this.isDirty) return true;
+		this.isSaving = true;
+		this.clearMessages();
+		this.emit("change", undefined);
+		try {
+			const result = await saveNoteContent({
+				rawPath: this.selected.rawPath,
+				title: this.editorTitle.trim() || this.selected.title,
+				tags: this.editorTags,
+				recordDate: this.editorRecordDate,
+				content: this.editorContent,
+			});
+			this.savedTitle = this.editorTitle.trim() || this.selected.title;
+			this.savedTags = [...this.editorTags];
+			this.savedRecordDate = this.editorRecordDate;
+			this.savedContent = this.editorContent;
+			this.notice = "saved";
+			await this.loadAll();
+			if (this.selected) {
+				this.selected = this.notes.find((note) => note.rawPath === result.rawPath) ?? this.selected;
+			}
+			return true;
+		} catch {
+			this.error = "saveFailed";
+			return false;
+		} finally {
+			this.isSaving = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	async archiveSelected(): Promise<string | null> {
+		if (!this.selected) return null;
+		if (this.selected.kind === "markdown" && this.isDirty) {
+			const saved = await this.saveSelected();
+			if (!saved) return null;
+		}
+		this.isArchiving = true;
+		this.clearMessages();
+		this.emit("change", undefined);
+		try {
+			const result = await archiveNote(this.selected.rawPath, {
+				title: this.selected.kind === "markdown" ? this.editorTitle.trim() || this.selected.title : undefined,
+				tags: this.selected.kind === "markdown" ? this.editorTags : undefined,
+			});
+			this.notice = "archived";
+			this.listBox = "archived";
+			await this.loadAll();
+			const updated = this.notes.find((note) => note.rawPath === result.rawPath);
+			if (updated) {
+				await this.selectNote(updated);
+			}
+			return result.wikiPagePath;
+		} catch {
+			this.error = "archiveFailed";
+			return null;
+		} finally {
+			this.isArchiving = false;
+			this.emit("change", undefined);
+		}
+	}
+
+	findNoteById(noteId: string): NoteSummary | undefined {
+		return this.notes.find((note) => note.noteId === noteId);
+	}
+}
+
+export const notesStore = new NotesStoreImpl();

--- a/apps/inno-agent/web/src/types/notes.ts
+++ b/apps/inno-agent/web/src/types/notes.ts
@@ -1,0 +1,98 @@
+export type NoteStatus = "draft" | "indexed" | "outdated" | "error";
+export type ManifestStatus = "pending" | "extracted" | "indexed" | "error";
+export type RawSourceType = "text" | "markdown" | "conversation" | "pdf" | "word" | "image";
+export type NotebookType = "conversation" | "file" | "note";
+export type NotebookItemKind = "markdown" | "orphan" | "archived";
+export type NotebookItemStatus = NoteStatus | ManifestStatus | "uploaded";
+
+export interface NoteSummary {
+	noteId: string;
+	rawPath: string;
+	title: string;
+	tags: string[];
+	notebookType: NotebookType;
+	contentType: RawSourceType;
+	status: NotebookItemStatus;
+	kind: NotebookItemKind;
+	wikiPagePath?: string;
+	wikiPages?: string[];
+	origin?: "user_upload" | "conversation" | "web" | "research" | "agent_inferred";
+	extractedPath?: string;
+	size?: number;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface NoteContent {
+	rawPath: string;
+	noteId: string;
+	title: string;
+	tags: string[];
+	recordDate: string;
+	status: NoteStatus;
+	sourceId?: string;
+	content: string;
+	attachments: NoteAttachment[];
+	createdAt: string;
+	updatedAt: string;
+}
+
+export type NoteAttachmentStatus = "uploaded" | "extracting" | "extracted" | "indexed" | "error";
+
+export interface NoteAttachment {
+	id: string;
+	noteRawPath: string;
+	noteId: string;
+	fileName: string;
+	mimeType: string;
+	size: number;
+	filePath: string;
+	status: NoteAttachmentStatus;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface UploadNoteAttachmentResult {
+	attachmentId: string;
+	filePath: string;
+	status: NoteAttachmentStatus;
+	attachment: NoteAttachment;
+}
+
+export interface NotesListResponse {
+	notes: NoteSummary[];
+}
+
+export interface CreateNoteResult {
+	rawPath: string;
+	status: NoteStatus;
+	noteId: string;
+	title: string;
+	notebookType: "note";
+}
+
+export interface SaveNoteResult {
+	rawPath: string;
+	status: NoteStatus;
+}
+
+export interface UploadNoteFileResult {
+	fileName: string;
+	mimeType: string;
+	size: number;
+	rawPath: string;
+	notebookType: "file";
+	status: "uploaded";
+}
+
+export interface ArchiveNoteResult {
+	noteId: string;
+	sourceId?: string;
+	title: string;
+	rawPath: string;
+	wikiPagePath: string;
+	wikiPages: string[];
+	status: "indexed";
+}
+
+export type NoteListBox = "drafts" | "archived";

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 			"electron/**/*",
 			"apps/inno-agent/dist/**/*",
 			"apps/inno-agent/web/dist/**/*",
+			"apps/inno-agent/note-templates/**/*",
 			"apps/inno-agent/presets/**/*",
 			"apps/inno-agent/scripts/**/*",
 			"node_modules/**/*",


### PR DESCRIPTION
## 依赖关系

- 本 PR 依赖 #180。
- #180 合并后，会将本分支重新变基到最新 `main`，以便只显示本组前端数据层差异。

## 改动内容

- 新增 Notebook 前端 API 封装，覆盖笔记、资料、附件、模板与归档请求。
- 新增笔记类型定义、Frontmatter 工具和模板加载/构建逻辑。
- 新增笔记状态管理，统一列表加载、选择、保存、上传和附件操作。
- 新增笔记属性与记录日期编辑组件。

## 改动原因

这部分为后续编辑器和 Notebook 页面提供稳定的数据访问与状态管理基础。将 API、Store 和属性组件放在同一组，可以完整审查前端数据模型，同时避免混入编辑器依赖和大段样式。

## 影响范围

本 PR 暂不接入主工作区，也不包含 Milkdown 编辑器和 Notebook 页面样式；现有界面不会直接出现新入口。

## 验证情况

- `git diff --check` 检查通过。
- 前端 TypeScript 检查仅保留仓库原有的 `Switch.test.tsx` 缺少 `@testing-library/react` 类型依赖问题；本 PR 新增文件没有类型错误。
