### PR TITLE
feat(workspaces): import workspace from zip archive

### DIFF
--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -69,7 +69,7 @@ import { applyRuntimeEnvironment, parseRuntimeArgs, resolveRuntimePaths } from "
 import { installProcessFallbacks } from "./utils/process-fallback.js";
 import { questionBridge } from "./agent/question-bridge.js";
 import { streamRegistry } from "./chat/stream-registry.js";
-import { DEFAULT_WORKSPACE_ID, WorkspaceRegistry } from "./workspace/workspace-registry.js";
+import { DEFAULT_WORKSPACE_ID, WorkspaceRegistry, type WorkspaceMeta } from "./workspace/workspace-registry.js";
 import type { RemoteContentSource } from "./content-source/index.js";
 import { ContentHubCatalog } from "./content-source/catalog-service.js";
 import { RunRecordStore } from "./terminal/run-record-store.js";
@@ -693,6 +693,120 @@ function installSkillMarkdown(fileName: string, data: Buffer, targetRoot: string
 	ensureDir(skillDir);
 	writeText(join(skillDir, "SKILL.md"), skill.content);
 	return { name: skill.name, filePath: join(skillDir, "SKILL.md") };
+}
+
+// ---------------------------------------------------------------------------
+// Workspace zip import
+// ---------------------------------------------------------------------------
+
+/** Entries that are archive noise, not workspace content. */
+function isImportNoise(name: string): boolean {
+	return name === "__MACOSX" || name === ".DS_Store" || name.startsWith("._");
+}
+
+/**
+ * Locate the actual content root inside an extracted workspace archive:
+ * a single top-level folder (the common "folder zipped by Finder" shape) or
+ * the extract dir itself when files sit at the archive root. Returns null
+ * when the archive has no importable content.
+ */
+function findWorkspaceContentRoot(extractDir: string): string | null {
+	const entries = readdirSync(extractDir, { withFileTypes: true })
+		.filter((entry) => !isImportNoise(entry.name));
+	if (entries.length === 0) return null;
+	if (entries.length === 1 && entries[0].isDirectory()) {
+		const nested = join(extractDir, entries[0].name);
+		const inner = readdirSync(nested, { withFileTypes: true })
+			.filter((entry) => !isImportNoise(entry.name));
+		return inner.length > 0 ? nested : null;
+	}
+	return extractDir;
+}
+
+/**
+ * Recursively copy imported content into the new workspace directory.
+ * File-by-file (not cpSync) for robustness against asar-unpacked paths in
+ * Electron packaged builds. `preset.json` is hub metadata, not content —
+ * it only contributes the default workspace name and is not copied.
+ */
+function copyWorkspaceImportContents(sourceDir: string, targetDir: string): void {
+	ensureDir(targetDir);
+	for (const entry of readdirSync(sourceDir, { withFileTypes: true })) {
+		if (isImportNoise(entry.name) || entry.name === "preset.json") continue;
+		const source = join(sourceDir, entry.name);
+		const target = join(targetDir, entry.name);
+		if (entry.isDirectory()) {
+			copyWorkspaceImportContents(source, target);
+		} else if (entry.isFile()) {
+			writeFileSync(target, readFileSync(source));
+		}
+	}
+}
+
+/**
+ * Import a workspace from a zip archive (e.g. an exported preset workspace
+ * bundle). Extraction reuses the skill-zip validation (no absolute paths or
+ * `..` entries), then a fresh workspace is created and seeded with the
+ * archive's content. Workspace name precedence: explicit `name` →
+ * `preset.json` name → top-level folder name → zip file name.
+ */
+function importWorkspaceZip(fileName: string, data: Buffer, name?: string): WorkspaceMeta {
+	const fallbackName = basename(fileName, extname(fileName)).trim() || "导入的工作区";
+	const tempRoot = join(tmpdir(), `inno-ws-import-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+	const zipPath = join(tempRoot, "workspace.zip");
+	const extractDir = join(tempRoot, "extract");
+	ensureDir(extractDir);
+	writeFileSync(zipPath, data);
+
+	try {
+		validateZipEntries(zipPath);
+		if (process.platform === "win32") {
+			const ps = `Add-Type -AssemblyName System.IO.Compression.FileSystem; ` +
+				`[System.IO.Compression.ZipFile]::ExtractToDirectory(` +
+				`'${zipPath.replace(/'/g, "''")}', '${extractDir.replace(/'/g, "''")}')`;
+			const unzipResult = spawnSync("powershell.exe", ["-NoProfile", "-Command", ps], { encoding: "utf-8" });
+			if (unzipResult.status !== 0) {
+				throw new Error((unzipResult.stderr || "").trim() || "Unable to unzip workspace archive");
+			}
+		} else {
+			const unzipResult = spawnSync("/usr/bin/unzip", ["-qq", "-o", zipPath, "-d", extractDir], { encoding: "utf-8" });
+			if (unzipResult.status !== 0) {
+				throw new Error((unzipResult.stderr || "").trim() || "Unable to unzip workspace archive");
+			}
+		}
+
+		const contentRoot = findWorkspaceContentRoot(extractDir);
+		if (!contentRoot) {
+			throw new Error("The archive does not contain any importable files");
+		}
+
+		// A bundled preset.json contributes the default display name.
+		let presetName = "";
+		const presetJsonPath = join(contentRoot, "preset.json");
+		if (existsSync(presetJsonPath) && statSync(presetJsonPath).isFile()) {
+			try {
+				const meta = JSON.parse(readFileSync(presetJsonPath, "utf-8")) as { name?: unknown };
+				if (typeof meta.name === "string") presetName = meta.name.trim();
+			} catch {
+				// Malformed preset.json is ignored — it is optional metadata.
+			}
+		}
+
+		const wsName = name?.trim()
+			|| presetName
+			|| (contentRoot !== extractDir ? basename(contentRoot).trim() : "")
+			|| fallbackName;
+		const ws = workspaceRegistry.createWorkspace({ name: wsName });
+		const destDir = workspaceRegistry.resolveWorkspaceDir(ws.id);
+		if (!destDir) {
+			throw new Error(`Failed to resolve workspace dir for ${ws.id}`);
+		}
+		copyWorkspaceImportContents(contentRoot, destDir);
+		logger.info({ workspaceId: ws.id, fileName }, "imported workspace from zip archive");
+		return ws;
+	} finally {
+		rmSync(tempRoot, { recursive: true, force: true });
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1378,7 +1492,7 @@ const server = createServer(async (req, res) => {
 		// --- Workspace API + registry + session binding (extracted to server/routes/workspaces.ts) ---
 		if (await handleWorkspacesRoutes(req, res, method, url, {
 			workspaceRegistry, dataDir, paths,
-			installSkillZip, installSkillMarkdown, scheduleSkillsReload,
+			installSkillZip, installSkillMarkdown, scheduleSkillsReload, importWorkspaceZip,
 			sessionFileFromId, releaseQueueFromQuestionBlockedTurn, runQueueOpWithTimeout,
 		})) return;
 

--- a/apps/inno-agent/src/server/routes/workspaces.ts
+++ b/apps/inno-agent/src/server/routes/workspaces.ts
@@ -21,7 +21,7 @@ import { logger } from "../../logger.js";
 import type { RuntimePaths } from "../../runtime.js";
 import { ensureDir } from "../../storage/file-store.js";
 import { isWithin } from "../../utils/path-safety.js";
-import { TEMP_WORKSPACE_ID, type WorkspaceRegistry } from "../../workspace/workspace-registry.js";
+import { TEMP_WORKSPACE_ID, type WorkspaceMeta, type WorkspaceRegistry } from "../../workspace/workspace-registry.js";
 import {
 	canonicalTreeRoot,
 	contentDispositionAttachment,
@@ -47,6 +47,7 @@ export interface WorkspacesRouteContext {
 	paths: RuntimePaths;
 	installSkillZip: (fileName: string, data: Buffer, targetRoot?: string) => { name: string; filePath: string };
 	installSkillMarkdown: (fileName: string, data: Buffer, targetRoot?: string) => { name: string; filePath: string };
+	importWorkspaceZip: (fileName: string, data: Buffer, name?: string) => WorkspaceMeta;
 	scheduleSkillsReload: () => void;
 	sessionFileFromId: (sessionDir: string, id: string) => string | null;
 	releaseQueueFromQuestionBlockedTurn: (sessionId: string) => void;
@@ -306,6 +307,7 @@ export async function handleWorkspacesRoutes(
 		paths,
 		installSkillZip,
 		installSkillMarkdown,
+		importWorkspaceZip,
 		scheduleSkillsReload,
 		sessionFileFromId,
 		releaseQueueFromQuestionBlockedTurn,
@@ -741,6 +743,28 @@ export async function handleWorkspacesRoutes(
 		} catch (err) {
 			logger.error({ err }, "failed to create workspace");
 			json(res, 400, { error: err instanceof Error ? err.message : "Failed to create workspace" });
+		}
+		return true;
+	}
+
+	// Import a workspace from a zip archive (e.g. an exported preset workspace
+	// bundle): extracts the archive and seeds a fresh workspace with its files.
+	if (method === "POST" && url === "/api/workspaces/import") {
+		const body = (await readBody(req)) as Record<string, unknown>;
+		const fileName = typeof body.fileName === "string" ? body.fileName : "";
+		const dataBase64 = typeof body.dataBase64 === "string" ? body.dataBase64 : "";
+		const name = typeof body.name === "string" ? body.name : undefined;
+		if (!fileName || !dataBase64) { json(res, 400, { error: "Missing fileName or dataBase64" }); return true; }
+		if (extname(fileName).toLowerCase() !== ".zip") {
+			json(res, 400, { error: "Only .zip workspace archives are supported" });
+			return true;
+		}
+		try {
+			const ws = importWorkspaceZip(fileName, Buffer.from(dataBase64, "base64"), name);
+			json(res, 201, ws);
+		} catch (err) {
+			logger.error({ err }, "failed to import workspace archive");
+			json(res, 400, { error: err instanceof Error ? err.message : "Failed to import workspace archive" });
 		}
 		return true;
 	}

--- a/apps/inno-agent/web/src/api/workspaces.ts
+++ b/apps/inno-agent/web/src/api/workspaces.ts
@@ -1,4 +1,5 @@
 import { apiFetch } from "./client.js";
+import { arrayBufferToBase64 } from "./uploads.js";
 
 export interface WorkspaceMeta {
 	id: string;
@@ -23,6 +24,15 @@ export async function createWorkspace(input: CreateWorkspaceInput): Promise<Work
 	return apiFetch<WorkspaceMeta>("/api/workspaces", {
 		method: "POST",
 		body: JSON.stringify(input),
+	});
+}
+
+/** Import a workspace from a .zip archive (e.g. an exported preset workspace bundle). */
+export async function importWorkspaceZip(file: File, name?: string): Promise<WorkspaceMeta> {
+	const dataBase64 = arrayBufferToBase64(await file.arrayBuffer());
+	return apiFetch<WorkspaceMeta>("/api/workspaces/import", {
+		method: "POST",
+		body: JSON.stringify({ fileName: file.name, dataBase64, name }),
 	});
 }
 

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -6,6 +6,7 @@
 		"searchPlaceholder": "Search workspaces",
 		"newWorkspace": "New workspace",
 		"newWorkspacePlaceholder": "Enter a workspace name",
+		"importWorkspace": "Import workspace",
 		"tempWorkspace": "Use temporary workspace",
 		"tempWorkspaceLabel": "Temporary workspace",
 		"noResults": "No workspaces found",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -6,6 +6,7 @@
 		"searchPlaceholder": "搜索工作区",
 		"newWorkspace": "新建工作区",
 		"newWorkspacePlaceholder": "输入工作区名称",
+		"importWorkspace": "导入工作区",
 		"tempWorkspace": "使用临时工作区",
 		"tempWorkspaceLabel": "临时工作区",
 		"noResults": "没有找到工作区",

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -361,6 +361,27 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		}
 	}, [activeWorkspaceId, chat.isSending, isUploading, isWelcome, sessions.currentSessionId, t, workspaces.list]);
 
+	// Import a workspace from a .zip archive: upload first, then route the
+	// freshly created workspace through the normal selection flow (welcome
+	// draft state or session binding).
+	const handleWorkspaceImport = useCallback(async (file: File) => {
+		setWsError("");
+		if (!isWelcome && !sessions.currentSessionId) return;
+		if (chat.isSending || isUploading) {
+			setWsError(t("chat.workspaceBusy"));
+			return;
+		}
+		setIsSwitchingWorkspace(true);
+		try {
+			const ws = await workspacesStore.importFromZip(file);
+			await handleWorkspaceChange({ kind: "workspace", workspaceId: ws.id });
+		} catch (error) {
+			setWsError(error instanceof Error ? error.message : t("chat.workspaceSwitchFailed"));
+		} finally {
+			setIsSwitchingWorkspace(false);
+		}
+	}, [chat.isSending, handleWorkspaceChange, isUploading, isWelcome, sessions.currentSessionId, t]);
+
 	const tempWorkspaceId = workspaces.list.find((workspace) => workspace.isTemp)?.id;
 	const uploadWorkspaceId: string | undefined | null = isWelcome
 		? (simpleMode || wsMode === "temp"
@@ -1400,6 +1421,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 				busy={isSwitchingWorkspace}
 				disabled={isUploading || Boolean(chat.pendingQuestion)}
 				onChange={handleWorkspaceChange}
+				onImport={handleWorkspaceImport}
 				smartInputSettings={smartSettings}
 				onToggleSmartInput={toggleSmartInput}
 				onToggleSmartInputRule={toggleSmartInputRule}

--- a/apps/inno-agent/web/src/react/QuestionDialog.tsx
+++ b/apps/inno-agent/web/src/react/QuestionDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { motion } from "motion/react";
 import { Check } from "lucide-react";
@@ -159,6 +159,29 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 	// 每个 tab 的自定义文字草稿，提升到外层避免切换 tab 丢失
 	const [customDrafts, setCustomDrafts] = useState<Map<number, string>>(new Map());
 
+	// Keep the card at its tallest observed height across question tabs.
+	// The dialog sits at the bottom of the conversation, so any height change
+	// (switching to a taller/shorter question, hovering preview options)
+	// triggers the stick-to-bottom pin and visibly shifts the viewport
+	// mid-interaction — the same mechanism as the streaming-bubble watermark.
+	const heightWatermarkRef = useRef(0);
+	const cardObserverRef = useRef<ResizeObserver | null>(null);
+	const cardRef = useCallback((el: HTMLDivElement | null) => {
+		cardObserverRef.current?.disconnect();
+		cardObserverRef.current = null;
+		if (!el) return;
+		heightWatermarkRef.current = 0;
+		el.style.minHeight = "";
+		const observer = new ResizeObserver(() => {
+			const height = el.offsetHeight;
+			if (height > heightWatermarkRef.current) heightWatermarkRef.current = height;
+			const minHeight = `${heightWatermarkRef.current}px`;
+			if (el.style.minHeight !== minHeight) el.style.minHeight = minHeight;
+		});
+		observer.observe(el);
+		cardObserverRef.current = observer;
+	}, []);
+
 	const handleAnswer = useCallback(
 		(a: QuestionAnswer) => {
 			setAnswers((prev) => {
@@ -228,7 +251,7 @@ export function QuestionDialog({ pending }: { pending: PendingQuestion }) {
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.3, ease: "easeOut" }}
 		>
-			<div className="w-full max-w-[36.5rem] rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-surface)] px-4 py-3 shadow-sm">
+			<div ref={cardRef} className="w-full max-w-[36.5rem] rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-surface)] px-4 py-3 shadow-sm">
 				{questions.length > 1 ? (
 					<div className="mb-3 flex gap-1">
 						{questions.map((q, i) => (

--- a/apps/inno-agent/web/src/react/WorkspaceSwitcher.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceSwitcher.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, ChevronDown, ChevronUp, Folder, Plus, Search, X, Ban, LoaderCircle } from "lucide-react";
+import { Check, ChevronDown, ChevronUp, Folder, FolderInput, Plus, Search, X, Ban, LoaderCircle } from "lucide-react";
 import type { WorkspaceMeta } from "../api/workspaces.js";
 import { PopoverSurface } from "./ui/PopoverSurface.js";
 
@@ -23,6 +23,8 @@ interface WorkspaceSwitcherProps {
 	disabled?: boolean;
 	className?: string;
 	onChange: (choice: WorkspaceChoice) => void;
+	/** Import a workspace from a .zip archive picked via the menu action. */
+	onImport?: (file: File) => void;
 }
 
 /**
@@ -39,11 +41,13 @@ export function WorkspaceSwitcher({
 	disabled = false,
 	className = "",
 	onChange,
+	onImport,
 }: WorkspaceSwitcherProps) {
 	const { t } = useTranslation();
 	const rootRef = useRef<HTMLDivElement | null>(null);
 	const searchRef = useRef<HTMLInputElement | null>(null);
 	const createInputRef = useRef<HTMLInputElement | null>(null);
+	const importInputRef = useRef<HTMLInputElement | null>(null);
 	const [open, setOpen] = useState(false);
 	const [query, setQuery] = useState("");
 	const [creating, setCreating] = useState(false);
@@ -116,6 +120,21 @@ export function WorkspaceSwitcher({
 		if (!name) return;
 		choose({ kind: "new", name });
 		setDraftName("");
+	};
+
+	const pickImportArchive = () => {
+		// Close the popover first: the native file dialog blocks the main
+		// thread, and the outside-pointer-down listener would otherwise fire
+		// on the dialog itself.
+		close();
+		importInputRef.current?.click();
+	};
+
+	const handleImportFile = (event: ChangeEvent<HTMLInputElement>) => {
+		const file = event.target.files?.[0];
+		// Reset so picking the same archive twice still fires change.
+		event.target.value = "";
+		if (file && onImport) onImport(file);
 	};
 
 	return (
@@ -229,6 +248,12 @@ export function WorkspaceSwitcher({
 								<span className="inno-workspace-action-icon" aria-hidden="true"><Plus size={15} /></span>
 								<span>{t("workspace.newWorkspace")}</span>
 							</button>
+							{onImport ? (
+								<button type="button" className="inno-workspace-action" role="menuitem" onClick={pickImportArchive}>
+									<span className="inno-workspace-action-icon" aria-hidden="true"><FolderInput size={15} /></span>
+									<span>{t("workspace.importWorkspace")}</span>
+								</button>
+							) : null}
 							<button
 								type="button"
 								className={`inno-workspace-action ${resolvedKind === "temp" ? "is-selected" : ""}`}
@@ -243,6 +268,15 @@ export function WorkspaceSwitcher({
 						</>
 					)}
 				</PopoverSurface>
+			) : null}
+			{onImport ? (
+				<input
+					ref={importInputRef}
+					type="file"
+					accept=".zip,application/zip,application/x-zip-compressed"
+					hidden
+					onChange={handleImportFile}
+				/>
 			) : null}
 		</div>
 	);

--- a/apps/inno-agent/web/src/react/chat/WorkspaceContext.tsx
+++ b/apps/inno-agent/web/src/react/chat/WorkspaceContext.tsx
@@ -11,6 +11,8 @@ interface WorkspaceContextProps {
 	busy?: boolean;
 	disabled?: boolean;
 	onChange: (choice: WorkspaceChoice) => void;
+	/** Import a workspace from a .zip archive picked via the menu action. */
+	onImport?: (file: File) => void;
 	smartInputSettings?: SmartInputSettings;
 	onToggleSmartInput: () => void;
 	onToggleSmartInputRule: (ruleId: string) => void;
@@ -27,6 +29,7 @@ export function WorkspaceContext({
 	busy = false,
 	disabled = false,
 	onChange,
+	onImport,
 	smartInputSettings,
 	onToggleSmartInput,
 	onToggleSmartInputRule,
@@ -43,6 +46,7 @@ export function WorkspaceContext({
 				busy={busy}
 				disabled={disabled}
 				onChange={onChange}
+				onImport={onImport}
 			/>
 			<SmartInputControl
 				smartInputSettings={smartInputSettings}

--- a/apps/inno-agent/web/src/stores/workspaces-store.ts
+++ b/apps/inno-agent/web/src/stores/workspaces-store.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "./event-emitter.js";
 import {
 	createWorkspace,
 	deleteWorkspace,
+	importWorkspaceZip,
 	listWorkspaces,
 	renameWorkspace,
 	type CreateWorkspaceInput,
@@ -41,6 +42,13 @@ class WorkspacesStoreImpl extends EventEmitter<WorkspacesStoreEvents> {
 
 	async create(input: CreateWorkspaceInput): Promise<WorkspaceMeta> {
 		const ws = await createWorkspace(input);
+		this.workspaces = [...this.workspaces, ws];
+		this.emit("change", undefined);
+		return ws;
+	}
+
+	async importFromZip(file: File): Promise<WorkspaceMeta> {
+		const ws = await importWorkspaceZip(file);
 		this.workspaces = [...this.workspaces, ws];
 		this.emit("change", undefined);
 		return ws;


### PR DESCRIPTION
## What

- **Import workspace**: new "Import workspace" action below "New workspace" in the workspace switcher. Picking a `.zip` uploads it to a new `POST /api/workspaces/import` endpoint, which safely extracts the archive (reusing the skill-zip entry validation), detects a single-top-folder or flat layout, derives the workspace name from `preset.json` / folder / file name, and seeds a fresh workspace with the content (skipping `__MACOSX`, `.DS_Store`, `._*`, `preset.json`). Works with exported preset-workspace bundles, e.g. `01-主题调研工作区-干净版.zip`.
- **Question card scroll fix**: answering one question in a multi-question `ask_user_question` dialog and advancing to the next changed the card's height; as the last element in the conversation this triggered the stick-to-bottom pin and visibly shifted the viewport mid-interaction. The card now keeps a height watermark (same pattern as the streaming bubble) so tab switches and preview hovers never resize it.

## Verification

- `npm run build` + full test suite (432 tests) pass.
- End-to-end against a scratch server with a real preset-workspace zip: import → 201, name from `preset.json`, all 19 `.skills` + `agent.md` + Chinese filenames intact, file set diffed identical to source; zip-slip, non-zip, flat, and empty archives behave correctly.