### PR TITLE
fix(web): stop force-collapsing sidebar when it would not free enough space

### DIFF
--- a/apps/inno-agent/web/src/react/App.tsx
+++ b/apps/inno-agent/web/src/react/App.tsx
@@ -186,10 +186,8 @@ export function App() {
 
 		const rightResult = await ensureWindowForPanel("right", previewWidth, "half");
 		if (rightResult === "busy") return;
-		if (rightResult === "unavailable" && !appStore.sidebarCollapsed) {
-			// Preserve the chat when the display cannot fit both panels.
-			appStore.setSidebarCollapsed(true);
-		}
+		// Do not force the sidebar closed here: setWorkspaceMode below already
+		// collapses it if (and only if) that is what makes the panel fit.
 		appStore.setRightPanelTab("preview");
 		appStore.setWorkspaceWidth(previewWidth);
 		appStore.setWorkspaceMode("half");
@@ -204,11 +202,8 @@ export function App() {
 			: Math.max(minimumWidth, appStore.workspaceWidth);
 		const result = await ensureWindowForPanel("right", previewWidth, "half");
 		if (result === "busy") return;
-		if (result === "unavailable" && !appStore.sidebarCollapsed) {
-			appStore.setSidebarCollapsed(true);
-		}
-		// Expand the native window before changing panel width so the chat is not
-		// temporarily squeezed by the preview pane.
+		// Do not force the sidebar closed here: setWorkspaceWidth/setWorkspaceMode
+		// below already collapse it if (and only if) that is what makes the panel fit.
 		appStore.setWorkspaceWidth(previewWidth);
 		appStore.setWorkspaceMode("half");
 	}, [ensureWindowForPanel]);
@@ -231,9 +226,9 @@ export function App() {
 		void (async () => {
 			const result = await ensureWindowForPanel("right");
 			if (result === "busy") return;
-			if (result === "unavailable" && !appStore.sidebarCollapsed) {
-				appStore.setSidebarCollapsed(true);
-			}
+			// Do not force the sidebar closed here: setWorkspaceMode below already
+			// collapses it if (and only if) that is what makes the panel fit, and
+			// otherwise leaves the layout untouched instead of collapsing for nothing.
 			appStore.setWorkspaceMode(mode);
 		})();
 	}, [app.workspaceMode, ensureWindowForPanel]);

--- a/apps/inno-agent/web/src/stores/app-layout.test.ts
+++ b/apps/inno-agent/web/src/stores/app-layout.test.ts
@@ -29,4 +29,18 @@ describe("fitPanelLayout", () => {
 	it("returns no layout when even the smallest workspace would squeeze chat", () => {
 		expect(fitPanelLayout(1_000, true, "half", 560)).toBeNull();
 	});
+
+	it("returns null without collapsing the sidebar when collapsing would not help either", () => {
+		// At this width, even fully collapsing the sidebar leaves less room than
+		// the smallest workspace needs, so the caller must not collapse it for nothing.
+		expect(fitPanelLayout(1_000, false, "half", 560)).toBeNull();
+	});
+
+	it("collapses the sidebar on its own when that is what makes the panel fit", () => {
+		expect(fitPanelLayout(1_080, false, "half", 560)).toEqual({
+			sidebarCollapsed: true,
+			workspaceMode: "quarter",
+			workspaceWidth: 280,
+		});
+	});
 });


### PR DESCRIPTION
## Summary
- Follow-up to #198's panel-layout system. `openPresetPanels`, `openFilePreview`, and the `setWorkspaceMode` wrapper in `App.tsx` force-collapsed the sidebar whenever `ensureWindowForPanel` returned `"unavailable"` (no Electron window-growth bridge, or the OS refused to grow the window), regardless of whether collapsing actually freed enough space.
- In a plain browser (`npm run server`, no Electron) at viewport widths around 960–1040px, this left the sidebar force-collapsed while the requested panel still failed to open, since `fitPanelLayout` already returns `null` with no side effects when nothing fits at that width even with the sidebar closed.
- `appStore.setWorkspaceMode`/`setWorkspaceWidth` already collapse the sidebar atomically via `fitPanelLayout` exactly when doing so makes the layout fit, and are a no-op otherwise. The manual pre-collapse was redundant and the actual source of the bug. `openSidebar` already followed the correct pattern (no manual pre-collapse); the other three call sites now match it.

## Test plan
- [x] `npm run build` — backend + frontend build clean, no chunk-size/circular-dependency warnings
- [x] `npm test -- --run` — 39 files / 288 tests pass, including 2 new cases in `app-layout.test.ts` covering the dead-zone (width 1000: no forced collapse) and the case where auto-collapsing does help (width 1080: auto-downgrades to quarter mode)