### PR TITLE
fix(web): stop resizing chat composer during IME composition

### DIFF
--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -389,11 +389,26 @@ export function ChatCenter({ onOpenPresetPanels }: ChatCenterProps) {
 		if (isWelcome) resizeInput();
 	}, [isWelcome, inlineImages, pasteBlocks, resizeInput]);
 
+	const isComposingRef = useRef(false);
+
 	const handleInput = useCallback(() => {
 		const el = inputRef.current;
 		if (!el) return;
 		draftRef.current = el.value;
 		setDraftValue(el.value);
+		// Safari drops in-progress IME composition (e.g. Chinese/Japanese input)
+		// when the textarea's height/overflow/selection is mutated mid-composition,
+		// which is what resizeInput does. Defer the resize until compositionend.
+		if (isComposingRef.current) return;
+		resizeInput();
+	}, [resizeInput]);
+
+	const handleCompositionStart = useCallback(() => {
+		isComposingRef.current = true;
+	}, []);
+
+	const handleCompositionEnd = useCallback(() => {
+		isComposingRef.current = false;
 		resizeInput();
 	}, [resizeInput]);
 
@@ -664,6 +679,8 @@ export function ChatCenter({ onOpenPresetPanels }: ChatCenterProps) {
 			hasSendableContent={hasSendableContent}
 			hasPendingQuestion={Boolean(chat.pendingQuestion)}
 			onInput={handleInput}
+			onCompositionStart={handleCompositionStart}
+			onCompositionEnd={handleCompositionEnd}
 			onKeyDown={handleKeyDown}
 			onPaste={handlePaste}
 			onFiles={handleFiles}

--- a/apps/inno-agent/web/src/react/chat/ChatComposer.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatComposer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type ChangeEvent, type ClipboardEvent, type KeyboardEvent as ReactKeyboardEvent, type RefObject } from "react";
+import { useEffect, useRef, type ChangeEvent, type ClipboardEvent, type CompositionEvent as ReactCompositionEvent, type KeyboardEvent as ReactKeyboardEvent, type RefObject } from "react";
 import { Paperclip, X, ArrowUp, Square, RotateCcw, Image, FileText, Check, ChevronDown, Settings2 } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "../ui/Spinner.js";
@@ -33,6 +33,8 @@ export interface ChatComposerProps {
 	hasSendableContent: boolean;
 	hasPendingQuestion: boolean;
 	onInput: () => void;
+	onCompositionStart: (event: ReactCompositionEvent<HTMLTextAreaElement>) => void;
+	onCompositionEnd: (event: ReactCompositionEvent<HTMLTextAreaElement>) => void;
 	onKeyDown: (event: ReactKeyboardEvent<HTMLTextAreaElement>) => void;
 	onPaste: (event: ClipboardEvent<HTMLTextAreaElement>) => void;
 	onFiles: (event: ChangeEvent<HTMLInputElement>) => void;
@@ -69,6 +71,8 @@ export function ChatComposer({
 	hasSendableContent,
 	hasPendingQuestion,
 	onInput,
+	onCompositionStart,
+	onCompositionEnd,
 	onKeyDown,
 	onPaste,
 	onFiles,
@@ -228,6 +232,8 @@ export function ChatComposer({
 				rows={2}
 				onKeyDown={onKeyDown}
 				onInput={onInput}
+				onCompositionStart={onCompositionStart}
+				onCompositionEnd={onCompositionEnd}
 				onPaste={onPaste}
 				disabled={chatIsSending || isUploading || hasPendingQuestion}
 			/>


### PR DESCRIPTION
## Summary
- Safari drops in-progress IME composition (typing Chinese/Japanese/Korean) when the chat composer's textarea has its height, overflow, or selection range mutated mid-composition — this is exactly what `resizeComposerTextarea` did on every `input` event, causing typed characters to visibly disappear while composing. Chrome tolerates this; Safari/WebKit does not.
- Track composition state via `onCompositionStart`/`onCompositionEnd` on the textarea (threaded through `ChatComposer` → `ChatCenter`) and skip the auto-resize while composing, running it once on `compositionend` instead. The Enter-to-send keydown handler already had an `isComposing` guard; the input-driven resize path was missing the equivalent guard.

## Test plan
- [x] `npm run build` — backend + frontend build clean, no new warnings
- [x] `npm test -- --run` — 39 files / 286 tests pass
- [x] User confirmed manually in Safari: typing Chinese via IME in the chat composer no longer drops characters (regression reproduced before the fix, resolved after)