### PR TITLE
fix: improve workspace resize preview and window expansion

### DIFF
--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -1647,11 +1647,11 @@ inno-workspace-panel textarea {
 .workspace-resize-preview::before {
 	content: "";
 	position: absolute;
-	left: -3px;
+	left: 0;
 	top: 50%;
 	width: 7px;
 	height: 38px;
-	transform: translateY(-50%);
+	transform: translate(-50%, -50%);
 	border: 1px solid color-mix(in srgb, var(--inno-accent) 28%, var(--inno-border));
 	border-radius: 999px;
 	background: color-mix(in srgb, var(--inno-surface) 94%, transparent);
@@ -1665,8 +1665,19 @@ inno-workspace-panel textarea {
 	top: 0;
 	bottom: 0;
 	width: 2px;
+	transform: translateX(-50%);
 	border-radius: 999px;
 	background: color-mix(in srgb, var(--inno-accent) 32%, transparent);
+}
+
+.workspace-resize-preview--limit::before {
+	border-color: color-mix(in srgb, var(--inno-danger) 72%, var(--inno-border));
+	box-shadow: 0 2px 10px rgba(220, 38, 38, 0.16), 0 0 0 2px color-mix(in srgb, var(--inno-danger) 10%, transparent);
+}
+
+.workspace-resize-preview--limit::after {
+	background: var(--inno-danger);
+	box-shadow: 0 0 8px color-mix(in srgb, var(--inno-danger) 42%, transparent);
 }
 
 /* Hide the old edge while the ghost edge is active so the user sees one

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -649,6 +649,25 @@ inno-workspace-panel textarea {
 	animation: inno-composer-model-menu-in var(--inno-dur-fast) var(--inno-ease-out) both;
 }
 
+/* Slash palette reuses the model menu treatment; only its anchoring differs. */
+.inno-slash-palette {
+	left: 0;
+	right: 0;
+	z-index: 20;
+	width: auto;
+	max-height: var(--inno-slash-palette-max-height, min(360px, calc(100vh - 24px)));
+	overflow: hidden;
+	display: flex;
+	flex-direction: column;
+	transform-origin: bottom left;
+}
+
+.inno-slash-palette-list {
+	min-height: 0;
+	flex: 1 1 auto;
+	overflow-y: auto;
+}
+
 @keyframes inno-composer-model-menu-in {
 	from {
 		opacity: 0;
@@ -1613,6 +1632,50 @@ inno-workspace-panel textarea {
 	user-select: none;
 }
 
+/* The panel stays in place while resizing; this ghost edge follows the
+ * pointer and is committed only when the pointer is released. */
+.workspace-resize-preview {
+	position: fixed;
+	top: 0;
+	right: 0;
+	bottom: 0;
+	width: var(--inno-workspace-preview-width);
+	z-index: 999;
+	pointer-events: none;
+}
+
+.workspace-resize-preview::before {
+	content: "";
+	position: absolute;
+	left: -3px;
+	top: 50%;
+	width: 7px;
+	height: 38px;
+	transform: translateY(-50%);
+	border: 1px solid color-mix(in srgb, var(--inno-accent) 28%, var(--inno-border));
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--inno-surface) 94%, transparent);
+	box-shadow: 0 2px 10px rgba(31, 35, 40, 0.12), 0 0 0 2px color-mix(in srgb, var(--inno-accent) 5%, transparent);
+}
+
+.workspace-resize-preview::after {
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0;
+	bottom: 0;
+	width: 2px;
+	border-radius: 999px;
+	background: color-mix(in srgb, var(--inno-accent) 32%, transparent);
+}
+
+/* Hide the old edge while the ghost edge is active so the user sees one
+ * unambiguous target position. */
+.workspace-resizing .workspace-resize-handle::after {
+	background: transparent;
+	box-shadow: none;
+}
+
 /* InnoSpark theme: inspired by agent.aiecnu.net's public chat UI. */
 :root[data-theme="innospark"] body {
 	background: var(--inno-background);
@@ -1936,6 +1999,29 @@ button.inno-smart-ref-chip:hover {
 .inno-smart-panel--status.is-single-column {
 	width: min(280px, calc(100vw - 16px));
 }
+.inno-smart-panel--agent {
+	box-sizing: border-box;
+	width: min(420px, calc(100vw - 16px));
+}
+.inno-smart-agent-list {
+	max-height: 260px;
+}
+.inno-smart-agent-skill-title {
+	display: block;
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	position: relative;
+}
+.inno-smart-agent-description {
+	min-width: 0;
+	max-width: 55%;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 10.5px;
+	color: var(--inno-text-subtle);
+}
 .inno-smart-panel--status .inno-smart-panel-list {
 	max-height: 180px;
 }
@@ -2150,6 +2236,9 @@ button.inno-smart-ref-chip:hover {
 .inno-smart-kw.is-hot {
 	color: var(--smart-kw, var(--inno-danger));
 }
+.inno-smart-kw-hit.is-agent {
+	--smart-kw: var(--inno-accent);
+}
 .inno-smart-kw-hit {
 	position: absolute;
 	min-width: 0;
@@ -2203,6 +2292,53 @@ button.inno-smart-ref-chip:hover {
 }
 .inno-smart-chip.is-filled {
 	border-style: solid;
+}
+.inno-smart-chip.is-agent {
+	gap: 3px;
+	padding: 0 7px 0 6px;
+	border-color: color-mix(in srgb, var(--smart-bc, #8b5cf6) 60%, transparent);
+	background: color-mix(in srgb, var(--smart-bc, #8b5cf6) 12%, var(--inno-surface));
+	color: color-mix(in srgb, var(--smart-bc, #8b5cf6) 78%, var(--inno-text));
+}
+.inno-smart-chip.is-agent .inno-smart-chip-word {
+	overflow: visible;
+	text-overflow: clip;
+	white-space: nowrap;
+}
+.inno-smart-chip.is-agent[data-agent-hint]::after {
+	content: attr(data-agent-hint);
+	position: absolute;
+	left: 50%;
+	top: calc(100% + 6px);
+	z-index: 80;
+	max-width: 260px;
+	padding: 4px 7px;
+	border: 1px solid var(--inno-border);
+	border-radius: 6px;
+	background: var(--inno-surface-raised);
+	box-shadow: var(--inno-shadow-soft);
+	color: var(--inno-text);
+	font-size: 10.5px;
+	font-weight: 400;
+	line-height: 15px;
+	white-space: normal;
+	text-align: left;
+	transform: translate(-50%, -2px);
+	visibility: hidden;
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity var(--inno-dur-fast) var(--inno-ease-out), transform var(--inno-dur-fast) var(--inno-ease-out), visibility var(--inno-dur-fast);
+}
+.inno-smart-chip.is-agent[data-agent-hint]:hover::after {
+	transform: translate(-50%, 0);
+	visibility: visible;
+	opacity: 1;
+}
+.inno-smart-agent-mark {
+	flex: 0 0 auto;
+	font-size: 10px;
+	line-height: 1;
+	display: block;
 }
 .inno-smart-chip.is-selected {
 	background: color-mix(in srgb, var(--smart-bc, var(--inno-accent)) 18%, var(--inno-selection-bg, rgba(37, 99, 235, 0.16)));

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -1632,8 +1632,8 @@ inno-workspace-panel textarea {
 	user-select: none;
 }
 
-/* The panel stays in place while resizing; this ghost edge follows the
- * pointer and is committed only when the pointer is released. */
+/* The panel stays in place only when a requested width cannot be applied to
+ * the live layout; this ghost edge follows the pointer until release. */
 .workspace-resize-preview {
 	position: fixed;
 	top: 0;
@@ -1681,8 +1681,9 @@ inno-workspace-panel textarea {
 }
 
 /* Hide the old edge while the ghost edge is active so the user sees one
- * unambiguous target position. */
-.workspace-resizing .workspace-resize-handle::after {
+ * unambiguous target position. During a normal resize the real edge remains
+ * visible and the workspace follows the pointer directly. */
+.workspace-resize-preview-active .workspace-resize-handle::after {
 	background: transparent;
 	box-shadow: none;
 }

--- a/apps/inno-agent/web/src/i18n/index.ts
+++ b/apps/inno-agent/web/src/i18n/index.ts
@@ -21,6 +21,7 @@ type CloseDialogCopy = {
 type DesktopBridge = {
 	setCloseDialogCopy(copy: CloseDialogCopy): void;
 	expandWindowWidth(side: "left" | "right", additionalWidth: number): Promise<boolean>;
+	getWindowWidthCapacity(side: "left" | "right"): Promise<number>;
 	openLocalFile(file: File): Promise<boolean>;
 };
 

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -211,15 +211,26 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 			const start = resizeStartRef.current;
 			if (!start || event.pointerId !== start.pointerId) return;
 			event.preventDefault();
-			const maxWidth = Math.max(
-				mode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH,
-				resizeMaxWidthRef.current,
-			);
+			const maxWidth = resizeMaxWidthRef.current;
 			const nextWidth = clampResizeWidth(
 				start.width + start.clientX - event.clientX,
 				mode,
 				resizeMaxWidthRef.current,
 			);
+			const directMaxWidth = Math.max(
+				start.width,
+				getMaximumWorkspaceWidth(window.innerWidth, appStore.sidebarCollapsed, mode),
+			);
+			if (nextWidth <= directMaxWidth) {
+				// Keep the workspace attached to the pointer while the current
+				// window has room for it. The preview edge is only a fallback for
+				// widths that cannot be applied to the live layout yet.
+				resizePreviewWidthRef.current = null;
+				setResizeLimitReached(false);
+				setResizePreviewWidth(null);
+				onWidthChange(nextWidth);
+				return;
+			}
 			resizePreviewWidthRef.current = nextWidth;
 			setResizeLimitReached(nextWidth >= maxWidth);
 			setResizePreviewWidth(nextWidth);
@@ -235,6 +246,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 			setResizePreviewWidth(null);
 			setIsResizing(false);
 			if (nextWidth !== null) void commitResize(nextWidth);
+			else if (!commit) onWidthChange(start.width);
 		};
 		const handlePointerUp = (event: PointerEvent) => {
 			if (resizeStartRef.current?.pointerId !== event.pointerId) return;
@@ -284,9 +296,9 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 			clientX: event.clientX,
 			width: startWidth,
 		};
-		resizePreviewWidthRef.current = startWidth;
-		setResizeLimitReached(startWidth >= layoutMaxWidth);
-		setResizePreviewWidth(startWidth);
+		resizePreviewWidthRef.current = null;
+		setResizeLimitReached(false);
+		setResizePreviewWidth(null);
 		setIsResizing(true);
 		if (event.currentTarget.setPointerCapture) {
 			event.currentTarget.setPointerCapture(event.pointerId);
@@ -313,10 +325,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 						getMaximumWorkspaceWidth(expandedViewportWidth, appStore.sidebarCollapsed, mode),
 					),
 				);
-				const maxWidth = Math.max(
-					mode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH,
-					resizeMaxWidthRef.current,
-				);
+				const maxWidth = resizeMaxWidthRef.current;
 				setResizeLimitReached(
 					resizePreviewWidthRef.current !== null && resizePreviewWidthRef.current >= maxWidth,
 				);
@@ -353,7 +362,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 	}, [dndManager]);
 
 	return (
-		<aside className={`workspace-panel inno-workspace-scope relative flex h-full min-h-0 min-w-0 flex-col ${collapsed ? "overflow-visible border-l-0 bg-transparent" : "overflow-hidden border-l border-[var(--inno-border)] bg-[var(--inno-workspace-bg)]"}`}>
+		<aside className={`workspace-panel inno-workspace-scope relative flex h-full min-h-0 min-w-0 flex-col ${resizePreviewWidth !== null ? "workspace-resize-preview-active" : ""} ${collapsed ? "overflow-visible border-l-0 bg-transparent" : "overflow-hidden border-l border-[var(--inno-border)] bg-[var(--inno-workspace-bg)]"}`}>
 			{resizePreviewPortal}
 			{collapsed ? (
 				<button

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -170,6 +170,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 	const { t } = useTranslation();
 	const dndManager = useDragDropManager();
 	const [isResizing, setIsResizing] = useState(false);
+	const [resizeLimitReached, setResizeLimitReached] = useState(false);
 	const [resizePreviewWidth, setResizePreviewWidth] = useState<number | null>(null);
 	const resizeStartRef = useRef<WorkspaceResizeStart | null>(null);
 	const resizePreviewWidthRef = useRef<number | null>(null);
@@ -216,12 +217,17 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 			const start = resizeStartRef.current;
 			if (!start || event.pointerId !== start.pointerId) return;
 			event.preventDefault();
+			const maxWidth = Math.max(
+				mode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH,
+				resizeMaxWidthRef.current,
+			);
 			const nextWidth = clampResizeWidth(
 				start.width + start.clientX - event.clientX,
 				mode,
 				resizeMaxWidthRef.current,
 			);
 			resizePreviewWidthRef.current = nextWidth;
+			setResizeLimitReached(nextWidth >= maxWidth);
 			setResizePreviewWidth(nextWidth);
 		};
 		const finishResize = (commit: boolean) => {
@@ -231,6 +237,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 			resizeStartRef.current = null;
 			resizePreviewWidthRef.current = null;
 			resizeMaxWidthRef.current = WORKSPACE_MAX_WIDTH;
+			setResizeLimitReached(false);
 			setResizePreviewWidth(null);
 			setIsResizing(false);
 			if (nextWidth !== null) void commitResize(nextWidth);
@@ -284,6 +291,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 			width: startWidth,
 		};
 		resizePreviewWidthRef.current = startWidth;
+		setResizeLimitReached(startWidth >= Math.max(startWidth, layoutMaxWidth));
 		setResizePreviewWidth(startWidth);
 		setIsResizing(true);
 		if (event.currentTarget.setPointerCapture) {
@@ -311,6 +319,13 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 						getMaximumWorkspaceWidth(expandedViewportWidth, appStore.sidebarCollapsed, mode),
 					),
 				);
+				const maxWidth = Math.max(
+					mode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH,
+					resizeMaxWidthRef.current,
+				);
+				setResizeLimitReached(
+					resizePreviewWidthRef.current !== null && resizePreviewWidthRef.current >= maxWidth,
+				);
 			});
 		}
 	}, [mode, width]);
@@ -321,7 +336,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 	const resizePreviewPortal = isResizing && resizePreviewWidth !== null && typeof document !== "undefined"
 		? createPortal(
 			<div
-				className="workspace-resize-preview"
+				className={`workspace-resize-preview ${resizeLimitReached ? "workspace-resize-preview--limit" : ""}`}
 				aria-hidden="true"
 				style={{ "--inno-workspace-preview-width": `${resizePreviewWidth}px` } as React.CSSProperties}
 			/>,

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -1,4 +1,5 @@
-import { Component, lazy, Suspense, useCallback, useEffect, useMemo, useState, type ErrorInfo, type ReactNode } from "react";
+import { Component, lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ErrorInfo, type ReactNode } from "react";
+import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { motion, AnimatePresence } from "motion/react";
 import { DndProvider, useDragDropManager } from "react-dnd";
@@ -6,8 +7,10 @@ import { HTML5Backend } from "react-dnd-html5-backend";
 import type { DragDropManager } from "dnd-core";
 import { PanelRightOpen, PanelRightClose, Columns2, Maximize2, BookOpen, BriefcaseBusiness, FolderKanban, Settings, Sparkles, UserRound } from "lucide-react";
 import type { RightPanelTab, WorkspaceMode } from "../stores/app-store.js";
+import { getMaximumWorkspaceWidth, WORKSPACE_MAX_WIDTH, WORKSPACE_MIN_WIDTH, WORKSPACE_QUARTER_MIN_WIDTH } from "../stores/app-layout.js";
 import { appStore } from "../stores/app-store.js";
 import { settingsStore } from "../stores/settings-store.js";
+import { ensureWindowForPanel } from "../stores/window-expansion.js";
 import { useStoreSnapshot } from "./hooks.js";
 import { isDynamicImportError, recoverFromDynamicImportError } from "../utils/dynamic-import-recovery.js";
 
@@ -35,6 +38,32 @@ const TAB_ICONS: Record<RightPanelTab, ReactNode> = {
 	jobs: <BriefcaseBusiness size={14} />,
 	skills: <Sparkles size={14} />,
 };
+
+interface WorkspaceResizeStart {
+	pointerId: number;
+	clientX: number;
+	width: number;
+}
+
+function getLayoutResizeMax(mode: WorkspaceMode): number {
+	return typeof window === "undefined"
+		? WORKSPACE_MAX_WIDTH
+		: getMaximumWorkspaceWidth(window.innerWidth, appStore.sidebarCollapsed, mode);
+}
+
+function clampResizeWidth(width: number, mode: WorkspaceMode, maxWidth = getLayoutResizeMax(mode)): number {
+	const minWidth = mode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH;
+	return Math.max(minWidth, Math.min(Math.max(minWidth, maxWidth), Math.round(width)));
+}
+
+function waitForWindowLayoutToSettle(): Promise<void> {
+	if (typeof window === "undefined" || typeof window.requestAnimationFrame !== "function") return Promise.resolve();
+	return new Promise((resolve) => {
+		window.requestAnimationFrame(() => {
+			window.requestAnimationFrame(() => resolve());
+		});
+	});
+}
 
 class WorkspaceContentErrorBoundary extends Component<
 	{ resetKey: string; onRetry(): void; children: ReactNode },
@@ -141,6 +170,11 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 	const { t } = useTranslation();
 	const dndManager = useDragDropManager();
 	const [isResizing, setIsResizing] = useState(false);
+	const [resizePreviewWidth, setResizePreviewWidth] = useState<number | null>(null);
+	const resizeStartRef = useRef<WorkspaceResizeStart | null>(null);
+	const resizePreviewWidthRef = useRef<number | null>(null);
+	const resizeMaxWidthRef = useRef(WORKSPACE_MAX_WIDTH);
+	const resizeCommitGenerationRef = useRef(0);
 	const [contentRetryKey, setContentRetryKey] = useState(0);
 	const [hasOpenedWorkspace, setHasOpenedWorkspace] = useState(mode !== "collapsed");
 	const retryContent = useCallback(() => setContentRetryKey((key) => key + 1), []);
@@ -158,25 +192,77 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 			onTabChange("preview");
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [simpleMode, activeTab, onTabChange]);
+		}, [simpleMode, activeTab, onTabChange]);
+
+	const commitResize = useCallback(async (nextWidth: number) => {
+		const generation = ++resizeCommitGenerationRef.current;
+		// When the current chat column is already at its baseline width, the
+		// renderer cannot fit a wider workspace without first making more room.
+		// Electron can expand the host window; browser builds safely fall back to
+		// the existing fitPanelLayout constraint inside onWidthChange.
+		await ensureWindowForPanel("right", nextWidth, mode);
+		// The host-window resize can emit a second renderer resize event after
+		// ensureWindowForPanel resolves. Commit after those fit passes settle so
+		// the requested workspace width is not overwritten by the old width.
+		await waitForWindowLayoutToSettle();
+		if (generation !== resizeCommitGenerationRef.current) return;
+		onWidthChange(nextWidth);
+	}, [mode, onWidthChange]);
 
 	useEffect(() => {
 		if (!isResizing) return;
 
 		const handlePointerMove = (event: PointerEvent) => {
-			onWidthChange(window.innerWidth - event.clientX);
+			const start = resizeStartRef.current;
+			if (!start || event.pointerId !== start.pointerId) return;
+			event.preventDefault();
+			const nextWidth = clampResizeWidth(
+				start.width + start.clientX - event.clientX,
+				mode,
+				resizeMaxWidthRef.current,
+			);
+			resizePreviewWidthRef.current = nextWidth;
+			setResizePreviewWidth(nextWidth);
 		};
-		const handlePointerUp = () => setIsResizing(false);
+		const finishResize = (commit: boolean) => {
+			const start = resizeStartRef.current;
+			if (!start) return;
+			const nextWidth = commit ? resizePreviewWidthRef.current : null;
+			resizeStartRef.current = null;
+			resizePreviewWidthRef.current = null;
+			resizeMaxWidthRef.current = WORKSPACE_MAX_WIDTH;
+			setResizePreviewWidth(null);
+			setIsResizing(false);
+			if (nextWidth !== null) void commitResize(nextWidth);
+		};
+		const handlePointerUp = (event: PointerEvent) => {
+			if (resizeStartRef.current?.pointerId !== event.pointerId) return;
+			finishResize(true);
+		};
+		const handlePointerCancel = (event: PointerEvent) => {
+			if (resizeStartRef.current?.pointerId !== event.pointerId) return;
+			finishResize(false);
+		};
+		const handleWindowBlur = () => finishResize(false);
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === "Escape") finishResize(false);
+		};
 
 		document.body.classList.add("workspace-resizing");
 		window.addEventListener("pointermove", handlePointerMove);
-		window.addEventListener("pointerup", handlePointerUp, { once: true });
+		window.addEventListener("pointerup", handlePointerUp);
+		window.addEventListener("pointercancel", handlePointerCancel);
+		window.addEventListener("blur", handleWindowBlur);
+		window.addEventListener("keydown", handleKeyDown);
 		return () => {
 			document.body.classList.remove("workspace-resizing");
 			window.removeEventListener("pointermove", handlePointerMove);
 			window.removeEventListener("pointerup", handlePointerUp);
+			window.removeEventListener("pointercancel", handlePointerCancel);
+			window.removeEventListener("blur", handleWindowBlur);
+			window.removeEventListener("keydown", handleKeyDown);
 		};
-	}, [isResizing, onWidthChange]);
+	}, [commitResize, isResizing, mode]);
 
 	// Keep the workspace browser mounted after its first open. Collapsing the
 	// panel should hide it, not restart its tree/preview lifecycle on reopen.
@@ -186,12 +272,57 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 
 	const startResize = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
 		event.preventDefault();
+		// Invalidate a previous asynchronous commit if the user starts another
+		// resize before a host-window expansion has finished.
+		resizeCommitGenerationRef.current += 1;
+		const layoutMaxWidth = getLayoutResizeMax(mode);
+		const startWidth = clampResizeWidth(width, mode, Math.max(width, layoutMaxWidth));
+		resizeMaxWidthRef.current = Math.max(startWidth, layoutMaxWidth);
+		resizeStartRef.current = {
+			pointerId: event.pointerId,
+			clientX: event.clientX,
+			width: startWidth,
+		};
+		resizePreviewWidthRef.current = startWidth;
+		setResizePreviewWidth(startWidth);
 		setIsResizing(true);
-	}, []);
+		if (event.currentTarget.setPointerCapture) {
+			event.currentTarget.setPointerCapture(event.pointerId);
+		}
+
+		// On desktop, include the amount of host-window space that can still be
+		// expanded on the right. Browser builds simply keep the layout-derived
+		// limit above.
+		const getWindowWidthCapacity = window.innoDesktop?.getWindowWidthCapacity;
+		if (getWindowWidthCapacity) {
+			void getWindowWidthCapacity("right").then((capacity) => {
+				const active = resizeStartRef.current;
+				if (!active || active.pointerId !== event.pointerId) return;
+				const expandedViewportWidth = window.innerWidth + Math.max(0, Math.round(capacity));
+				resizeMaxWidthRef.current = Math.min(
+					WORKSPACE_MAX_WIDTH,
+					Math.max(
+						resizeMaxWidthRef.current,
+						getMaximumWorkspaceWidth(expandedViewportWidth, appStore.sidebarCollapsed, mode),
+					),
+				);
+			});
+		}
+	}, [mode, width]);
 
 	const compact = mode !== "full" && width < 500;
 	const collapsed = mode === "collapsed";
 	const shouldMountContent = hasOpenedWorkspace || !collapsed;
