### PR TITLE
fix(web): improve chat upload, smart input, and message actions

### DIFF
--- a/apps/inno-agent/web/src/api/skills.ts
+++ b/apps/inno-agent/web/src/api/skills.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "./client.js";
+import { assertUploadSize } from "../utils/upload-limits.js";
 import type { SkillInfo, SkillLibraryItem } from "../types/skills.js";
 import type { WorkspaceTreeNode, WorkspaceFileDetail } from "../types/workspace.js";
 
@@ -18,6 +19,7 @@ export async function importSkillFromLibrary(name: string): Promise<SkillInfo> {
 }
 
 export async function uploadSkill(file: File): Promise<SkillInfo> {
+	assertUploadSize(file);
 	const dataBase64 = await new Promise<string>((resolve, reject) => {
 		const reader = new FileReader();
 		reader.onload = () => {

--- a/apps/inno-agent/web/src/api/uploads.ts
+++ b/apps/inno-agent/web/src/api/uploads.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "./client.js";
+import { assertUploadSize } from "../utils/upload-limits.js";
 
 export interface RawUploadResult {
 	fileName: string;
@@ -19,6 +20,7 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
 }
 
 export async function uploadRawFile(file: File): Promise<RawUploadResult> {
+	assertUploadSize(file);
 	const dataBase64 = arrayBufferToBase64(await file.arrayBuffer());
 	return apiFetch<RawUploadResult>("/api/l2/raw/upload", {
 		method: "POST",

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -384,6 +384,93 @@ inno-workspace-panel textarea {
 	display: block;
 }
 
+.inno-message-wrap {
+	margin-bottom: 30px;
+}
+
+.inno-assistant-message {
+	margin-bottom: 30px;
+}
+
+.inno-message-actions {
+	position: absolute;
+	top: calc(100% + 2px);
+	right: 0;
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	min-height: 28px;
+	color: var(--inno-text-muted);
+	font-size: 12px;
+	line-height: 18px;
+	font-variant-numeric: tabular-nums;
+	opacity: 0;
+	visibility: hidden;
+	pointer-events: none;
+	transform: translateY(-2px);
+	transition: opacity var(--inno-dur-fast) var(--inno-ease-out), transform var(--inno-dur-fast) var(--inno-ease-out), visibility var(--inno-dur-fast);
+}
+
+.inno-message-wrap:hover .inno-message-actions,
+.inno-message-wrap:focus-within .inno-message-actions,
+.inno-assistant-message:hover .inno-message-actions,
+.inno-assistant-message:focus-within .inno-message-actions {
+	opacity: 1;
+	visibility: visible;
+	pointer-events: auto;
+	transform: translateY(0);
+}
+
+.inno-assistant-message .inno-message-actions {
+	right: auto;
+	left: 0;
+}
+
+.inno-message-action {
+	display: inline-flex;
+	width: 28px;
+	height: 28px;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	border: 0;
+	border-radius: 4px;
+	background: transparent;
+	color: inherit;
+	cursor: pointer;
+	touch-action: manipulation;
+	transition: color var(--inno-dur-fast) var(--inno-ease-out), background-color var(--inno-dur-fast) var(--inno-ease-out);
+}
+
+@media (pointer: coarse) {
+	.inno-message-wrap {
+		margin-bottom: 36px;
+	}
+
+	.inno-assistant-message {
+		margin-bottom: 36px;
+	}
+
+	.inno-message-actions {
+		min-height: 32px;
+	}
+
+	.inno-message-action {
+		width: 32px;
+		height: 32px;
+	}
+}
+
+.inno-message-action:hover {
+	background: var(--inno-surface-muted);
+	color: var(--inno-text);
+}
+
+.inno-message-action:focus-visible {
+	outline: none;
+	box-shadow: var(--inno-ring);
+}
+
 /* The streaming bubble splits the reply into a memoized stable region and a
    live tail, each rendered as its own markdown-artifact. Each artifact carries
    p-4 padding, so without correction the junction would show 2rem of vertical
@@ -1801,12 +1888,19 @@ inno-workspace-panel textarea {
 	box-shadow: none;
 }
 
-:root[data-theme="innospark"] .justify-end > .inno-message {
+:root[data-theme="innospark"] .justify-end .inno-user-message {
+	border-radius: 16px 16px 0 16px;
 	border-color: transparent;
 	background: var(--inno-accent-soft);
 }
 
 :root[data-theme="innospark"] .justify-start > .inno-message:has(markdown-artifact) {
+	border-color: transparent;
+	background: transparent;
+	box-shadow: none;
+}
+
+:root[data-theme="innospark"] .justify-start > .inno-assistant-message {
 	border-color: transparent;
 	background: transparent;
 	box-shadow: none;

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -380,10 +380,6 @@ inno-workspace-panel textarea {
 	white-space: pre-wrap;
 }
 
-.inno-message markdown-artifact {
-	display: block;
-}
-
 .inno-message-wrap {
 	margin-bottom: 30px;
 }
@@ -469,15 +465,6 @@ inno-workspace-panel textarea {
 .inno-message-action:focus-visible {
 	outline: none;
 	box-shadow: var(--inno-ring);
-}
-
-/* The streaming bubble splits the reply into a memoized stable region and a
-   live tail, each rendered as its own markdown-artifact. Each artifact carries
-   p-4 padding, so without correction the junction would show 2rem of vertical
-   space where a single artifact would show a 1rem paragraph margin. Pull the
-   second artifact up by 1rem to make the split seam invisible. */
-.inno-streaming-blocks markdown-artifact + markdown-artifact {
-	margin-top: -1rem;
 }
 
 .inno-composer {
@@ -1892,12 +1879,6 @@ inno-workspace-panel textarea {
 	border-radius: 16px 16px 0 16px;
 	border-color: transparent;
 	background: var(--inno-accent-soft);
-}
-
-:root[data-theme="innospark"] .justify-start > .inno-message:has(markdown-artifact) {
-	border-color: transparent;
-	background: transparent;
-	box-shadow: none;
 }
 
 :root[data-theme="innospark"] .justify-start > .inno-assistant-message {

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -384,7 +384,14 @@ inno-workspace-panel textarea {
 	margin-bottom: 30px;
 }
 
-.inno-assistant-message {
+.inno-message.inno-assistant-message,
+.inno-message.inno-streaming-blocks {
+	border: 0;
+	background: transparent;
+	box-shadow: none;
+}
+
+.inno-message.inno-assistant-message {
 	margin-bottom: 30px;
 }
 
@@ -1879,12 +1886,6 @@ inno-workspace-panel textarea {
 	border-radius: 16px 16px 0 16px;
 	border-color: transparent;
 	background: var(--inno-accent-soft);
-}
-
-:root[data-theme="innospark"] .justify-start > .inno-assistant-message {
-	border-color: transparent;
-	background: transparent;
-	box-shadow: none;
 }
 
 :root[data-theme="innospark"] .justify-start > details.inno-message {

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -2667,12 +2667,11 @@ body.inno-smart-dragging .inno-smart-kw-hit::before {
 	100% { transform: scale(1); }
 }
 
-/* ── Smart input toast (auto-dismissing, bottom-center) ── */
+/* ── Smart input toast (auto-dismissing, centered in the chat area) ── */
 .inno-smart-toast {
-	position: fixed;
+	position: absolute;
 	left: 50%;
-	bottom: 108px;
-	transform: translateX(-50%);
+  top: 30px;
 	z-index: 70;
 	max-width: min(420px, calc(100vw - 48px));
 	padding: 6px 14px;
@@ -2681,10 +2680,17 @@ body.inno-smart-dragging .inno-smart-kw-hit::before {
 	background: var(--inno-surface-raised);
 	color: var(--inno-text);
 	font-size: 12px;
+	transform: translateX(-50%);
 	box-shadow: var(--inno-shadow-soft);
-	animation: inno-smart-panel-in var(--inno-dur-ui) var(--inno-ease-out);
+	animation: inno-smart-toast-in var(--inno-dur-ui) var(--inno-ease-out);
 	pointer-events: none;
 }
+
+@keyframes inno-smart-toast-in {
+	from { opacity: 0; transform: translate(-50%, -4px); }
+	to { opacity: 1; transform: translate(-50%, 0); }
+}
+
 .inno-smart-toast.is-error {
 	border-color: var(--inno-danger-border);
 	background: color-mix(in srgb, var(--inno-danger-bg) 60%, var(--inno-surface-raised));

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -375,7 +375,6 @@
 		"reload": "Reload",
 		"upload": "Upload",
 		"uploading": "Uploading…",
-		"uploadTooLarge": "The file exceeds the {{limit}} limit and was not uploaded.",
 		"package": "Default package:",
 		"packageDesc": "ZIP must contain a SKILL.md file.",
 		"empty": "No skills yet",

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -375,6 +375,7 @@
 		"reload": "Reload",
 		"upload": "Upload",
 		"uploading": "Uploading…",
+		"uploadTooLarge": "The file exceeds the {{limit}} limit and was not uploaded.",
 		"package": "Default package:",
 		"packageDesc": "ZIP must contain a SKILL.md file.",
 		"empty": "No skills yet",
@@ -754,6 +755,7 @@
 		"emptySessionHint": "Type a message below to start the conversation.",
 		"uploadFiles": "Upload files to workspace",
 		"uploadHint": "Select an existing workspace or start a conversation before uploading files",
+		"uploadTooLarge": "{{count}} file(s) exceed the {{limit}} limit and were not added.",
 		"attachImage": "Attach image",
 		"attachImageViaOcr": "Attach image (the current model will use OCR)",
 		"selectModel": "Select model",
@@ -970,7 +972,8 @@
 		"fileSelectionOnly": "Select files (folders cannot be selected)",
 		"deleteSelected": "Delete selected files",
 		"uploadSkill": "Upload skill package (.zip/.md) to .skills",
-		"dropToUpload": "Drop files to upload"
+		"dropToUpload": "Drop files to upload",
+		"uploadTooLarge": "{{count}} file(s) exceed the {{limit}} limit and were not uploaded."
 	},
 	"categories": {
 		"教学辅导": "Teaching & Tutoring",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -375,6 +375,7 @@
 		"reload": "重新加载",
 		"upload": "上传",
 		"uploading": "上传中…",
+		"uploadTooLarge": "文件超过 {{limit}} 上限，未上传。",
 		"package": "默认包格式：",
 		"packageDesc": "ZIP 包内需包含 SKILL.md 文件。",
 		"empty": "暂无技能",
@@ -754,6 +755,7 @@
 		"emptySessionHint": "在下方输入消息，开始新的对话。",
 		"uploadFiles": "上传文件到工作区",
 		"uploadHint": "请先选择已有工作区或开始对话后再上传文件",
+		"uploadTooLarge": "有 {{count}} 个文件超过 {{limit}} 上限，未添加。",
 		"attachImage": "添加图片",
 		"attachImageViaOcr": "添加图片（当前模型将通过 OCR 处理）",
 		"selectModel": "选择模型",
@@ -970,7 +972,8 @@
 		"fileSelectionOnly": "请选择文件（文件夹不可选）",
 		"deleteSelected": "删除已选文件",
 		"uploadSkill": "上传技能包 (.zip/.md) 到 .skills",
-		"dropToUpload": "拖放文件以上传"
+		"dropToUpload": "拖放文件以上传",
+		"uploadTooLarge": "有 {{count}} 个文件超过 {{limit}} 上限，未上传。"
 	},
 	"categories": {
 		"教学辅导": "教学辅导",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -375,7 +375,6 @@
 		"reload": "重新加载",
 		"upload": "上传",
 		"uploading": "上传中…",
-		"uploadTooLarge": "文件超过 {{limit}} 上限，未上传。",
 		"package": "默认包格式：",
 		"packageDesc": "ZIP 包内需包含 SKILL.md 文件。",
 		"empty": "暂无技能",

--- a/apps/inno-agent/web/src/main.tsx
+++ b/apps/inno-agent/web/src/main.tsx
@@ -2,8 +2,7 @@ import "./app.css";
 import "./agent-command-bubbles.css";
 import "./i18n/index.js";
 import "./stores/theme-store.js";
-// Register <markdown-block> explicitly — QuestionDialog depends on it and must not
-// rely on pi-web-ui's side-effect import chain (ChatCenter → MarkdownArtifact → mini-lit).
+// Register <markdown-block> explicitly — QuestionDialog depends on it.
 import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 
 import { Component, StrictMode, type ErrorInfo, type ReactNode } from "react";

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1352,7 +1352,6 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 			hitRef={hitRef}
 			chatIsSending={chat.isSending}
 			canReconnect={chat.canReconnect}
-			lastUserPrompt={chat.lastUserPrompt}
 			isUploading={isUploading}
 			hasSendableContent={hasSendableContent}
 			hasPendingQuestion={Boolean(chat.pendingQuestion)}
@@ -1377,7 +1376,6 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 			onSend={handleSend}
 			onStop={handleStop}
 			onReconnect={handleReconnect}
-			onRetry={handleRetry}
 			slashPalette={slashPaletteOpen ? (
 				<SlashCommandPalette
 					entries={slashEntries}
@@ -1492,6 +1490,8 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 			onOpenAttachment={openChatAttachmentPreview}
 			onOpenSkill={openSkillPanel}
 			onEditMessage={handleEditMessage}
+			canRetry={Boolean(chat.lastUserPrompt) && !chat.isSending && !chat.pendingQuestion && !isUploading}
+			onRetry={handleRetry}
 			wsError={wsError}
 		/>
 		</>

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -9,7 +9,6 @@ import {
 	type KeyboardEvent,
 	type PointerEvent as ReactPointerEvent,
 } from "react";
-import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import type { InnoModelInfo, SmartInputSettings } from "../types/settings.js";
 import { chatStore } from "../stores/chat-store.js";
@@ -44,6 +43,7 @@ import {
 import { fetchSlashCommands, type SlashCommandItem } from "../api/commands.js";
 import { WorkspaceContext } from "./chat/WorkspaceContext.js";
 import type { WorkspaceChoice } from "./WorkspaceSwitcher.js";
+import { DEFAULT_UPLOAD_MAX_BYTES, DEFAULT_UPLOAD_MAX_LABEL, getOversizedFiles } from "../utils/upload-limits.js";
 import {
 	flattenWorkspaceFiles,
 	isLargeTextPaste,
@@ -61,6 +61,8 @@ import type { EngineAttachmentItem } from "./chat/smart-input/engine.js";
 import type { KwRange } from "./chat/smart-input/rules.js";
 import { useSmartInput } from "./chat/smart-input/useSmartInput.js";
 import { SmartInputOverlay, type SmartPanelState } from "./chat/smart-input/SmartInputOverlay.js";
+import { collapseSkillMessage } from "./chat/skill-message-collapse.js";
+import { parseAgentCommandMessage } from "./chat/agent-command-message.js";
 
 type PresetRefreshStatus = "success" | "error";
 
@@ -97,6 +99,17 @@ function rememberWsChoice(mode: WsMode, existingId: string): void {
 
 const SMART_FILE_PREVIEW_WIDTH = 560;
 const SMART_HOVER_OPEN_MS = 250;
+
+function pendingUploadsFromRefs(refs: AttachmentRef[]): PendingUpload[] {
+	const seen = new Set<string>();
+	return refs.flatMap((file) => {
+		if (!file.path || seen.has(file.path)) return [];
+		seen.add(file.path);
+		// Sent files already live in the session workspace, regardless of whether
+		// they originally came from the workspace or a local upload.
+		return [workspacePendingUpload(file.path)];
+	});
+}
 
 export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile }: ChatCenterProps) {
 	const { t } = useTranslation();
@@ -540,6 +553,16 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		if (smartToastTimer.current !== null) window.clearTimeout(smartToastTimer.current);
 		smartToastTimer.current = window.setTimeout(() => setSmartToast(null), 2200);
 	}, []);
+	const filterUploadFiles = useCallback((files: File[]): File[] => {
+		const oversized = getOversizedFiles(files);
+		if (oversized.length > 0) {
+			showSmartToast(t("chat.uploadTooLarge", "有 {{count}} 个文件超过 {{limit}} 上限，未添加。", {
+				count: oversized.length,
+				limit: DEFAULT_UPLOAD_MAX_LABEL,
+			}), true);
+		}
+		return files.filter((file) => file.size <= DEFAULT_UPLOAD_MAX_BYTES);
+	}, [showSmartToast, t]);
 	const saveSmartInput = useCallback((next: SmartInputSettings) => {
 		void settingsStore.saveSmartInput(next).catch(() => {
 			showSmartToast(t("settings.smartInput.saveFailed", "便捷输入设置保存失败"), true);
@@ -1015,13 +1038,43 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		const sessionId = sessions.currentSessionId;
 		if (!sessionId || !message.entryId) return;
 		const content = message.content.trim();
-		if (!content) return;
+		const attachments = message.attachments;
+		const bindingFiles = attachments?.bindings.flatMap((binding) => binding.files) ?? [];
+		const hasAttachments = bindingFiles.length > 0 || Boolean(attachments?.loose.length);
+		if (!content && !hasAttachments) return;
+		const collapsedSkill = collapseSkillMessage(content);
+		const command = collapsedSkill
+			? { command: `skill:${collapsedSkill.skillName}`, args: collapsedSkill.args }
+			: parseAgentCommandMessage(content);
+		const editableText = command ? (command.args ? ` ${command.args}` : "") : content;
 		const currentDraft = inputRef.current?.value ?? draftRef.current;
-		if (currentDraft.trim() && currentDraft.trim() !== content && !window.confirm(t("chat.replaceDraftConfirm"))) return;
+		if (currentDraft.trim() && currentDraft.trim() !== editableText.trim() && !window.confirm(t("chat.replaceDraftConfirm"))) return;
 		editTargetRef.current = { sessionId, entryId: message.entryId };
-		setComposerText(content);
+		setInlineImages([]);
+		setPasteBlocks([]);
+
+		if (command) {
+			setComposerText(editableText);
+			const engine = engineRef.current;
+			const useAgentBubble = Boolean(engine && smartInputEnabled && smartSettings?.allowAgentCommands === true);
+			if (!useAgentBubble || !engine || !engine.insertAgentCommandAsBubble(command.command, 0, 0)) {
+				setComposerText(`/${command.command}${command.args ? ` ${command.args}` : ""}`);
+			}
+		} else {
+			setComposerText(content);
+			const engine = smartInputEnabled ? engineRef.current : null;
+			const unplacedBindings = engine?.restoreBindings(attachments?.bindings ?? []) ?? bindingFiles;
+			const looseFiles = engine ? [...(attachments?.loose ?? []), ...unplacedBindings] : [...bindingFiles, ...(attachments?.loose ?? [])];
+			setUploads(pendingUploadsFromRefs(looseFiles));
+		}
+
+		if (command) {
+			// Agent command bubbles cannot own files, so keep any unusual mixed
+			// command/file message editable by returning every file to the loose row.
+			setUploads(pendingUploadsFromRefs([...bindingFiles, ...(attachments?.loose ?? [])]));
+		}
 		showSmartToast(t("chat.editLoaded"));
-	}, [chat.isSending, isUploading, sessions.currentSessionId, setComposerText, showSmartToast, t]);
+	}, [chat.isSending, isUploading, sessions.currentSessionId, setComposerText, showSmartToast, smartInputEnabled, smartSettings?.allowAgentCommands, t]);
 
 	const slashQuery = slashQueryFromDraft(draftValue);
 	const slashPaletteOpen = slashQuery !== null && slashDismissedFor !== draftValue && !chat.isSending;
@@ -1140,16 +1193,17 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 	}, []);
 
 	const addImageFiles = useCallback((files: File[]) => {
-		files.forEach((file) => {
+		filterUploadFiles(files).forEach((file) => {
 			void prepareInlineImage(file).then((prepared) => setInlineImages((prev) => [...prev, prepared]));
 		});
-	}, []);
+	}, [filterUploadFiles]);
 
 	const addLocalFiles = useCallback((files: File[]) => {
-		if (files.length === 0) return;
+		const accepted = filterUploadFiles(files);
+		if (accepted.length === 0) return;
 		setWsError("");
-		setUploads((current) => [...current, ...files.map(localPendingUpload)]);
-	}, []);
+		setUploads((current) => [...current, ...accepted.map(localPendingUpload)]);
+	}, [filterUploadFiles]);
 
 	const showPasteInTextField = useCallback((blockId: number) => {
 		const el = inputRef.current;
@@ -1356,9 +1410,8 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 
 	const questionHint = chat.pendingQuestion ? <QuestionHint scrollRef={scrollRef} /> : null;
 	const busyBlocker = <BusyBlocker busyBlocker={sessions.busyBlocker} />;
-	const smartToastNode = smartToast && typeof document !== "undefined" ? createPortal(
-		<div className={`inno-smart-toast ${smartToast.error ? "is-error" : ""}`} role="status">{smartToast.message}</div>,
-		document.body,
+	const smartToastNode = smartToast ? (
+		<div className={`inno-smart-toast ${smartToast.error ? "is-error" : ""}`} role="status">{smartToast.message}</div>
 	) : null;
 	const smartOverlayNode = smartInputEnabled ? (
 		<SmartInputOverlay
@@ -1390,7 +1443,6 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 	if (isWelcome) {
 		return (
 			<>
-			{smartToastNode}
 			{smartOverlayNode}
 			<ChatWelcome
 				welcomeLayoutRef={welcomeLayoutRef}
@@ -1399,6 +1451,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 				onToggleMode={toggleMode}
 				questionHint={questionHint}
 				busyBlocker={busyBlocker}
+				smartToast={smartToastNode}
 				composer={renderComposer(t("chat.welcomePlaceholder"))}
 				workspaceContext={workspaceContext}
 				presets={presets}
@@ -1421,7 +1474,6 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 
 	return (
 		<>
-		{smartToastNode}
 		{smartOverlayNode}
 		<ChatConversation
 			chat={chat}
@@ -1433,6 +1485,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 			onPauseAutoScroll={pauseAutoScroll}
 			questionHint={questionHint}
 			busyBlocker={busyBlocker}
+			smartToast={smartToastNode}
 			composer={renderComposer(t("chat.composerPlaceholder"))}
 			onOpenAttachment={openChatAttachmentPreview}
 			onOpenSkill={openSkillPanel}

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -553,16 +553,17 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		if (smartToastTimer.current !== null) window.clearTimeout(smartToastTimer.current);
 		smartToastTimer.current = window.setTimeout(() => setSmartToast(null), 2200);
 	}, []);
+	const notifyUploadLimitExceeded = useCallback((count: number) => {
+		showSmartToast(t("chat.uploadTooLarge", "有 {{count}} 个文件超过 {{limit}} 上限，未添加。", {
+			count,
+			limit: DEFAULT_UPLOAD_MAX_LABEL,
+		}), true);
+	}, [showSmartToast, t]);
 	const filterUploadFiles = useCallback((files: File[]): File[] => {
 		const oversized = getOversizedFiles(files);
-		if (oversized.length > 0) {
-			showSmartToast(t("chat.uploadTooLarge", "有 {{count}} 个文件超过 {{limit}} 上限，未添加。", {
-				count: oversized.length,
-				limit: DEFAULT_UPLOAD_MAX_LABEL,
-			}), true);
-		}
+		if (oversized.length > 0) notifyUploadLimitExceeded(oversized.length);
 		return files.filter((file) => file.size <= DEFAULT_UPLOAD_MAX_BYTES);
-	}, [showSmartToast, t]);
+	}, [notifyUploadLimitExceeded]);
 	const saveSmartInput = useCallback((next: SmartInputSettings) => {
 		void settingsStore.saveSmartInput(next).catch(() => {
 			showSmartToast(t("settings.smartInput.saveFailed", "便捷输入设置保存失败"), true);
@@ -748,6 +749,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 			if (smartPanelRef.current?.slotId === slot.id) updateSmartPanel(null);
 		},
 		onChipHover: handleChipHover,
+		onUploadLimitExceeded: notifyUploadLimitExceeded,
 		onWorkspaceHighlight: highlightWorkspace,
 	});
 

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1334,7 +1334,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 			modelState={modelState}
 			modelOptions={modelOptions}
 			currentModel={currentModel}
-			smartInputControl={!isWelcome && !simpleMode ? (
+			smartInputControl={((isWelcome && simpleMode) || (!isWelcome && !simpleMode)) ? (
 				<SmartInputControl
 					smartInputSettings={smartSettings}
 					onToggleSmartInput={toggleSmartInput}

--- a/apps/inno-agent/web/src/react/MarkdownArtifact.tsx
+++ b/apps/inno-agent/web/src/react/MarkdownArtifact.tsx
@@ -1,20 +1,10 @@
-import { lazy, Suspense } from "react";
+import "@mariozechner/mini-lit/dist/CodeBlock.js";
+import "@mariozechner/mini-lit/dist/MarkdownBlock.js";
 
 interface MarkdownArtifactProps {
 	content: string;
 }
 
-const MarkdownArtifactElement = lazy(async () => {
-	await import("@earendil-works/pi-web-ui");
-	return {
-		default: ({ content }: MarkdownArtifactProps) => <markdown-artifact content={content} />,
-	};
-});
-
 export function MarkdownArtifact({ content }: MarkdownArtifactProps) {
-	return (
-		<Suspense fallback={<pre className="whitespace-pre-wrap break-words font-sans text-[13px] leading-relaxed">{content}</pre>}>
-			<MarkdownArtifactElement content={content} />
-		</Suspense>
-	);
+	return <markdown-block content={content} />;
 }

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -16,7 +16,6 @@ import { Spinner } from "./ui/Spinner.js";
 import { LazyCodeEditor } from "./LazyCodeEditor.js";
 import { LazyMarkdownEditor } from "./LazyMarkdownEditor.js";
 import { FileName } from "./FileName.js";
-import { DEFAULT_UPLOAD_MAX_LABEL, getOversizedFiles } from "../utils/upload-limits.js";
 import "@earendil-works/pi-web-ui";
 
 /* ---------- helpers (same as WorkspaceBrowser) ---------- */
@@ -482,7 +481,6 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 export function SkillsPanel({ dndManager }: { dndManager: DragDropManager }) {
 	const { t } = useTranslation();
 	const uploadRef = useRef<HTMLInputElement | null>(null);
-	const [uploadError, setUploadError] = useState("");
 	const state = useStoreSnapshot(skillsStore, () => ({
 		skills: skillsStore.skills,
 		selectedSkill: skillsStore.selectedSkill,
@@ -500,12 +498,6 @@ export function SkillsPanel({ dndManager }: { dndManager: DragDropManager }) {
 	function handleUpload(event: React.ChangeEvent<HTMLInputElement>) {
 		const file = event.target.files?.[0];
 		if (!file) return;
-		if (getOversizedFiles([file]).length > 0) {
-			setUploadError(t("skills.uploadTooLarge", "文件超过 {{limit}} 上限，未上传。", { limit: DEFAULT_UPLOAD_MAX_LABEL }));
-			event.target.value = "";
-			return;
-		}
-		setUploadError("");
 		void skillsStore.upload(file);
 		event.target.value = "";
 	}
@@ -552,8 +544,6 @@ export function SkillsPanel({ dndManager }: { dndManager: DragDropManager }) {
 						</button>
 					</div>
 				</div>
-				{uploadError ? <div className="border-b border-[var(--inno-border)] bg-[var(--inno-danger-bg)] px-4 py-2 text-xs text-[var(--inno-danger)]" role="alert">{uploadError}</div> : null}
-
 				{/* Search (visible when there's anything to search through) */}
 				{state.skills.length > 0 ? (
 					<div className="flex items-center gap-2 border-b border-[var(--inno-border)] px-3 py-2">

--- a/apps/inno-agent/web/src/react/SkillsPanel.tsx
+++ b/apps/inno-agent/web/src/react/SkillsPanel.tsx
@@ -16,6 +16,7 @@ import { Spinner } from "./ui/Spinner.js";
 import { LazyCodeEditor } from "./LazyCodeEditor.js";
 import { LazyMarkdownEditor } from "./LazyMarkdownEditor.js";
 import { FileName } from "./FileName.js";
+import { DEFAULT_UPLOAD_MAX_LABEL, getOversizedFiles } from "../utils/upload-limits.js";
 import "@earendil-works/pi-web-ui";
 
 /* ---------- helpers (same as WorkspaceBrowser) ---------- */
@@ -481,6 +482,7 @@ function SkillLibraryModal({ onClose }: { onClose: () => void }) {
 export function SkillsPanel({ dndManager }: { dndManager: DragDropManager }) {
 	const { t } = useTranslation();
 	const uploadRef = useRef<HTMLInputElement | null>(null);
+	const [uploadError, setUploadError] = useState("");
 	const state = useStoreSnapshot(skillsStore, () => ({
 		skills: skillsStore.skills,
 		selectedSkill: skillsStore.selectedSkill,
@@ -498,6 +500,12 @@ export function SkillsPanel({ dndManager }: { dndManager: DragDropManager }) {
 	function handleUpload(event: React.ChangeEvent<HTMLInputElement>) {
 		const file = event.target.files?.[0];
 		if (!file) return;
+		if (getOversizedFiles([file]).length > 0) {
+			setUploadError(t("skills.uploadTooLarge", "文件超过 {{limit}} 上限，未上传。", { limit: DEFAULT_UPLOAD_MAX_LABEL }));
+			event.target.value = "";
+			return;
+		}
+		setUploadError("");
 		void skillsStore.upload(file);
 		event.target.value = "";
 	}
@@ -544,6 +552,7 @@ export function SkillsPanel({ dndManager }: { dndManager: DragDropManager }) {
 						</button>
 					</div>
 				</div>
+				{uploadError ? <div className="border-b border-[var(--inno-border)] bg-[var(--inno-danger-bg)] px-4 py-2 text-xs text-[var(--inno-danger)]" role="alert">{uploadError}</div> : null}
 
 				{/* Search (visible when there's anything to search through) */}
 				{state.skills.length > 0 ? (

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -22,6 +22,7 @@ import { useStoreSnapshot } from "./hooks.js";
 import { ContextMenu, type ContextMenuItem } from "./ui/ContextMenu.js";
 import { FileName } from "./FileName.js";
 import { buildDragFilePanel, hiddenDragImage } from "./chat/smart-input/drag-utils.js";
+import { DEFAULT_UPLOAD_MAX_LABEL, getOversizedFiles } from "../utils/upload-limits.js";
 import "@earendil-works/pi-web-ui";
 
 // Heavy office renderers are lazy-loaded so docx-preview / xlsx stay off the
@@ -866,6 +867,7 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 	const [ctxMenu, setCtxMenu] = useState<CtxMenuState | null>(null);
 	const [deleteConfirm, setDeleteConfirm] = useState<{ ids: string[] } | null>(null);
 	const [isDragOver, setIsDragOver] = useState(false);
+	const [uploadError, setUploadError] = useState("");
 	const [multiSelectMode, setMultiSelectMode] = useState(false);
 	const [selectedFileIds, setSelectedFileIds] = useState<string[]>([]);
 
@@ -1086,6 +1088,19 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 
 	/* --- Upload handlers --- */
 
+	const filterUploadFiles = useCallback((files: File[]): File[] => {
+		const oversized = getOversizedFiles(files);
+		if (oversized.length > 0) {
+			setUploadError(t("files.uploadTooLarge", "有 {{count}} 个文件超过 {{limit}} 上限，未上传。", {
+				count: oversized.length,
+				limit: DEFAULT_UPLOAD_MAX_LABEL,
+			}));
+		} else {
+			setUploadError("");
+		}
+		return files.filter((file) => !oversized.includes(file));
+	}, [t]);
+
 	const selectedParentPath = useCallback(() => {
 		const sel = treeRef.current?.selectedNodes?.[0];
 		if (!sel) return "";
@@ -1095,12 +1110,12 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 	const handleSkillUploadChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
 		const files = e.target.files;
 		if (files?.length) {
-			for (const file of Array.from(files)) {
+			for (const file of filterUploadFiles(Array.from(files))) {
 				void workspaceStore.uploadSkillPackage(file);
 			}
 			e.target.value = "";
 		}
-	}, []);
+	}, [filterUploadFiles]);
 
 	/** Only true when dragging files from OS (not internal react-dnd tree drags) */
 	const isExternalFileDrag = useCallback((e: DragEvent) => {
@@ -1124,9 +1139,10 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 		e.preventDefault();
 		setIsDragOver(false);
 		if (e.dataTransfer.files?.length) {
-			void workspaceStore.uploadFiles(selectedParentPath(), e.dataTransfer.files);
+			const files = filterUploadFiles(Array.from(e.dataTransfer.files));
+			if (files.length > 0) void workspaceStore.uploadFiles(selectedParentPath(), files);
 		}
-	}, [selectedParentPath, isExternalFileDrag]);
+	}, [selectedParentPath, isExternalFileDrag, filterUploadFiles]);
 
 	/* --- Toolbar button helpers --- */
 	const busy = state.isMutating || state.isLoadingTree;
@@ -1169,6 +1185,7 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 					</button>
 					<input ref={skillUploadRef} type="file" multiple accept=".zip,application/zip,.md,text/markdown" className="hidden" onChange={handleSkillUploadChange} />
 				</div>
+				{uploadError ? <div className="border-b border-[var(--inno-border)] bg-[var(--inno-danger-bg)] px-3 py-2 text-xs text-[var(--inno-danger)]" role="alert">{uploadError}</div> : null}
 
 				{multiSelectMode ? (
 					<div className="flex h-9 shrink-0 items-center gap-2 border-b border-[var(--inno-border)] bg-[var(--inno-accent-soft)] px-2">

--- a/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceBrowser.tsx
@@ -95,6 +95,21 @@ function formatSize(size = 0): string {
 	return `${(size / 1024 / 1024).toFixed(1)} MB`;
 }
 
+/**
+ * OS file drags expose their files differently across browsers and drag
+ * phases. During dragover, `dataTransfer.files` can be empty while the file
+ * entries are still available through `dataTransfer.items`.
+ */
+function filesFromDataTransfer(dataTransfer: DataTransfer | null | undefined): File[] {
+	if (!dataTransfer) return [];
+	const files = Array.from(dataTransfer.files ?? []);
+	if (files.length > 0) return files;
+	return Array.from(dataTransfer.items ?? [])
+		.filter((item) => item.kind === "file")
+		.map((item) => item.getAsFile())
+		.filter((file): file is File => file !== null);
+}
+
 function nodeIcon(name: string, isDir: boolean, isOpen: boolean) {
 	if (isDir) return isOpen ? <FolderOpen size={14} /> : <Folder size={14} />;
 	const lower = name.toLowerCase();
@@ -868,6 +883,7 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 	const [deleteConfirm, setDeleteConfirm] = useState<{ ids: string[] } | null>(null);
 	const [isDragOver, setIsDragOver] = useState(false);
 	const [uploadError, setUploadError] = useState("");
+	const uploadErrorTimerRef = useRef<number | null>(null);
 	const [multiSelectMode, setMultiSelectMode] = useState(false);
 	const [selectedFileIds, setSelectedFileIds] = useState<string[]>([]);
 
@@ -1086,20 +1102,40 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 		exit: exitMultiSelect,
 	}), [multiSelectMode, selectedFileIdSet, selectedFiles, toggleSelectedFile, addSelectedFile, exitMultiSelect]);
 
+	useEffect(() => () => {
+		if (uploadErrorTimerRef.current !== null) window.clearTimeout(uploadErrorTimerRef.current);
+	}, []);
+
 	/* --- Upload handlers --- */
+	const showUploadError = useCallback((message: string) => {
+		if (uploadErrorTimerRef.current !== null) window.clearTimeout(uploadErrorTimerRef.current);
+		setUploadError(message);
+		uploadErrorTimerRef.current = window.setTimeout(() => {
+			uploadErrorTimerRef.current = null;
+			setUploadError("");
+		}, 2200);
+	}, []);
+
+	const clearUploadError = useCallback(() => {
+		if (uploadErrorTimerRef.current !== null) {
+			window.clearTimeout(uploadErrorTimerRef.current);
+			uploadErrorTimerRef.current = null;
+		}
+		setUploadError("");
+	}, []);
 
 	const filterUploadFiles = useCallback((files: File[]): File[] => {
 		const oversized = getOversizedFiles(files);
 		if (oversized.length > 0) {
-			setUploadError(t("files.uploadTooLarge", "有 {{count}} 个文件超过 {{limit}} 上限，未上传。", {
+			showUploadError(t("files.uploadTooLarge", "有 {{count}} 个文件超过 {{limit}} 上限，未上传。", {
 				count: oversized.length,
 				limit: DEFAULT_UPLOAD_MAX_LABEL,
 			}));
 		} else {
-			setUploadError("");
+			clearUploadError();
 		}
 		return files.filter((file) => !oversized.includes(file));
-	}, [t]);
+	}, [clearUploadError, showUploadError, t]);
 
 	const selectedParentPath = useCallback(() => {
 		const sel = treeRef.current?.selectedNodes?.[0];
@@ -1119,30 +1155,50 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 
 	/** Only true when dragging files from OS (not internal react-dnd tree drags) */
 	const isExternalFileDrag = useCallback((e: DragEvent) => {
-		return e.dataTransfer.types.includes("Files");
+		return Array.from(e.dataTransfer?.types ?? []).includes("Files")
+			|| Array.from(e.dataTransfer?.items ?? []).some((item) => item.kind === "file");
 	}, []);
 
 	const handleDragOver = useCallback((e: DragEvent) => {
 		if (!isExternalFileDrag(e)) return;
 		e.preventDefault();
+		e.dataTransfer.dropEffect = "copy";
+		const oversized = getOversizedFiles(filesFromDataTransfer(e.dataTransfer));
+		if (oversized.length > 0) {
+			if (uploadErrorTimerRef.current !== null) {
+				window.clearTimeout(uploadErrorTimerRef.current);
+				uploadErrorTimerRef.current = null;
+			}
+			setUploadError(t("files.uploadTooLarge", "有 {{count}} 个文件超过 {{limit}} 上限，未上传。", {
+				count: oversized.length,
+				limit: DEFAULT_UPLOAD_MAX_LABEL,
+			}));
+		} else if (uploadError) {
+			clearUploadError();
+		}
 		setIsDragOver(true);
-	}, [isExternalFileDrag]);
+	}, [clearUploadError, isExternalFileDrag, t, uploadError]);
 
 	const handleDragLeave = useCallback((e: DragEvent) => {
 		if (!isExternalFileDrag(e)) return;
 		e.preventDefault();
 		setIsDragOver(false);
-	}, [isExternalFileDrag]);
+		clearUploadError();
+	}, [clearUploadError, isExternalFileDrag]);
 
 	const handleDrop = useCallback((e: DragEvent) => {
 		if (!isExternalFileDrag(e)) return;
 		e.preventDefault();
+		e.stopPropagation();
 		setIsDragOver(false);
-		if (e.dataTransfer.files?.length) {
-			const files = filterUploadFiles(Array.from(e.dataTransfer.files));
+		const droppedFiles = filesFromDataTransfer(e.dataTransfer);
+		if (droppedFiles.length > 0) {
+			const files = filterUploadFiles(droppedFiles);
 			if (files.length > 0) void workspaceStore.uploadFiles(selectedParentPath(), files);
+		} else {
+			clearUploadError();
 		}
-	}, [selectedParentPath, isExternalFileDrag, filterUploadFiles]);
+	}, [clearUploadError, selectedParentPath, isExternalFileDrag, filterUploadFiles]);
 
 	/* --- Toolbar button helpers --- */
 	const busy = state.isMutating || state.isLoadingTree;
@@ -1154,7 +1210,7 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 				className={`inno-workspace-card relative flex min-h-0 flex-col overflow-hidden rounded-lg transition-opacity duration-200 ${isDragOver ? "border-[var(--inno-accent)] bg-[var(--inno-accent-soft)]" : ""} ${sidebarOpen ? "opacity-100" : "pointer-events-none opacity-0"}`}
 				onDragOver={handleDragOver}
 				onDragLeave={handleDragLeave}
-				onDrop={handleDrop}
+				onDropCapture={handleDrop}
 			>
 				{/* Toolbar */}
 				<div className="flex h-10 items-center gap-1 border-b border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2">
@@ -1255,7 +1311,9 @@ export function WorkspaceBrowser({ onPreviewFile, dndManager }: { onPreviewFile?
 				{/* Drag overlay */}
 				{isDragOver && (
 					<div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-lg bg-[var(--inno-accent-soft)]">
-						<div className="rounded-lg bg-[var(--inno-surface)] px-4 py-2 text-xs font-medium text-[var(--inno-accent)] shadow-sm">{t("files.dropToUpload", "Drop files to upload")}</div>
+						<div className={`rounded-lg bg-[var(--inno-surface)] px-4 py-2 text-xs font-medium shadow-sm ${uploadError ? "text-[var(--inno-danger)]" : "text-[var(--inno-accent)]"}`}>
+							{uploadError || t("files.dropToUpload", "Drop files to upload")}
+						</div>
 					</div>
 				)}
 			</aside>

--- a/apps/inno-agent/web/src/react/chat/ChatComposer.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatComposer.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useRef, useState, type ChangeEvent, type ClipboardEvent, type CompositionEvent as ReactCompositionEvent, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, type RefObject } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ChangeEvent, type ClipboardEvent, type CompositionEvent as ReactCompositionEvent, type DragEvent as ReactDragEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode, type RefObject } from "react";
+import { createPortal } from "react-dom";
 import { Paperclip, X, ArrowUp, Square, RotateCcw, Image, ScrollText, Check, ChevronDown, ChevronUp, Settings2, HardDriveUpload } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "../ui/Spinner.js";
@@ -119,7 +120,9 @@ export function ChatComposer({
 }: ChatComposerProps) {
 	const { t } = useTranslation();
 	const modelPickerRef = useRef<HTMLDivElement | null>(null);
+	const attachTriggerRef = useRef<HTMLDivElement | null>(null);
 	const attachMenuRef = useRef<HTMLDivElement | null>(null);
+	const [attachMenuPosition, setAttachMenuPosition] = useState({ left: 8, top: 8 });
 	const [osFileDragOver, setOsFileDragOver] = useState(false);
 	const currentModelLabel = currentModel?.name || currentModel?.id || modelState.defaultModel || t("chat.modelUnavailable");
 
@@ -142,7 +145,9 @@ export function ChatComposer({
 	useEffect(() => {
 		if (!attachMenuOpen) return;
 		const handlePointerDown = (event: PointerEvent) => {
-			if (!attachMenuRef.current?.contains(event.target as Node)) onCloseAttachMenu();
+			const target = event.target as Node;
+			if (attachTriggerRef.current?.contains(target) || attachMenuRef.current?.contains(target)) return;
+			onCloseAttachMenu();
 		};
 		const handleKeyDown = (event: KeyboardEvent) => {
 			if (event.key === "Escape") onCloseAttachMenu();
@@ -154,6 +159,32 @@ export function ChatComposer({
 			window.removeEventListener("keydown", handleKeyDown);
 		};
 	}, [attachMenuOpen, onCloseAttachMenu]);
+
+	const repositionAttachMenu = useCallback(() => {
+		const trigger = attachTriggerRef.current;
+		const menu = attachMenuRef.current;
+		if (!trigger || !menu) return;
+		const triggerRect = trigger.getBoundingClientRect();
+		const menuRect = menu.getBoundingClientRect();
+		const width = menuRect.width || Math.min(220, Math.max(0, window.innerWidth - 16));
+		const height = menuRect.height || 264;
+		const maxLeft = Math.max(8, window.innerWidth - width - 8);
+		const maxTop = Math.max(8, window.innerHeight - height - 8);
+		const left = Math.max(8, Math.min(triggerRect.right - width, maxLeft));
+		const top = Math.max(8, Math.min(triggerRect.top - height - 8, maxTop));
+		setAttachMenuPosition((previous) => previous.left === left && previous.top === top ? previous : { left, top });
+	}, []);
+
+	useLayoutEffect(() => {
+		if (!attachMenuOpen) return;
+		repositionAttachMenu();
+		window.addEventListener("resize", repositionAttachMenu);
+		document.addEventListener("scroll", repositionAttachMenu, true);
+		return () => {
+			window.removeEventListener("resize", repositionAttachMenu);
+			document.removeEventListener("scroll", repositionAttachMenu, true);
+		};
+	}, [attachMenuOpen, repositionAttachMenu, workspaceFiles.length]);
 
 	const isOsFileDrag = (event: ReactDragEvent<HTMLElement>): boolean =>
 		Array.from(event.dataTransfer?.types ?? []).includes("Files");
@@ -304,7 +335,7 @@ export function ChatComposer({
 	);
 
 	const renderAttachMenu = () => (
-		<div ref={attachMenuRef} className="inno-composer-model-picker relative shrink-0">
+		<div ref={attachTriggerRef} className="inno-composer-model-picker relative shrink-0">
 			<button
 				type="button"
 				className="inno-composer-action inno-icon-button flex h-9 w-9 shrink-0 rounded-full disabled:opacity-50"
@@ -316,8 +347,14 @@ export function ChatComposer({
 			>
 				{isUploading ? <Spinner size={16} /> : <Paperclip size={16} />}
 			</button>
-			{attachMenuOpen ? (
-				<div className="inno-composer-model-menu inno-smart-attach-menu" role="menu" aria-label={t("chat.uploadFiles")}>
+			{attachMenuOpen && typeof document !== "undefined" ? createPortal(
+				<div
+					ref={attachMenuRef}
+					className="inno-composer-model-menu inno-smart-attach-menu"
+					role="menu"
+					aria-label={t("chat.uploadFiles")}
+					style={{ position: "fixed", left: attachMenuPosition.left, top: attachMenuPosition.top, right: "auto", bottom: "auto", zIndex: 100 }}
+				>
 					<button
 						type="button"
 						role="menuitem"
@@ -355,7 +392,8 @@ export function ChatComposer({
 							</span>
 						</button>
 					))}
-				</div>
+				</div>,
+				document.body,
 			) : null}
 		</div>
 	);

--- a/apps/inno-agent/web/src/react/chat/ChatComposer.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatComposer.tsx
@@ -39,7 +39,6 @@ export interface ChatComposerProps {
 	hitRef: RefObject<HTMLDivElement | null>;
 	chatIsSending: boolean;
 	canReconnect: boolean;
-	lastUserPrompt: string | null;
 	isUploading: boolean;
 	hasSendableContent: boolean;
 	hasPendingQuestion: boolean;
@@ -64,7 +63,6 @@ export interface ChatComposerProps {
 	onSend: () => void;
 	onStop: () => void;
 	onReconnect: () => void;
-	onRetry: () => void;
 	/** Slash-command palette rendered above the composer (ChatCenter owns its state). */
 	slashPalette?: ReactNode;
 }
@@ -90,7 +88,6 @@ export function ChatComposer({
 	hitRef,
 	chatIsSending,
 	canReconnect,
-	lastUserPrompt,
 	isUploading,
 	hasSendableContent,
 	hasPendingQuestion,
@@ -115,7 +112,6 @@ export function ChatComposer({
 	onSend,
 	onStop,
 	onReconnect,
-	onRetry,
 	slashPalette,
 }: ChatComposerProps) {
 	const { t } = useTranslation();
@@ -523,17 +519,6 @@ export function ChatComposer({
 						</>
 					) : (
 						<>
-							{lastUserPrompt ? (
-								<button
-									type="button"
-									className="inno-composer-action inno-icon-button flex h-9 w-9 shrink-0 rounded-full disabled:opacity-50"
-									title={t("chat.retryLast")}
-									disabled={isUploading}
-									onClick={onRetry}
-								>
-									<RotateCcw size={16} />
-								</button>
-							) : null}
 							<button
 								type="button"
 								className={`inno-composer-send flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors ${sendDisabled ? "is-disabled" : ""}`}

--- a/apps/inno-agent/web/src/react/chat/ChatConversation.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatConversation.tsx
@@ -38,6 +38,8 @@ interface ChatConversationProps {
 	onOpenAttachment: (file: AttachmentRef) => void;
 	onOpenSkill: (skillName: string) => void;
 	onEditMessage: (message: ChatMessage) => void;
+	canRetry: boolean;
+	onRetry: () => void;
 	wsError: string;
 }
 
@@ -56,6 +58,8 @@ export function ChatConversation({
 	onOpenAttachment,
 	onOpenSkill,
 	onEditMessage,
+	canRetry,
+	onRetry,
 	wsError,
 }: ChatConversationProps) {
 	const { t } = useTranslation();
@@ -116,6 +120,8 @@ export function ChatConversation({
 											onOpenAttachment={onOpenAttachment}
 											onOpenSkill={onOpenSkill}
 											onEdit={chat.isSending || chat.pendingQuestion ? undefined : onEditMessage}
+											showRetry={canRetry && index === chat.messages.length - 1}
+											onRetry={onRetry}
 										/>
 									</div>
 								);

--- a/apps/inno-agent/web/src/react/chat/ChatConversation.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatConversation.tsx
@@ -33,6 +33,7 @@ interface ChatConversationProps {
 	onPauseAutoScroll: () => void;
 	questionHint: ReactNode;
 	busyBlocker: ReactNode;
+	smartToast: ReactNode;
 	composer: ReactNode;
 	onOpenAttachment: (file: AttachmentRef) => void;
 	onOpenSkill: (skillName: string) => void;
@@ -50,6 +51,7 @@ export function ChatConversation({
 	onPauseAutoScroll,
 	questionHint,
 	busyBlocker,
+	smartToast,
 	composer,
 	onOpenAttachment,
 	onOpenSkill,
@@ -73,7 +75,8 @@ export function ChatConversation({
 	);
 
 	return (
-		<section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[var(--inno-chat-bg)]">
+		<section className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[var(--inno-chat-bg)]">
+			{smartToast}
 			<div className="conversation-stage relative flex-1 min-h-0">
 				<div
 					ref={scrollRef}

--- a/apps/inno-agent/web/src/react/chat/ChatWelcome.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatWelcome.tsx
@@ -12,6 +12,7 @@ interface ChatWelcomeProps {
 	onToggleMode: () => void;
 	questionHint: ReactNode;
 	busyBlocker: ReactNode;
+	smartToast: ReactNode;
 	composer: ReactNode;
 	workspaceContext: ReactNode;
 	presets: PresetMeta[];
@@ -36,6 +37,7 @@ export function ChatWelcome({
 	onToggleMode,
 	questionHint,
 	busyBlocker,
+	smartToast,
 	composer,
 	workspaceContext,
 	presets,
@@ -54,7 +56,8 @@ export function ChatWelcome({
 }: ChatWelcomeProps) {
 	const { t } = useTranslation();
 	return (
-		<section className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[var(--inno-chat-bg)]">
+		<section className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[var(--inno-chat-bg)]">
+			{smartToast}
 			<div className="inno-chat-grid flex flex-1 min-h-0 justify-center overflow-y-auto px-4">
 				<div ref={welcomeLayoutRef} className="inno-welcome-layout w-full max-w-2xl pt-[18vh] pb-12">
 					<div className="inno-welcome-upper">

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.edit.test.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.edit.test.tsx
@@ -31,7 +31,7 @@ describe("MessageBubble edit and resend", () => {
 		expect(onEdit).toHaveBeenCalledWith(plainUserMessage);
 	});
 
-	it("does not offer text-only editing when the original message has attachments", () => {
+	it("offers a file message for editing", () => {
 		const message: ChatMessage = {
 			...plainUserMessage,
 			attachments: {
@@ -40,9 +40,23 @@ describe("MessageBubble edit and resend", () => {
 			},
 		};
 
-		render(<MessageBubble message={message} onEdit={vi.fn()} />);
+		const onEdit = vi.fn();
+		render(<MessageBubble message={message} onEdit={onEdit} />);
 
-		expect(screen.queryByRole("button", { name: "Edit and resend" })).toBeNull();
+		fireEvent.click(screen.getByRole("button", { name: "Edit and resend" }));
+		expect(onEdit).toHaveBeenCalledWith(message);
+	});
+
+	it("offers an expanded skill message for editing", () => {
+		const message: ChatMessage = {
+			...plainUserMessage,
+			content: '<skill name="lesson-plan" location="/tmp/lesson-plan/SKILL.md">\n# Lesson Plan\n</skill>',
+		};
+		const onEdit = vi.fn();
+		render(<MessageBubble message={message} onEdit={onEdit} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "Edit and resend" }));
+		expect(onEdit).toHaveBeenCalledWith(message);
 	});
 
 	it("does not offer editing for a transient message without a persisted entry id", () => {

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.edit.test.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.edit.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("react-i18next", () => ({
@@ -66,4 +66,48 @@ describe("MessageBubble edit and resend", () => {
 
 		expect(screen.queryByRole("button", { name: "Edit and resend" })).toBeNull();
 	});
+
+	it("shows the sent-message time and copies the original content", async () => {
+		const writeText = vi.fn().mockResolvedValue(undefined);
+		const previousClipboard = navigator.clipboard;
+		Object.defineProperty(navigator, "clipboard", {
+			configurable: true,
+			value: { writeText },
+		});
+
+		try {
+			const timestamp = new Date(2026, 7, 30, 22, 35).getTime();
+			render(<MessageBubble message={{ ...plainUserMessage, timestamp }} />);
+
+			expect(screen.getByText("22:35")).toBeTruthy();
+			fireEvent.click(screen.getByRole("button", { name: "common.copy" }));
+
+			await waitFor(() => {
+				expect(writeText).toHaveBeenCalledWith(plainUserMessage.content);
+			});
+		} finally {
+			Object.defineProperty(navigator, "clipboard", {
+				configurable: true,
+				value: previousClipboard,
+			});
+		}
+	});
+
+	it("shows copy, time, and retry actions for the last assistant message", () => {
+		const onRetry = vi.fn();
+		const timestamp = new Date(2026, 7, 30, 22, 35).getTime();
+		render(
+			<MessageBubble
+				message={{ role: "assistant", content: "answer", timestamp }}
+				showRetry
+				onRetry={onRetry}
+			/>,
+		);
+
+		expect(screen.getByText("22:35")).toBeTruthy();
+		expect(screen.getByRole("button", { name: "common.copy" })).toBeTruthy();
+		fireEvent.click(screen.getByRole("button", { name: "chat.retryLast" }));
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
 });

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
@@ -588,7 +588,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.25, ease: "easeOut" }}
 		>
-			<div className={`inno-message inno-assistant-message group relative min-w-0 ${hasAnsweredQuestionnaire ? "w-full max-w-[76%]" : "max-w-[78%]"} overflow-visible rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
+			<div className={`inno-message inno-assistant-message group relative min-w-0 ${hasAnsweredQuestionnaire ? "w-full max-w-[76%]" : "max-w-[78%]"} overflow-visible px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
 				{showChannel && message.channel ? (
 					<div className="mb-1"><ChannelBadge channel={message.channel} /></div>
 				) : null}
@@ -624,9 +624,6 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 					>
 						{copied ? <Check size={14} /> : <Copy size={14} />}
 					</button>
-					{messageTime ? (
-						<time dateTime={new Date(message.timestamp).toISOString()}>{messageTime}</time>
-					) : null}
 					{showRetry && onRetry ? (
 						<button
 							type="button"
@@ -637,6 +634,9 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 						>
 							<RotateCcw size={14} />
 						</button>
+					) : null}
+					{messageTime ? (
+						<time dateTime={new Date(message.timestamp).toISOString()}>{messageTime}</time>
 					) : null}
 				</div>
 			</div>

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
@@ -443,7 +443,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 	onOpenAttachment?: AttachmentOpenHandler;
 	/** Open the right-side skill detail panel for a sent skill bubble. */
 	onOpenSkill?: (skillName: string) => void;
-	/** Restore a persisted plain Web user message and branch from that turn. */
+	/** Restore a persisted Web user message and branch from that turn. */
 	onEdit?: (message: ChatMessage) => void;
 }) {
 	const { t } = useTranslation();
@@ -465,9 +465,8 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 		const canEdit = Boolean(
 			onEdit
 			&& message.entryId
-			&& message.content.trim()
+			&& (message.content.trim() || hasAttachments)
 			&& !message.images?.length
-			&& !hasAttachments
 			&& (!message.channel || message.channel === "web"),
 		);
 		return (

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
@@ -508,7 +508,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 				animate={{ opacity: 1, y: 0 }}
 				transition={{ duration: 0.25, ease: "easeOut" }}
 			>
-				<div className="inno-message-wrap inno-message-wrap--user group relative w-fit max-w-full" style={{ maxWidth: "min(70%, 38rem)" }}>
+				<div className="inno-message-wrap group relative w-fit max-w-full" style={{ maxWidth: "min(70%, 38rem)" }}>
 					<div className="inno-message inno-user-message whitespace-pre-wrap break-words rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
 						{showChannel && message.channel ? (
 							<div className="mb-1 flex justify-end"><ChannelBadge channel={message.channel} /></div>
@@ -583,7 +583,6 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 
 	return (
 		<motion.div
-			key={`assistant-message-${message.timestamp}`}
 			className="flex justify-start"
 			initial={{ opacity: 0, y: 12 }}
 			animate={{ opacity: 1, y: 0 }}

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
@@ -2,7 +2,7 @@ import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
-import { X, AlertTriangle, FileCode2, History, BookmarkPlus, BookOpen, Pencil, TerminalSquare } from "lucide-react";
+import { X, AlertTriangle, FileCode2, History, BookmarkPlus, BookOpen, Check, Copy, Pencil, RotateCcw, TerminalSquare } from "lucide-react";
 import type { AttachmentBinding, AttachmentRef, ChatMessage, ChatToolRecord } from "../../types/chat.js";
 import { normalizeMarkdownMath } from "../../utils/markdown-math.js";
 import { splitContentByBindings } from "../../utils/attachment-render.js";
@@ -351,6 +351,13 @@ function shouldCollapseAssistantContent(content: string): boolean {
 	return content.split(/\r\n|\r|\n/).length > LONG_ASSISTANT_LINES;
 }
 
+function formatMessageTime(timestamp: number): string {
+	if (!Number.isFinite(timestamp)) return "";
+	const date = new Date(timestamp);
+	if (Number.isNaN(date.getTime())) return "";
+	return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
 function AssistantContent({ content }: { content: string }) {
 	const { t } = useTranslation();
 	const [expanded, setExpanded] = useState(false);
@@ -433,7 +440,7 @@ export function ToolRecordDetails({ tool, className }: { tool: ChatToolRecord; c
 	);
 }
 
-export const MessageBubble = memo(function MessageBubble({ message, showChannel, resolveAttachmentUrl, onOpenAttachment, onOpenSkill, onEdit }: {
+export const MessageBubble = memo(function MessageBubble({ message, showChannel, resolveAttachmentUrl, onOpenAttachment, onOpenSkill, onEdit, showRetry, onRetry }: {
 	message: ChatMessage;
 	showChannel?: boolean;
 	/** Optional URL resolver for attachment chips (workspace raw link). Kept as
@@ -445,9 +452,14 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 	onOpenSkill?: (skillName: string) => void;
 	/** Restore a persisted Web user message and branch from that turn. */
 	onEdit?: (message: ChatMessage) => void;
+	/** Show the retry action in this message's action row. */
+	showRetry?: boolean;
+	onRetry?: () => void;
 }) {
 	const { t } = useTranslation();
 	const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
+	const [copied, setCopied] = useState(false);
+	const copyResetTimerRef = useRef<number | null>(null);
 	const answeredQuestionnaires = (message.tools ?? []).flatMap((tool): AnsweredQuestionnaireView[] => {
 		const questionnaire = answeredQuestionnaireFromTool(tool);
 		return questionnaire ? [{ tool, questionnaire }] : [];
@@ -455,6 +467,26 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 	const hasAnsweredQuestionnaire = answeredQuestionnaires.length > 0;
 	const answeredToolCallIds = new Set(answeredQuestionnaires.map((view) => view.tool.toolCallId));
 	const regularTools = (message.tools ?? []).filter((tool) => !answeredToolCallIds.has(tool.toolCallId));
+	const messageTime = formatMessageTime(message.timestamp);
+
+	useEffect(() => () => {
+		if (copyResetTimerRef.current !== null) window.clearTimeout(copyResetTimerRef.current);
+	}, []);
+
+	const copyMessage = async () => {
+		if (typeof navigator === "undefined" || !navigator.clipboard?.writeText) return;
+		try {
+			await navigator.clipboard.writeText(message.content);
+			setCopied(true);
+			if (copyResetTimerRef.current !== null) window.clearTimeout(copyResetTimerRef.current);
+			copyResetTimerRef.current = window.setTimeout(() => {
+				copyResetTimerRef.current = null;
+				setCopied(false);
+			}, 1600);
+		} catch {
+			// Clipboard access can be denied by the browser; leave the action quiet.
+		}
+	};
 
 	if (message.role === "user") {
 		const skillMessage = collapseSkillMessage(message.content);
@@ -476,47 +508,74 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 				animate={{ opacity: 1, y: 0 }}
 				transition={{ duration: 0.25, ease: "easeOut" }}
 			>
-				<div className="inno-message group relative w-fit whitespace-pre-wrap break-words rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]" style={{ maxWidth: "min(70%, 38rem)" }}>
-					{showChannel && message.channel ? (
-						<div className="mb-1 flex justify-end"><ChannelBadge channel={message.channel} /></div>
-					) : null}
-					{message.images?.length ? (
-						<div className="mb-2 flex flex-wrap gap-1.5">
-							{message.images.map((img, i) => (
-								<img
-									key={i}
-									src={img.previewUrl}
-									alt="attached"
-									className="max-h-48 max-w-full cursor-zoom-in rounded object-contain"
-									onClick={() => setLightboxSrc(img.previewUrl)}
-								/>
-							))}
-						</div>
-					) : null}
-					{lightboxSrc ? <ImageLightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} /> : null}
-					{message.attachments && (message.attachments.bindings.length > 0 || message.attachments.loose.length > 0) ? (
-						<UserAttachmentContent
-							content={message.content.trim()}
-							attachments={message.attachments}
-							resolveUrl={resolveAttachmentUrl}
-							onOpenFile={onOpenAttachment}
-						/>
-					) : agentCommandMessage ? (
-						<AgentCommandMessageContent {...agentCommandMessage} onOpenSkill={onOpenSkill} />
-					) : (
-						message.content.trim()
-					)}
-					{canEdit ? (
+				<div className="inno-message-wrap inno-message-wrap--user group relative w-fit max-w-full" style={{ maxWidth: "min(70%, 38rem)" }}>
+					<div className="inno-message inno-user-message whitespace-pre-wrap break-words rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]">
+						{showChannel && message.channel ? (
+							<div className="mb-1 flex justify-end"><ChannelBadge channel={message.channel} /></div>
+						) : null}
+						{message.images?.length ? (
+							<div className="mb-2 flex flex-wrap gap-1.5">
+								{message.images.map((img, i) => (
+									<img
+										key={i}
+										src={img.previewUrl}
+										alt="attached"
+										className="max-h-48 max-w-full cursor-zoom-in rounded object-contain"
+										onClick={() => setLightboxSrc(img.previewUrl)}
+									/>
+								))}
+							</div>
+						) : null}
+						{lightboxSrc ? <ImageLightbox src={lightboxSrc} onClose={() => setLightboxSrc(null)} /> : null}
+						{message.attachments && (message.attachments.bindings.length > 0 || message.attachments.loose.length > 0) ? (
+							<UserAttachmentContent
+								content={message.content.trim()}
+								attachments={message.attachments}
+								resolveUrl={resolveAttachmentUrl}
+								onOpenFile={onOpenAttachment}
+							/>
+						) : agentCommandMessage ? (
+							<AgentCommandMessageContent {...agentCommandMessage} onOpenSkill={onOpenSkill} />
+						) : (
+							message.content.trim()
+						)}
+					</div>
+					<div className="inno-message-actions">
+						{messageTime ? (
+							<time dateTime={new Date(message.timestamp).toISOString()}>{messageTime}</time>
+						) : null}
+						{canEdit ? (
+							<button
+								type="button"
+								className="inno-message-action"
+								title={t("chat.editAndResend")}
+								aria-label={t("chat.editAndResend")}
+								onClick={() => onEdit?.(message)}
+							>
+								<Pencil size={13} />
+							</button>
+						) : null}
 						<button
 							type="button"
-							className="absolute -bottom-2 -right-2 inline-flex items-center justify-center rounded-full border border-[var(--inno-border)] bg-[var(--inno-surface)] p-1 text-[var(--inno-text-subtle)] opacity-0 shadow-sm transition-opacity duration-150 hover:text-[var(--inno-text)] focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--inno-accent)] group-hover:opacity-100"
-							title={t("chat.editAndResend")}
-							aria-label={t("chat.editAndResend")}
-							onClick={() => onEdit?.(message)}
+							className="inno-message-action"
+							title={copied ? t("common.copied") : t("common.copy")}
+							aria-label={copied ? t("common.copied") : t("common.copy")}
+							onClick={() => { void copyMessage(); }}
 						>
-							<Pencil size={12} />
+							{copied ? <Check size={14} /> : <Copy size={14} />}
 						</button>
-					) : null}
+						{showRetry && onRetry ? (
+							<button
+								type="button"
+								className="inno-message-action"
+								title={t("chat.retryLast")}
+								aria-label={t("chat.retryLast")}
+								onClick={onRetry}
+							>
+								<RotateCcw size={14} />
+							</button>
+						) : null}
+					</div>
 				</div>
 			</motion.div>
 		);
@@ -524,12 +583,13 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 
 	return (
 		<motion.div
+			key={`assistant-message-${message.timestamp}`}
 			className="flex justify-start"
 			initial={{ opacity: 0, y: 12 }}
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.25, ease: "easeOut" }}
 		>
-			<div className={`inno-message min-w-0 ${hasAnsweredQuestionnaire ? "w-full max-w-[76%]" : "max-w-[78%]"} overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
+			<div className={`inno-message inno-assistant-message group relative min-w-0 ${hasAnsweredQuestionnaire ? "w-full max-w-[76%]" : "max-w-[78%]"} overflow-visible rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
 				{showChannel && message.channel ? (
 					<div className="mb-1"><ChannelBadge channel={message.channel} /></div>
 				) : null}
@@ -555,6 +615,31 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 						<ErrorBlock error={message.error} />
 					</div>
 				) : null}
+				<div className="inno-message-actions">
+					<button
+						type="button"
+						className="inno-message-action"
+						title={copied ? t("common.copied") : t("common.copy")}
+						aria-label={copied ? t("common.copied") : t("common.copy")}
+						onClick={() => { void copyMessage(); }}
+					>
+						{copied ? <Check size={14} /> : <Copy size={14} />}
+					</button>
+					{messageTime ? (
+						<time dateTime={new Date(message.timestamp).toISOString()}>{messageTime}</time>
+					) : null}
+					{showRetry && onRetry ? (
+						<button
+							type="button"
+							className="inno-message-action"
+							title={t("chat.retryLast")}
+							aria-label={t("chat.retryLast")}
+							onClick={onRetry}
+						>
+							<RotateCcw size={14} />
+						</button>
+					) : null}
+				</div>
 			</div>
 		</motion.div>
 	);

--- a/apps/inno-agent/web/src/react/chat/SmartInputControl.tsx
+++ b/apps/inno-agent/web/src/react/chat/SmartInputControl.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, ChevronUp, FlaskConical, Keyboard } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { SmartInputRule, SmartInputSettings } from "../../types/settings.js";
 import { PopoverSurface } from "../ui/PopoverSurface.js";
@@ -24,12 +25,43 @@ export function SmartInputControl({
 }: SmartInputControlProps) {
 	const { t } = useTranslation();
 	const smartInputRef = useRef<HTMLDivElement | null>(null);
+	const smartInputTriggerRef = useRef<HTMLButtonElement | null>(null);
+	const smartInputPanelRef = useRef<HTMLDivElement | null>(null);
 	const [smartInputMenuOpen, setSmartInputMenuOpen] = useState(false);
+	const [smartInputMenuPosition, setSmartInputMenuPosition] = useState({ left: 8, top: 8 });
+
+	const repositionSmartInputMenu = useCallback(() => {
+		if (!smartInputMenuOpen) return;
+		const trigger = smartInputTriggerRef.current;
+		const panel = smartInputPanelRef.current;
+		if (!trigger || !panel) return;
+
+		const margin = 8;
+		const triggerRect = trigger.getBoundingClientRect();
+		const panelRect = panel.getBoundingClientRect();
+		const width = panel.offsetWidth || panelRect.width;
+		const height = panel.offsetHeight || panelRect.height;
+		const maxLeft = Math.max(margin, window.innerWidth - width - margin);
+		const preferredLeft = compact ? triggerRect.left - width - margin : triggerRect.left;
+		const left = Math.max(margin, Math.min(preferredLeft, maxLeft));
+		const aboveSpace = triggerRect.top - margin;
+		const belowSpace = window.innerHeight - triggerRect.bottom - margin;
+		const openAbove = aboveSpace >= height || aboveSpace >= belowSpace;
+		const preferredTop = openAbove
+			? triggerRect.top - height - margin
+			: triggerRect.bottom + margin;
+		const maxTop = Math.max(margin, window.innerHeight - height - margin);
+		const top = Math.max(margin, Math.min(preferredTop, maxTop));
+
+		setSmartInputMenuPosition((previous) => previous.left === left && previous.top === top ? previous : { left, top });
+	}, [compact, smartInputMenuOpen]);
 
 	useEffect(() => {
 		if (!smartInputMenuOpen) return;
 		const onPointerDown = (event: PointerEvent) => {
-			if (!smartInputRef.current?.contains(event.target as Node)) setSmartInputMenuOpen(false);
+			const target = event.target as Node;
+			if (smartInputRef.current?.contains(target) || smartInputPanelRef.current?.contains(target)) return;
+			setSmartInputMenuOpen(false);
 		};
 		const onKeyDown = (event: KeyboardEvent) => {
 			if (event.key === "Escape") setSmartInputMenuOpen(false);
@@ -41,6 +73,22 @@ export function SmartInputControl({
 			window.removeEventListener("keydown", onKeyDown);
 		};
 	}, [smartInputMenuOpen]);
+
+	useLayoutEffect(() => {
+		if (!smartInputMenuOpen) return;
+		repositionSmartInputMenu();
+		const resizeObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(repositionSmartInputMenu);
+		for (const target of [smartInputTriggerRef.current, smartInputPanelRef.current]) {
+			if (target) resizeObserver?.observe(target);
+		}
+		window.addEventListener("resize", repositionSmartInputMenu);
+		document.addEventListener("scroll", repositionSmartInputMenu, true);
+		return () => {
+			resizeObserver?.disconnect();
+			window.removeEventListener("resize", repositionSmartInputMenu);
+			document.removeEventListener("scroll", repositionSmartInputMenu, true);
+		};
+	}, [repositionSmartInputMenu, smartInputMenuOpen]);
 
 	const rules = smartInputSettings?.rules ?? [];
 	const enabledRuleCount = rules.filter((rule) => rule.enabled).length;
@@ -58,6 +106,7 @@ export function SmartInputControl({
 		<div ref={smartInputRef} className={`inno-workspace-smart-input ${compact ? "inno-composer-smart-input" : ""}`}>
 			<button
 				type="button"
+				ref={smartInputTriggerRef}
 				className={compact
 					? "inno-composer-action inno-icon-button flex h-9 w-9 shrink-0 rounded-full disabled:opacity-50"
 					: "inno-workspace-switcher-trigger inno-workspace-smart-input-trigger"}
@@ -75,8 +124,22 @@ export function SmartInputControl({
 					</>
 				)}
 			</button>
-			{smartInputMenuOpen ? (
-				<PopoverSurface className="inno-workspace-switcher-menu inno-workspace-smart-input-panel" role="dialog" aria-label={t("settings.smartInput.title", "便捷输入")}>
+			{smartInputMenuOpen && typeof document !== "undefined" ? createPortal(
+				<PopoverSurface
+					ref={smartInputPanelRef}
+					className="inno-workspace-switcher-menu inno-workspace-smart-input-panel"
+					role="dialog"
+					aria-label={t("settings.smartInput.title", "便捷输入")}
+					style={{
+						position: "fixed",
+						left: smartInputMenuPosition.left,
+						top: smartInputMenuPosition.top,
+						right: "auto",
+						bottom: "auto",
+						zIndex: 100,
+						transformOrigin: compact ? "bottom right" : "bottom left",
+					}}
+				>
 					<div className="inno-workspace-smart-input-panel-head">
 						<div className="min-w-0">
 							<div className="inno-workspace-smart-input-panel-title">{t("settings.smartInput.master", "便捷输入")} <span className="inno-smart-beta">Beta</span></div>
@@ -152,7 +215,8 @@ export function SmartInputControl({
 						<FlaskConical size={14} aria-hidden="true" />
 						<span>{t("settings.smartInput.openSettings", "打开实验室中的便捷输入设置")}</span>
 					</button>
-				</PopoverSurface>
+				</PopoverSurface>,
+				document.body,
 			) : null}
 		</div>
 	);

--- a/apps/inno-agent/web/src/react/chat/StreamingBubbles.tsx
+++ b/apps/inno-agent/web/src/react/chat/StreamingBubbles.tsx
@@ -106,7 +106,7 @@ export function StreamingBubbles() {
 				</motion.div>
 			) : stream.text || questionnaires.length ? (
 				<motion.div key="chat-streaming-bubble" className="flex justify-start" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2, ease: "easeOut" }}>
-					<div ref={streamingBubbleRef} className={`inno-message inno-streaming-blocks ${questionnaires.length > 0 ? "w-full max-w-[76%]" : "max-w-[78%]"} rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
+					<div ref={streamingBubbleRef} className={`inno-message inno-streaming-blocks ${questionnaires.length > 0 ? "w-full max-w-[76%]" : "max-w-[78%]"} px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
 						{timeline.entries.map(({ tool, questionnaire, before }) => (
 							<Fragment key={tool.toolCallId}>
 								{before.trim() ? <StableStreamingMarkdown content={normalizeMarkdownMath(before.trim())} /> : null}

--- a/apps/inno-agent/web/src/react/chat/smart-input/engine.test.ts
+++ b/apps/inno-agent/web/src/react/chat/smart-input/engine.test.ts
@@ -292,6 +292,31 @@ describe("SmartInputEngine token editing", () => {
 		expect(openedAnchorIsChip).toBe(true);
 	});
 
+	it("rehydrates persisted file bindings at their recorded word occurrence", () => {
+		const { engine, textarea, hitLayer } = makeEngine("请阅读 pdf 和 pdf");
+		engine.attach();
+
+		const unplaced = engine.restoreBindings([{
+			word: "pdf",
+			wordIndex: 1,
+			files: [{ path: "slides.pdf", kind: "pdf", source: "upload" }],
+		}]);
+
+		expect(unplaced).toEqual([]);
+		expect(engine.slots).toHaveLength(1);
+		expect(engine.slots[0]?.files[0]).toMatchObject({
+			name: "slides.pdf",
+			path: "slides.pdf",
+			state: "workspace",
+		});
+		expect(engine.buildOutgoing()).toMatchObject({
+			visibleText: "请阅读 pdf 和 pdf",
+			readyBindings: [{ word: "pdf", wordIndex: 1, files: [{ path: "slides.pdf" }] }],
+		});
+		expect(textarea.value).not.toBe("请阅读 pdf 和 pdf");
+		expect(hitLayer.querySelector(".inno-smart-chip")).not.toBeNull();
+	});
+
 	it("opens the skill picker for 技能 and deletes the selected command as one bubble", () => {
 		let keyword: KwRange | null = null;
 		const { engine, textarea, hitLayer } = makeEngine(

--- a/apps/inno-agent/web/src/react/chat/smart-input/engine.ts
+++ b/apps/inno-agent/web/src/react/chat/smart-input/engine.ts
@@ -1,5 +1,5 @@
 import type { SmartInputRule } from "../../../types/settings.js";
-import type { AttachmentBinding } from "../../../types/chat.js";
+import type { AttachmentBinding, AttachmentRef } from "../../../types/chat.js";
 import type { SlashCommandItem } from "../../../api/commands.js";
 import { KIND_COLORS, activeRules, kindFromName, kindFromRule, nameMatchesRule, sameRuleFormat } from "./kinds.js";
 import {
@@ -1930,6 +1930,97 @@ export class SmartInputEngine {
 		this.ta.focus();
 		this.ta.setSelectionRange(caret + token.length, caret + token.length);
 		this.sync();
+	}
+
+	/**
+	 * Rehydrate persisted file bindings after a user message enters edit mode.
+	 * The session stores the visible text and attachment metadata separately;
+	 * this puts the metadata back into atomic bubbles at the recorded word
+	 * occurrences so the next send produces the same structured payload.
+	 * Bindings whose word no longer exists are returned for the loose row.
+	 */
+	restoreBindings(bindings: AttachmentBinding[]): AttachmentRef[] {
+		if (bindings.length === 0) return [];
+
+		// Editing normally starts from a plain value, but clear any in-progress
+		// bubbles as a safety net when the user edits while a draft is present.
+		if (this.slots.length > 0) {
+			this.restoreAllTokens();
+			for (const slot of this.slots) this.returnFilesToAttachments(slot);
+			this.slots = [];
+		}
+
+		const value = this.ta.value;
+		const findOccurrence = (needle: string, occurrence: number): number => {
+			if (!needle) return -1;
+			const target = Math.max(0, Math.floor(occurrence));
+			let from = 0;
+			for (let index = 0; index <= target; index++) {
+				const found = value.indexOf(needle, from);
+				if (found === -1) return -1;
+				if (index === target) return found;
+				from = found + needle.length;
+			}
+			return -1;
+		};
+
+		const placements: Array<{ start: number; end: number; binding: AttachmentBinding }> = [];
+		const unplaced: AttachmentRef[] = [];
+		for (const binding of bindings) {
+			const start = findOccurrence(binding.word, binding.wordIndex);
+			if (start === -1 || binding.files.length === 0) {
+				unplaced.push(...binding.files);
+				continue;
+			}
+			placements.push({ start, end: start + binding.word.length, binding });
+		}
+		placements.sort((a, b) => a.start - b.start || a.end - b.end);
+
+		const ruleFor = (word: string): SmartInputRule => this.opts.data.getRules().find((rule) => rule.keyword === word) ?? ({
+			id: `restored-${word}`,
+			isPreset: false,
+			keyword: word,
+			extensions: [],
+			allExtensions: true,
+			excludeExtensions: [],
+			enabled: true,
+		} satisfies SmartInputRule);
+		const fileName = (path: string): string => path.split("/").pop() ?? path;
+
+		let nextValue = "";
+		let cursor = 0;
+		for (const placement of placements) {
+			if (placement.start < cursor) {
+				unplaced.push(...placement.binding.files);
+				continue;
+			}
+			nextValue += value.slice(cursor, placement.start);
+			const slot: Slot = {
+				id: this.nextSlotId++,
+				word: placement.binding.word,
+				rule: ruleFor(placement.binding.word),
+				files: [],
+			};
+			for (const file of placement.binding.files) {
+				slot.files.push({
+					uid: this.nextFileId++,
+					name: fileName(file.path),
+					path: file.path,
+					source: "workspace",
+					state: "workspace",
+					pct: 100,
+				});
+			}
+			this.slots.push(slot);
+			nextValue += this.buildToken(slot).token;
+			cursor = placement.end;
+		}
+		nextValue += value.slice(cursor);
+		this.ta.value = nextValue;
+		this.ta.focus({ preventScroll: true });
+		this.ta.setSelectionRange(nextValue.length, nextValue.length);
+		this.sync();
+		return unplaced;
 	}
 
 	// ── token atomicity ─────────────────────────────────────────────────────

--- a/apps/inno-agent/web/src/react/chat/smart-input/engine.ts
+++ b/apps/inno-agent/web/src/react/chat/smart-input/engine.ts
@@ -29,6 +29,7 @@ import {
 	type DropMatchState,
 	type FlowAtom,
 } from "./drag-utils.js";
+import { getOversizedFiles } from "../../../utils/upload-limits.js";
 
 /**
  * SmartInputEngine — imperative port of the v76 prototype's three-layer
@@ -99,6 +100,7 @@ export interface EngineCallbacks {
 	onBubbleClose?: (slot: Slot, anchor: HTMLElement) => void;
 	/** Filled-chip hover — drives the 250ms hover-open of the status panel. */
 	onChipHover?: (slot: Slot, anchor: HTMLElement, entering: boolean) => void;
+	onUploadLimitExceeded?: (count: number) => void;
 	onWorkspaceHighlight: (paths: string[] | null) => void;
 }
 
@@ -1853,7 +1855,9 @@ export class SmartInputEngine {
 	 * loses the rejected files.
 	 */
 	bindLocalFiles(slot: Slot, files: File[]): void {
-		this.bindAttachmentFiles(slot, files.map((file) => this.localAttachmentItem(file)));
+		const oversized = getOversizedFiles(files);
+		if (oversized.length > 0) this.opts.callbacks.onUploadLimitExceeded?.(oversized.length);
+		this.bindAttachmentFiles(slot, files.filter((file) => !oversized.includes(file)).map((file) => this.localAttachmentItem(file)));
 	}
 
 	/** Bind a mixed in-page batch, returning mismatches to the loose row. */

--- a/apps/inno-agent/web/src/react/chat/smart-input/useSmartInput.ts
+++ b/apps/inno-agent/web/src/react/chat/smart-input/useSmartInput.ts
@@ -22,6 +22,7 @@ export interface UseSmartInputOptions {
 	onBubbleContextMenu: EngineCallbacks["onBubbleContextMenu"];
 	onBubbleClose?: EngineCallbacks["onBubbleClose"];
 	onChipHover?: EngineCallbacks["onChipHover"];
+	onUploadLimitExceeded?: EngineCallbacks["onUploadLimitExceeded"];
 	onWorkspaceHighlight: EngineCallbacks["onWorkspaceHighlight"];
 }
 
@@ -105,6 +106,7 @@ export function useSmartInput(options: UseSmartInputOptions) {
 				onBubbleContextMenu: (...args) => optionsRef.current.onBubbleContextMenu(...args),
 				onBubbleClose: (...args) => optionsRef.current.onBubbleClose?.(...args),
 				onChipHover: (...args) => optionsRef.current.onChipHover?.(...args),
+				onUploadLimitExceeded: (...args) => optionsRef.current.onUploadLimitExceeded?.(...args),
 				onWorkspaceHighlight: (paths) => optionsRef.current.onWorkspaceHighlight(paths),
 			},
 		});

--- a/apps/inno-agent/web/src/react/ui/ModeSegmentedControl.tsx
+++ b/apps/inno-agent/web/src/react/ui/ModeSegmentedControl.tsx
@@ -32,7 +32,6 @@ export function ModeSegmentedControl({
 				onClick={() => selectMode(true)}
 				disabled={togglingMode}
 				aria-pressed={simpleMode}
-				title={simpleMode ? t("mode.currentSimpleClickNormal") : t("mode.switchToSimple")}
 				className={`inno-mode-segmented-control__option ${simpleMode ? "is-active" : ""}`.trim()}
 			>
 				<WandSparkles size={14} strokeWidth={1.8} aria-hidden="true" />
@@ -43,7 +42,6 @@ export function ModeSegmentedControl({
 				onClick={() => selectMode(false)}
 				disabled={togglingMode}
 				aria-pressed={!simpleMode}
-				title={!simpleMode ? t("mode.currentNormalClickSimple") : t("mode.switchToNormal")}
 				className={`inno-mode-segmented-control__option ${!simpleMode ? "is-active" : ""}`.trim()}
 			>
 				<SlidersHorizontal size={14} strokeWidth={1.8} aria-hidden="true" />

--- a/apps/inno-agent/web/src/stores/workspace-store.ts
+++ b/apps/inno-agent/web/src/stores/workspace-store.ts
@@ -12,6 +12,7 @@ import {
 	inlineWorkspaceHtml,
 } from "../api/workspace.js";
 import type { WorkspaceFileDetail, WorkspaceTree } from "../types/workspace.js";
+import { DEFAULT_UPLOAD_MAX_BYTES, getOversizedFiles, UploadLimitError } from "../utils/upload-limits.js";
 
 export interface StreamingWorkspacePreview {
 	id: string;
@@ -306,11 +307,19 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 	}
 
 	async uploadFiles(parentPath: string, fileList: FileList | File[]): Promise<void> {
+		const files = Array.from(fileList);
+		const oversized = getOversizedFiles(files);
+		if (oversized.length > 0) {
+			this.isMutating = false;
+			this.error = new UploadLimitError(oversized[0].name).message;
+			this.emit("change", undefined);
+			return;
+		}
 		this.isMutating = true;
 		this.emit("change", undefined);
 		try {
 			const items: Array<{ path: string; dataBase64: string }> = [];
-			for (const file of Array.from(fileList)) {
+			for (const file of files) {
 				const buffer = await file.arrayBuffer();
 				const bytes = new Uint8Array(buffer);
 				let binary = "";
@@ -331,6 +340,12 @@ class WorkspaceStoreImpl extends EventEmitter<WorkspaceStoreEvents> {
 
 	/** Install a skill package (.zip / .md) into the workspace's private `.skills` dir. */
 	async uploadSkillPackage(file: File): Promise<void> {
+		if (file.size > DEFAULT_UPLOAD_MAX_BYTES) {
+			this.isMutating = false;
+			this.error = new UploadLimitError(file.name).message;
+			this.emit("change", undefined);
+			return;
+		}
 		this.isMutating = true;
 		this.error = "";
 		this.emit("change", undefined);

--- a/apps/inno-agent/web/src/utils/upload-limits.test.ts
+++ b/apps/inno-agent/web/src/utils/upload-limits.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { DEFAULT_UPLOAD_MAX_BYTES, getOversizedFiles, UploadLimitError, assertUploadSize } from "./upload-limits.js";
+
+describe("upload limits", () => {
+	it("uses a 32 MB default and rejects only files above it", () => {
+		const accepted = { name: "accepted.bin", size: DEFAULT_UPLOAD_MAX_BYTES };
+		const oversized = { name: "oversized.bin", size: DEFAULT_UPLOAD_MAX_BYTES + 1 };
+
+		expect(getOversizedFiles([accepted, oversized])).toEqual([oversized]);
+		expect(() => assertUploadSize(accepted)).not.toThrow();
+		expect(() => assertUploadSize(oversized)).toThrow(UploadLimitError);
+	});
+});

--- a/apps/inno-agent/web/src/utils/upload-limits.ts
+++ b/apps/inno-agent/web/src/utils/upload-limits.ts
@@ -1,0 +1,22 @@
+/** Maximum source-file size accepted by browser upload entry points. */
+export const DEFAULT_UPLOAD_MAX_BYTES = 32 * 1024 * 1024;
+export const DEFAULT_UPLOAD_MAX_LABEL = "32 MB";
+
+export class UploadLimitError extends Error {
+	constructor(fileName: string) {
+		super(`File "${fileName}" exceeds the ${DEFAULT_UPLOAD_MAX_LABEL} upload limit.`);
+		this.name = "UploadLimitError";
+	}
+}
+
+export function getOversizedFiles<T extends { size: number }>(
+	files: readonly T[],
+	maxBytes = DEFAULT_UPLOAD_MAX_BYTES,
+): T[] {
+	return files.filter((file) => file.size > maxBytes);
+}
+
+/** Validate before any FileReader/arrayBuffer work allocates a large buffer. */
+export function assertUploadSize(file: { name: string; size: number }, maxBytes = DEFAULT_UPLOAD_MAX_BYTES): void {
+	if (file.size > maxBytes) throw new UploadLimitError(file.name);
+}


### PR DESCRIPTION
## 概述

本 PR 汇总当前分支相对于 `upstream/main` 的 7 个连续提交，集中修复聊天页面的上传交互、便捷输入面板布局、消息操作体验、Markdown 渲染稳定性，以及聊天气泡样式一致性。

## 主要改动

### 1. 聊天编辑、重新发送与上传流程

- 完善用户消息编辑后重新发送的流程，并保持会话分支行为一致。
- 将“重试上一次提问”从输入框操作区移动到最后一条助手消息的操作区，避免输入框出现与当前上下文不匹配的操作。
- 仅在没有发送中消息、待处理问题或上传任务时展示重试操作，避免重复触发请求。
- 补充技能上传、文件上传以及工作区状态同步所需的接口和状态处理。

<img width="633" height="356" alt="Screenshot 2026-08-30 at 03-31-09" src="https://github.com/user-attachments/assets/ee7739f5-91c8-4f45-95d1-e4b39ddfe115" />

### 2. 统一上传大小限制处理（解决上传文件过大时会卡死的问题）

- 新增统一的上传大小判断工具和对应测试，复用同一套字节限制逻辑。
- 在聊天便捷输入、工作区文件上传和拖拽上传入口统一过滤超大文件。
- 超出限制时通过统一提示反馈被拒绝的文件数量，不再在技能面板维护独立错误状态。
- 拖拽过程中支持从 `DataTransfer.items` 读取文件，兼容部分浏览器在 `dragover` 阶段 `dataTransfer.files` 为空的情况。
- 改进外部文件拖拽识别、`drop` 捕获与事件阻止，避免和工作区内部树节点拖拽互相干扰。
- 拖拽覆盖层实时显示大小限制错误，并在离开拖拽区域或提示超时后自动清理状态。

### 3. 便捷输入面板布局与简易模式

- 使用 portal 将便捷输入面板挂载到 `document.body`，避免被父级容器的 `overflow` 裁切。
- 基于触发按钮和面板尺寸计算位置，支持视口边界约束、上方/下方自动选择，以及紧凑模式下的左右侧适配。
- 在窗口尺寸变化、滚动和面板尺寸变化时重新定位，并增加 `ResizeObserver` 监听。
- 保留点击外部关闭和 Escape 关闭行为。
- 修正简易模式欢迎页中的便捷输入控件展示条件。
- 移除模式切换按钮上已经不再需要的冗余 title 提示。

### 4. 消息操作与 Markdown 渲染

- 为用户消息和助手消息增加悬停/聚焦后显示的操作栏。
- 增加消息复制、发送时间展示和最后一条助手消息重试操作。
- 复制成功后提供短暂的完成状态反馈，并为触摸设备提供更大的点击区域。
- 调整 Innospark 主题下用户气泡和助手消息的视觉样式。
- 将 Markdown 渲染切换为显式注册的 `mini-lit` `markdown-block`，减少对懒加载链路和 `pi-web-ui` 副作用导入的依赖。
- 清理切换渲染实现后不再需要的 CSS、注释和消息 key 逻辑。

<img width="864" height="416" alt="image" src="https://github.com/user-attachments/assets/de28b2d8-5459-42a7-935b-17c258a100d8" />

### 5. 聊天气泡样式统一与代码清理

- 统一已完成助手消息和流式消息的无边框、透明背景样式，避免不同渲染阶段出现不一致的气泡外观。
- 移除仅针对 Innospark 主题的重复覆盖规则，将通用样式上移到消息组件类名。
- 简化 `MessageBubble` 与 `StreamingBubbles` 的 className，去除重复的边框和背景声明。
- 调整助手消息操作栏中重试按钮与时间的排列顺序，保持操作区信息层级一致。

### 6. 测试覆盖

- 扩展消息编辑/重新发送测试，覆盖消息时间、复制和助手消息重试操作。
- 增加上传大小限制工具测试及便捷输入引擎相关覆盖。
- 保留现有聊天、工作区、服务端和存储层测试。

## 验证结果

- [x]  `npm test`：56 个测试文件通过，432 个测试通过。
- [x] `npm run build`：TypeScript 编译和 Vite 生产构建通过。

## 包含提交

- `3da0909` 优化聊天编辑与上传行为
- `df01b16` 简化上传大小限制处理
- `b893909` 对齐简易模式下的便捷输入控件
- `ef7fd36` 防止便捷输入面板被裁切
- `64c5320` 稳定聊天 Markdown 渲染与消息操作
- `da4f681` 移除冗余聊天代码
- `33993e2` 移除冗余聊天气泡样式