### PR TITLE
feat: 优化面板布局、文件预览与聊天首页体验

### DIFF
--- a/apps/inno-agent/src/content-source/catalog-service.ts
+++ b/apps/inno-agent/src/content-source/catalog-service.ts
@@ -20,6 +20,8 @@ export interface ContentHubCatalogOptions {
 	getConfig: () => InnoConfig;
 }
 
+type RemoteSkillLibraryItem = Omit<SkillLibraryItem, "installed">;
+
 /**
  * Owns remote catalog lifecycle: source reuse, persistent snapshots, and
  * background warming. The HTTP server only wires these methods to routes, so
@@ -61,7 +63,7 @@ export class ContentHubCatalog {
 	}
 
 	async listSkillLibrary(forceRefresh = false): Promise<SkillLibraryItem[]> {
-		const remote = await this.loadCatalog(
+		const remote = await this.loadCatalog<RemoteSkillLibraryItem>(
 			"skills",
 			forceRefresh,
 			() => this.fetchSkillLibrary(forceRefresh),
@@ -141,11 +143,10 @@ export class ContentHubCatalog {
 		}
 	}
 
-	private async fetchSkillLibrary(forceRefresh: boolean): Promise<SkillLibraryItem[]> {
+	private async fetchSkillLibrary(forceRefresh: boolean): Promise<RemoteSkillLibraryItem[]> {
 		const source = this.getSource();
 		const items = await source.listItems("skills", { forceRefresh });
-		const localNames = this.currentInstalledSkillNames();
-		const result = await mapWithConcurrency(items, 5, async (item): Promise<SkillLibraryItem> => {
+		const result = await mapWithConcurrency(items, 5, async (item): Promise<RemoteSkillLibraryItem> => {
 			let description = typeof item.meta?.description === "string" ? item.meta.description : "";
 			let category = typeof item.meta?.category === "string" ? item.meta.category.trim() : "";
 			if (!description || !category) {
@@ -160,7 +161,6 @@ export class ContentHubCatalog {
 				name: item.name,
 				description,
 				category: category || undefined,
-				installed: localNames.has(slugifySkillName(item.name)),
 			};
 		});
 		return result.sort((a, b) => a.name.localeCompare(b.name));
@@ -174,7 +174,7 @@ export class ContentHubCatalog {
 		);
 	}
 
-	private withCurrentInstallState(items: SkillLibraryItem[]): SkillLibraryItem[] {
+	private withCurrentInstallState(items: RemoteSkillLibraryItem[]): SkillLibraryItem[] {
 		const localNames = this.currentInstalledSkillNames();
 		return items.map((item) => ({
 			...item,

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1271,7 +1271,7 @@ function releaseQueueFromQuestionBlockedTurn(targetSessionId: string): void {
  * it never executes out from under a user who already gave up.
  */
 async function runQueueOpWithTimeout<T>(
-	req: HttpReq,
+	_req: HttpReq,
 	res: ServerResponse,
 	op: (signal: AbortSignal) => Promise<T>,
 	timeoutMs = 8_000,

--- a/apps/inno-agent/src/server/routes/presets.ts
+++ b/apps/inno-agent/src/server/routes/presets.ts
@@ -1,6 +1,6 @@
 import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
 import { logger } from "../../logger.js";
-import { listBundledPresets, listPresets } from "../../presets/preset-store.js";
+import { listPresets } from "../../presets/preset-store.js";
 import type { PresetMeta } from "../../presets/preset-store.js";
 import type { RuntimePaths } from "../../runtime.js";
 import { json } from "../http-helpers.js";
@@ -16,7 +16,7 @@ export interface PresetsRouteContext {
  * from server.ts during the P2 route split — behavior unchanged.
  */
 export async function handlePresetsRoutes(
-	req: HttpReq,
+	_req: HttpReq,
 	res: ServerResponse,
 	method: string,
 	url: string,
@@ -38,16 +38,10 @@ export async function handlePresetsRoutes(
 	if (method === "GET" && url.split("?")[0] === "/api/preset-library") {
 		const forceRefresh = new URL(url, "http://localhost").searchParams.get("refresh") === "1";
 		try {
-			const remote = await listPresetLibrary(forceRefresh);
-			// A successful remote snapshot is authoritative. Do not merge the
-			// downloaded cache here: a preset removed from GitHub must not come back
-			// as a stale card after refresh. The cache remains available through
-			// /api/presets for offline fallback.
-			const available = Array.from(new Map([
-				...listBundledPresets(paths).map((preset) => [preset.id, preset] as const),
-				...remote.map((preset) => [preset.id, preset] as const),
-			]).values()).sort((a, b) => a.name.localeCompare(b.name));
-			json(res, 200, available);
+			// listPresetLibrary already merges bundled presets with the
+			// authoritative remote snapshot. The local cache remains available
+			// through /api/presets for offline fallback.
+			json(res, 200, await listPresetLibrary(forceRefresh));
 		} catch (err) {
 			logger.warn({ err }, "failed to list preset library; falling back to bundled presets");
 			if (forceRefresh) {

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -637,15 +637,6 @@ inno-workspace-panel textarea {
 	min-height: 36px;
 }
 
-.inno-workspace-context-hint {
-	min-width: 0;
-	color: var(--inno-text-subtle);
-	font-size: 11px;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
-
 .inno-workspace-switcher {
 	position: relative;
 	min-width: 0;

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -483,9 +483,53 @@ inno-workspace-panel textarea {
 }
 
 .inno-welcome-composer-shell {
-	margin-top: calc(-1 * var(--inno-welcome-composer-half-growth));
+	margin-top: calc(1.125rem - var(--inno-welcome-composer-half-growth));
 	/* Keep following welcome content in normal flow so it is pushed down by
 	   the expanded composer instead of being covered by it. */
+}
+
+.inno-mode-segmented-control {
+	display: inline-flex;
+	align-items: center;
+	gap: 2px;
+	padding: 3px;
+	border: 1px solid var(--inno-border);
+	border-radius: 999px;
+	background: var(--inno-surface-muted);
+	box-shadow: 0 1px 2px rgba(31, 35, 40, 0.04);
+}
+
+.inno-mode-segmented-control__option {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 5px;
+	min-height: 28px;
+	padding: 0 11px;
+	border: 0;
+	border-radius: 999px;
+	color: var(--inno-text-muted);
+	font-size: 14px;
+	font-weight: 500;
+	line-height: 1;
+	white-space: nowrap;
+	transition: background-color var(--inno-dur-ui) var(--inno-ease-out), color var(--inno-dur-ui) var(--inno-ease-out), box-shadow var(--inno-dur-ui) var(--inno-ease-out);
+}
+
+.inno-mode-segmented-control__option:hover:not(:disabled):not(.is-active) {
+	background: rgba(255, 255, 255, 0.7);
+	color: var(--inno-text);
+}
+
+.inno-mode-segmented-control__option.is-active {
+	background: var(--inno-accent);
+	color: #fff;
+	box-shadow: 0 1px 2px rgba(31, 35, 40, 0.18);
+}
+
+.inno-mode-segmented-control__option:disabled {
+	cursor: wait;
+	opacity: 0.65;
 }
 
 .inno-composer-toolbar {
@@ -753,6 +797,14 @@ inno-workspace-panel textarea {
 .inno-workspace-search-clear:hover {
 	background: var(--inno-surface);
 	color: var(--inno-text);
+}
+
+.inno-preset-search-input,
+.inno-preset-search-input:focus,
+.inno-preset-search-input:focus-visible {
+	border: 0;
+	outline: none;
+	box-shadow: none;
 }
 
 .inno-workspace-options {

--- a/apps/inno-agent/web/src/i18n/index.ts
+++ b/apps/inno-agent/web/src/i18n/index.ts
@@ -20,6 +20,7 @@ type CloseDialogCopy = {
 
 type DesktopBridge = {
 	setCloseDialogCopy(copy: CloseDialogCopy): void;
+	expandWindowWidth(side: "left" | "right", additionalWidth: number): Promise<boolean>;
 };
 
 declare global {

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -754,8 +754,6 @@
 		"currentNormalClickSimple": "Current: Normal Mode · click to switch to Simple Mode",
 		"switchToNormal": "Switch to Normal Mode",
 		"switchToSimple": "Switch to Simple Mode",
-		"simpleShort": "Simple Mode · switch to Normal",
-		"normalShort": "Normal Mode · switch to Simple",
 		"simpleTag": "(Simple Mode)"
 	},
 	"terminal": {

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -673,7 +673,6 @@
 		"send": "Send",
 		"describeImage": "Please describe this image",
 		"uploadedToWorkspace": "[Uploaded to workspace]",
-		"newChatHere": "New conversations will be created in this workspace",
 		"wsTemp": "Temporary · disposable",
 		"wsNew": "New workspace",
 		"wsExisting": "Existing workspace",

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -748,6 +748,9 @@
 		"deleteWsEmpty": "This workspace has no conversations; the workspace record will be removed."
 	},
 	"mode": {
+		"selectorLabel": "Work mode",
+		"simpleLabel": "Simple Mode",
+		"normalLabel": "Normal Mode",
 		"currentSimpleClickNormal": "Current: Simple Mode · click to switch to Normal Mode",
 		"currentNormalClickSimple": "Current: Normal Mode · click to switch to Simple Mode",
 		"switchToNormal": "Switch to Normal Mode",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -673,7 +673,6 @@
 		"send": "发送",
 		"describeImage": "请描述这张图片",
 		"uploadedToWorkspace": "[已上传到工作区]",
-		"newChatHere": "新对话将创建于此工作区",
 		"wsTemp": "临时·用完即弃",
 		"wsNew": "新建工作区",
 		"wsExisting": "已有工作区",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -754,8 +754,6 @@
 		"currentNormalClickSimple": "当前:普通模式 · 点击切换到简单模式",
 		"switchToNormal": "切换到普通模式",
 		"switchToSimple": "切换到简单模式",
-		"simpleShort": "简单模式 · 切换到普通模式",
-		"normalShort": "普通模式 · 切换到简单模式",
 		"simpleTag": "(简单模式)"
 	},
 	"terminal": {

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -748,6 +748,9 @@
 		"deleteWsEmpty": "该工作区当前没有会话,工作区记录将被移除。"
 	},
 	"mode": {
+		"selectorLabel": "工作模式",
+		"simpleLabel": "简单模式",
+		"normalLabel": "普通模式",
 		"currentSimpleClickNormal": "当前:简单模式 · 点击切换到普通模式",
 		"currentNormalClickSimple": "当前:普通模式 · 点击切换到简单模式",
 		"switchToNormal": "切换到普通模式",

--- a/apps/inno-agent/web/src/react/App.tsx
+++ b/apps/inno-agent/web/src/react/App.tsx
@@ -10,9 +10,15 @@ import { SessionSidebar } from "./SessionSidebar.js";
 import { WorkspacePanel } from "./WorkspacePanel.js";
 import { SettingsOverlay } from "./settings/SettingsOverlay.js";
 
-/** Breakpoint below which sidebars auto-collapse */
-const SIDEBAR_COLLAPSE_BP = 960;
-const WORKSPACE_COLLAPSE_BP = 820;
+/** Below this width the chat takes the whole window. */
+const CHAT_ONLY_BP = 960;
+/** The Electron window's minimum usable width: the chat-only baseline. */
+const CHAT_BASELINE_WIDTH = 800;
+const SIDEBAR_WIDTH = 264;
+const WORKSPACE_MIN_WIDTH = 320;
+const WORKSPACE_MAX_WIDTH = 920;
+
+type WindowExpansionSide = "left" | "right";
 
 let initializationPromise: Promise<void> | null = null;
 
@@ -26,6 +32,30 @@ function initializeApp(): Promise<void> {
 	return initializationPromise;
 }
 
+function getEffectiveWorkspaceWidth(width: number): number {
+	return Math.max(WORKSPACE_MIN_WIDTH, Math.min(WORKSPACE_MAX_WIDTH, Math.round(width)));
+}
+
+function waitForViewportWidth(minWidth: number): Promise<boolean> {
+	if (window.innerWidth >= minWidth) return Promise.resolve(true);
+
+	return new Promise((resolve) => {
+		const startedAt = performance.now();
+		const check = () => {
+			if (window.innerWidth >= minWidth) {
+				resolve(true);
+				return;
+			}
+			if (performance.now() - startedAt >= 600) {
+				resolve(false);
+				return;
+			}
+			window.requestAnimationFrame(check);
+		};
+		check();
+	});
+}
+
 export function App() {
 	const app = useStoreSnapshot(appStore, () => ({
 		rightPanelTab: appStore.rightPanelTab,
@@ -33,6 +63,7 @@ export function App() {
 		workspaceMode: appStore.workspaceMode,
 		workspaceWidth: appStore.workspaceWidth,
 	}));
+	const pendingExpansion = useRef<WindowExpansionSide | null>(null);
 
 	useEffect(() => {
 		void initializeApp();
@@ -61,57 +92,62 @@ export function App() {
 		return unsubscribe;
 	}, []);
 
-	// Track whether user manually toggled the sidebar so we don't fight them
-	const userExpandedSidebar = useRef(false);
-	const userExpandedWorkspace = useRef(false);
-
-	// Auto-collapse left sidebar when viewport narrows
+	// At narrow widths the chat is the primary surface: remove both optional
+	// columns together so they cannot squeeze the conversation into a sliver.
+	// We intentionally do not restore either column when the window widens again;
+	// reopening a panel is an explicit user action.
 	useEffect(() => {
-		const mql = window.matchMedia(`(max-width: ${SIDEBAR_COLLAPSE_BP}px)`);
-		const handler = (e: MediaQueryListEvent | MediaQueryList) => {
-			if (e.matches) {
-				// Narrow: collapse if expanded
-				if (!appStore.sidebarCollapsed) {
-					userExpandedSidebar.current = false;
-					appStore.setSidebarCollapsed(true);
-				}
-			} else {
-				// Wide: restore if not manually collapsed
-				if (appStore.sidebarCollapsed && !userExpandedSidebar.current) {
-					appStore.setSidebarCollapsed(false);
-				}
-			}
+		const mql = window.matchMedia(`(max-width: ${CHAT_ONLY_BP}px)`);
+		const enforceChatOnly = (e: MediaQueryListEvent | MediaQueryList) => {
+			if (!e.matches) return;
+			if (!appStore.sidebarCollapsed) appStore.setSidebarCollapsed(true);
+			if (appStore.workspaceMode !== "collapsed") appStore.setWorkspaceMode("collapsed");
 		};
-		handler(mql);
-		mql.addEventListener("change", handler);
-		return () => mql.removeEventListener("change", handler);
-	}, []);
-
-	// Auto-collapse right workspace panel when viewport narrows
-	useEffect(() => {
-		const mql = window.matchMedia(`(max-width: ${WORKSPACE_COLLAPSE_BP}px)`);
-		const handler = (e: MediaQueryListEvent | MediaQueryList) => {
-			if (e.matches) {
-				if (appStore.workspaceMode === "half") {
-					userExpandedWorkspace.current = false;
-					appStore.setWorkspaceMode("collapsed");
-				}
-			} else {
-				if (appStore.workspaceMode === "collapsed" && !userExpandedWorkspace.current) {
-					// Don't auto-expand workspace — it starts collapsed by default
-				}
-			}
-		};
-		handler(mql);
-		mql.addEventListener("change", handler);
-		return () => mql.removeEventListener("change", handler);
-	}, []);
+		enforceChatOnly(mql);
+		mql.addEventListener("change", enforceChatOnly);
+		return () => mql.removeEventListener("change", enforceChatOnly);
+	}, [app.sidebarCollapsed, app.workspaceMode]);
 
 	const setTab = useCallback((tab: RightPanelTab) => appStore.setRightPanelTab(tab), []);
+	const ensureWindowForPanel = useCallback(async (side: WindowExpansionSide): Promise<boolean> => {
+		const leftWidth = app.sidebarCollapsed && side !== "left" ? 0 : SIDEBAR_WIDTH;
+		const rightWidth = app.workspaceMode === "collapsed" && side !== "right"
+			? 0
+			: getEffectiveWorkspaceWidth(app.workspaceWidth);
+		const requiredWidth = CHAT_BASELINE_WIDTH + leftWidth + rightWidth;
+		const additionalWidth = Math.max(0, requiredWidth - window.innerWidth);
+		if (additionalWidth === 0) return true;
+
+		const expandWindowWidth = window.innoDesktop?.expandWindowWidth;
+		if (!expandWindowWidth) return true;
+		if (pendingExpansion.current) return false;
+		pendingExpansion.current = side;
+		try {
+			const expanded = await expandWindowWidth(side, additionalWidth);
+			if (!expanded) return false;
+			return waitForViewportWidth(requiredWidth);
+		} finally {
+			pendingExpansion.current = null;
+		}
+	}, [app.sidebarCollapsed, app.workspaceMode, app.workspaceWidth]);
+
+	const openSidebar = useCallback(() => {
+		void (async () => {
+			if (!(await ensureWindowForPanel("left"))) return;
+			appStore.setSidebarCollapsed(false);
+		})();
+	}, [ensureWindowForPanel]);
+
 	const setWorkspaceMode = useCallback((mode: WorkspaceMode) => {
-		userExpandedWorkspace.current = mode !== "collapsed";
-		appStore.setWorkspaceMode(mode);
-	}, []);
+		if (mode === "collapsed" || app.workspaceMode !== "collapsed") {
+			appStore.setWorkspaceMode(mode);
+			return;
+		}
+		void (async () => {
+			if (!(await ensureWindowForPanel("right"))) return;
+			appStore.setWorkspaceMode(mode);
+		})();
+	}, [app.workspaceMode, ensureWindowForPanel]);
 	const setWorkspaceWidth = useCallback((width: number) => appStore.setWorkspaceWidth(width), []);
 
 	return (
@@ -120,7 +156,7 @@ export function App() {
 				className={`app-layout app-layout--sidebar-${app.sidebarCollapsed ? "collapsed" : "expanded"} app-layout--workspace-${app.workspaceMode}`}
 				style={{ "--inno-workspace-width": `${app.workspaceWidth}px` } as React.CSSProperties}
 			>
-				<SessionSidebar collapsed={app.sidebarCollapsed} />
+				<SessionSidebar collapsed={app.sidebarCollapsed} onOpen={openSidebar} />
 				<ChatCenter />
 				<WorkspacePanel
 					activeTab={app.rightPanelTab}

--- a/apps/inno-agent/web/src/react/App.tsx
+++ b/apps/inno-agent/web/src/react/App.tsx
@@ -9,16 +9,17 @@ import { ChatCenter } from "./ChatCenter.js";
 import { SessionSidebar } from "./SessionSidebar.js";
 import { WorkspacePanel } from "./WorkspacePanel.js";
 import { SettingsOverlay } from "./settings/SettingsOverlay.js";
+import {
+	CHAT_BASELINE_WIDTH,
+	SIDEBAR_WIDTH,
+	getEffectiveWorkspaceWidth,
+	fitPanelLayout,
+} from "../stores/app-layout.js";
 
 /** Below this width the chat takes the whole window. */
 const CHAT_ONLY_BP = 960;
-/** The Electron window's minimum usable width: the chat-only baseline. */
-const CHAT_BASELINE_WIDTH = 800;
-const SIDEBAR_WIDTH = 264;
-const WORKSPACE_MIN_WIDTH = 320;
-const WORKSPACE_MAX_WIDTH = 920;
-
 type WindowExpansionSide = "left" | "right";
+type PanelSpaceResult = "ready" | "busy" | "unavailable";
 
 let initializationPromise: Promise<void> | null = null;
 
@@ -30,10 +31,6 @@ function initializeApp(): Promise<void> {
 		if (requestedSession) await sessionsStore.openSession(requestedSession, { historyMode: "none" });
 	})();
 	return initializationPromise;
-}
-
-function getEffectiveWorkspaceWidth(width: number): number {
-	return Math.max(WORKSPACE_MIN_WIDTH, Math.min(WORKSPACE_MAX_WIDTH, Math.round(width)));
 }
 
 function waitForViewportWidth(minWidth: number): Promise<boolean> {
@@ -108,32 +105,120 @@ export function App() {
 		return () => mql.removeEventListener("change", enforceChatOnly);
 	}, [app.sidebarCollapsed, app.workspaceMode]);
 
+	// A window can be resized after a panel was opened. Keep that action from
+	// leaving the chat squeezed beside a stale, oversized workspace preview.
+	useEffect(() => {
+		const fitCurrentLayout = () => {
+			const currentMode = appStore.workspaceMode;
+			if (currentMode === "collapsed" || currentMode === "full") return;
+			const fitted = fitPanelLayout(
+				window.innerWidth,
+				appStore.sidebarCollapsed,
+				currentMode,
+				appStore.workspaceWidth,
+			);
+			if (!fitted) {
+				appStore.setWorkspaceMode("collapsed");
+				return;
+			}
+			if (fitted.sidebarCollapsed !== appStore.sidebarCollapsed) {
+				appStore.setSidebarCollapsed(fitted.sidebarCollapsed);
+			}
+			if (fitted.workspaceMode !== appStore.workspaceMode) {
+				appStore.setWorkspaceMode(fitted.workspaceMode);
+			}
+			if (fitted.workspaceWidth !== appStore.workspaceWidth) {
+				appStore.setWorkspaceWidth(fitted.workspaceWidth);
+			}
+		};
+
+		fitCurrentLayout();
+		window.addEventListener("resize", fitCurrentLayout);
+		return () => window.removeEventListener("resize", fitCurrentLayout);
+	}, []);
+
 	const setTab = useCallback((tab: RightPanelTab) => appStore.setRightPanelTab(tab), []);
-	const ensureWindowForPanel = useCallback(async (side: WindowExpansionSide): Promise<boolean> => {
-		const leftWidth = app.sidebarCollapsed && side !== "left" ? 0 : SIDEBAR_WIDTH;
-		const rightWidth = app.workspaceMode === "collapsed" && side !== "right"
+	const ensureWindowForPanel = useCallback(async (
+		side: WindowExpansionSide,
+		requestedWorkspaceWidth?: number,
+		requestedWorkspaceMode?: WorkspaceMode,
+	): Promise<PanelSpaceResult> => {
+		// Read the store at call time. Opening both panels is sequential, so the
+		// second expansion must see the sidebar state changed by the first one.
+		const currentSidebarCollapsed = appStore.sidebarCollapsed;
+		const currentWorkspaceMode = appStore.workspaceMode;
+		const workspaceWidth = requestedWorkspaceWidth ?? appStore.workspaceWidth;
+		const workspaceMode = requestedWorkspaceMode ?? currentWorkspaceMode;
+		const leftWidth = currentSidebarCollapsed && side !== "left" ? 0 : SIDEBAR_WIDTH;
+		const rightWidth = currentWorkspaceMode === "collapsed" && side !== "right"
 			? 0
-			: getEffectiveWorkspaceWidth(app.workspaceWidth);
+			: getEffectiveWorkspaceWidth(workspaceWidth, workspaceMode === "collapsed" ? "half" : workspaceMode);
 		const requiredWidth = CHAT_BASELINE_WIDTH + leftWidth + rightWidth;
 		const additionalWidth = Math.max(0, requiredWidth - window.innerWidth);
-		if (additionalWidth === 0) return true;
+		if (additionalWidth === 0) return "ready";
 
 		const expandWindowWidth = window.innoDesktop?.expandWindowWidth;
-		if (!expandWindowWidth) return true;
-		if (pendingExpansion.current) return false;
+		if (!expandWindowWidth) return "unavailable";
+		if (pendingExpansion.current) return "busy";
 		pendingExpansion.current = side;
 		try {
 			const expanded = await expandWindowWidth(side, additionalWidth);
-			if (!expanded) return false;
-			return waitForViewportWidth(requiredWidth);
+			if (!expanded) return "unavailable";
+			return (await waitForViewportWidth(requiredWidth)) ? "ready" : "unavailable";
 		} finally {
 			pendingExpansion.current = null;
 		}
-	}, [app.sidebarCollapsed, app.workspaceMode, app.workspaceWidth]);
+	}, []);
+
+	const openPresetPanels = useCallback(async () => {
+		const previewWidth = 560;
+		if (appStore.workspaceMode === "full") {
+			// Full mode overlays the chat; start from the normal split state before
+			// making room for both optional columns.
+			appStore.setWorkspaceMode("collapsed");
+		}
+
+		if (appStore.sidebarCollapsed) {
+			const leftResult = await ensureWindowForPanel("left");
+			if (leftResult === "busy") return;
+			appStore.setSidebarCollapsed(false);
+		}
+
+		const rightResult = await ensureWindowForPanel("right", previewWidth, "half");
+		if (rightResult === "busy") return;
+		if (rightResult === "unavailable" && !appStore.sidebarCollapsed) {
+			// Preserve the chat when the display cannot fit both panels.
+			appStore.setSidebarCollapsed(true);
+		}
+		appStore.setRightPanelTab("preview");
+		appStore.setWorkspaceWidth(previewWidth);
+		appStore.setWorkspaceMode("half");
+	}, [ensureWindowForPanel]);
+
+	const openFilePreview = useCallback(async (minimumWidth: number) => {
+		// Full mode is already the reading surface; selecting another file should
+		// not unexpectedly return the user to a split layout.
+		if (appStore.workspaceMode === "full") return;
+		const previewWidth = appStore.workspaceMode === "collapsed"
+			? minimumWidth
+			: Math.max(minimumWidth, appStore.workspaceWidth);
+		const result = await ensureWindowForPanel("right", previewWidth, "half");
+		if (result === "busy") return;
+		if (result === "unavailable" && !appStore.sidebarCollapsed) {
+			appStore.setSidebarCollapsed(true);
+		}
+		// Expand the native window before changing panel width so the chat is not
+		// temporarily squeezed by the preview pane.
+		appStore.setWorkspaceWidth(previewWidth);
+		appStore.setWorkspaceMode("half");
+	}, [ensureWindowForPanel]);
 
 	const openSidebar = useCallback(() => {
 		void (async () => {
-			if (!(await ensureWindowForPanel("left"))) return;
+			const result = await ensureWindowForPanel("left");
+			if (result === "busy") return;
+			// If the display cannot fit both optional columns, the store fits the
+			// workspace or closes it so the clicked panel still responds.
 			appStore.setSidebarCollapsed(false);
 		})();
 	}, [ensureWindowForPanel]);
@@ -144,7 +229,11 @@ export function App() {
 			return;
 		}
 		void (async () => {
-			if (!(await ensureWindowForPanel("right"))) return;
+			const result = await ensureWindowForPanel("right");
+			if (result === "busy") return;
+			if (result === "unavailable" && !appStore.sidebarCollapsed) {
+				appStore.setSidebarCollapsed(true);
+			}
 			appStore.setWorkspaceMode(mode);
 		})();
 	}, [app.workspaceMode, ensureWindowForPanel]);
@@ -157,7 +246,7 @@ export function App() {
 				style={{ "--inno-workspace-width": `${app.workspaceWidth}px` } as React.CSSProperties}
 			>
 				<SessionSidebar collapsed={app.sidebarCollapsed} onOpen={openSidebar} />
-				<ChatCenter />
+				<ChatCenter onOpenPresetPanels={openPresetPanels} />
 				<WorkspacePanel
 					activeTab={app.rightPanelTab}
 					mode={app.workspaceMode}
@@ -165,6 +254,7 @@ export function App() {
 					onTabChange={setTab}
 					onModeChange={setWorkspaceMode}
 					onWidthChange={setWorkspaceWidth}
+					onPreviewFile={openFilePreview}
 				/>
 			</div>
 			<SettingsOverlay />

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -192,12 +192,6 @@ export function ChatCenter({ onOpenPresetPanels }: ChatCenterProps) {
 	const activeWorkspaceId = useStoreSnapshot(workspaceStore, () => workspaceStore.activeWorkspaceId);
 	const isWelcome = sessions.isWelcome;
 
-	const preselectedWs = useMemo(
-		() => sessions.preselectedWorkspaceId
-			? workspaces.list.find((workspace) => workspace.id === sessions.preselectedWorkspaceId) ?? null
-			: null,
-		[sessions.preselectedWorkspaceId, workspaces.list],
-	);
 	const selectableWorkspaces = useMemo(
 		() => workspaces.list.filter((workspace) => !workspace.isTemp && !workspace.id.startsWith("channel-")),
 		[workspaces.list],
@@ -693,25 +687,20 @@ export function ChatCenter({ onOpenPresetPanels }: ChatCenterProps) {
 	);
 
 	const renderWorkspaceContext = (context: "welcome" | "session") => {
-		const draftWorkspaceId = context === "welcome" && wsMode === "existing" ? wsExistingId : null;
-		const sessionWorkspace = context === "session" && activeWorkspaceId
-			? workspaces.list.find((workspace) => workspace.id === activeWorkspaceId)
-			: undefined;
-		const selectedWorkspaceId = context === "welcome" ? draftWorkspaceId : activeWorkspaceId;
-		if (selectedWorkspaceId) return null;
-		const selectedKind: "workspace" | "temp" | "new" = context === "welcome"
-			? wsMode === "existing" ? "workspace" : wsMode
-			: sessionWorkspace?.isTemp || !activeWorkspaceId ? "temp" : "workspace";
+		// The workspace selector belongs to the new-chat home page. A real
+		// conversation already has a fixed workspace context and should keep the
+		// composer uncluttered.
+		if (context === "session") return null;
+		const selectedWorkspaceId = wsMode === "existing" ? wsExistingId : null;
+		const selectedKind: "workspace" | "temp" | "new" = wsMode === "existing" ? "workspace" : wsMode;
 		return (
 			<WorkspaceContext
-				context={context}
 				workspaces={workspaces.list}
 				selectedWorkspaceId={selectedWorkspaceId}
 				selectedKind={selectedKind}
-				newWorkspaceName={context === "welcome" && wsMode === "new" ? wsName : ""}
+				newWorkspaceName={wsMode === "new" ? wsName : ""}
 				busy={isSwitchingWorkspace}
-				disabled={isUploading || Boolean(chat.pendingQuestion) || (context === "session" && chat.isSending)}
-				showHint={Boolean(preselectedWs)}
+				disabled={isUploading || Boolean(chat.pendingQuestion)}
 				onChange={handleWorkspaceChange}
 			/>
 		);

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -51,6 +51,10 @@ type WsMode = "temp" | "new" | "existing";
 const LAST_WS_MODE_KEY = "inno.lastWorkspaceMode";
 const LAST_WS_ID_KEY = "inno.lastWorkspaceId";
 
+interface ChatCenterProps {
+	onOpenPresetPanels?: () => void | Promise<void>;
+}
+
 function readLastWsMode(): WsMode {
 	if (typeof window === "undefined") return "temp";
 	const value = window.localStorage.getItem(LAST_WS_MODE_KEY);
@@ -68,7 +72,7 @@ function rememberWsChoice(mode: WsMode, existingId: string): void {
 	if (mode === "existing" && existingId) window.localStorage.setItem(LAST_WS_ID_KEY, existingId);
 }
 
-export function ChatCenter() {
+export function ChatCenter({ onOpenPresetPanels }: ChatCenterProps) {
 	const { t } = useTranslation();
 	const inputRef = useRef<HTMLTextAreaElement | null>(null);
 	const welcomeLayoutRef = useRef<HTMLDivElement | null>(null);
@@ -464,7 +468,11 @@ export function ChatCenter() {
 		setOpeningPresetId(presetId);
 		void (async () => {
 			try {
-				await sessionsStore.createSessionWith({ presetId });
+				const panelsPromise = Promise.resolve(onOpenPresetPanels?.());
+				await Promise.all([
+					sessionsStore.createSessionWith({ presetId }),
+					panelsPromise,
+				]);
 				appStore.setRightPanelTab("preview");
 				appStore.setWorkspaceWidth(560);
 				appStore.setWorkspaceMode("half");
@@ -482,7 +490,7 @@ export function ChatCenter() {
 				setOpeningPresetId(null);
 			}
 		})();
-	}, [t]);
+	}, [onOpenPresetPanels, t]);
 
 	const handleSend = useCallback(() => {
 		const rawValue = inputRef.current?.value ?? draftValue;
@@ -689,6 +697,8 @@ export function ChatCenter() {
 		const sessionWorkspace = context === "session" && activeWorkspaceId
 			? workspaces.list.find((workspace) => workspace.id === activeWorkspaceId)
 			: undefined;
+		const selectedWorkspaceId = context === "welcome" ? draftWorkspaceId : activeWorkspaceId;
+		if (selectedWorkspaceId) return null;
 		const selectedKind: "workspace" | "temp" | "new" = context === "welcome"
 			? wsMode === "existing" ? "workspace" : wsMode
 			: sessionWorkspace?.isTemp || !activeWorkspaceId ? "temp" : "workspace";
@@ -696,7 +706,7 @@ export function ChatCenter() {
 			<WorkspaceContext
 				context={context}
 				workspaces={workspaces.list}
-				selectedWorkspaceId={context === "welcome" ? draftWorkspaceId : activeWorkspaceId}
+				selectedWorkspaceId={selectedWorkspaceId}
 				selectedKind={selectedKind}
 				newWorkspaceName={context === "welcome" && wsMode === "new" ? wsName : ""}
 				busy={isSwitchingWorkspace}

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -52,7 +52,7 @@ const LAST_WS_MODE_KEY = "inno.lastWorkspaceMode";
 const LAST_WS_ID_KEY = "inno.lastWorkspaceId";
 
 interface ChatCenterProps {
-	onOpenPresetPanels?: () => void | Promise<void>;
+	onOpenPresetPanels: () => void | Promise<void>;
 }
 
 function readLastWsMode(): WsMode {
@@ -462,14 +462,10 @@ export function ChatCenter({ onOpenPresetPanels }: ChatCenterProps) {
 		setOpeningPresetId(presetId);
 		void (async () => {
 			try {
-				const panelsPromise = Promise.resolve(onOpenPresetPanels?.());
 				await Promise.all([
 					sessionsStore.createSessionWith({ presetId }),
-					panelsPromise,
+					onOpenPresetPanels(),
 				]);
-				appStore.setRightPanelTab("preview");
-				appStore.setWorkspaceWidth(560);
-				appStore.setWorkspaceMode("half");
 			} catch (err) {
 				const unavailable = err instanceof ApiError
 					&& err.status === 404

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -38,6 +38,7 @@ import { Spinner } from "./ui/Spinner.js";
 
 interface SessionSidebarProps {
 	collapsed: boolean;
+	onOpen(): void;
 }
 
 const CHANNEL_FILTER_ORDER = ["web", "feishu", "wechat", "cli", "scheduler"] as const;
@@ -488,7 +489,7 @@ function SessionCard({
 
 /* ── Main sidebar ── */
 
-export function SessionSidebar({ collapsed }: SessionSidebarProps) {
+export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 	const { t } = useTranslation();
 	const [editingId, setEditingId] = useState<string | null>(null);
 	const [editingName, setEditingName] = useState("");
@@ -845,7 +846,7 @@ export function SessionSidebar({ collapsed }: SessionSidebarProps) {
 				<button
 					className="absolute left-2 top-2 z-20 flex h-8 w-8 items-center justify-center rounded-lg text-[var(--inno-text-subtle)] transition-colors hover:bg-white/90 hover:text-[var(--inno-text)] hover:shadow-sm"
 					title={t("sidebar.expand")}
-					onClick={() => appStore.setSidebarCollapsed(false)}
+					onClick={onOpen}
 				>
 					<PanelLeftOpen size={16} />
 				</button>

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Tree, type NodeRendererProps } from "react-arborist";
 import { RefreshCw, Upload, Trash2, ChevronLeft, File, FileText, FileType, Folder, FolderOpen, Globe, Pencil, Save, X, PanelLeftClose, PanelLeftOpen, Library, Download, Check, FileCode2, Search } from "lucide-react";

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -26,6 +26,7 @@ const DocxPreview = lazy(() => import("./office/DocxPreview.js"));
 const XlsxPreview = lazy(() => import("./office/XlsxPreview.js"));
 
 const MAX_STREAMING_MARKDOWN_FORMAT_CHARS = 160_000;
+type PreviewFileHandler = (minimumWidth: number) => void | Promise<void>;
 const TREE_PANE_WIDTH = 260;
 const CONTENT_REVEAL_WIDTH = TREE_PANE_WIDTH + 150;
 const DEFAULT_PREVIEW_PANEL_WIDTH = 560;
@@ -616,7 +617,7 @@ const WorkspaceMultiSelectContext = createContext<WorkspaceMultiSelectState>({
 	addFile: () => undefined,
 });
 
-function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
+function Node({ node, style, dragHandle, onPreviewFile }: NodeRendererProps<ArboristNode> & { onPreviewFile?: PreviewFileHandler }) {
 	const isDir = !node.isLeaf;
 	const multiSelect = useContext(WorkspaceMultiSelectContext);
 	const selected = multiSelect.enabled ? multiSelect.selectedIds.has(node.data.path) : node.isSelected;
@@ -639,16 +640,23 @@ function Node({ node, style, dragHandle }: NodeRendererProps<ArboristNode>) {
 						return;
 					}
 					if (node.isSelected) {
+						if (onPreviewFile) {
+							void onPreviewFile(DEFAULT_PREVIEW_PANEL_WIDTH);
+							return;
+						}
 						node.deselect();
 						return;
 					}
 					node.select();
 					workspaceStore.clearStreamingPreview();
-					if (appStore.workspaceWidth < CONTENT_REVEAL_WIDTH) {
-						appStore.setWorkspaceWidth(DEFAULT_PREVIEW_PANEL_WIDTH);
-					}
-					if (appStore.workspaceMode === "quarter") {
-						appStore.setWorkspaceMode("half");
+					if (onPreviewFile) void onPreviewFile(DEFAULT_PREVIEW_PANEL_WIDTH);
+					else {
+						if (appStore.workspaceWidth < CONTENT_REVEAL_WIDTH) {
+							appStore.setWorkspaceWidth(DEFAULT_PREVIEW_PANEL_WIDTH);
+						}
+						if (appStore.workspaceMode === "quarter") {
+							appStore.setWorkspaceMode("half");
+						}
 					}
 					void workspaceStore.selectFile(node.data.path);
 				}
@@ -785,7 +793,7 @@ function DeleteConfirm({ paths, onConfirm, onCancel }: { paths: string[]; onConf
 
 /* ---------- Main Component ---------- */
 
-export function WorkspaceBrowser() {
+export function WorkspaceBrowser({ onPreviewFile }: { onPreviewFile?: PreviewFileHandler }) {
 	const { t } = useTranslation();
 	const treeRef = useRef<TreeApi<ArboristNode>>(null);
 	const skillUploadRef = useRef<HTMLInputElement>(null);
@@ -1102,7 +1110,7 @@ export function WorkspaceBrowser() {
 									onDelete={onDelete}
 									onMove={onMove}
 								>
-									{Node}
+									{(nodeProps) => <Node {...nodeProps} onPreviewFile={onPreviewFile} />}
 								</Tree>
 							</WorkspaceMultiSelectContext.Provider>
 							{!arboristData.length && (

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -21,6 +21,7 @@ interface WorkspacePanelProps {
 	onTabChange(tab: RightPanelTab): void;
 	onModeChange(mode: WorkspaceMode): void;
 	onWidthChange(width: number): void;
+	onPreviewFile(width: number): void | Promise<void>;
 }
 
 const TAB_ORDER: RightPanelTab[] = ["preview", "notebook", "profile", "jobs", "skills"];
@@ -84,12 +85,12 @@ function WorkspaceContentFallback() {
 	);
 }
 
-function WorkspaceContent({ activeTab }: { activeTab: RightPanelTab }) {
+function WorkspaceContent({ activeTab, onPreviewFile }: { activeTab: RightPanelTab; onPreviewFile: WorkspacePanelProps["onPreviewFile"] }) {
 	switch (activeTab) {
 		case "notebook":
 			return <Notebook />;
 		case "preview":
-			return <WorkspaceBrowser />;
+			return <WorkspaceBrowser onPreviewFile={onPreviewFile} />;
 		case "profile":
 			return <LearnerProfilePanel />;
 		case "skills":
@@ -99,7 +100,7 @@ function WorkspaceContent({ activeTab }: { activeTab: RightPanelTab }) {
 	}
 }
 
-export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChange, onWidthChange }: WorkspacePanelProps) {
+export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChange, onWidthChange, onPreviewFile }: WorkspacePanelProps) {
 	const { t } = useTranslation();
 	const [isResizing, setIsResizing] = useState(false);
 
@@ -231,7 +232,7 @@ export function WorkspacePanel({ activeTab, mode, width, onTabChange, onModeChan
 					>
 						<WorkspaceContentErrorBoundary resetKey={activeTab}>
 							<Suspense fallback={<WorkspaceContentFallback />}>
-								<WorkspaceContent activeTab={activeTab} />
+								<WorkspaceContent activeTab={activeTab} onPreviewFile={onPreviewFile} />
 							</Suspense>
 						</WorkspaceContentErrorBoundary>
 					</motion.div>

--- a/apps/inno-agent/web/src/react/chat/ChatConversation.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatConversation.tsx
@@ -144,7 +144,7 @@ export function ChatConversation({
 					{busyBlocker}
 					{wsError ? <p className="mb-2 text-xs text-[var(--inno-danger)]">{wsError}</p> : null}
 					{composer}
-					<div className="mt-2">{workspaceContext}</div>
+					{workspaceContext ? <div className="mt-2">{workspaceContext}</div> : null}
 				</div>
 			</div>
 		</section>

--- a/apps/inno-agent/web/src/react/chat/ChatWelcome.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatWelcome.tsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
 import type { PresetMeta } from "../../types/presets.js";
 import { PresetPicker } from "./PresetPicker.js";
+import { ModeSegmentedControl } from "../ui/ModeSegmentedControl.js";
 
 interface ChatWelcomeProps {
 	welcomeLayoutRef: RefObject<HTMLDivElement | null>;
@@ -59,7 +60,7 @@ export function ChatWelcome({
 			<div className="inno-chat-grid flex flex-1 min-h-0 justify-center overflow-y-auto px-4">
 				<div ref={welcomeLayoutRef} className="inno-welcome-layout w-full max-w-2xl pt-[18vh] pb-12">
 					<div className="inno-welcome-upper">
-						<div className="mb-6 flex flex-col items-center text-center">
+						<div className="flex flex-col items-center text-center">
 							<button
 								type="button"
 								onClick={onToggleMode}
@@ -78,15 +79,12 @@ export function ChatWelcome({
 								</motion.div>
 							</button>
 							<h2 className="text-lg font-medium text-[var(--inno-text)]">Inno Agent</h2>
-							<button
-								type="button"
-								onClick={onToggleMode}
-								disabled={togglingMode}
-								className="mt-2 inline-flex items-center gap-1.5 rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2.5 py-1 text-[11px] text-[var(--inno-text-muted)] transition-colors hover:border-[var(--inno-accent)] hover:text-[var(--inno-accent)] disabled:cursor-wait disabled:opacity-60"
-							>
-								<span className={`h-1.5 w-1.5 rounded-full ${simpleMode ? "bg-[var(--inno-accent)]" : "bg-[var(--inno-border-strong)]"}`} />
-								{simpleMode ? t("mode.simpleShort") : t("mode.normalShort")}
-							</button>
+							<ModeSegmentedControl
+								simpleMode={simpleMode}
+								togglingMode={togglingMode}
+								onToggleMode={onToggleMode}
+								className="mt-2"
+							/>
 						</div>
 
 						{uploadChips}

--- a/apps/inno-agent/web/src/react/chat/ChatWelcome.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatWelcome.tsx
@@ -96,7 +96,7 @@ export function ChatWelcome({
 
 					<div className="inno-welcome-composer-shell">
 						{composer}
-						{simpleMode ? null : <div className="mt-2">{workspaceContext}</div>}
+						{simpleMode || !workspaceContext ? null : <div className="mt-2">{workspaceContext}</div>}
 					</div>
 
 					{simpleMode && (presets.length > 0 || presetsLoaded || isLoadingPresets || presetsRefreshError) ? (

--- a/apps/inno-agent/web/src/react/chat/PresetPicker.tsx
+++ b/apps/inno-agent/web/src/react/chat/PresetPicker.tsx
@@ -83,7 +83,7 @@ export function PresetPicker({
 						value={query}
 						onChange={(event) => onQueryChange(event.target.value)}
 						placeholder={t("presets.searchPlaceholder")}
-						className="min-w-0 flex-1 bg-transparent text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:outline-none"
+						className="inno-preset-search-input min-w-0 flex-1 bg-transparent text-xs text-[var(--inno-text)] placeholder:text-[var(--inno-text-subtle)] focus:outline-none"
 					/>
 					{query ? (
 						<button

--- a/apps/inno-agent/web/src/react/chat/WorkspaceContext.tsx
+++ b/apps/inno-agent/web/src/react/chat/WorkspaceContext.tsx
@@ -1,32 +1,26 @@
-import { useTranslation } from "react-i18next";
 import type { WorkspaceMeta } from "../../api/workspaces.js";
 import { WorkspaceSwitcher, type WorkspaceChoice, type WorkspaceSelectionKind } from "../WorkspaceSwitcher.js";
 
 interface WorkspaceContextProps {
-	context: "welcome" | "session";
 	workspaces: WorkspaceMeta[];
 	selectedWorkspaceId: string | null;
 	selectedKind: WorkspaceSelectionKind;
 	newWorkspaceName?: string;
 	busy?: boolean;
 	disabled?: boolean;
-	showHint?: boolean;
 	onChange: (choice: WorkspaceChoice) => void;
 }
 
-/** Shared workspace context row used below both composer variants. */
+/** Workspace context row used below the welcome composer. */
 export function WorkspaceContext({
-	context,
 	workspaces,
 	selectedWorkspaceId,
 	selectedKind,
 	newWorkspaceName = "",
 	busy = false,
 	disabled = false,
-	showHint = false,
 	onChange,
 }: WorkspaceContextProps) {
-	const { t } = useTranslation();
 	return (
 		<div className="inno-workspace-context-row">
 			<WorkspaceSwitcher
@@ -38,9 +32,6 @@ export function WorkspaceContext({
 				disabled={disabled}
 				onChange={onChange}
 			/>
-			{context === "welcome" && showHint ? (
-				<span className="inno-workspace-context-hint">{t("chat.newChatHere")}</span>
-			) : null}
 		</div>
 	);
 }

--- a/apps/inno-agent/web/src/react/settings/ChannelsSettings.tsx
+++ b/apps/inno-agent/web/src/react/settings/ChannelsSettings.tsx
@@ -134,7 +134,6 @@ function FeishuChannel({ settings, state, onStateChange }: {
 
 	// QR registration state
 	const [qrUrl, setQrUrl] = useState<string | null>(null);
-	const [qrDeviceCode, setQrDeviceCode] = useState<string | null>(null);
 	const [qrState, setQrState] = useState<string | null>(null); // scanning | waitingScan | confirmed | expired | denied
 	const [qrError, setQrError] = useState<string | null>(null);
 	const qrPollRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -150,7 +149,6 @@ function FeishuChannel({ settings, state, onStateChange }: {
 		if (qrPollRef.current) clearInterval(qrPollRef.current);
 		try {
 			const { deviceCode, qrUrl: url, interval } = await feishuQrRegister();
-			setQrDeviceCode(deviceCode);
 			setQrUrl(url);
 			setQrState("waitingScan");
 			// Poll status
@@ -250,8 +248,7 @@ function FeishuChannel({ settings, state, onStateChange }: {
 
 /* ---------- WeChat channel (iLink native) ---------- */
 
-function WechatChannel({ settings, state, onStateChange }: {
-	settings: InnoSettings;
+function WechatChannel({ state, onStateChange }: {
 	state: {
 		enabled: boolean;
 		allowedUsers: string;
@@ -262,7 +259,6 @@ function WechatChannel({ settings, state, onStateChange }: {
 
 	// QR login state
 	const [qrUrl, setQrUrl] = useState<string | null>(null);
-	const [qrId, setQrId] = useState<string | null>(null);
 	const [qrStatus, setQrStatus] = useState<string | null>(null); // scanning | waitingScan | scanned | confirmed | expired
 	const [qrError, setQrError] = useState<string | null>(null);
 	const [wxConnected, setWxConnected] = useState(false);
@@ -287,7 +283,6 @@ function WechatChannel({ settings, state, onStateChange }: {
 		if (qrPollRef.current) clearInterval(qrPollRef.current);
 		try {
 			const { qrId: id, qrUrl: url } = await wechatQrLogin();
-			setQrId(id);
 			setQrUrl(url);
 			setQrStatus("waitingScan");
 			// Poll status every 2s
@@ -498,7 +493,7 @@ export function ChannelsSettings({ settings }: { settings: InnoSettings }) {
 				</div>
 			)}
 
-			<WechatChannel settings={settings} state={wechat} onStateChange={patchWechat} />
+			<WechatChannel state={wechat} onStateChange={patchWechat} />
 
 			{/* Bridge Token (used by QQ sidecar) */}
 			{QQ_CHANNEL_READY && qqEnabled && (

--- a/apps/inno-agent/web/src/react/ui/ModeSegmentedControl.tsx
+++ b/apps/inno-agent/web/src/react/ui/ModeSegmentedControl.tsx
@@ -1,0 +1,54 @@
+import { SlidersHorizontal, WandSparkles } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface ModeSegmentedControlProps {
+	simpleMode: boolean;
+	togglingMode: boolean;
+	onToggleMode: () => void;
+	className?: string;
+}
+
+export function ModeSegmentedControl({
+	simpleMode,
+	togglingMode,
+	onToggleMode,
+	className = "",
+}: ModeSegmentedControlProps) {
+	const { t } = useTranslation();
+
+	const selectMode = (nextSimpleMode: boolean) => {
+		if (togglingMode || nextSimpleMode === simpleMode) return;
+		onToggleMode();
+	};
+
+	return (
+		<div
+			className={`inno-mode-segmented-control ${className}`.trim()}
+			role="group"
+			aria-label={t("mode.selectorLabel")}
+		>
+			<button
+				type="button"
+				onClick={() => selectMode(true)}
+				disabled={togglingMode}
+				aria-pressed={simpleMode}
+				title={simpleMode ? t("mode.currentSimpleClickNormal") : t("mode.switchToSimple")}
+				className={`inno-mode-segmented-control__option ${simpleMode ? "is-active" : ""}`.trim()}
+			>
+				<WandSparkles size={14} strokeWidth={1.8} aria-hidden="true" />
+				<span>{t("mode.simpleLabel")}</span>
+			</button>
+			<button
+				type="button"
+				onClick={() => selectMode(false)}
+				disabled={togglingMode}
+				aria-pressed={!simpleMode}
+				title={!simpleMode ? t("mode.currentNormalClickSimple") : t("mode.switchToNormal")}
+				className={`inno-mode-segmented-control__option ${!simpleMode ? "is-active" : ""}`.trim()}
+			>
+				<SlidersHorizontal size={14} strokeWidth={1.8} aria-hidden="true" />
+				<span>{t("mode.normalLabel")}</span>
+			</button>
+		</div>
+	);
+}

--- a/apps/inno-agent/web/src/stores/app-layout.test.ts
+++ b/apps/inno-agent/web/src/stores/app-layout.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { fitPanelLayout } from "./app-layout.js";
+
+describe("fitPanelLayout", () => {
+	it("keeps the chat baseline when the workspace is resized too wide", () => {
+		expect(fitPanelLayout(1_100, true, "half", 920)).toEqual({
+			sidebarCollapsed: true,
+			workspaceMode: "quarter",
+			workspaceWidth: 300,
+		});
+	});
+
+	it("fits both panels by reducing the workspace width", () => {
+		expect(fitPanelLayout(1_700, false, "half", 920)).toEqual({
+			sidebarCollapsed: false,
+			workspaceMode: "half",
+			workspaceWidth: 636,
+		});
+	});
+
+	it("prioritizes the requested workspace over the sidebar when needed", () => {
+		expect(fitPanelLayout(1_300, false, "half", 560)).toEqual({
+			sidebarCollapsed: true,
+			workspaceMode: "half",
+			workspaceWidth: 500,
+		});
+	});
+
+	it("returns no layout when even the smallest workspace would squeeze chat", () => {
+		expect(fitPanelLayout(1_000, true, "half", 560)).toBeNull();
+	});
+});

--- a/apps/inno-agent/web/src/stores/app-layout.ts
+++ b/apps/inno-agent/web/src/stores/app-layout.ts
@@ -1,0 +1,71 @@
+import type { WorkspaceMode } from "./app-store.js";
+
+/** The chat should remain usable while optional panels are visible. */
+export const CHAT_BASELINE_WIDTH = 800;
+export const SIDEBAR_WIDTH = 264;
+export const WORKSPACE_QUARTER_MIN_WIDTH = 240;
+export const WORKSPACE_MIN_WIDTH = 320;
+export const WORKSPACE_MAX_WIDTH = 920;
+
+export function getEffectiveWorkspaceWidth(width: number, mode: WorkspaceMode = "half"): number {
+	const minWidth = mode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH;
+	return Math.max(minWidth, Math.min(WORKSPACE_MAX_WIDTH, Math.round(width)));
+}
+
+export interface FittedPanelLayout {
+	sidebarCollapsed: boolean;
+	workspaceMode: WorkspaceMode;
+	workspaceWidth: number;
+}
+
+/**
+ * Fit a requested non-overlay layout into the current viewport.
+ *
+ * The left sidebar is optional when opening the workspace, and the workspace
+ * can fall back from half to quarter mode when the viewport can only support
+ * a narrower preview. Returning null means even the smallest useful layout
+ * cannot coexist with the chat, so the requested workspace should stay closed.
+ */
+export function fitPanelLayout(
+	viewportWidth: number,
+	sidebarCollapsed: boolean,
+	workspaceMode: WorkspaceMode,
+	workspaceWidth: number,
+): FittedPanelLayout | null {
+	if (workspaceMode === "collapsed" || workspaceMode === "full") {
+		return { sidebarCollapsed, workspaceMode, workspaceWidth };
+	}
+
+	let nextSidebarCollapsed = sidebarCollapsed;
+	let availableWorkspaceWidth = viewportWidth
+		- CHAT_BASELINE_WIDTH
+		- (nextSidebarCollapsed ? 0 : SIDEBAR_WIDTH);
+
+	// If the requested workspace would squeeze the chat, hide the optional
+	// left column first. This is used by direct workspace-opening call sites
+	// that do not go through the Electron window-expansion path.
+	if (availableWorkspaceWidth < WORKSPACE_QUARTER_MIN_WIDTH && !nextSidebarCollapsed) {
+		nextSidebarCollapsed = true;
+		availableWorkspaceWidth = viewportWidth - CHAT_BASELINE_WIDTH;
+	}
+
+	let nextWorkspaceMode = workspaceMode;
+	if (nextWorkspaceMode === "half" && availableWorkspaceWidth < WORKSPACE_MIN_WIDTH) {
+		if (availableWorkspaceWidth >= WORKSPACE_QUARTER_MIN_WIDTH) {
+			nextWorkspaceMode = "quarter";
+		} else {
+			return null;
+		}
+	}
+	const minWidth = nextWorkspaceMode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH;
+	if (availableWorkspaceWidth < minWidth) return null;
+
+	return {
+		sidebarCollapsed: nextSidebarCollapsed,
+		workspaceMode: nextWorkspaceMode,
+		workspaceWidth: Math.min(
+			getEffectiveWorkspaceWidth(workspaceWidth, nextWorkspaceMode),
+			availableWorkspaceWidth,
+		),
+	};
+}

--- a/apps/inno-agent/web/src/stores/app-store.ts
+++ b/apps/inno-agent/web/src/stores/app-store.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "./event-emitter.js";
+import { fitPanelLayout } from "./app-layout.js";
 
 export type RightPanelTab = "notebook" | "preview" | "profile" | "skills" | "jobs";
 export type SidebarSection = "chat" | "wiki" | "jobs" | "settings";
@@ -55,25 +56,82 @@ class AppStoreImpl extends EventEmitter<AppStoreEvents> {
 	}
 
 	toggleSidebar() {
-		this.sidebarCollapsed = !this.sidebarCollapsed;
-		this.emit("change", undefined);
+		this.setSidebarCollapsed(!this.sidebarCollapsed);
 	}
 
 	setSidebarCollapsed(collapsed: boolean) {
+		let nextWorkspaceMode = this.workspaceMode;
+		let nextWorkspaceWidth = this.workspaceWidth;
+		if (!collapsed) {
+			// Full mode intentionally overlays the chat, so opening the sidebar
+			// first returns to a normal two-column layout.
+			if (nextWorkspaceMode === "full") {
+				nextWorkspaceMode = "collapsed";
+			} else if (typeof window !== "undefined") {
+				const fitted = fitPanelLayout(window.innerWidth, false, nextWorkspaceMode, this.workspaceWidth);
+				if (fitted?.sidebarCollapsed === false) {
+					nextWorkspaceMode = fitted.workspaceMode;
+					nextWorkspaceWidth = fitted.workspaceWidth;
+				} else if (nextWorkspaceMode !== "collapsed") {
+					nextWorkspaceMode = "collapsed";
+				}
+			}
+		}
+		if (
+			this.sidebarCollapsed === collapsed
+			&& this.workspaceMode === nextWorkspaceMode
+			&& this.workspaceWidth === nextWorkspaceWidth
+		) return;
 		this.sidebarCollapsed = collapsed;
+		this.workspaceMode = nextWorkspaceMode;
+		this.workspaceWidth = nextWorkspaceWidth;
 		this.emit("change", undefined);
 	}
 
 	setWorkspaceMode(mode: WorkspaceMode) {
-		if (this.workspaceMode === mode) return;
-		this.workspaceMode = mode;
+		let nextSidebarCollapsed = this.sidebarCollapsed;
+		let nextWorkspaceMode = mode;
+		let nextWorkspaceWidth = this.workspaceWidth;
+		if (typeof window !== "undefined") {
+			const fitted = fitPanelLayout(window.innerWidth, nextSidebarCollapsed, nextWorkspaceMode, nextWorkspaceWidth);
+			if (!fitted) return;
+			nextSidebarCollapsed = fitted.sidebarCollapsed;
+			nextWorkspaceMode = fitted.workspaceMode;
+			nextWorkspaceWidth = fitted.workspaceWidth;
+		}
+		if (
+			this.sidebarCollapsed === nextSidebarCollapsed
+			&& this.workspaceMode === nextWorkspaceMode
+			&& this.workspaceWidth === nextWorkspaceWidth
+		) return;
+		this.sidebarCollapsed = nextSidebarCollapsed;
+		this.workspaceMode = nextWorkspaceMode;
+		this.workspaceWidth = nextWorkspaceWidth;
 		this.emit("change", undefined);
 	}
 
 	setWorkspaceWidth(width: number) {
-		const next = Math.max(240, Math.min(920, Math.round(width)));
-		if (this.workspaceWidth === next) return;
-		this.workspaceWidth = next;
+		let nextWorkspaceWidth = Math.max(240, Math.min(920, Math.round(width)));
+		let nextSidebarCollapsed = this.sidebarCollapsed;
+		let nextWorkspaceMode = this.workspaceMode;
+		if (typeof window !== "undefined") {
+			const fitted = fitPanelLayout(window.innerWidth, nextSidebarCollapsed, nextWorkspaceMode, nextWorkspaceWidth);
+			if (fitted) {
+				nextSidebarCollapsed = fitted.sidebarCollapsed;
+				nextWorkspaceMode = fitted.workspaceMode;
+				nextWorkspaceWidth = fitted.workspaceWidth;
+			} else if (nextWorkspaceMode !== "collapsed" && nextWorkspaceMode !== "full") {
+				nextWorkspaceMode = "collapsed";
+			}
+		}
+		if (
+			this.workspaceWidth === nextWorkspaceWidth
+			&& this.sidebarCollapsed === nextSidebarCollapsed
+			&& this.workspaceMode === nextWorkspaceMode
+		) return;
+		this.sidebarCollapsed = nextSidebarCollapsed;
+		this.workspaceMode = nextWorkspaceMode;
+		this.workspaceWidth = nextWorkspaceWidth;
 		if (typeof window !== "undefined") {
 			window.localStorage.setItem("inno.workspaceWidth", String(this.workspaceWidth));
 		}
@@ -81,8 +139,7 @@ class AppStoreImpl extends EventEmitter<AppStoreEvents> {
 	}
 
 	toggleWorkspace() {
-		this.workspaceMode = this.workspaceMode === "collapsed" ? "half" : "collapsed";
-		this.emit("change", undefined);
+		this.setWorkspaceMode(this.workspaceMode === "collapsed" ? "half" : "collapsed");
 	}
 }
 

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -68,8 +68,6 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	 *  would resurrect a resolved question. */
 	private optimisticQuestionToolIds = new Set<string>();
 	canReconnect = false;
-	private abortController: AbortController | null = null;
-	private detachMode = false;
 	private wikiInvalidated = false;
 	private streamChangeTimer: ReturnType<typeof setTimeout> | null = null;
 	private workspacePreviewId: string | null = null;
@@ -91,7 +89,6 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			: sessionIdOverride;
 		if (!targetSessionId || this.isSending) return;
 
-		this.detachMode = false;
 		this.currentSessionContext = targetSessionId;
 		this.retryInputBySession.set(targetSessionId, { prompt, images });
 		this.lastUserPrompt = prompt;
@@ -112,7 +109,6 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.setStreamingActivity("正在分析请求");
 		this.wikiInvalidated = false;
 		const controller = new AbortController();
-		this.abortController = controller;
 		const owner: ActiveStreamOwner = {
 			sessionId: targetSessionId,
 			clientRequestId: crypto.randomUUID(),
@@ -167,11 +163,9 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	 * Used when the user navigates to a different session.
 	 */
 	detach(): void {
-		this.detachMode = true;
 		this.activeOwner?.controller.abort();
 		this.activeOwner = null;
 		this.ownerGeneration++;
-		this.abortController = null;
 		this.isSending = false;
 		this.canReconnect = false;
 		this.currentSessionContext = null;
@@ -216,9 +210,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.resetTransientStreamState();
 		this.isSending = true;
 		this.streamingActivity = "正在恢复生成";
-		this.detachMode = false;
 		const controller = new AbortController();
-		this.abortController = controller;
 		const owner: ActiveStreamOwner = {
 			sessionId,
 			clientRequestId: stream.clientRequestId,
@@ -320,7 +312,6 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				}
 				const reconnectController = new AbortController();
 				owner.controller = reconnectController;
-				this.abortController = reconnectController;
 				for await (const envelope of streamSessionEvents(owner.sessionId, owner.turnId, owner.lastAppliedEventId, reconnectController.signal)) {
 					await this._handleStreamEnvelope(owner, envelope);
 				}
@@ -408,10 +399,8 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		if (!this.owns(owner)) return;
 		this.flushStreamChange();
 		this.activeOwner = null;
-		this.abortController = null;
 		this.isSending = false;
 		this.canReconnect = false;
-		this.detachMode = false;
 		this.resetTransientStreamState();
 		const shouldRefreshWiki = this.wikiInvalidated;
 		this.wikiInvalidated = false;

--- a/apps/inno-agent/web/vite.config.ts
+++ b/apps/inno-agent/web/vite.config.ts
@@ -239,6 +239,10 @@ export default defineConfig({
 		},
 	},
 	build: {
+		// The editor and office-preview dependencies are intentionally lazy-loaded
+		// and can produce large, standalone chunks. Keep the warning focused on
+		// accidental growth of the initial application payload.
+		chunkSizeWarningLimit: 2048,
 		modulePreload: {
 			resolveDependencies: (_filename, deps) => deps.filter((dep) => !HEAVY_LAZY_CHUNK_PATTERNS.some((pattern) => dep.includes(pattern))),
 		},
@@ -256,16 +260,6 @@ export default defineConfig({
 						return "vite-preload-helper";
 					}
 					if (!id.includes("node_modules")) return undefined;
-					if (
-						id.includes("/node_modules/react/") ||
-						id.includes("/node_modules/react-dom/") ||
-						id.includes("/node_modules/scheduler/")
-					) {
-						return "react-vendor";
-					}
-					if (id.includes("/node_modules/@uiw/react-codemirror/") || id.includes("/node_modules/@codemirror/")) {
-						return "codemirror";
-					}
 					if (
 						id.includes("/node_modules/@uiw/react-md-editor/") ||
 						id.includes("/node_modules/@uiw/react-markdown-preview/")

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, Tray, Menu, shell, dialog, nativeImage, ipcMain } from "electron";
+import { app, BrowserWindow, Tray, Menu, shell, dialog, nativeImage, ipcMain, screen } from "electron";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { join, dirname } from "node:path";
@@ -104,6 +104,51 @@ ipcMain.on("inno-close-dialog-copy", (_event, copy) => {
     },
     remember: copy.remember,
   };
+});
+
+const MAX_WINDOW_EXPANSION = 1200;
+
+function isWindowExpansionRequest(value) {
+  return value
+    && typeof value === "object"
+    && (value.side === "left" || value.side === "right")
+    && Number.isFinite(value.additionalWidth)
+    && value.additionalWidth >= 0;
+}
+
+ipcMain.handle("inno-expand-window-width", (event, request) => {
+  if (!isWindowExpansionRequest(request)
+    || !mainWindow
+    || mainWindow.isDestroyed()
+    || event.sender !== mainWindow.webContents) {
+    return false;
+  }
+
+  const additionalWidth = Math.min(Math.round(request.additionalWidth), MAX_WINDOW_EXPANSION);
+  if (additionalWidth === 0) return true;
+
+  const currentBounds = mainWindow.getBounds();
+  const display = screen.getDisplayMatching(currentBounds);
+  const workArea = display.workArea;
+  const nextWidth = currentBounds.width + additionalWidth;
+
+  // Never expand beyond the usable display area. In that case the renderer
+  // keeps the panel collapsed instead of squeezing the chat into the gap.
+  if (nextWidth > workArea.width) return false;
+
+  const requestedX = request.side === "left"
+    ? currentBounds.x - additionalWidth
+    : currentBounds.x;
+  const minX = workArea.x;
+  const maxX = workArea.x + workArea.width - nextWidth;
+  const nextX = Math.max(minX, Math.min(requestedX, maxX));
+
+  mainWindow.setBounds({
+    ...currentBounds,
+    x: nextX,
+    width: nextWidth,
+  }, true);
+  return true;
 });
 
 // ── Loading 窗口（服务启动期间显示） ────────────────────────────────────────

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -15,10 +15,20 @@ function isCloseDialogCopy(value) {
     && typeof buttons.cancel === "string";
 }
 
+function isWindowExpansionSide(value) {
+  return value === "left" || value === "right";
+}
+
 contextBridge.exposeInMainWorld("innoDesktop", {
   setCloseDialogCopy(copy) {
     if (isCloseDialogCopy(copy)) {
       ipcRenderer.send("inno-close-dialog-copy", copy);
     }
+  },
+  expandWindowWidth(side, additionalWidth) {
+    if (!isWindowExpansionSide(side) || !Number.isFinite(additionalWidth) || additionalWidth < 0) {
+      return Promise.resolve(false);
+    }
+    return ipcRenderer.invoke("inno-expand-window-width", { side, additionalWidth });
   },
 });


### PR DESCRIPTION
## 背景

本 PR 集中解决桌面端窗口尺寸、侧栏与工作区面板布局、文件预览以及聊天首页交互体验问题，避免面板打开后聊天区域被过度压缩，同时简化工作区选择和模式切换流程。

## 主要改动

### 1. 优化桌面窗口与面板布局

- 新增 Electron 窗口宽度扩展能力，支持从左侧或右侧扩展窗口。
- 扩展窗口前校验请求来源、扩展方向和宽度参数，并限制最大扩展宽度。
- 根据当前显示器可用工作区限制窗口最大尺寸，避免窗口超出屏幕。
- 打开侧栏或工作区面板前，先计算聊天区域、侧栏和预览区域所需的最小宽度。
- 窗口宽度变化后自动重新适配面板：
  - 优先保持聊天区域可用；
  - 必要时将工作区从半屏模式降级为四分之一模式；
  - 空间不足时优先隐藏左侧会话侧栏；
  - 连最小预览区域都无法容纳时保持工作区收起。
- 窗口宽度小于 960px 时自动进入聊天优先布局，同时收起两侧可选面板，避免聊天内容被挤成狭窄区域。
- 面板收起后不会随着窗口变宽自动恢复，重新打开由用户主动触发。

### 2. 改进文件预览和预设打开流程

- 文件选中时统一通过 App 层协调窗口扩展、预览宽度和工作区模式。
- 在切换到文件预览前先扩展原生窗口，避免预览面板出现时聊天区域短暂闪烁或被挤压。
- 预设创建新会话时，同时完成会话创建和预览面板打开。
- 预设预览默认使用 560px 宽度，并自动切换到右侧 Preview 面板。
- 从全屏预览模式切换预设时，先恢复到普通分栏布局，再打开侧栏和预览面板。
- 新增布局计算模块及对应测试，集中管理聊天区域、侧栏和工作区的尺寸约束。

### 3. 重做首页模式切换控件

- 将原有的小型模式切换按钮改为清晰的分段控件。
- 支持 Simple Mode 和 Normal Mode 两个明确选项。
- 增加图标、激活态、悬停态、禁用态和无障碍属性。
- 补充中英文模式名称、控件标签和提示文案。
- 优化首页输入框与预设搜索框的边框、焦点和间距表现。

### 4. 简化工作区选择器

- 工作区选择器只在新建聊天首页显示。
- 已进入真实会话后不再重复显示工作区选择器，减少输入区域干扰。
- 删除“新对话将在此工作区创建”等冗余提示、样式和国际化文案。
- 简化 WorkspaceContext 参数，移除不再需要的上下文判断和提示逻辑。

### 5. 清理冗余实现

- 预设路由统一复用 `listPresetLibrary`，避免重复合并内置预设和远程预设。
- 技能目录将远程数据和本地安装状态分离，统一在本地状态组装阶段补充 `installed` 信息。
- 删除未使用的请求参数、React 导入、二维码状态字段和组件参数。
- 移除聊天状态中已由活动流所有权机制取代的冗余 `AbortController` 和 detach 状态。
- 删除已不再使用的模式切换短文案。

### 6. 清理构建分包警告

- 为编辑器和办公预览等有意懒加载的重依赖设置合理的 2 MB chunk 提示阈值。
- 移除会产生循环依赖的 React 和 CodeMirror 手动分包规则。
- 保留现有懒加载和重依赖的独立 chunk，避免把大模块提前并入初始加载路径。
- 构建输出中的“大体积 chunk”和“循环分包”提示已消失。

## 用户可感知变化

- 打开侧栏、工作区或文件预览时，桌面窗口会根据需要自动扩展。
- 窗口缩放后，聊天区域会优先保持可用，工作区会自动缩小或收起。
- 点击预设后会同时创建会话并打开对应的预览面板。
- 首页的 Simple Mode / Normal Mode 切换更加清晰。
- 进入已有会话后，输入区域不再重复显示工作区选择器。

## 提交概览

- `9f48ba0` — 扩展窗口宽度以支持侧栏和工作区面板。
- `c3e1caa` — 改进面板适配、文件预览和布局测试。
- `58bdec4` — 优化模式切换控件和预设搜索输入框。
- `3dc72d5` — 仅在新聊天首页保留工作区选择器。
- `83244be` — 清理重复逻辑和未使用代码。
- `c108dfc` — 移除循环手动分包并整理 chunk 大小提示。

## 验证情况

- `npm test -- --run`：39 个测试文件通过，286 个测试全部通过。
- `npm run build`：后端 TypeScript 构建和前端 Vite 构建均通过。
- `git diff --check`：通过。
- 构建输出中的大体积 chunk 和循环分包提示已消失；当前仅保留 Vite 关于部分模块同时被动态和静态导入的非阻断提示。

## 截图

<img width="805" height="473" alt="Codex Image Aug 20, 2026, 09_22_59 PM" src="https://github.com/user-attachments/assets/7bd34f9d-c480-4b39-92d6-bdfee88c0bdb" />

<img width="480" height="211" alt="GIFSpeed-6-2" src="https://github.com/user-attachments/assets/1ab1970a-b008-4dcc-90a9-d767ddca2e03" />