+	const resizePreviewPortal = isResizing && resizePreviewWidth !== null && typeof document !== "undefined"
+		? createPortal(
+			<div
+				className="workspace-resize-preview"
+				aria-hidden="true"
+				style={{ "--inno-workspace-preview-width": `${resizePreviewWidth}px` } as React.CSSProperties}
+			/>,
+			document.body,
+		)
+		: null;
 	const handleTabChange = useCallback((tab: RightPanelTab) => {
 		if (tab !== activeTab && dndManager.getMonitor().isDragging()) {
 			// A file drag can outlive the source tree for a tick after drop. End
@@ -209,6 +340,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 
 	return (
 		<aside className={`workspace-panel inno-workspace-scope relative flex h-full min-h-0 min-w-0 flex-col ${collapsed ? "overflow-visible border-l-0 bg-transparent" : "overflow-hidden border-l border-[var(--inno-border)] bg-[var(--inno-workspace-bg)]"}`}>
+			{resizePreviewPortal}
 			{collapsed ? (
 				<button
 					className="absolute right-2 top-2 z-20 flex h-8 w-8 items-center justify-center rounded-lg text-[var(--inno-text-subtle)] transition-colors hover:bg-white/90 hover:text-[var(--inno-text)] hover:shadow-sm"

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -291,14 +291,19 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 		}
 
 		// On desktop, include the amount of host-window space that can still be
-		// expanded on the right. Browser builds simply keep the layout-derived
-		// limit above.
+		// expanded on either edge. The commit uses the right edge first and moves
+		// the window left when the right edge is already at the display boundary.
 		const getWindowWidthCapacity = window.innoDesktop?.getWindowWidthCapacity;
 		if (getWindowWidthCapacity) {
-			void getWindowWidthCapacity("right").then((capacity) => {
+			void Promise.all([
+				getWindowWidthCapacity("right").catch(() => 0),
+				getWindowWidthCapacity("left").catch(() => 0),
+			]).then(([rightCapacity, leftCapacity]) => {
 				const active = resizeStartRef.current;
 				if (!active || active.pointerId !== event.pointerId) return;
-				const expandedViewportWidth = window.innerWidth + Math.max(0, Math.round(capacity));
+				const expandedViewportWidth = window.innerWidth
+					+ Math.max(0, Math.round(rightCapacity))
+					+ Math.max(0, Math.round(leftCapacity));
 				resizeMaxWidthRef.current = Math.min(
 					WORKSPACE_MAX_WIDTH,
 					Math.max(

--- a/apps/inno-agent/web/src/react/WorkspacePanel.tsx
+++ b/apps/inno-agent/web/src/react/WorkspacePanel.tsx
@@ -45,13 +45,7 @@ interface WorkspaceResizeStart {
 	width: number;
 }
 
-function getLayoutResizeMax(mode: WorkspaceMode): number {
-	return typeof window === "undefined"
-		? WORKSPACE_MAX_WIDTH
-		: getMaximumWorkspaceWidth(window.innerWidth, appStore.sidebarCollapsed, mode);
-}
-
-function clampResizeWidth(width: number, mode: WorkspaceMode, maxWidth = getLayoutResizeMax(mode)): number {
+function clampResizeWidth(width: number, mode: WorkspaceMode, maxWidth: number): number {
 	const minWidth = mode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH;
 	return Math.max(minWidth, Math.min(Math.max(minWidth, maxWidth), Math.round(width)));
 }
@@ -282,7 +276,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 		// Invalidate a previous asynchronous commit if the user starts another
 		// resize before a host-window expansion has finished.
 		resizeCommitGenerationRef.current += 1;
-		const layoutMaxWidth = getLayoutResizeMax(mode);
+		const layoutMaxWidth = getMaximumWorkspaceWidth(window.innerWidth, appStore.sidebarCollapsed, mode);
 		const startWidth = clampResizeWidth(width, mode, Math.max(width, layoutMaxWidth));
 		resizeMaxWidthRef.current = Math.max(startWidth, layoutMaxWidth);
 		resizeStartRef.current = {
@@ -291,7 +285,7 @@ function WorkspacePanelContent({ activeTab, mode, width, onTabChange, onModeChan
 			width: startWidth,
 		};
 		resizePreviewWidthRef.current = startWidth;
-		setResizeLimitReached(startWidth >= Math.max(startWidth, layoutMaxWidth));
+		setResizeLimitReached(startWidth >= layoutMaxWidth);
 		setResizePreviewWidth(startWidth);
 		setIsResizing(true);
 		if (event.currentTarget.setPointerCapture) {

--- a/apps/inno-agent/web/src/stores/app-layout.test.ts
+++ b/apps/inno-agent/web/src/stores/app-layout.test.ts
@@ -3,11 +3,18 @@ import {
 	canOpenWorkspaceBesideSidebar,
 	CHAT_BASELINE_WIDTH,
 	fitPanelLayout,
+	getMaximumWorkspaceWidth,
 	SIDEBAR_WIDTH,
 	WORKSPACE_QUARTER_MIN_WIDTH,
 } from "./app-layout.js";
 
 describe("fitPanelLayout", () => {
+	it("limits resize previews to the space the current layout can actually use", () => {
+		expect(getMaximumWorkspaceWidth(1_140, true, "quarter")).toBe(340);
+		expect(getMaximumWorkspaceWidth(1_700, false, "half")).toBe(636);
+		expect(getMaximumWorkspaceWidth(2_800, true, "half")).toBe(920);
+	});
+
 	it("keeps the chat baseline when the workspace is resized too wide", () => {
 		expect(fitPanelLayout(1_100, true, "half", 920)).toEqual({
 			sidebarCollapsed: true,

--- a/apps/inno-agent/web/src/stores/app-layout.ts
+++ b/apps/inno-agent/web/src/stores/app-layout.ts
@@ -12,6 +12,20 @@ export function getEffectiveWorkspaceWidth(width: number, mode: WorkspaceMode = 
 	return Math.max(minWidth, Math.min(WORKSPACE_MAX_WIDTH, Math.round(width)));
 }
 
+/**
+ * Maximum workspace width that can fit in the current non-overlay layout
+ * without squeezing the chat below its baseline width.
+ */
+export function getMaximumWorkspaceWidth(
+	viewportWidth: number,
+	sidebarCollapsed: boolean,
+	mode: WorkspaceMode,
+): number {
+	const minWidth = mode === "quarter" ? WORKSPACE_QUARTER_MIN_WIDTH : WORKSPACE_MIN_WIDTH;
+	const availableWidth = viewportWidth - CHAT_BASELINE_WIDTH - (sidebarCollapsed ? 0 : SIDEBAR_WIDTH);
+	return Math.max(minWidth, Math.min(WORKSPACE_MAX_WIDTH, Math.round(availableWidth)));
+}
+
 export interface FittedPanelLayout {
 	sidebarCollapsed: boolean;
 	workspaceMode: WorkspaceMode;

--- a/apps/inno-agent/web/src/stores/window-expansion.test.ts
+++ b/apps/inno-agent/web/src/stores/window-expansion.test.ts
@@ -22,4 +22,29 @@ describe("ensureWindowForPanel", () => {
 
 		await expect(ensureWindowForPanel("right", 640, "half")).resolves.toBe("unavailable");
 	});
+
+	it("moves the window left when the right edge has no room", async () => {
+		const windowMock = {
+			innerWidth: 1200,
+			innoDesktop: {} as NonNullable<Window["innoDesktop"]>,
+		};
+		const expandWindowWidth = vi.fn(async (side: "left" | "right", additionalWidth: number) => {
+			if (side !== "left") return false;
+			windowMock.innerWidth += additionalWidth;
+			return true;
+		});
+		const getWindowWidthCapacity = vi.fn(async (side: "left" | "right") => side === "left" ? 400 : 0);
+		windowMock.innoDesktop = {
+			setCloseDialogCopy: vi.fn(),
+			expandWindowWidth,
+			getWindowWidthCapacity,
+			openLocalFile: vi.fn(async () => false),
+		};
+		vi.stubGlobal("window", windowMock);
+
+		await expect(ensureWindowForPanel("right", 500, "half")).resolves.toBe("ready");
+		expect(getWindowWidthCapacity).toHaveBeenCalledWith("right");
+		expect(getWindowWidthCapacity).toHaveBeenCalledWith("left");
+		expect(expandWindowWidth).toHaveBeenCalledWith("left", 364);
+	});
 });

--- a/apps/inno-agent/web/src/stores/window-expansion.ts
+++ b/apps/inno-agent/web/src/stores/window-expansion.ts
@@ -30,6 +30,42 @@ function waitForViewportWidth(minWidth: number): Promise<boolean> {
 	});
 }
 
+async function expandRightPanelWindow(requiredWidth: number, additionalWidth: number): Promise<boolean> {
+	if (typeof window === "undefined") return false;
+	const expandWindowWidth = window.innoDesktop?.expandWindowWidth;
+	if (!expandWindowWidth) return false;
+
+	const getWindowWidthCapacity = window.innoDesktop?.getWindowWidthCapacity;
+	if (!getWindowWidthCapacity) {
+		const expanded = await expandWindowWidth("right", additionalWidth);
+		return expanded && await waitForViewportWidth(requiredWidth);
+	}
+
+	const [rightCapacity, leftCapacity] = await Promise.all([
+		getWindowWidthCapacity("right").catch(() => 0),
+		getWindowWidthCapacity("left").catch(() => 0),
+	]);
+	let remainingWidth = additionalWidth;
+
+	// Keep the existing right edge stable whenever possible. If the window is
+	// already at the display's right edge, consume the left-side capacity next
+	// so the right workspace can still grow by moving the window left.
+	for (const [expansionSide, capacity] of [["right", rightCapacity], ["left", leftCapacity]] as const) {
+		if (remainingWidth <= 0) break;
+		const expansionWidth = Math.min(remainingWidth, Math.max(0, Math.round(capacity)));
+		if (expansionWidth <= 0) continue;
+
+		const viewportBeforeExpansion = window.innerWidth;
+		const expanded = await expandWindowWidth(expansionSide, expansionWidth);
+		if (!expanded) continue;
+		const viewportReady = await waitForViewportWidth(viewportBeforeExpansion + expansionWidth);
+		if (!viewportReady) continue;
+		remainingWidth -= expansionWidth;
+	}
+
+	return remainingWidth <= 0 && await waitForViewportWidth(requiredWidth);
+}
+
 /**
  * Make room for a non-overlay panel before changing the app layout.
  *
@@ -55,15 +91,18 @@ export async function ensureWindowForPanel(
 	const additionalWidth = Math.max(0, requiredWidth - viewportWidth);
 	if (additionalWidth === 0) return "ready";
 
-	const expandWindowWidth = typeof window === "undefined" ? undefined : window.innoDesktop?.expandWindowWidth;
-	if (!expandWindowWidth) return "unavailable";
 	if (pendingExpansion) return "busy";
 
 	pendingExpansion = side;
 	try {
-		const expanded = await expandWindowWidth(side, additionalWidth);
+		const expanded = side === "right"
+			? await expandRightPanelWindow(requiredWidth, additionalWidth)
+			: typeof window !== "undefined" && window.innoDesktop?.expandWindowWidth
+				? await window.innoDesktop.expandWindowWidth(side, additionalWidth)
+					&& await waitForViewportWidth(requiredWidth)
+				: false;
 		if (!expanded) return "unavailable";
-		return (await waitForViewportWidth(requiredWidth)) ? "ready" : "unavailable";
+		return "ready";
 	} catch {
 		// A browser build, a closed Electron window, or a failed IPC request
 		// should fall back to the renderer's fitted layout instead of blocking

--- a/electron/main.js
+++ b/electron/main.js
@@ -119,6 +119,10 @@ ipcMain.on("inno-close-dialog-copy", (_event, copy) => {
 
 const MAX_WINDOW_EXPANSION = 1200;
 
+function isWindowExpansionSide(value) {
+  return value === "left" || value === "right";
+}
+
 function isWindowExpansionRequest(value) {
   return value
     && typeof value === "object"
@@ -160,6 +164,23 @@ ipcMain.handle("inno-expand-window-width", (event, request) => {
     width: nextWidth,
   }, true);
   return true;
+});
+
+ipcMain.handle("inno-window-width-capacity", (event, side) => {
+  if (!isWindowExpansionSide(side)
+    || !mainWindow
+    || mainWindow.isDestroyed()
+    || event.sender !== mainWindow.webContents) {
+    return 0;
+  }
+
+  const currentBounds = mainWindow.getBounds();
+  const display = screen.getDisplayMatching(currentBounds);
+  const workArea = display.workArea;
+  const capacity = side === "left"
+    ? currentBounds.x - workArea.x
+    : workArea.x + workArea.width - (currentBounds.x + currentBounds.width);
+  return Math.max(0, Math.min(MAX_WINDOW_EXPANSION, Math.floor(capacity)));
 });
 
 // ── Loading 窗口（服务启动期间显示） ────────────────────────────────────────

--- a/electron/preload.cjs
+++ b/electron/preload.cjs
@@ -43,4 +43,8 @@ contextBridge.exposeInMainWorld("innoDesktop", {
     }
     return ipcRenderer.invoke("inno-expand-window-width", { side, additionalWidth });
   },
+  getWindowWidthCapacity(side) {
+    if (!isWindowExpansionSide(side)) return Promise.resolve(0);
+    return ipcRenderer.invoke("inno-window-width-capacity", side);
+  },
 });


### PR DESCRIPTION
## 背景

右侧工作区的左边界原先无法在中间聊天区固定时继续向左拖动。此次改动让拖动过程先显示预览位置，释放后再提交实际宽度，并在必要时扩展桌面窗口。

## 改动内容

- 增加独立的拖动预览线，拖动过程中不立即改变工作区布局，释放鼠标后才提交宽度。
- 预览线使用固定定位，覆盖整个内容高度；拖动把手和竖线使用同一中心轴，避免视觉偏移。
- 最大宽度按实际空间计算：
  - 聊天区基准宽度：800px
  - 左侧栏展开时额外扣除：264px
  - 工作区硬上限：920px
  - 同时计算桌面窗口左右两侧可扩展空间
- 右侧工作区扩宽时优先向右扩展窗口；右侧已经贴近屏幕边缘时，窗口向左移动并增加宽度。
- 窗口扩展完成后等待视口和布局稳定，避免新的窗口尺寸事件把目标宽度恢复成旧值。
- 到达真实最大拖动位置时，预览线和把手变为红色；离开最大位置后恢复正常颜色。
- 支持 pointer cancel、窗口失焦和 Escape 取消拖动。
- 增加 Electron IPC，用于查询窗口左右剩余可扩展空间。
- 删除了拖动尺寸计算中的冗余 helper 和未使用的默认参数。

## 用户可见行为

1. 打开右侧工作区。
2. 拖动工作区左边界向左移动。
3. 拖动期间看到预览线，原工作区保持不变。
4. 释放后，窗口先扩展，工作区再切换到预览宽度。
5. 屏幕边缘或 920px 上限到达后，预览线变红并停止继续移动。

## 验证

- app-layout 与 window-expansion 测试：10 个测试全部通过。
- 前端生产构建：通过。
- electron/main.js 与 electron/preload.cjs 语法检查：通过。
- git diff 检查：通过。
- 新增回归测试覆盖：右侧无空间时通过左侧移动窗口扩展。

## 手动测试

需要完全重启桌面应用，以加载最新 preload。然后验证：

- 普通拖动、向右收窄、向左扩宽。
- 窗口右边贴近屏幕边缘时，窗口左边界是否向左移动。
- 到达最大位置时预览线是否变红。
- 释放、Escape、窗口失焦和 pointer cancel 后状态是否正确清理。

## 范围说明

本 PR 只包含从 upstream/main 之后的 4 个工作区拖动相关提交。当前本地工作区中其他未提交或未跟踪的修改没有被暂存、提交或推送。