### PR TITLE
fix(web): hover-reveal edit button + composer mirror sync on programmatic edits

### DIFF
--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1001,9 +1001,14 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		if (el) {
 			el.value = text;
 			el.focus();
+			// Programmatic value assignment fires no input event, and while smart
+			// input is enabled the textarea's own text is transparent — without an
+			// explicit sync the mirror stays stale and the draft renders invisible
+			// until the next click/selection.
+			engineRef.current?.syncNow();
 			resizeInput();
 		}
-	}, [resizeInput]);
+	}, [engineRef, resizeInput]);
 
 	const handleEditMessage = useCallback((message: ChatMessage) => {
 		if (chat.isSending || isUploading) return;

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
@@ -472,12 +472,12 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 		);
 		return (
 			<motion.div
-				className="flex flex-col items-end"
+				className="flex justify-end"
 				initial={{ opacity: 0, y: 12 }}
 				animate={{ opacity: 1, y: 0 }}
 				transition={{ duration: 0.25, ease: "easeOut" }}
 			>
-				<div className="inno-message w-fit whitespace-pre-wrap break-words rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]" style={{ maxWidth: "min(70%, 38rem)" }}>
+				<div className="inno-message group relative w-fit whitespace-pre-wrap break-words rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]" style={{ maxWidth: "min(70%, 38rem)" }}>
 					{showChannel && message.channel ? (
 						<div className="mb-1 flex justify-end"><ChannelBadge channel={message.channel} /></div>
 					) : null}
@@ -507,19 +507,18 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 					) : (
 						message.content.trim()
 					)}
+					{canEdit ? (
+						<button
+							type="button"
+							className="absolute -bottom-2 -right-2 inline-flex items-center justify-center rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] p-1 text-[var(--inno-text-subtle)] opacity-0 shadow-sm transition-opacity duration-150 hover:text-[var(--inno-text)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--inno-accent)] group-hover:opacity-100"
+							title={t("chat.editAndResend")}
+							aria-label={t("chat.editAndResend")}
+							onClick={() => onEdit?.(message)}
+						>
+							<Pencil size={12} />
+						</button>
+					) : null}
 				</div>
-				{canEdit ? (
-					<button
-						type="button"
-						className="mt-1 inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-[var(--inno-text-subtle)] transition-colors hover:bg-[var(--inno-surface-muted)] hover:text-[var(--inno-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--inno-accent)]"
-						title={t("chat.editAndResend")}
-						aria-label={t("chat.editAndResend")}
-						onClick={() => onEdit?.(message)}
-					>
-						<Pencil size={11} />
-						<span>{t("chat.editAndResend")}</span>
-					</button>
-				) : null}
 			</motion.div>
 		);
 	}


### PR DESCRIPTION
## Summary

Two follow-up fixes to the message edit feature from #209:

1. **Edit button restyle** — the "再次编辑" action was an always-visible text row below every plain user message, which read as detached from its bubble and added vertical noise. It is now a hover-revealed circular icon chip overlapping the bubble's bottom-right corner (fade-in via `group-hover`, still reachable by keyboard through `focus-visible`, label moved to tooltip/aria-label).

2. **Invisible draft fix** — after clicking the edit button, the restored draft rendered transparent until the user clicked the composer. Root cause: with smart input enabled, the textarea's own text is `color: transparent` and the visible text is painted by the engine's mirror layer, which only syncs on `input` events. `setComposerText` assigns `el.value` programmatically (no `input` event), leaving the mirror stale. Fixed by calling the engine's public `syncNow()` — the API intended for programmatic edits — after assignment. This also fixes the same latent issue for the slash-command pick path, which uses `setComposerText` too.

## Test plan

- [x] `npm --workspace inno-agent-web run build` (type-check + vite) passes
- [x] `vitest run apps/inno-agent/web/src/react/chat` — 68 tests pass
- [x] Manual: hover user bubble → pencil fades in at corner; click it → draft visible immediately in composer