### PR TITLE
feat(web):  Fix sidebar conversation title marquee behavior

### DIFF
--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -1210,6 +1210,38 @@ inno-workspace-panel textarea {
 	line-height: 1.25;
 }
 
+.inno-sidebar-title-fade {
+	-webkit-mask-image: linear-gradient(to right, #000 0%, #000 calc(100% - 16px), transparent 100%);
+	mask-image: linear-gradient(to right, #000 0%, #000 calc(100% - 16px), transparent 100%);
+}
+
+.inno-sidebar-title-marquee-tail {
+	display: inline-block;
+	width: 16px;
+}
+
+.inno-sidebar-title-marquee {
+	display: block;
+	width: max-content;
+	white-space: nowrap;
+	animation: inno-sidebar-title-marquee var(--inno-title-duration, 8s) linear 1 forwards;
+}
+
+@keyframes inno-sidebar-title-marquee {
+	0% {
+		transform: translateX(0);
+	}
+	100% {
+		transform: translateX(var(--inno-title-shift, 0px));
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.inno-sidebar-title-marquee {
+		animation: none;
+	}
+}
+
 .inno-sidebar-text {
 	font-size: 11px;
 	line-height: 1.35;

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -139,6 +139,116 @@ function channelFilterClass(channel: SessionChannel | null, active: boolean): st
 	return map[channel] ?? "inno-primary-button ring-1 ring-[var(--inno-accent)]";
 }
 
+function menuLabel(icon: ReactNode, label: string) {
+	return (
+		<span className="flex items-center gap-2">
+			{icon}
+			<span>{label}</span>
+		</span>
+	);
+}
+
+function useTitleMarquee(name: string, hovered: boolean) {
+	const titleViewportRef = useRef<HTMLDivElement>(null);
+	const titleMeasureRef = useRef<HTMLSpanElement>(null);
+	const [titleOverflowing, setTitleOverflowing] = useState(false);
+	const [titleShift, setTitleShift] = useState(0);
+
+	useEffect(() => {
+		const viewport = titleViewportRef.current;
+		const measure = titleMeasureRef.current;
+		if (!viewport || !measure) return;
+		const updateTitleOverflow = () => {
+			const shift = Math.max(0, measure.getBoundingClientRect().width - viewport.clientWidth);
+			setTitleOverflowing(shift > 2);
+			setTitleShift(Math.ceil(shift));
+		};
+		updateTitleOverflow();
+		if (typeof ResizeObserver === "undefined") return;
+		const observer = new ResizeObserver(updateTitleOverflow);
+		observer.observe(viewport);
+		observer.observe(measure);
+		return () => observer.disconnect();
+	}, [name]);
+
+	const marqueeActive = titleOverflowing && hovered;
+	const marqueeShift = titleShift + TITLE_MARQUEE_END_PADDING_PX;
+	return {
+		titleViewportRef,
+		titleMeasureRef,
+		titleOverflowing,
+		marqueeActive,
+		marqueeShift,
+		titleMarqueeDuration: Math.max(0.05, marqueeShift / TITLE_MARQUEE_SPEED_PX_PER_SECOND),
+	};
+}
+
+type TitleMarqueeState = ReturnType<typeof useTitleMarquee>;
+
+function SessionTitleRow({
+	session,
+	titleState,
+	editing,
+	editingName,
+	onEditChange,
+	onEditSave,
+	onEditCancel,
+}: {
+	session: SessionMeta;
+	titleState: TitleMarqueeState;
+	editing: boolean;
+	editingName: string;
+	onEditChange: (value: string) => void;
+	onEditSave: () => void;
+	onEditCancel: () => void;
+}) {
+	const {
+		titleViewportRef,
+		titleMeasureRef,
+		titleOverflowing,
+		marqueeActive,
+		marqueeShift,
+		titleMarqueeDuration,
+	} = titleState;
+
+	return (
+		<div className="flex min-w-0 items-start gap-1.5">
+			{editing ? (
+				<input
+					className="inno-sidebar-title min-w-0 flex-1 rounded border border-[var(--inno-accent)] bg-[var(--inno-surface)] px-1.5 py-0.5 outline-none focus-visible:shadow-[var(--inno-ring)]"
+					value={editingName}
+					autoFocus
+					onClick={(event) => event.stopPropagation()}
+					onChange={(event) => onEditChange(event.target.value)}
+					onBlur={onEditSave}
+					onKeyDown={(event) => {
+						event.stopPropagation();
+						if (event.key === "Enter") onEditSave();
+						if (event.key === "Escape") onEditCancel();
+					}}
+				/>
+			) : (
+				<div ref={titleViewportRef} className="relative min-w-0 flex-1 overflow-hidden" title={session.name}>
+					<span
+						className={`inno-sidebar-title ${marqueeActive ? "inno-sidebar-title-marquee" : "block overflow-hidden whitespace-nowrap"}${titleOverflowing ? " inno-sidebar-title-fade" : ""} font-medium text-[var(--inno-text)]`}
+						style={marqueeActive ? ({
+							"--inno-title-shift": `-${marqueeShift}px`,
+							"--inno-title-duration": `${titleMarqueeDuration}s`,
+						} as CSSProperties) : undefined}
+					>
+						{session.name}
+						{titleOverflowing ? <span aria-hidden="true" className="inno-sidebar-title-marquee-tail" /> : null}
+					</span>
+					<span ref={titleMeasureRef} aria-hidden="true" className="pointer-events-none invisible absolute left-0 top-0 -z-10 w-max whitespace-nowrap">
+						{session.name}
+					</span>
+				</div>
+			)}
+			<span className="inno-sidebar-meta shrink-0 pt-0.5 tabular-nums text-[var(--inno-text-subtle)]">{formatTime(session.updatedAt)}</span>
+		</div>
+	);
+}
+
 /* ── Workspace group definition ── */
 
 interface WsGroup {
@@ -361,36 +471,9 @@ function SessionCard({
 }) {
 	const { t } = useTranslation();
 	const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
-	const titleViewportRef = useRef<HTMLDivElement>(null);
-	const titleMeasureRef = useRef<HTMLSpanElement>(null);
-	const [titleOverflowing, setTitleOverflowing] = useState(false);
-	const [titleShift, setTitleShift] = useState(0);
 	const [hovered, setHovered] = useState(false);
 	const titleChannel = session.origin ?? session.channels[0] ?? "unknown";
-
-	useEffect(() => {
-		const viewport = titleViewportRef.current;
-		const measure = titleMeasureRef.current;
-		if (!viewport || !measure) return;
-		const updateTitleOverflow = () => {
-			const shift = Math.max(0, measure.getBoundingClientRect().width - viewport.clientWidth);
-			setTitleOverflowing(shift > 2);
-			setTitleShift(Math.ceil(shift));
-		};
-		updateTitleOverflow();
-		if (typeof ResizeObserver === "undefined") return;
-		const observer = new ResizeObserver(updateTitleOverflow);
-		observer.observe(viewport);
-		observer.observe(measure);
-		return () => observer.disconnect();
-	}, [session.name, active]);
-
-	const menuLabel = (icon: ReactNode, label: string) => (
-		<span className="flex items-center gap-2">
-			{icon}
-			<span>{label}</span>
-		</span>
-	);
+	const titleState = useTitleMarquee(session.name, hovered);
 	const menuItems: ContextMenuItem[] = [
 		{
 			label: menuLabel(
@@ -431,17 +514,13 @@ function SessionCard({
 			onSelect: onDelete,
 		},
 	];
-	const marqueeActive = titleOverflowing && hovered;
-	const marqueeShift = titleShift + TITLE_MARQUEE_END_PADDING_PX;
-	const titleMarqueeDuration = Math.max(0.05, marqueeShift / TITLE_MARQUEE_SPEED_PX_PER_SECOND);
 	return (
 		<div
-			className={`inno-sidebar-card group/card relative mb-1 w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
+			className={`group/card relative mb-1 w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
 				active
 					? "border-[var(--inno-border)] bg-[var(--inno-surface-muted)] shadow-sm"
 					: "border-transparent hover:border-[var(--inno-border)] hover:bg-[var(--inno-surface)]"
 			}`}
-			data-active={active ? "true" : "false"}
 			role="button"
 			tabIndex={0}
 			onMouseEnter={() => setHovered(true)}
@@ -458,45 +537,15 @@ function SessionCard({
 				setMenu({ x: e.clientX, y: e.clientY });
 			}}
 		>
-			{/* Top row: title + time */}
-			<div className="flex min-w-0 items-start gap-1.5">
-				{editing ? (
-					<input
-						className="inno-sidebar-title min-w-0 flex-1 rounded border border-[var(--inno-accent)] bg-[var(--inno-surface)] px-1.5 py-0.5 outline-none focus-visible:shadow-[var(--inno-ring)]"
-						value={editingName}
-						autoFocus
-						onClick={(e) => e.stopPropagation()}
-						onChange={(e) => onEditChange(e.target.value)}
-						onBlur={onEditSave}
-						onKeyDown={(e) => {
-							e.stopPropagation();
-							if (e.key === "Enter") onEditSave();
-							if (e.key === "Escape") onEditCancel();
-						}}
-					/>
-				) : (
-					<div
-						ref={titleViewportRef}
-						className="relative min-w-0 flex-1 overflow-hidden"
-						title={session.name}
-					>
-						<span
-							className={`inno-sidebar-title ${marqueeActive ? "inno-sidebar-title-marquee" : "block overflow-hidden whitespace-nowrap"}${titleOverflowing ? " inno-sidebar-title-fade" : ""} font-medium text-[var(--inno-text)]`}
-							style={marqueeActive ? ({
-								"--inno-title-shift": `-${marqueeShift}px`,
-								"--inno-title-duration": `${titleMarqueeDuration}s`,
-							} as CSSProperties) : undefined}
-						>
-							{session.name}
-							{titleOverflowing ? <span aria-hidden="true" className="inno-sidebar-title-marquee-tail" /> : null}
-						</span>
-						<span ref={titleMeasureRef} aria-hidden="true" className="pointer-events-none invisible absolute left-0 top-0 -z-10 w-max whitespace-nowrap">
-							{session.name}
-						</span>
-					</div>
-				)}
-				<span className="inno-sidebar-meta shrink-0 pt-0.5 tabular-nums text-[var(--inno-text-subtle)]">{formatTime(session.updatedAt)}</span>
-			</div>
+			<SessionTitleRow
+				session={session}
+				titleState={titleState}
+				editing={editing}
+				editingName={editingName}
+				onEditChange={onEditChange}
+				onEditSave={onEditSave}
+				onEditCancel={onEditCancel}
+			/>
 
 			{/* Subtitle row: preview + channel/actions */}
 			<div className="mt-1 flex min-w-0 items-center justify-between gap-1">
@@ -576,35 +625,8 @@ function SimpleSessionRow({
 }: SimpleSessionRowProps) {
 	const { t } = useTranslation();
 	const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
-	const titleViewportRef = useRef<HTMLDivElement>(null);
-	const titleMeasureRef = useRef<HTMLSpanElement>(null);
-	const [titleOverflowing, setTitleOverflowing] = useState(false);
-	const [titleShift, setTitleShift] = useState(0);
 	const [hovered, setHovered] = useState(false);
-
-	useEffect(() => {
-		const viewport = titleViewportRef.current;
-		const measure = titleMeasureRef.current;
-		if (!viewport || !measure) return;
-		const updateTitleOverflow = () => {
-			const shift = Math.max(0, measure.getBoundingClientRect().width - viewport.clientWidth);
-			setTitleOverflowing(shift > 2);
-			setTitleShift(Math.ceil(shift));
-		};
-		updateTitleOverflow();
-		if (typeof ResizeObserver === "undefined") return;
-		const observer = new ResizeObserver(updateTitleOverflow);
-		observer.observe(viewport);
-		observer.observe(measure);
-		return () => observer.disconnect();
-	}, [session.name, active]);
-
-	const menuLabel = (icon: ReactNode, label: string) => (
-		<span className="flex items-center gap-2">
-			{icon}
-			<span>{label}</span>
-		</span>
-	);
+	const titleState = useTitleMarquee(session.name, hovered);
 	const menuItems: ContextMenuItem[] = [
 		{
 			label: menuLabel(
@@ -631,18 +653,13 @@ function SimpleSessionRow({
 			onSelect: onDelete,
 		},
 	];
-	const marqueeActive = titleOverflowing && hovered;
-	const marqueeShift = titleShift + TITLE_MARQUEE_END_PADDING_PX;
-	const titleMarqueeDuration = Math.max(0.05, marqueeShift / TITLE_MARQUEE_SPEED_PX_PER_SECOND);
-
 	return (
 		<div
-			className={`inno-sidebar-card group/srow relative mb-1 block w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
+			className={`group/srow relative mb-1 block w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
 				active
 					? "border-[var(--inno-border)] bg-[var(--inno-surface-muted)] shadow-sm"
 					: "border-transparent hover:border-[var(--inno-border)] hover:bg-[var(--inno-surface)]"
 			}`}
-			data-active={active ? "true" : "false"}
 			role="button"
 			tabIndex={0}
 			onMouseEnter={() => setHovered(true)}
@@ -659,41 +676,15 @@ function SimpleSessionRow({
 				setMenu({ x: event.clientX, y: event.clientY });
 			}}
 		>
-			{/* Title row: title left, time pinned to the far right. */}
-			<div className="flex min-w-0 items-start gap-1.5">
-				{editing ? (
-					<input
-						className="inno-sidebar-title min-w-0 flex-1 rounded border border-[var(--inno-accent)] bg-[var(--inno-surface)] px-1.5 py-0.5 outline-none focus-visible:shadow-[var(--inno-ring)]"
-						value={editingName}
-						autoFocus
-						onClick={(event) => event.stopPropagation()}
-						onChange={(event) => onEditChange(event.target.value)}
-						onBlur={onEditSave}
-						onKeyDown={(event) => {
-							event.stopPropagation();
-							if (event.key === "Enter") onEditSave();
-							if (event.key === "Escape") onEditCancel();
-						}}
-					/>
-				) : (
-					<div ref={titleViewportRef} className="relative min-w-0 flex-1 overflow-hidden" title={session.name}>
-						<span
-							className={`inno-sidebar-title ${marqueeActive ? "inno-sidebar-title-marquee" : "block overflow-hidden whitespace-nowrap"}${titleOverflowing ? " inno-sidebar-title-fade" : ""} font-medium text-[var(--inno-text)]`}
-							style={marqueeActive ? ({
-								"--inno-title-shift": `-${marqueeShift}px`,
-								"--inno-title-duration": `${titleMarqueeDuration}s`,
-							} as CSSProperties) : undefined}
-						>
-							{session.name}
-							{titleOverflowing ? <span aria-hidden="true" className="inno-sidebar-title-marquee-tail" /> : null}
-						</span>
-						<span ref={titleMeasureRef} aria-hidden="true" className="pointer-events-none invisible absolute left-0 top-0 -z-10 w-max whitespace-nowrap">
-							{session.name}
-						</span>
-					</div>
-				)}
-				<span className="inno-sidebar-meta shrink-0 pt-0.5 tabular-nums text-[var(--inno-text-subtle)]">{formatTime(session.updatedAt)}</span>
-			</div>
+			<SessionTitleRow
+				session={session}
+				titleState={titleState}
+				editing={editing}
+				editingName={editingName}
+				onEditChange={onEditChange}
+				onEditSave={onEditSave}
+				onEditCancel={onEditCancel}
+			/>
 
 			{/* Subtitle row: preview left, workspace right; hover replaces workspace with delete. */}
 			<div className="mt-1 flex min-w-0 items-center justify-between gap-1">

--- a/apps/inno-agent/web/src/react/SessionSidebar.tsx
+++ b/apps/inno-agent/web/src/react/SessionSidebar.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "motion/react";
 import {
@@ -11,6 +12,8 @@ import {
 	Trash2,
 	Archive,
 	ArchiveRestore,
+	Pin,
+	PinOff,
 	Download,
 	Clapperboard,
 	ChevronRight,
@@ -24,6 +27,7 @@ import {
 	ChevronDown,
 } from "lucide-react";
 import { appStore } from "../stores/app-store.js";
+import { canOpenWorkspaceBesideSidebar } from "../stores/app-layout.js";
 import { chatStore } from "../stores/chat-store.js";
 import { sessionsStore } from "../stores/sessions-store.js";
 import { workspacesStore } from "../stores/workspaces-store.js";
@@ -35,6 +39,7 @@ import { exportSessionShowcase } from "../api/sessions.js";
 import type { SessionChannel, SessionMeta } from "../api/sessions.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { Spinner } from "./ui/Spinner.js";
+import { ContextMenu, type ContextMenuItem } from "./ui/ContextMenu.js";
 
 interface SessionSidebarProps {
 	collapsed: boolean;
@@ -44,6 +49,9 @@ interface SessionSidebarProps {
 const CHANNEL_FILTER_ORDER = ["web", "feishu", "wechat", "cli", "scheduler"] as const;
 const WORKSPACE_SORT_STORAGE_KEY = "inno.sidebarWorkspaceSort";
 const WORKSPACE_CUSTOM_ORDER_STORAGE_KEY = "inno.sidebarWorkspaceCustomOrder";
+const PINNED_SESSIONS_STORAGE_KEY = "inno.sidebarPinnedSessions";
+const TITLE_MARQUEE_SPEED_PX_PER_SECOND = 28;
+const TITLE_MARQUEE_END_PADDING_PX = 2;
 
 type WorkspaceSort = "recent" | "oldest" | "nameAsc" | "nameDesc" | "custom";
 
@@ -62,6 +70,16 @@ function readWorkspaceCustomOrder(): string[] {
 		return Array.isArray(saved) ? saved.filter((id): id is string => typeof id === "string") : [];
 	} catch {
 		return [];
+	}
+}
+
+function readPinnedSessionIds(): Set<string> {
+	if (typeof window === "undefined") return new Set();
+	try {
+		const saved = JSON.parse(window.localStorage.getItem(PINNED_SESSIONS_STORAGE_KEY) ?? "[]");
+		return new Set(Array.isArray(saved) ? saved.filter((id): id is string => typeof id === "string") : []);
+	} catch {
+		return new Set();
 	}
 }
 
@@ -105,38 +123,6 @@ function channelClass(channel: SessionChannel): string {
 		unknown: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-subtle)]",
 	};
 	return classes[channel] ?? classes.unknown;
-}
-
-/**
- * Outline (interaction) badge: the session merely interacted with this channel
- * (e.g. a web session that pushed a file to feishu). Distinct from the solid
- * origin badge (channelClass), which marks where the session was born.
- */
-function channelInteractionClass(channel: SessionChannel): string {
-	const classes: Record<string, string> = {
-		cli: "bg-transparent text-[var(--inno-accent)]",
-		web: "bg-transparent text-[var(--inno-text-muted)] ring-1 ring-[var(--inno-border-strong)]",
-		feishu: "bg-transparent text-[var(--inno-success)]",
-		scheduler: "bg-transparent text-[var(--inno-warning)] ring-1 ring-[var(--inno-warning-border)]",
-		qq: "bg-transparent text-cyan-500 ring-1 ring-cyan-300/70",
-		wechat: "bg-transparent text-lime-500 ring-1 ring-lime-300/70",
-		unknown: "bg-transparent text-[var(--inno-text-subtle)]",
-	};
-	return classes[channel] ?? classes.unknown;
-}
-
-/**
- * Order a session's channel badges: the origin channel first (solid), then the
- * remaining interaction channels (outline). De-duplicates and keeps a stable
- * display order.
- */
-function orderedSessionChannels(session: SessionMeta): Array<{ channel: SessionChannel; isOrigin: boolean }> {
-	const origin = session.origin;
-	const rest = session.channels.filter((c) => c !== origin);
-	const ordered: Array<{ channel: SessionChannel; isOrigin: boolean }> = [];
-	if (origin) ordered.push({ channel: origin, isOrigin: true });
-	for (const c of rest) ordered.push({ channel: c, isOrigin: false });
-	return ordered;
 }
 
 function channelFilterClass(channel: SessionChannel | null, active: boolean): string {
@@ -338,6 +324,7 @@ function SessionCard({
 	session,
 	active,
 	opening,
+	pinned,
 	editing,
 	editingName,
 	generatingId,
@@ -348,6 +335,7 @@ function SessionCard({
 	onEditCancel,
 	onGenerate,
 	onArchive,
+	onTogglePin,
 	onDelete,
 	onExport,
 	onExportShowcase,
@@ -355,6 +343,7 @@ function SessionCard({
 	session: SessionMeta;
 	active: boolean;
 	opening: boolean;
+	pinned: boolean;
 	editing: boolean;
 	editingName: string;
 	generatingId: string | null;
@@ -365,20 +354,98 @@ function SessionCard({
 	onEditCancel: () => void;
 	onGenerate: () => void;
 	onArchive: () => void;
+	onTogglePin: () => void;
 	onDelete: () => void;
 	onExport: () => void;
 	onExportShowcase: () => void;
 }) {
 	const { t } = useTranslation();
+	const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+	const titleViewportRef = useRef<HTMLDivElement>(null);
+	const titleMeasureRef = useRef<HTMLSpanElement>(null);
+	const [titleOverflowing, setTitleOverflowing] = useState(false);
+	const [titleShift, setTitleShift] = useState(0);
+	const [hovered, setHovered] = useState(false);
+	const titleChannel = session.origin ?? session.channels[0] ?? "unknown";
+
+	useEffect(() => {
+		const viewport = titleViewportRef.current;
+		const measure = titleMeasureRef.current;
+		if (!viewport || !measure) return;
+		const updateTitleOverflow = () => {
+			const shift = Math.max(0, measure.getBoundingClientRect().width - viewport.clientWidth);
+			setTitleOverflowing(shift > 2);
+			setTitleShift(Math.ceil(shift));
+		};
+		updateTitleOverflow();
+		if (typeof ResizeObserver === "undefined") return;
+		const observer = new ResizeObserver(updateTitleOverflow);
+		observer.observe(viewport);
+		observer.observe(measure);
+		return () => observer.disconnect();
+	}, [session.name, active]);
+
+	const menuLabel = (icon: ReactNode, label: string) => (
+		<span className="flex items-center gap-2">
+			{icon}
+			<span>{label}</span>
+		</span>
+	);
+	const menuItems: ContextMenuItem[] = [
+		{
+			label: menuLabel(
+				generatingId === session.id ? <Spinner size={14} /> : <Sparkles size={14} aria-hidden="true" />,
+				t("sidebar.generateTopic"),
+			),
+			onSelect: onGenerate,
+		},
+		{
+			label: menuLabel(<Pencil size={14} aria-hidden="true" />, t("sidebar.rename")),
+			onSelect: onStartEdit,
+		},
+		{
+			label: menuLabel(<Download size={14} aria-hidden="true" />, t("sessions.export", "导出为 Markdown")),
+			onSelect: onExport,
+		},
+		{
+			label: menuLabel(<Clapperboard size={14} aria-hidden="true" />, t("sessions.exportShowcase", "导出为回放案例")),
+			onSelect: onExportShowcase,
+		},
+		{
+			label: menuLabel(
+				session.archived ? <ArchiveRestore size={14} aria-hidden="true" /> : <Archive size={14} aria-hidden="true" />,
+				session.archived ? t("sidebar.unarchive") : t("sidebar.archive"),
+			),
+			onSelect: onArchive,
+		},
+		{
+			label: menuLabel(
+				pinned ? <PinOff size={14} aria-hidden="true" /> : <Pin size={14} aria-hidden="true" />,
+				pinned ? t("sidebar.unpin") : t("sidebar.pin"),
+			),
+			onSelect: onTogglePin,
+		},
+		{
+			label: menuLabel(<Trash2 size={14} aria-hidden="true" />, t("common.delete")),
+			danger: true,
+			onSelect: onDelete,
+		},
+	];
+	const marqueeActive = titleOverflowing && hovered;
+	const marqueeShift = titleShift + TITLE_MARQUEE_END_PADDING_PX;
+	const titleMarqueeDuration = Math.max(0.05, marqueeShift / TITLE_MARQUEE_SPEED_PX_PER_SECOND);
 	return (
 		<div
-			className={`group/card relative mb-1 w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
+			className={`inno-sidebar-card group/card relative mb-1 w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
 				active
 					? "border-[var(--inno-border)] bg-[var(--inno-surface-muted)] shadow-sm"
 					: "border-transparent hover:border-[var(--inno-border)] hover:bg-[var(--inno-surface)]"
 			}`}
+			data-active={active ? "true" : "false"}
 			role="button"
 			tabIndex={0}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
 			onClick={onOpen}
 			onKeyDown={(e) => {
 				if (e.key === "Enter" || e.key === " ") {
@@ -386,9 +453,13 @@ function SessionCard({
 					onOpen();
 				}
 			}}
+			onContextMenu={(e) => {
+				e.preventDefault();
+				setMenu({ x: e.clientX, y: e.clientY });
+			}}
 		>
-			{/* Top row: name + time */}
-			<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
+			{/* Top row: title + time */}
+			<div className="flex min-w-0 items-start gap-1.5">
 				{editing ? (
 					<input
 						className="inno-sidebar-title min-w-0 flex-1 rounded border border-[var(--inno-accent)] bg-[var(--inno-surface)] px-1.5 py-0.5 outline-none focus-visible:shadow-[var(--inno-ring)]"
@@ -404,85 +475,254 @@ function SessionCard({
 						}}
 					/>
 				) : (
-					<div className="inno-sidebar-title min-w-0 truncate font-medium text-[var(--inno-text)] transition-colors group-hover/card:text-[var(--inno-text)]">
-						{session.name}
+					<div
+						ref={titleViewportRef}
+						className="relative min-w-0 flex-1 overflow-hidden"
+						title={session.name}
+					>
+						<span
+							className={`inno-sidebar-title ${marqueeActive ? "inno-sidebar-title-marquee" : "block overflow-hidden whitespace-nowrap"}${titleOverflowing ? " inno-sidebar-title-fade" : ""} font-medium text-[var(--inno-text)]`}
+							style={marqueeActive ? ({
+								"--inno-title-shift": `-${marqueeShift}px`,
+								"--inno-title-duration": `${titleMarqueeDuration}s`,
+							} as CSSProperties) : undefined}
+						>
+							{session.name}
+							{titleOverflowing ? <span aria-hidden="true" className="inno-sidebar-title-marquee-tail" /> : null}
+						</span>
+						<span ref={titleMeasureRef} aria-hidden="true" className="pointer-events-none invisible absolute left-0 top-0 -z-10 w-max whitespace-nowrap">
+							{session.name}
+						</span>
 					</div>
 				)}
 				<span className="inno-sidebar-meta shrink-0 pt-0.5 tabular-nums text-[var(--inno-text-subtle)]">{formatTime(session.updatedAt)}</span>
 			</div>
 
-			{/* Preview */}
-			{session.preview && session.preview !== session.name ? (
-				<div className="inno-sidebar-meta mt-0.5 truncate text-[var(--inno-text-subtle)]">{session.preview}</div>
-			) : null}
-
-			{/* Bottom row: channels + actions */}
-			<div className="mt-1.5 flex items-center justify-between gap-1">
-				<div className="flex flex-wrap items-center gap-1">
-					{orderedSessionChannels(session).map(({ channel, isOrigin }) => (
-						<span
-							key={channel}
-							title={isOrigin ? t("sidebar.originChannel", { channel: channelLabel(channel) }) : t("sidebar.interactedChannel", { channel: channelLabel(channel) })}
-							className={`rounded px-1.5 py-px text-[9px] font-medium leading-none ${isOrigin ? channelClass(channel) : channelInteractionClass(channel)}`}
-						>
-							{channelLabel(channel)}
-						</span>
-					))}
+			{/* Subtitle row: preview + channel/actions */}
+			<div className="mt-1 flex min-w-0 items-center justify-between gap-1">
+				<div className="inno-sidebar-meta min-w-0 flex-1 truncate text-[var(--inno-text-subtle)]">
+					{session.preview && session.preview !== session.name ? session.preview : null}
 				</div>
-				<div className="flex items-center gap-0.5 opacity-0 group-hover/card:opacity-100 transition-opacity duration-150">
-					{opening ? (
-						<Spinner size={12} className="text-[var(--inno-border-strong)]" />
+				<div className="relative flex h-4 min-w-[2.25rem] shrink-0 items-center justify-end">
+					<span
+						title={t("sidebar.originChannel", { channel: channelLabel(titleChannel) })}
+						className={`rounded px-1.5 py-px text-[9px] font-medium leading-none transition-opacity duration-150 group-hover/card:opacity-0 ${channelClass(titleChannel)}`}
+					>
+						{channelLabel(titleChannel)}
+					</span>
+					<div className="pointer-events-none absolute right-0 flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-hover/card:pointer-events-auto group-hover/card:opacity-100">
+						{opening ? (
+							<Spinner size={12} className="text-[var(--inno-border-strong)]" />
+						) : null}
+						<button
+							className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
+							title={session.archived ? t("sidebar.unarchive") : t("sidebar.archive")}
+							onClick={(e) => { e.stopPropagation(); onArchive(); }}
+						>
+							{session.archived ? <ArchiveRestore size={12} /> : <Archive size={12} />}
+						</button>
+						<button
+							className={`rounded p-0.5 ${pinned ? "text-[var(--inno-accent)] hover:bg-[var(--inno-accent-soft)]" : "text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"}`}
+							title={pinned ? t("sidebar.unpin") : t("sidebar.pin")}
+							onClick={(e) => { e.stopPropagation(); onTogglePin(); }}
+						>
+							{pinned ? <PinOff size={12} /> : <Pin size={12} />}
+						</button>
+					</div>
+				</div>
+			</div>
+			{menu ? createPortal(
+				<ContextMenu x={menu.x} y={menu.y} items={menuItems} onClose={() => setMenu(null)} />,
+				document.body,
+			) : null}
+		</div>
+	);
+}
+
+interface SimpleSessionRowProps {
+	session: SessionMeta;
+	workspace?: WorkspaceMeta;
+	active: boolean;
+	editing: boolean;
+	editingName: string;
+	generating: boolean;
+	onOpen: () => void;
+	onStartEdit: () => void;
+	onEditChange: (value: string) => void;
+	onEditSave: () => void;
+	onEditCancel: () => void;
+	onGenerate: () => void;
+	onDelete: () => void;
+	onExport: () => void;
+	onExportShowcase: () => void;
+}
+
+function SimpleSessionRow({
+	session,
+	workspace,
+	active,
+	editing,
+	editingName,
+	generating,
+	onOpen,
+	onStartEdit,
+	onEditChange,
+	onEditSave,
+	onEditCancel,
+	onGenerate,
+	onDelete,
+	onExport,
+	onExportShowcase,
+}: SimpleSessionRowProps) {
+	const { t } = useTranslation();
+	const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
+	const titleViewportRef = useRef<HTMLDivElement>(null);
+	const titleMeasureRef = useRef<HTMLSpanElement>(null);
+	const [titleOverflowing, setTitleOverflowing] = useState(false);
+	const [titleShift, setTitleShift] = useState(0);
+	const [hovered, setHovered] = useState(false);
+
+	useEffect(() => {
+		const viewport = titleViewportRef.current;
+		const measure = titleMeasureRef.current;
+		if (!viewport || !measure) return;
+		const updateTitleOverflow = () => {
+			const shift = Math.max(0, measure.getBoundingClientRect().width - viewport.clientWidth);
+			setTitleOverflowing(shift > 2);
+			setTitleShift(Math.ceil(shift));
+		};
+		updateTitleOverflow();
+		if (typeof ResizeObserver === "undefined") return;
+		const observer = new ResizeObserver(updateTitleOverflow);
+		observer.observe(viewport);
+		observer.observe(measure);
+		return () => observer.disconnect();
+	}, [session.name, active]);
+
+	const menuLabel = (icon: ReactNode, label: string) => (
+		<span className="flex items-center gap-2">
+			{icon}
+			<span>{label}</span>
+		</span>
+	);
+	const menuItems: ContextMenuItem[] = [
+		{
+			label: menuLabel(
+				generating ? <Spinner size={14} /> : <Sparkles size={14} aria-hidden="true" />,
+				t("sidebar.generateTopic"),
+			),
+			onSelect: onGenerate,
+		},
+		{
+			label: menuLabel(<Pencil size={14} aria-hidden="true" />, t("sidebar.rename")),
+			onSelect: onStartEdit,
+		},
+		{
+			label: menuLabel(<Download size={14} aria-hidden="true" />, t("sessions.export", "导出为 Markdown")),
+			onSelect: onExport,
+		},
+		{
+			label: menuLabel(<Clapperboard size={14} aria-hidden="true" />, t("sessions.exportShowcase", "导出为回放案例")),
+			onSelect: onExportShowcase,
+		},
+		{
+			label: menuLabel(<Trash2 size={14} aria-hidden="true" />, t("common.delete")),
+			danger: true,
+			onSelect: onDelete,
+		},
+	];
+	const marqueeActive = titleOverflowing && hovered;
+	const marqueeShift = titleShift + TITLE_MARQUEE_END_PADDING_PX;
+	const titleMarqueeDuration = Math.max(0.05, marqueeShift / TITLE_MARQUEE_SPEED_PX_PER_SECOND);
+
+	return (
+		<div
+			className={`inno-sidebar-card group/srow relative mb-1 block w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
+				active
+					? "border-[var(--inno-border)] bg-[var(--inno-surface-muted)] shadow-sm"
+					: "border-transparent hover:border-[var(--inno-border)] hover:bg-[var(--inno-surface)]"
+			}`}
+			data-active={active ? "true" : "false"}
+			role="button"
+			tabIndex={0}
+			onMouseEnter={() => setHovered(true)}
+			onMouseLeave={() => setHovered(false)}
+			onClick={onOpen}
+			onKeyDown={(event) => {
+				if (event.key === "Enter" || event.key === " ") {
+					event.preventDefault();
+					onOpen();
+				}
+			}}
+			onContextMenu={(event) => {
+				event.preventDefault();
+				setMenu({ x: event.clientX, y: event.clientY });
+			}}
+		>
+			{/* Title row: title left, time pinned to the far right. */}
+			<div className="flex min-w-0 items-start gap-1.5">
+				{editing ? (
+					<input
+						className="inno-sidebar-title min-w-0 flex-1 rounded border border-[var(--inno-accent)] bg-[var(--inno-surface)] px-1.5 py-0.5 outline-none focus-visible:shadow-[var(--inno-ring)]"
+						value={editingName}
+						autoFocus
+						onClick={(event) => event.stopPropagation()}
+						onChange={(event) => onEditChange(event.target.value)}
+						onBlur={onEditSave}
+						onKeyDown={(event) => {
+							event.stopPropagation();
+							if (event.key === "Enter") onEditSave();
+							if (event.key === "Escape") onEditCancel();
+						}}
+					/>
+				) : (
+					<div ref={titleViewportRef} className="relative min-w-0 flex-1 overflow-hidden" title={session.name}>
+						<span
+							className={`inno-sidebar-title ${marqueeActive ? "inno-sidebar-title-marquee" : "block overflow-hidden whitespace-nowrap"}${titleOverflowing ? " inno-sidebar-title-fade" : ""} font-medium text-[var(--inno-text)]`}
+							style={marqueeActive ? ({
+								"--inno-title-shift": `-${marqueeShift}px`,
+								"--inno-title-duration": `${titleMarqueeDuration}s`,
+							} as CSSProperties) : undefined}
+						>
+							{session.name}
+							{titleOverflowing ? <span aria-hidden="true" className="inno-sidebar-title-marquee-tail" /> : null}
+						</span>
+						<span ref={titleMeasureRef} aria-hidden="true" className="pointer-events-none invisible absolute left-0 top-0 -z-10 w-max whitespace-nowrap">
+							{session.name}
+						</span>
+					</div>
+				)}
+				<span className="inno-sidebar-meta shrink-0 pt-0.5 tabular-nums text-[var(--inno-text-subtle)]">{formatTime(session.updatedAt)}</span>
+			</div>
+
+			{/* Subtitle row: preview left, workspace right; hover replaces workspace with delete. */}
+			<div className="mt-1 flex min-w-0 items-center justify-between gap-1">
+				<div className="inno-sidebar-meta min-w-0 flex-1 truncate text-[var(--inno-text-subtle)]">
+					{session.preview && session.preview !== session.name ? session.preview : null}
+				</div>
+				<div className="relative flex min-w-[2.25rem] max-w-[140px] shrink-0 items-center justify-end">
+					{workspace ? (
+						<span
+							className="inline-flex max-w-[140px] min-w-0 items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-1.5 py-px text-[9px] font-medium leading-none text-[var(--inno-text-muted)] transition-opacity duration-150 group-hover/srow:opacity-0"
+							title={t("sidebar.workspaceLabel", { name: workspace.name })}
+						>
+							<FolderKanban size={12} className="shrink-0" />
+							<span className="truncate">{workspace.name}</span>
+						</span>
 					) : null}
 					<button
-						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] disabled:opacity-40"
-						title={t("sidebar.generateTopic")}
-						disabled={generatingId === session.id}
-						onClick={(e) => { e.stopPropagation(); onGenerate(); }}
-					>
-						{generatingId === session.id ? (
-							<Spinner size={12} />
-						) : (
-							<Sparkles size={12} />
-						)}
-					</button>
-					<button
-						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
-						title={t("sidebar.rename")}
-						onClick={(e) => { e.stopPropagation(); onStartEdit(); }}
-					>
-						<Pencil size={12} />
-					</button>
-					<button
-						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
-						title={t("sessions.export", "导出为 Markdown")}
-						onClick={(e) => { e.stopPropagation(); onExport(); }}
-					>
-						<Download size={12} />
-					</button>
-					<button
-						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
-						title={t("sessions.exportShowcase", "导出为回放案例")}
-						onClick={(e) => { e.stopPropagation(); onExportShowcase(); }}
-					>
-						<Clapperboard size={12} />
-					</button>
-					<button
-						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)]"
-						title={session.archived ? t("sidebar.unarchive") : t("sidebar.archive")}
-						onClick={(e) => { e.stopPropagation(); onArchive(); }}
-					>
-						{session.archived ? <ArchiveRestore size={12} /> : <Archive size={12} />}
-					</button>
-					<button
-						className="rounded p-0.5 text-[var(--inno-text-subtle)] hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)]"
-						title={t("common.delete")}
-						onClick={(e) => { e.stopPropagation(); onDelete(); }}
+						className="absolute right-0 rounded p-0.5 text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)] group-hover/srow:opacity-100"
+						title={t("sidebar.deleteConversation")}
+						onClick={(event) => { event.stopPropagation(); onDelete(); }}
 					>
 						<Trash2 size={12} />
 					</button>
-					<span className="inno-sidebar-meta ml-0.5 tabular-nums text-[var(--inno-text-subtle)]">{session.messageCount}</span>
 				</div>
 			</div>
+			{menu ? createPortal(
+				<ContextMenu x={menu.x} y={menu.y} items={menuItems} onClose={() => setMenu(null)} />,
+				document.body,
+			) : null}
 		</div>
 	);
 }
@@ -505,6 +745,7 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 	const [isCustomSorting, setIsCustomSorting] = useState(false);
 	const [customOrderDraft, setCustomOrderDraft] = useState<string[]>([]);
 	const [draggingWorkspaceId, setDraggingWorkspaceId] = useState<string | null>(null);
+	const [pinnedSessionIds, setPinnedSessionIds] = useState<Set<string>>(readPinnedSessionIds);
 
 	const state = useStoreSnapshot(sessionsStore, () => ({
 		sessions: sessionsStore.sessions,
@@ -549,6 +790,9 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 	// their bound workspace (in workspace recency order); archived sessions go to
 	// a single trailing group.
 	const groups = useMemo<WsGroup[]>(() => {
+		const sortSessions = (sessions: SessionMeta[]) => sessions.slice().sort((a, b) => (
+			Number(pinnedSessionIds.has(b.id)) - Number(pinnedSessionIds.has(a.id))
+		));
 		const sessionToWs = new Map<string, WorkspaceMeta>();
 		for (const w of wsState.list) {
 			for (const sid of w.sessionIds ?? []) sessionToWs.set(sid, w);
@@ -596,7 +840,7 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 				manageable: !w.isTemp && !isChannel,
 				sortable: !isChannel,
 				canCreate: true,
-				sessions,
+				sessions: sortSessions(sessions),
 			};
 			if (isChannel) {
 				channelGroups.set(w.id, g);
@@ -633,13 +877,13 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 			if (g) result.push(g);
 		}
 		if (unknown.length > 0) {
-			result.push({ id: "__unknown__", name: t("sidebar.ungrouped"), activityAt: 0, manageable: false, sortable: false, canCreate: false, sessions: unknown });
+			result.push({ id: "__unknown__", name: t("sidebar.ungrouped"), activityAt: 0, manageable: false, sortable: false, canCreate: false, sessions: sortSessions(unknown) });
 		}
 		if (archived.length > 0) {
-			result.push({ id: "archived", name: t("sidebar.archived"), activityAt: 0, manageable: false, sortable: false, canCreate: false, sessions: archived });
+			result.push({ id: "archived", name: t("sidebar.archived"), activityAt: 0, manageable: false, sortable: false, canCreate: false, sessions: sortSessions(archived) });
 		}
 		return result;
-	}, [wsState.list, state.filteredSessions, state.searchQuery, state.channelFilter, simpleMode, t, workspaceSort, customOrder, isCustomSorting, customOrderDraft]);
+	}, [wsState.list, state.filteredSessions, state.searchQuery, state.channelFilter, simpleMode, t, workspaceSort, customOrder, isCustomSorting, customOrderDraft, pinnedSessionIds]);
 
 	const sortableGroupIds = useMemo(() => groups.filter((group) => group.sortable).map((group) => group.id), [groups]);
 
@@ -710,8 +954,11 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 		return state.filteredSessions
 			.filter((s) => !s.archived && (!s.origin || s.origin === "web"))
 			.slice()
-			.sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
-	}, [simpleMode, state.filteredSessions]);
+			.sort((a, b) => {
+				const pinnedDiff = Number(pinnedSessionIds.has(b.id)) - Number(pinnedSessionIds.has(a.id));
+				return pinnedDiff || Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+			});
+	}, [simpleMode, state.filteredSessions, pinnedSessionIds]);
 
 	// Session → bound workspace lookup (shared by the Simple Mode list so each
 	// row can show which workspace its files live in).
@@ -730,6 +977,20 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 			appStore.setRightPanelTab("preview");
 			appStore.setWorkspaceMode("collapsed");
 		})();
+	}, []);
+
+	const togglePinned = useCallback((id: string) => {
+		setPinnedSessionIds((current) => {
+			const next = new Set(current);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			try {
+				window.localStorage.setItem(PINNED_SESSIONS_STORAGE_KEY, JSON.stringify([...next]));
+			} catch {
+				// Pinning is a local UI preference; keep the in-memory state if storage is unavailable.
+			}
+			return next;
+		});
 	}, []);
 
 	// Click a workspace group header → load that workspace into the right panel (half screen).
@@ -752,9 +1013,18 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 
 	// Open a session → preview its workspace files (quarter, tree only).
 	const openSession = useCallback((session: SessionMeta) => {
-		appStore.setRightPanelTab("preview");
-		appStore.setWorkspaceWidth(300);
-		appStore.setWorkspaceMode("quarter");
+		// At the narrowest split layout, opening the preview would make the
+		// layout hide the session sidebar to reclaim its width. Keep both the
+		// current conversation and the session list accessible in that case.
+		const canOpenWorkspace = appStore.workspaceMode !== "collapsed"
+			|| typeof window === "undefined"
+			|| appStore.sidebarCollapsed
+			|| canOpenWorkspaceBesideSidebar(window.innerWidth, 300);
+		if (canOpenWorkspace) {
+			appStore.setRightPanelTab("preview");
+			appStore.setWorkspaceWidth(300);
+			appStore.setWorkspaceMode("quarter");
+		}
 		void sessionsStore.openSession(session.id);
 	}, []);
 
@@ -805,6 +1075,17 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 	const handleDelete = useCallback((session: SessionMeta) => {
 		const confirmed = typeof window === "undefined" ? true : window.confirm(t("sidebar.confirmDeleteSession", { name: session.name }));
 		if (!confirmed) return;
+		setPinnedSessionIds((current) => {
+			if (!current.has(session.id)) return current;
+			const next = new Set(current);
+			next.delete(session.id);
+			try {
+				window.localStorage.setItem(PINNED_SESSIONS_STORAGE_KEY, JSON.stringify([...next]));
+			} catch {
+				// The session is still removed from the in-memory pin list.
+			}
+			return next;
+		});
 		void sessionsStore.deleteSession(session.id);
 	}, [t]);
 
@@ -913,49 +1194,24 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 						recentSessions.map((session) => {
 							const ws = sessionToWorkspace.get(session.id);
 							return (
-								<div
+								<SimpleSessionRow
 									key={session.id}
-									role="button"
-									tabIndex={0}
-									onClick={() => openSession(session)}
-									onKeyDown={(e) => {
-										if (e.key === "Enter" || e.key === " ") {
-											e.preventDefault();
-											openSession(session);
-										}
-									}}
-									className={`group/srow relative mb-1 block w-full cursor-pointer rounded-lg border px-2.5 py-2 text-left transition-all duration-150 ${
-										state.currentSessionId === session.id
-											? "border-[var(--inno-border)] bg-[var(--inno-surface-muted)] shadow-sm"
-											: "border-transparent hover:border-[var(--inno-border)] hover:bg-[var(--inno-surface)]"
-									}`}
-								>
-									<div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2">
-										<div className="inno-sidebar-title min-w-0 truncate font-medium text-[var(--inno-text)]">{session.name}</div>
-										<button
-											className="rounded p-0.5 text-[var(--inno-text-subtle)] opacity-0 transition-opacity hover:bg-[var(--inno-danger-bg)] hover:text-[var(--inno-danger)] group-hover/srow:opacity-100"
-											title={t("sidebar.deleteConversation")}
-											onClick={(e) => { e.stopPropagation(); handleDelete(session); }}
-										>
-											<Trash2 size={12} />
-										</button>
-									</div>
-									{session.preview && session.preview !== session.name ? (
-										<div className="inno-sidebar-meta mt-0.5 truncate text-[var(--inno-text-subtle)]">{session.preview}</div>
-									) : null}
-									<div className="mt-1 flex items-center gap-1.5">
-										{ws ? (
-											<span
-												className="inline-flex max-w-[140px] items-center gap-1 rounded bg-[var(--inno-surface-muted)] px-1.5 py-px text-[9px] font-medium leading-none text-[var(--inno-text-muted)]"
-												title={t("sidebar.workspaceLabel", { name: ws.name })}
-											>
-												<FolderKanban size={12} className="shrink-0" />
-												<span className="truncate">{ws.name}</span>
-											</span>
-										) : null}
-										<span className="inno-sidebar-meta tabular-nums text-[var(--inno-text-subtle)]">{formatTime(session.updatedAt)}</span>
-									</div>
-								</div>
+									session={session}
+									workspace={ws}
+									active={state.currentSessionId === session.id}
+									editing={editingId === session.id}
+									editingName={editingName}
+									generating={generatingId === session.id}
+									onOpen={() => openSession(session)}
+									onStartEdit={() => { setEditingId(session.id); setEditingName(session.name); }}
+									onEditChange={setEditingName}
+									onEditSave={() => saveName(session.id)}
+									onEditCancel={() => setEditingId(null)}
+									onGenerate={() => generateName(session)}
+									onDelete={() => handleDelete(session)}
+									onExport={() => handleExport(session)}
+									onExportShowcase={() => handleExportShowcase(session)}
+								/>
 							);
 						})
 					)}
@@ -1212,6 +1468,7 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 													session={session}
 													active={state.currentSessionId === session.id}
 													opening={state.openingSessionId === session.id}
+													pinned={pinnedSessionIds.has(session.id)}
 													editing={editingId === session.id}
 													editingName={editingName}
 													generatingId={generatingId}
@@ -1222,8 +1479,9 @@ export function SessionSidebar({ collapsed, onOpen }: SessionSidebarProps) {
 													onEditCancel={() => setEditingId(null)}
 													onGenerate={() => generateName(session)}
 													onArchive={() => handleArchive(session)}
-													onDelete={() => handleDelete(session)}
-													onExport={() => handleExport(session)}
+													onTogglePin={() => togglePinned(session.id)}
+												onDelete={() => handleDelete(session)}
+												onExport={() => handleExport(session)}
 												onExportShowcase={() => handleExportShowcase(session)}
 												/>
 											))}

--- a/apps/inno-agent/web/src/react/ui/ContextMenu.tsx
+++ b/apps/inno-agent/web/src/react/ui/ContextMenu.tsx
@@ -1,0 +1,56 @@
+import { useEffect, type ReactNode } from "react";
+
+export interface ContextMenuItem {
+	label: ReactNode;
+	onSelect: () => void;
+	danger?: boolean;
+}
+
+interface ContextMenuProps {
+	x: number;
+	y: number;
+	items: ContextMenuItem[];
+	onClose: () => void;
+}
+
+/** Shared fixed-position context menu used by workspace files and attachments. */
+export function ContextMenu({ x, y, items, onClose }: ContextMenuProps) {
+	useEffect(() => {
+		const onKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") onClose();
+		};
+		window.addEventListener("keydown", onKeyDown);
+		return () => window.removeEventListener("keydown", onKeyDown);
+	}, [onClose]);
+
+	return (
+		<>
+			<div
+				className="fixed inset-0 z-40"
+				aria-hidden="true"
+				onClick={(event) => { event.stopPropagation(); onClose(); }}
+				onContextMenu={(event) => event.stopPropagation()}
+			/>
+			<div
+				className="inno-smart-menu"
+				style={{ left: x, top: y }}
+				onClick={(event) => event.stopPropagation()}
+				onContextMenu={(event) => event.stopPropagation()}
+			>
+				{items.map((item, index) => (
+					<button
+						key={index}
+						type="button"
+						className={`inno-smart-menu-item ${item.danger ? "is-danger" : ""}`}
+						onClick={() => {
+							item.onSelect();
+							onClose();
+						}}
+					>
+						{item.label}
+					</button>
+				))}
+			</div>
+		</>
+	);
+}

--- a/apps/inno-agent/web/src/stores/app-layout.test.ts
+++ b/apps/inno-agent/web/src/stores/app-layout.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { fitPanelLayout } from "./app-layout.js";
+import {
+	canOpenWorkspaceBesideSidebar,
+	CHAT_BASELINE_WIDTH,
+	fitPanelLayout,
+	SIDEBAR_WIDTH,
+	WORKSPACE_QUARTER_MIN_WIDTH,
+} from "./app-layout.js";
 
 describe("fitPanelLayout", () => {
 	it("keeps the chat baseline when the workspace is resized too wide", () => {
@@ -42,5 +48,10 @@ describe("fitPanelLayout", () => {
 			workspaceMode: "quarter",
 			workspaceWidth: 280,
 		});
+	});
+
+	it("only opens a session preview when it can keep the sidebar visible", () => {
+		expect(canOpenWorkspaceBesideSidebar(CHAT_BASELINE_WIDTH + SIDEBAR_WIDTH, 300)).toBe(false);
+		expect(canOpenWorkspaceBesideSidebar(CHAT_BASELINE_WIDTH + SIDEBAR_WIDTH + WORKSPACE_QUARTER_MIN_WIDTH, 300)).toBe(true);
 	});
 });

--- a/apps/inno-agent/web/src/stores/app-layout.ts
+++ b/apps/inno-agent/web/src/stores/app-layout.ts
@@ -69,3 +69,9 @@ export function fitPanelLayout(
 		),
 	};
 }
+
+/** Whether a quarter-width workspace can open while keeping the sidebar visible. */
+export function canOpenWorkspaceBesideSidebar(viewportWidth: number, workspaceWidth: number): boolean {
+	const fitted = fitPanelLayout(viewportWidth, false, "quarter", workspaceWidth);
+	return fitted?.sidebarCollapsed === false;
+}


### PR DESCRIPTION
## 变更背景

本 PR 完成侧边栏会话卡片的一轮交互和布局调整，并清理了之前多次迭代后遗留的重复标题渲染、旧渠道徽标逻辑和无效 DOM 标记。

## 用户可见行为

### 普通模式

- 第一行显示会话标题，时间固定在标题行最右侧。
- 第二行左侧显示预览文本，右侧默认显示来源渠道，例如 `Web`。
- 鼠标悬停在当前会话卡片时，来源渠道被归档和置顶按钮替换；移开后恢复渠道显示。
- 右键会话打开统一的上下文菜单，包含：生成标题、重命名、导出 Markdown、导出回放案例、归档/取消归档、置顶/取消置顶、删除。
- 置顶会话保存在本地存储中，并在会话列表中排在未置顶会话之前；删除会话时同步移除置顶状态。

### 简单模式

- 使用与普通模式一致的标题行和时间布局。
- 第二行右侧显示所属临时工作区。
- 鼠标悬停时，删除按钮替换临时工作区标记。
- 简单模式不显示归档和置顶按钮，右键菜单也不包含归档和置顶；其余操作保持可用。

### 长标题

- 标题超出可用宽度时，未悬停状态就显示渐隐截断，不等待动画开始才显示渐变。
- 仅当鼠标悬停在该会话卡片上时播放滚动；每次悬停只播放一次，使用 `linear` 匀速动画，移开后停止。
- 滚动距离按实际文字宽度测量，并额外保留末尾间距，避免最后一个字符被裁掉。
- 动画只作用于标题文字，不改变卡片外层尺寸，避免悬停时卡片出现细微放大或位移。
- 尊重 `prefers-reduced-motion: reduce` 设置。

### 右键菜单和工作区行为

- 普通模式和简单模式均使用同一个 `ContextMenu` 组件及同一套面板样式。
- 菜单通过 portal 挂载到 `document.body`，不会被侧边栏的裁剪区域截断；取消菜单只关闭菜单，不会触发打开当前工作会话。
- 在最窄的分栏宽度下，如果打开工作区预览会导致侧边栏被迫隐藏，则保留当前会话列表可见并继续打开会话。

## 代码整理

- 在 `SessionSidebar.tsx` 中抽取共享的 `useTitleMarquee` 和 `SessionTitleRow`，消除普通模式与简单模式重复的标题测量、ResizeObserver、编辑输入框和标题 JSX。
- 抽取共享的 `menuLabel`，删除两处重复实现。
- 删除不再参与当前布局的旧渠道交互徽标计算与排序渲染路径。
- 删除无消费者的 `inno-sidebar-card`、`data-active` 标记。
- 将 `canOpenWorkspaceBesideSidebar` 与对应测试纳入本 PR，避免依赖主工作区未提交代码。

## 涉及文件

- `apps/inno-agent/web/src/react/SessionSidebar.tsx`：会话卡片布局、标题滚动、归档/置顶、右键菜单和简单模式交互。
- `apps/inno-agent/web/src/react/ui/ContextMenu.tsx`：统一右键菜单组件。
- `apps/inno-agent/web/src/app.css`：渐隐遮罩、一次性匀速滚动动画和末尾留白。
- `apps/inno-agent/web/src/stores/app-layout.ts`：分栏可见性判断。
- `apps/inno-agent/web/src/stores/app-layout.test.ts`：分栏可见性测试。

## 验证

- `npm --workspace inno-agent-web run build`：通过。
- `npm test -- --run apps/inno-agent/web/src/stores/app-layout.test.ts`：通过，7 项测试。
- 已执行全量测试尝试：32 个测试文件通过、221 个测试通过、31 个跳过；另有 7 个与本次侧边栏无关的 server/agent 测试套件因临时工作树复用的本地依赖缺少 `@earendil-works/pi-ai/compat` 导入失败。

## 范围

本 PR 仅涉及 Web 端侧边栏及其布局辅助逻辑，不涉及后端 API、会话数据结构或持久化协议变更。
