### PR TITLE
feat(web): slash command palette with inno agent commands

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `@juicesharp/rpiv-todo` (`todo` task-list tool), `pi-web-access` (`fetch_content`/`get_search_content` URL/GitHub/PDF/YouTube extraction), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is ~38 files (282 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is 42 files (312 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 
@@ -261,6 +261,7 @@ Plain Node `http.createServer` (no framework), ~1600 lines plus route domains ex
 - `GET/POST/PATCH/DELETE /api/jobs[/:id]` — job management; `POST /api/jobs/:id/run` for manual execution.
 - `GET /api/sessions` / `GET /api/sessions/:id` — session listing; `PATCH /api/sessions/:id` for archive/unarchive/topic.
 - `GET /api/skills` — list loaded skills.
+- `GET /api/commands` — slash commands the agent session can dispatch/expand (extension commands, prompt templates, skills), backing the composer's slash palette. PI's builtin commands are TUI-only and deliberately excluded.
 - `POST /api/skills/upload` — accepts `<skill-name>.zip`, unpacks into `skillsDir/<name>/` via `spawnSync('unzip', ...)`.
 - `GET/PUT /api/skills/:name/content` — read/write skill file content (skill editor).
 - `GET /api/skills/:name/tree` — directory tree of a skill's files.

--- a/apps/inno-agent/README.md
+++ b/apps/inno-agent/README.md
@@ -181,6 +181,7 @@ web/                  # 前端 (React + Lit + Tailwind + Vite)
 | GET | `/api/wiki/graph` | 知识图谱数据 |
 | GET | `/api/wiki/stats` | Wiki 统计 |
 | GET | `/api/skills` | Skills 列表（读取 `.inno/skills/`） |
+| GET | `/api/commands` | 斜杠命令列表（extension 命令 / prompt 模板 / skills），供前端对话框命令面板使用 |
 | POST | `/api/skills/upload` | 上传 `<skill-name>.zip` 并解压到 `.inno/skills/<name>/` |
 | PATCH | `/api/skills/:name` | 启用/关闭 Skill |
 | DELETE | `/api/skills/:name` | 删除 Skill |

--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -145,6 +145,71 @@ function isOpenLaunchCommand(command: string): boolean {
 	return OPEN_LAUNCH_CMD_RE.test(command);
 }
 
+/**
+ * Inno's own slash commands. Each expands into a user message that steers the
+ * agent to the right memory tool — no TUI overlay needed, so they work
+ * identically from the web composer palette and the CLI. The name set is
+ * exported so pi-runner.listSlashCommands() can mark them webSafe (inline
+ * extension factories receive a synthetic "<inline:N>" sourceInfo, making the
+ * command's origin path unusable for this).
+ */
+interface InnoSlashCommand {
+	name: string;
+	description: string;
+	buildMessage: (args: string) => string;
+}
+
+const INNO_SLASH_COMMANDS: InnoSlashCommand[] = [
+	{
+		name: "recall",
+		description: "回忆过去的对话（L3 跨会话记忆）。用法: /recall <问题>",
+		buildMessage: (query) =>
+			query
+				? `请使用 l3_recall 工具检索我们过去的对话，并结合检索结果回答：${query}`
+				: "请使用 l3_recall 工具回顾我们之前的对话，总结一下最近学过的重点。",
+	},
+	{
+		name: "remember",
+		description: "把关于你的事实写入学习者画像（L1）。用法: /remember <事实>",
+		buildMessage: (fact) =>
+			fact
+				? `请将以下关于我的信息记录到学习者画像（L1），并简短确认你记住了什么：${fact}`
+				: "我想让你记住一些关于我学习情况的信息（学习者画像 L1）。请问我需要告诉你什么？",
+	},
+	{
+		name: "wiki",
+		description: "检索 L2 Wiki 知识库并回答问题。用法: /wiki <问题>",
+		buildMessage: (query) =>
+			query
+				? `请使用 l2_query 工具检索 Wiki 知识库，并结合检索结果回答：${query}`
+				: "请使用 l2_query 工具查看 Wiki 知识库的索引概览，告诉我里面都归档了哪些内容。",
+	},
+];
+
+export const INNO_SLASH_COMMAND_NAMES: ReadonlySet<string> = new Set(INNO_SLASH_COMMANDS.map((command) => command.name));
+
+/**
+ * Expand an Inno slash command ("/recall <q>") into its user-message form.
+ * Returns null when the text is not an Inno command. pi-runner applies this
+ * before session.prompt(): the registerCommand handler routes through
+ * pi.sendUserMessage, which the SDK binds fire-and-forget, so a command
+ * dispatched inside prompt() returns immediately while the turn it triggers
+ * is still running — and per-prompt event subscriptions (runPromptStreaming,
+ * used by web and channels) would close before the reply streams. Expanding
+ * up front makes the turn an ordinary prompt. The CLI uses the
+ * registerCommand path instead, where the TUI's long-lived subscription is
+ * unaffected.
+ */
+export function expandInnoSlashCommand(text: string): string | null {
+	if (!text.startsWith("/")) return null;
+	const spaceIndex = text.indexOf(" ");
+	const name = spaceIndex === -1 ? text.slice(1) : text.slice(1, spaceIndex);
+	const command = INNO_SLASH_COMMANDS.find((entry) => entry.name === name);
+	if (!command) return null;
+	const args = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
+	return command.buildMessage(args);
+}
+
 export function createInnoExtension(
 	configHolder: ConfigHolder,
 	paths: RuntimePaths,
@@ -207,6 +272,21 @@ export function createInnoExtension(
 		);
 		for (const tool of learnerTools) {
 			pi.registerTool(tool);
+		}
+
+		// 2b. Inno slash commands (web + CLI). Unlike the bundled plugins' TUI
+		// overlay commands, these run headless: the handler expands into a normal
+		// user message that steers the agent to the right memory tool, so the
+		// result streams back as an ordinary turn. listSlashCommands() marks
+		// them webSafe via INNO_SLASH_COMMAND_NAMES (inline extension factories
+		// get a synthetic "<inline:N>" sourceInfo, so the path is not usable).
+		for (const command of INNO_SLASH_COMMANDS) {
+			pi.registerCommand(command.name, {
+				description: command.description,
+				handler: async (args) => {
+					pi.sendUserMessage(command.buildMessage(args.trim()));
+				},
+			});
 		}
 
 		// 3. Register scheduler tools

--- a/apps/inno-agent/src/agent/inno-slash-commands.test.ts
+++ b/apps/inno-agent/src/agent/inno-slash-commands.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { expandInnoSlashCommand, INNO_SLASH_COMMAND_NAMES } from "./inno-extension.js";
+
+describe("expandInnoSlashCommand", () => {
+	it("returns null for non-command text", () => {
+		expect(expandInnoSlashCommand("hello")).toBeNull();
+		expect(expandInnoSlashCommand("")).toBeNull();
+	});
+
+	it("returns null for commands Inno does not own (skills, plugin commands)", () => {
+		expect(expandInnoSlashCommand("/skill:ppt-creation make slides")).toBeNull();
+		expect(expandInnoSlashCommand("/todos")).toBeNull();
+		expect(expandInnoSlashCommand("/model")).toBeNull();
+	});
+
+	it("expands /recall with a query into an l3_recall instruction", () => {
+		const expanded = expandInnoSlashCommand("/recall 链式法则我上次卡在哪？");
+		expect(expanded).toContain("l3_recall");
+		expect(expanded).toContain("链式法则我上次卡在哪？");
+	});
+
+	it("expands a bare /recall into a default review request", () => {
+		const expanded = expandInnoSlashCommand("/recall");
+		expect(expanded).toContain("l3_recall");
+		expect(expanded).not.toBeNull();
+	});
+
+	it("expands /remember with a fact into an L1 write instruction", () => {
+		const expanded = expandInnoSlashCommand("/remember 我更喜欢用例子学概念");
+		expect(expanded).toContain("学习者画像");
+		expect(expanded).toContain("我更喜欢用例子学概念");
+	});
+
+	it("expands /wiki with a query into an l2_query instruction", () => {
+		const expanded = expandInnoSlashCommand("/wiki 贝叶斯定理的笔记在哪？");
+		expect(expanded).toContain("l2_query");
+		expect(expanded).toContain("贝叶斯定理的笔记在哪？");
+	});
+
+	it("expands a bare /wiki into an index overview request", () => {
+		const expanded = expandInnoSlashCommand("/wiki");
+		expect(expanded).toContain("l2_query");
+		expect(expanded).toContain("索引");
+	});
+
+	it("trims extra whitespace around args", () => {
+		const expanded = expandInnoSlashCommand("/recall   微积分  ");
+		expect(expanded).toContain("微积分");
+		expect(expanded).not.toContain("  微积分");
+	});
+
+	it("registers exactly the expandable commands", () => {
+		expect([...INNO_SLASH_COMMAND_NAMES].sort()).toEqual(["recall", "remember", "wiki"]);
+	});
+});

--- a/apps/inno-agent/src/agent/pi-runner.ts
+++ b/apps/inno-agent/src/agent/pi-runner.ts
@@ -18,7 +18,7 @@ import { complete } from "@earendil-works/pi-ai/compat";
 import type { AssistantMessage, ImageContent, Model, UserMessage } from "@earendil-works/pi-ai";
 import { basename, join, resolve } from "node:path";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
-import { createInnoExtension, type ConfigHolder, type InnoExtensionDeps } from "./inno-extension.js";
+import { createInnoExtension, expandInnoSlashCommand, INNO_SLASH_COMMAND_NAMES, type ConfigHolder, type InnoExtensionDeps } from "./inno-extension.js";
 import { createMcpStatusExtension, loadMcpAdapterExtension } from "./mcp-extension.js";
 import { createObservabilityExtension, createPromptObserver, obsLogger } from "./observability-extension.js";
 import type { InnoConfig } from "../config.js";
@@ -403,6 +403,62 @@ export function syncConfig(config: InnoConfig): void {
 export function getSession(): AgentSession {
 	if (!_runtime) throw new Error("Session not initialized. Call initSession() first.");
 	return _runtime.session;
+}
+
+export interface SlashCommandItem {
+	/** Command name without the leading slash. Skills use the `skill:<name>` form. */
+	name: string;
+	description?: string;
+	source: "extension" | "prompt" | "skill";
+	/**
+	 * Extension commands safe to offer in the web composer. Inno's own
+	 * commands (registered in inno-extension.ts, matched by
+	 * INNO_SLASH_COMMAND_NAMES) expand into a normal turn via
+	 * ctx.sendUserMessage; bundled plugins' commands are TUI overlays
+	 * gated on ctx.hasUI and would no-op server-side.
+	 */
+	webSafe?: boolean;
+}
+
+/**
+ * List the slash commands the current runtime session would actually dispatch
+ * or expand in `session.prompt()`: extension commands (pi.registerCommand),
+ * prompt templates, and skills (invoked as `/skill:<name>`). PI's builtin
+ * commands (/model, /new, ...) are TUI-only and intentionally excluded — the
+ * web UI re-implements those as app-level actions. Returns [] before the
+ * session is initialized. All reads are in-memory and safe during streaming.
+ */
+export function listSlashCommands(): SlashCommandItem[] {
+	let session: AgentSession;
+	try {
+		session = getSession();
+	} catch {
+		return [];
+	}
+	const items: SlashCommandItem[] = [];
+	try {
+		for (const command of session.extensionRunner.getRegisteredCommands()) {
+			items.push({
+				name: command.invocationName,
+				description: command.description,
+				source: "extension",
+				webSafe: INNO_SLASH_COMMAND_NAMES.has(command.invocationName),
+			});
+		}
+	} catch {
+		// A mid-reload runner may throw; commands are best-effort listing.
+	}
+	for (const template of session.promptTemplates ?? []) {
+		items.push({ name: template.name, description: template.description, source: "prompt" });
+	}
+	try {
+		for (const skill of session.resourceLoader.getSkills().skills) {
+			items.push({ name: `skill:${skill.name}`, description: skill.description, source: "skill" });
+		}
+	} catch {
+		// Skills listing should never break the endpoint.
+	}
+	return items;
 }
 
 function nativeImagesForSession(
@@ -1087,6 +1143,12 @@ export async function runPrompt(
 	imageFallbackPrompt?: string,
 	attachmentContext?: string,
 ): Promise<string> {
+	// See expandInnoSlashCommand for why Inno commands can't ride
+	// session.prompt()'s extension-command dispatch. The fallback twin must
+	// be expanded too: text-only models run fallbackPrompt ?? prompt, and the
+	// routes always build it from the raw (unexpanded) text.
+	prompt = expandInnoSlashCommand(prompt) ?? prompt;
+	if (imageFallbackPrompt) imageFallbackPrompt = expandInnoSlashCommand(imageFallbackPrompt) ?? imageFallbackPrompt;
 	const session = getSession();
 
 	let output = "";
@@ -1271,6 +1333,8 @@ export function runPromptStreaming(
 	images?: ImageContent[],
 	imageFallbackPrompt?: string,
 ): Promise<string> {
+	prompt = expandInnoSlashCommand(prompt) ?? prompt;
+	if (imageFallbackPrompt) imageFallbackPrompt = expandInnoSlashCommand(imageFallbackPrompt) ?? imageFallbackPrompt;
 	return enqueue(async () => {
 		const session = getSession();
 		let output = "";
@@ -1379,6 +1443,8 @@ export function runPromptStreamingInSession(
 	imageFallbackPrompt?: string,
 	attachmentContext?: string,
 ): Promise<string> {
+	prompt = expandInnoSlashCommand(prompt) ?? prompt;
+	if (imageFallbackPrompt) imageFallbackPrompt = expandInnoSlashCommand(imageFallbackPrompt) ?? imageFallbackPrompt;
 	return enqueue(async () => {
 		let output = "";
 		let streamError: string | undefined;

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -52,6 +52,7 @@ import { handleWikiRoutes } from "./server/routes/wiki.js";
 import { handlePresetsRoutes } from "./server/routes/presets.js";
 import { handlePracticeRoutes } from "./server/routes/practice.js";
 import { handleChatRoutes } from "./server/routes/chat.js";
+import { handleCommandsRoutes } from "./server/routes/commands.js";
 import {
 	mergeChannels,
 	type SessionChannel,
@@ -1388,6 +1389,9 @@ const server = createServer(async (req, res) => {
 			scheduleSkillsReload,
 			invalidateContentSource,
 		})) return;
+
+		// --- Slash commands API (extracted to server/routes/commands.ts) ---
+		if (await handleCommandsRoutes(req, res, method, url)) return;
 
 		// --- Chat API (extracted to server/routes/chat.ts) ---
 		if (await handleChatRoutes(req, res, method, url, {

--- a/apps/inno-agent/src/server/routes/commands.ts
+++ b/apps/inno-agent/src/server/routes/commands.ts
@@ -1,0 +1,22 @@
+import type { IncomingMessage as HttpReq, ServerResponse } from "node:http";
+import { listSlashCommands } from "../../agent/pi-runner.js";
+import { json } from "../http-helpers.js";
+
+/**
+ * /api/commands route domain. Exposes the slash commands the agent session
+ * can dispatch or expand (extension commands, prompt templates, skills) so
+ * the web composer can offer Codex-style autocomplete. PI's builtin TUI
+ * commands are not listed — the web UI surfaces those as app-level actions.
+ */
+export async function handleCommandsRoutes(
+	req: HttpReq,
+	res: ServerResponse,
+	method: string,
+	url: string,
+): Promise<boolean> {
+	if (method === "GET" && url === "/api/commands") {
+		json(res, 200, { commands: listSlashCommands() });
+		return true;
+	}
+	return false;
+}

--- a/apps/inno-agent/web/src/api/commands.ts
+++ b/apps/inno-agent/web/src/api/commands.ts
@@ -1,0 +1,16 @@
+import { apiFetch } from "./client.js";
+
+/** Slash command the agent session can dispatch or expand (see GET /api/commands). */
+export interface SlashCommandItem {
+	/** Command name without the leading slash. Skills use the `skill:<name>` form. */
+	name: string;
+	description?: string;
+	source: "extension" | "prompt" | "skill";
+	/** Extension commands that run headless (Inno's own); plugin TUI-overlay commands omit this. */
+	webSafe?: boolean;
+}
+
+export async function fetchSlashCommands(): Promise<SlashCommandItem[]> {
+	const res = await apiFetch<{ commands?: SlashCommandItem[] }>("/api/commands");
+	return res.commands ?? [];
+}

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -722,6 +722,18 @@
 	},
 	"chat": {
 		"welcomePlaceholder": "What would you like to learn or build? Send a message to start…",
+		"slashPalette": {
+			"ariaLabel": "Slash commands",
+			"appGroup": "App actions",
+			"agentGroup": "Agent commands",
+			"newChatDesc": "Start a new chat",
+			"modelDesc": "Switch model",
+			"empty": "No commands matching \"/{{query}}\"",
+			"profileDesc": "Open learner profile",
+			"jobsDesc": "View scheduled jobs",
+			"skillsDesc": "Manage skills",
+			"settingsDesc": "Open settings"
+		},
 		"loadingSession": "Loading session…",
 		"emptySessionTitle": "No messages in this conversation",
 		"emptySessionHint": "Type a message below to start the conversation.",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -722,6 +722,18 @@
 	},
 	"chat": {
 		"welcomePlaceholder": "有什么想学习或实践的?发送消息开始…",
+		"slashPalette": {
+			"ariaLabel": "斜杠命令",
+			"appGroup": "应用操作",
+			"agentGroup": "Agent 命令",
+			"newChatDesc": "开始新会话",
+			"modelDesc": "切换模型",
+			"empty": "没有匹配 \"/{{query}}\" 的命令",
+			"profileDesc": "查看学习者画像",
+			"jobsDesc": "查看定时任务",
+			"skillsDesc": "管理技能",
+			"settingsDesc": "打开设置"
+		},
 		"loadingSession": "正在加载会话…",
 		"emptySessionTitle": "此会话暂无消息",
 		"emptySessionHint": "在下方输入消息，开始新的对话。",

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -33,6 +33,14 @@ import { BusyBlocker, QuestionHint } from "./chat/ChatStatusBanners.js";
 import { ChatUploadChips } from "./chat/ChatUploadChips.js";
 import { ChatWelcome } from "./chat/ChatWelcome.js";
 import { SmartInputControl } from "./chat/SmartInputControl.js";
+import { SlashCommandPalette } from "./chat/SlashCommandPalette.js";
+import {
+	buildSlashPaletteEntries,
+	slashQueryFromDraft,
+	type SlashPaletteAction,
+	type SlashPaletteEntry,
+} from "./chat/slash-palette-utils.js";
+import { fetchSlashCommands, type SlashCommandItem } from "../api/commands.js";
 import { WorkspaceContext } from "./chat/WorkspaceContext.js";
 import type { WorkspaceChoice } from "./WorkspaceSwitcher.js";
 import {
@@ -93,6 +101,7 @@ export function ChatCenter({ onOpenPresetPanels, onPreviewFile }: ChatCenterProp
 	const welcomeLayoutRef = useRef<HTMLDivElement | null>(null);
 	const resizeFrameRef = useRef<number | null>(null);
 	const draftRef = useRef("");
+	const [draftValue, setDraftValue] = useState(draftRef.current);
 	const fileInputRef = useRef<HTMLInputElement | null>(null);
 	const imageInputRef = useRef<HTMLInputElement | null>(null);
 	const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -120,6 +129,22 @@ export function ChatCenter({ onOpenPresetPanels, onPreviewFile }: ChatCenterProp
 	const [draftHasContent, setDraftHasContent] = useState(() => Boolean(draftRef.current.trim()));
 	const [modelPickerOpen, setModelPickerOpen] = useState(false);
 	const [pasteBlocks, setPasteBlocks] = useState<PendingPasteBlock[]>([]);
+
+	// Slash-command palette (Codex-style): opens while the draft is a bare
+	// "/query". App actions (new chat, model picker) run locally; agent
+	// commands come from GET /api/commands and are inserted into the composer —
+	// the backend session expands/dispatches them in session.prompt().
+	const [slashCommands, setSlashCommands] = useState<SlashCommandItem[]>([]);
+	const [slashActiveIndex, setSlashActiveIndex] = useState(0);
+	const [slashDismissedFor, setSlashDismissedFor] = useState<string | null>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		fetchSlashCommands()
+			.then((items) => { if (!cancelled) setSlashCommands(items); })
+			.catch(() => { /* palette simply stays limited to app actions */ });
+		return () => { cancelled = true; };
+	}, []);
 
 	// New-chat workspace selection is draft state until the first message creates
 	// a session. The active session path is bound in handleWorkspaceChange.
@@ -475,6 +500,7 @@ export function ChatCenter({ onOpenPresetPanels, onPreviewFile }: ChatCenterProp
 		const el = inputRef.current;
 		if (!el) return;
 		draftRef.current = el.value;
+		setDraftValue(el.value);
 		setDraftHasContent(el.value.trim().length > 0);
 		// Safari drops in-progress IME composition (e.g. Chinese/Japanese input)
 		// when the textarea's height/overflow/selection is mutated mid-composition,
@@ -551,6 +577,7 @@ export function ChatCenter({ onOpenPresetPanels, onPreviewFile }: ChatCenterProp
 		const el = inputRef.current;
 		if (!el) return;
 		draftRef.current = el.value;
+		setDraftValue(el.value);
 		setDraftHasContent(el.value.trim().length > 0);
 		scheduleResizeInput();
 	}, [scheduleResizeInput]);
@@ -775,6 +802,7 @@ export function ChatCenter({ onOpenPresetPanels, onPreviewFile }: ChatCenterProp
 
 		const resetComposer = () => {
 			draftRef.current = "";
+			setDraftValue("");
 			setDraftHasContent(false);
 			if (inputRef.current) {
 				inputRef.current.value = "";
@@ -922,13 +950,120 @@ export function ChatCenter({ onOpenPresetPanels, onPreviewFile }: ChatCenterProp
 		wsMode,
 	]);
 
+	const setComposerText = useCallback((text: string) => {
+		draftRef.current = text;
+		setDraftValue(text);
+		const el = inputRef.current;
+		if (el) {
+			el.value = text;
+			el.focus();
+			resizeInput();
+		}
+	}, [resizeInput]);
+
+	const slashQuery = slashQueryFromDraft(draftValue);
+	const slashPaletteOpen = slashQuery !== null && slashDismissedFor !== draftValue && !chat.isSending;
+
+	const slashAppActions = useMemo(() => {
+		const actions: Array<{ action: SlashPaletteAction; name: string; description: string }> = [];
+		// On the welcome screen the composer is already a fresh session draft,
+		// so "new chat" would be a no-op.
+		if (!isWelcome) actions.push({ action: "new-chat", name: "new", description: t("chat.slashPalette.newChatDesc") });
+		actions.push({ action: "model", name: "model", description: t("chat.slashPalette.modelDesc") });
+		// Simple Mode hides the Notebook/Profile surfaces, so don't offer them.
+		if (!simpleMode) {
+			actions.push({ action: "profile", name: "profile", description: t("chat.slashPalette.profileDesc") });
+		}
+		actions.push({ action: "jobs", name: "jobs", description: t("chat.slashPalette.jobsDesc") });
+		actions.push({ action: "skills", name: "skills", description: t("chat.slashPalette.skillsDesc") });
+		actions.push({ action: "settings", name: "settings", description: t("chat.slashPalette.settingsDesc") });
+		return actions;
+	}, [isWelcome, simpleMode, t]);
+
+	const slashEntries = useMemo(() => {
+		if (slashQuery === null) return [];
+		// Bundled plugins' extension commands (rpiv-todo, pi-web-access, MCP
+		// adapter) are TUI overlays gated on ctx.hasUI — they no-op server-side,
+		// so only Inno's own webSafe commands are offered alongside skills and
+		// prompt templates (both expand into a normal turn).
+		const agentCommands = slashCommands.filter((command) => command.source !== "extension" || command.webSafe === true);
+		return buildSlashPaletteEntries(slashAppActions, agentCommands, slashQuery);
+	}, [slashAppActions, slashCommands, slashQuery]);
+
+	// Restart keyboard navigation from the top whenever the query changes.
+	useEffect(() => {
+		setSlashActiveIndex(0);
+	}, [slashQuery]);
+
+	const handleSlashSelect = useCallback((entry: SlashPaletteEntry) => {
+		if (entry.group === "app") {
+			setComposerText("");
+			const openRightPanelTab = (tab: "notebook" | "profile" | "skills" | "jobs") => {
+				appStore.setRightPanelTab(tab);
+				if (appStore.workspaceMode === "collapsed") appStore.setWorkspaceMode("quarter");
+			};
+			switch (entry.action) {
+				case "new-chat": {
+					const workspaceId = workspaceStore.activeWorkspaceId;
+					if (workspaceId) sessionsStore.beginNewSessionIn(workspaceId);
+					else sessionsStore.beginNewSession();
+					break;
+				}
+				case "model":
+					setModelPickerOpen(true);
+					break;
+				case "profile":
+					openRightPanelTab("profile");
+					break;
+				case "jobs":
+					openRightPanelTab("jobs");
+					break;
+				case "skills":
+					openRightPanelTab("skills");
+					break;
+				case "settings":
+					appStore.openSettings();
+					break;
+			}
+			return;
+		}
+		// Agent command: stage "/name " in the composer so the user can add
+		// arguments; sending goes through the normal chat path, where the
+		// backend session expands skills/templates or runs extension commands.
+		setComposerText(`/${entry.name} `);
+	}, [setComposerText]);
+
 	const handleKeyDown = useCallback((event: KeyboardEvent<HTMLTextAreaElement>) => {
 		if (event.nativeEvent.isComposing || event.keyCode === 229) return;
+		if (slashPaletteOpen) {
+			if (event.key === "Escape") {
+				event.preventDefault();
+				setSlashDismissedFor(draftValue);
+				return;
+			}
+			if (slashEntries.length > 0) {
+				if (event.key === "ArrowDown") {
+					event.preventDefault();
+					setSlashActiveIndex((index) => (index + 1) % slashEntries.length);
+					return;
+				}
+				if (event.key === "ArrowUp") {
+					event.preventDefault();
+					setSlashActiveIndex((index) => (index - 1 + slashEntries.length) % slashEntries.length);
+					return;
+				}
+				if (event.key === "Enter" || event.key === "Tab") {
+					event.preventDefault();
+					handleSlashSelect(slashEntries[Math.min(slashActiveIndex, slashEntries.length - 1)]);
+					return;
+				}
+			}
+		}
 		if (event.key === "Enter" && !event.shiftKey) {
 			event.preventDefault();
 			handleSend();
 		}
-	}, [handleSend]);
+	}, [handleSend, slashPaletteOpen, slashEntries, slashActiveIndex, draftValue, handleSlashSelect]);
 
 	const handleStop = useCallback(() => chatStore.cancel(), []);
 	const handleReconnect = useCallback(() => void chatStore.reconnect(), []);
@@ -958,6 +1093,7 @@ export function ChatCenter({ onOpenPresetPanels, onPreviewFile }: ChatCenterProp
 		el.focus();
 		el.setRangeText(block.text, start, end, "end");
 		draftRef.current = el.value;
+		setDraftValue(el.value);
 		setDraftHasContent(el.value.trim().length > 0);
 		setPasteBlocks((prev) => prev.filter((item) => item.id !== blockId));
 		resizeInput();
@@ -1119,6 +1255,15 @@ export function ChatCenter({ onOpenPresetPanels, onPreviewFile }: ChatCenterProp
 			onStop={handleStop}
 			onReconnect={handleReconnect}
 			onRetry={handleRetry}
+			slashPalette={slashPaletteOpen ? (
+				<SlashCommandPalette
+					entries={slashEntries}
+					activeIndex={slashActiveIndex}
+					query={slashQuery ?? ""}
+					onSelect={handleSlashSelect}
+					onActiveChange={setSlashActiveIndex}
+				/>
+			) : undefined}
 			/>
 		);
 	};

--- a/apps/inno-agent/web/src/react/chat/ChatComposer.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatComposer.tsx
@@ -64,6 +64,8 @@ export interface ChatComposerProps {
 	onStop: () => void;
 	onReconnect: () => void;
 	onRetry: () => void;
+	/** Slash-command palette rendered above the composer (ChatCenter owns its state). */
+	slashPalette?: ReactNode;
 }
 
 export function ChatComposer({
@@ -113,6 +115,7 @@ export function ChatComposer({
 	onStop,
 	onReconnect,
 	onRetry,
+	slashPalette,
 }: ChatComposerProps) {
 	const { t } = useTranslation();
 	const modelPickerRef = useRef<HTMLDivElement | null>(null);
@@ -410,7 +413,7 @@ export function ChatComposer({
 	const sendDisabled = !hasSendableContent || isUploading;
 	return (
 		<div
-			className={`inno-composer rounded-2xl p-2 ${osFileDragOver ? "is-osfile-over" : ""}`}
+			className={`inno-composer relative rounded-2xl p-2 ${osFileDragOver ? "is-osfile-over" : ""}`}
 			onDragOverCapture={handleComposerDragOver}
 			onDragOver={handleComposerDragOver}
 			onDragLeave={(event) => {
@@ -419,6 +422,7 @@ export function ChatComposer({
 			onDropCapture={handleComposerDrop}
 			onDrop={handleComposerDrop}
 		>
+			{slashPalette}
 			<input ref={fileInputRef} id="file-input" type="file" className="hidden" multiple onChange={onFiles} />
 			<input ref={imageInputRef} id="image-input" type="file" className="hidden" multiple accept="image/*" onChange={onImageFiles} />
 			{renderComposerAttachments()}

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
@@ -2,7 +2,7 @@ import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
-import { X, AlertTriangle, FileCode2 } from "lucide-react";
+import { X, AlertTriangle, FileCode2, Zap } from "lucide-react";
 import type { AttachmentBinding, AttachmentRef, ChatMessage, ChatToolRecord } from "../../types/chat.js";
 import { normalizeMarkdownMath } from "../../utils/markdown-math.js";
 import { splitContentByBindings } from "../../utils/attachment-render.js";
@@ -13,6 +13,7 @@ import { MarkdownArtifact } from "../MarkdownArtifact.js";
 import { AnsweredQuestionCard } from "./AnsweredQuestionCard.js";
 import { FileName } from "../FileName.js";
 import { FileTypeIcon } from "../FileTypeIcon.js";
+import { collapseSkillMessage } from "./skill-message-collapse.js";
 
 // Pure, props-driven chat rendering components. This module must NOT import
 // stores or the api/ layer — apps/showcase reuses it to replay recorded
@@ -391,6 +392,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 	const regularTools = (message.tools ?? []).filter((tool) => !answeredToolCallIds.has(tool.toolCallId));
 
 	if (message.role === "user") {
+		const skillMessage = collapseSkillMessage(message.content);
 		return (
 			<motion.div
 				className="flex justify-end"
@@ -423,6 +425,14 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 								resolveUrl={resolveAttachmentUrl}
 								onOpenFile={onOpenAttachment}
 						/>
+					) : skillMessage ? (
+						<span className="inline-flex items-center gap-1.5 whitespace-normal">
+							<span className="inline-flex items-center gap-1 rounded-md bg-[var(--inno-accent-soft)] px-2 py-0.5 text-xs font-medium text-[var(--inno-accent)]">
+								<Zap size={12} />
+								/skill:{skillMessage.skillName}
+							</span>
+							{skillMessage.args ? <span>{skillMessage.args}</span> : null}
+						</span>
 					) : (
 						message.content.trim()
 					)}

--- a/apps/inno-agent/web/src/react/chat/SlashCommandPalette.tsx
+++ b/apps/inno-agent/web/src/react/chat/SlashCommandPalette.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useRef, type ReactNode } from "react";
+import { FilePlus2, Cpu, TerminalSquare, Zap, GraduationCap, BookOpen, CalendarClock, Puzzle, Settings, History, BookmarkPlus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { SlashPaletteEntry } from "./slash-palette-utils.js";
+
+export interface SlashCommandPaletteProps {
+	entries: SlashPaletteEntry[];
+	activeIndex: number;
+	query: string;
+	onSelect: (entry: SlashPaletteEntry) => void;
+	onActiveChange: (index: number) => void;
+}
+
+const APP_ACTION_ICONS = {
+	"new-chat": <FilePlus2 size={15} />,
+	model: <Cpu size={15} />,
+	profile: <GraduationCap size={15} />,
+	jobs: <CalendarClock size={15} />,
+	skills: <Puzzle size={15} />,
+	settings: <Settings size={15} />,
+} as const;
+
+const AGENT_COMMAND_ICONS: Record<string, ReactNode> = {
+	recall: <History size={15} />,
+	remember: <BookmarkPlus size={15} />,
+	wiki: <BookOpen size={15} />,
+};
+
+function entryIcon(entry: SlashPaletteEntry) {
+	if (entry.group === "app") {
+		return entry.action ? APP_ACTION_ICONS[entry.action] : <TerminalSquare size={15} />;
+	}
+	const known = AGENT_COMMAND_ICONS[entry.name];
+	if (known) return known;
+	if (entry.name.startsWith("skill:")) return <Zap size={15} />;
+	return <TerminalSquare size={15} />;
+}
+
+/**
+ * Codex-style slash-command menu shown above the composer while the draft is
+ * a bare `/query`. Purely presentational — ChatCenter owns filtering,
+ * keyboard navigation, and what "select" means per entry.
+ */
+export function SlashCommandPalette({ entries, activeIndex, query, onSelect, onActiveChange }: SlashCommandPaletteProps) {
+	const { t } = useTranslation();
+	const listRef = useRef<HTMLDivElement | null>(null);
+
+	// Keep the active row in view during keyboard navigation.
+	useEffect(() => {
+		const list = listRef.current;
+		const active = list?.querySelector<HTMLElement>('[data-active="true"]');
+		active?.scrollIntoView({ block: "nearest" });
+	}, [activeIndex]);
+
+	let lastGroup: SlashPaletteEntry["group"] | null = null;
+	return (
+		<div
+			className="absolute bottom-full left-0 right-0 z-20 mb-2 overflow-hidden rounded-xl border border-[var(--inno-border)] bg-[var(--inno-surface)] shadow-lg"
+			role="listbox"
+			aria-label={t("chat.slashPalette.ariaLabel")}
+		>
+			<div ref={listRef} className="max-h-72 overflow-y-auto py-1">
+				{entries.length === 0 ? (
+					<div className="px-3 py-2 text-xs text-[var(--inno-text-muted)]">
+						{t("chat.slashPalette.empty", { query })}
+					</div>
+				) : (
+					entries.map((entry, index) => {
+						const showGroupHeader = entry.group !== lastGroup;
+						lastGroup = entry.group;
+						return (
+							<div key={entry.key}>
+								{showGroupHeader ? (
+									<div className="px-3 pb-0.5 pt-1.5 text-[10px] font-medium uppercase tracking-wide text-[var(--inno-text-subtle)]">
+										{entry.group === "app" ? t("chat.slashPalette.appGroup") : t("chat.slashPalette.agentGroup")}
+									</div>
+								) : null}
+								<button
+									type="button"
+									role="option"
+									aria-selected={index === activeIndex}
+									data-active={index === activeIndex}
+									className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left text-sm ${
+										index === activeIndex
+											? "bg-[var(--inno-accent-soft)] text-[var(--inno-text)]"
+											: "text-[var(--inno-text)] hover:bg-[var(--inno-surface-muted)]"
+									}`}
+									onMouseEnter={() => onActiveChange(index)}
+									onClick={() => onSelect(entry)}
+								>
+									<span className="shrink-0 text-[var(--inno-text-muted)]">{entryIcon(entry)}</span>
+									<span className="shrink-0 font-medium">/{entry.name}</span>
+									{entry.description ? (
+										<span className="min-w-0 flex-1 truncate text-right text-xs text-[var(--inno-text-muted)]" title={entry.description}>
+											{entry.description}
+										</span>
+									) : null}
+								</button>
+							</div>
+						);
+					})
+				)}
+			</div>
+		</div>
+	);
+}

--- a/apps/inno-agent/web/src/react/chat/skill-message-collapse.test.ts
+++ b/apps/inno-agent/web/src/react/chat/skill-message-collapse.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { collapseSkillMessage } from "./skill-message-collapse.js";
+
+const ENVELOPE = (body: string) => `<skill name="lesson-plan" location="/tmp/skills/lesson-plan/SKILL.md">\nReferences are relative to /tmp/skills/lesson-plan.\n\n${body}\n</skill>`;
+
+describe("collapseSkillMessage", () => {
+	it("collapses a skill message without args", () => {
+		expect(collapseSkillMessage(ENVELOPE("# Lesson Plan\nDo the thing."))).toEqual({ skillName: "lesson-plan", args: "" });
+	});
+
+	it("captures trailing args after the envelope", () => {
+		const result = collapseSkillMessage(`${ENVELOPE("body")}\n\n给初二学生讲一次函数`);
+		expect(result).toEqual({ skillName: "lesson-plan", args: "给初二学生讲一次函数" });
+	});
+
+	it("trims surrounding whitespace", () => {
+		expect(collapseSkillMessage(`\n${ENVELOPE("body")}\n`)?.skillName).toBe("lesson-plan");
+	});
+
+	it("returns null for plain text", () => {
+		expect(collapseSkillMessage("/skill:lesson-plan")).toBeNull();
+		expect(collapseSkillMessage("hello")).toBeNull();
+	});
+
+	it("returns null when <skill> appears inside normal text", () => {
+		expect(collapseSkillMessage(`我试了下 ${ENVELOPE("body")} 这个东西`)).toBeNull();
+	});
+
+	it("returns null for an unclosed or malformed envelope", () => {
+		expect(collapseSkillMessage('<skill name="x" location="y">\nbody')).toBeNull();
+		expect(collapseSkillMessage('<skill name="x">body</skill>')).toBeNull();
+	});
+});

--- a/apps/inno-agent/web/src/react/chat/skill-message-collapse.ts
+++ b/apps/inno-agent/web/src/react/chat/skill-message-collapse.ts
@@ -1,0 +1,22 @@
+/**
+ * The PI SDK expands `/skill:name args` into a full `<skill …>…</skill>`
+ * document BEFORE the user message is persisted, so session history stores the
+ * whole skill body. Rendering that verbatim floods the chat — collapse the
+ * envelope back into a compact placeholder chip for display only. The LLM-side
+ * content is untouched; this is a pure presentation-layer transform.
+ */
+export interface CollapsedSkillMessage {
+	skillName: string;
+	args: string;
+}
+
+// Mirrors the envelope built by the SDK's skill expansion:
+//   <skill name="…" location="…">\n…\n</skill>            (no args)
+//   <skill name="…" location="…">\n…\n</skill>\n\n<args>  (with args)
+const SKILL_MESSAGE_RE = /^<skill name="([^"]+)" location="[^"]*">\n[\s\S]*?\n<\/skill>(?:\n\n([\s\S]+))?$/;
+
+export function collapseSkillMessage(text: string): CollapsedSkillMessage | null {
+	const match = SKILL_MESSAGE_RE.exec(text.trim());
+	if (!match) return null;
+	return { skillName: match[1], args: (match[2] ?? "").trim() };
+}

--- a/apps/inno-agent/web/src/react/chat/slash-palette-utils.test.ts
+++ b/apps/inno-agent/web/src/react/chat/slash-palette-utils.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { buildSlashPaletteEntries, slashQueryFromDraft } from "./slash-palette-utils.js";
+import type { SlashCommandItem } from "../../api/commands.js";
+
+const APP_ACTIONS = [
+	{ action: "new-chat" as const, name: "new", description: "Start a new chat" },
+	{ action: "model" as const, name: "model", description: "Switch model" },
+];
+
+const COMMANDS: SlashCommandItem[] = [
+	{ name: "review", description: "Review code", source: "prompt" },
+	{ name: "skill:ppt-creation", description: "Create slides", source: "skill" },
+	{ name: "skill:lesson-plan", description: "Plan a lesson", source: "skill" },
+	{ name: "todos", description: "List todo items", source: "extension" },
+];
+
+describe("slashQueryFromDraft", () => {
+	it("opens on a bare slash", () => {
+		expect(slashQueryFromDraft("/")).toBe("");
+	});
+
+	it("captures the partial query", () => {
+		expect(slashQueryFromDraft("/sk")).toBe("sk");
+		expect(slashQueryFromDraft("/skill:ppt")).toBe("skill:ppt");
+	});
+
+	it("closes once the command takes arguments", () => {
+		expect(slashQueryFromDraft("/skill:ppt make slides")).toBeNull();
+	});
+
+	it("ignores non-command drafts and slashes mid-text", () => {
+		expect(slashQueryFromDraft("")).toBeNull();
+		expect(slashQueryFromDraft("hello /world")).toBeNull();
+		expect(slashQueryFromDraft(" /new")).toBeNull();
+	});
+});
+
+describe("buildSlashPaletteEntries", () => {
+	it("lists app actions first, then agent commands grouped by source", () => {
+		const entries = buildSlashPaletteEntries(APP_ACTIONS, COMMANDS, "");
+		expect(entries.map((e) => e.key)).toEqual([
+			"app:new-chat",
+			"app:model",
+			"agent:todos", // extension before prompt before skill
+			"agent:review",
+			"agent:skill:lesson-plan", // skills sorted by name
+			"agent:skill:ppt-creation",
+		]);
+		expect(entries[0].group).toBe("app");
+		expect(entries[2].group).toBe("agent");
+	});
+
+	it("filters both groups by substring, case-insensitively", () => {
+		const entries = buildSlashPaletteEntries(APP_ACTIONS, COMMANDS, "MO");
+		expect(entries.map((e) => e.key)).toEqual(["app:model"]);
+	});
+
+	it("matches skill commands by their full name", () => {
+		const entries = buildSlashPaletteEntries(APP_ACTIONS, COMMANDS, "skill:");
+		expect(entries.map((e) => e.name)).toEqual(["skill:lesson-plan", "skill:ppt-creation"]);
+	});
+
+	it("also matches against descriptions (localized queries find English slugs)", () => {
+		expect(buildSlashPaletteEntries(APP_ACTIONS, COMMANDS, "slides").map((e) => e.key)).toEqual(["agent:skill:ppt-creation"]);
+		expect(buildSlashPaletteEntries(APP_ACTIONS, COMMANDS, "Switch").map((e) => e.key)).toEqual(["app:model"]);
+	});
+
+	it("returns an empty list when nothing matches", () => {
+		expect(buildSlashPaletteEntries(APP_ACTIONS, COMMANDS, "zzz")).toEqual([]);
+	});
+});

--- a/apps/inno-agent/web/src/react/chat/slash-palette-utils.ts
+++ b/apps/inno-agent/web/src/react/chat/slash-palette-utils.ts
@@ -1,0 +1,57 @@
+import type { SlashCommandItem } from "../../api/commands.js";
+
+/**
+ * Pure helpers for the composer slash-command palette. Kept free of React so
+ * the filtering semantics are unit-testable (mirrors workspace.test.ts style).
+ */
+
+export type SlashPaletteAction = "new-chat" | "model" | "profile" | "jobs" | "skills" | "settings";
+
+export interface SlashPaletteEntry {
+	key: string;
+	/** Text after the leading `/`, e.g. `new` or `skill:ppt-creation`. */
+	name: string;
+	description?: string;
+	group: "app" | "agent";
+	/** App actions execute in the UI; agent commands are inserted into the composer. */
+	action?: SlashPaletteAction;
+}
+
+/** The palette opens only while the draft is a bare `/query` (no whitespace). */
+export function slashQueryFromDraft(draft: string): string | null {
+	const match = /^\/(\S*)$/.exec(draft);
+	return match ? match[1] : null;
+}
+
+function matchesQuery(name: string, description: string | undefined, query: string): boolean {
+	if (!query) return true;
+	const needle = query.toLowerCase();
+	return name.toLowerCase().includes(needle) || (description?.toLowerCase().includes(needle) ?? false);
+}
+
+/**
+ * Build the flat, display-ordered palette entries: app actions first
+ * (Codex-style), then agent commands sorted by name within each source group
+ * (extension → prompt → skill). Matches against both the command name and
+ * its description, so localized queries (e.g. "画像") find English slugs.
+ */
+export function buildSlashPaletteEntries(
+	appActions: Array<{ action: SlashPaletteAction; name: string; description: string }>,
+	commands: SlashCommandItem[],
+	query: string,
+): SlashPaletteEntry[] {
+	const entries: SlashPaletteEntry[] = [];
+	for (const item of appActions) {
+		if (matchesQuery(item.name, item.description, query)) {
+			entries.push({ key: `app:${item.action}`, name: item.name, description: item.description, group: "app", action: item.action });
+		}
+	}
+	const sourceOrder: Record<SlashCommandItem["source"], number> = { extension: 0, prompt: 1, skill: 2 };
+	const sorted = [...commands].sort((a, b) => sourceOrder[a.source] - sourceOrder[b.source] || a.name.localeCompare(b.name));
+	for (const command of sorted) {
+		if (matchesQuery(command.name, command.description, query)) {
+			entries.push({ key: `agent:${command.name}`, name: command.name, description: command.description, group: "agent" });
+		}
+	}
+	return entries;
+}


### PR DESCRIPTION
## 概述

在聊天输入框上方新增 Codex 风格的斜杠命令面板,并补齐 inno agent 命令的 Web 端打通。

- 输入 \`/\` 弹出命令面板:应用动作(新会话、模型选择、profile、jobs、skills、settings)+ agent 命令(inno 扩展命令与技能),支持键盘导航、过滤和中英文 i18n。
- 新增 \`GET /api/commands\`,列出已注册的扩展命令、prompt 模板和技能;打包插件中仅 TUI 可用的命令标记为非 webSafe,不在面板中显示。
- 新增 inno 斜杠命令 \`/recall\`、\`/remember\`、\`/wiki\`,展开为普通用户消息,引导 agent 调用 l3_recall、L1 学习者画像和 l2_query。展开发生在 pi-runner 的 session.prompt() 之前,因为 SDK 的命令分发走 fire-and-forget 的 pi.sendUserMessage,会导致按 prompt 订阅的事件在流式开始前关闭。
- prompt 与 imageFallbackPrompt 双胞胎都做展开(纯文本模型走 fallback),修复纯文本模型发送 /recall 时报 "Final chat history could not be confirmed"。
- 将 SDK 展开的 \`<skill>...</skill>\` 用户消息在聊天气泡中折叠为紧凑的 \`/skill:name\` 芯片(仅展示层)。

## 与 main 的合并说明

rebase 到 main(PR #204 之后)解决了 4 个文件冲突:pi-runner 的附件上下文与斜杠展开共存、ChatCenter 的 renderComposer 闭包内补 slashPalette 属性并按 main 的 draftRef 非受控方案补 draftValue 状态同步、ChatComposer 保留 #204 的拖拽处理器同时挂入 slashPalette、MessageBubble 的附件渲染与技能折叠链式共存。

## 验证

- \`npm run build\`(后端 tsc + web vite)通过。
- 全量 vitest:50 个测试文件、377 个测试通过。