### PR TITLE
feat(chat): add agent trace timeline and replay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ PI SDK packages (`@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, `@e
 
 Key dependencies: `ws` (WebSocket), `node-pty` (PTY terminal), `cron-parser` (scheduler), `@larksuiteoapi/node-sdk` (Feishu), `typebox` (validation), `undici` (HTTP client), `@juicesharp/rpiv-ask-user-question` (bridges agent `ask_user_question` tool calls to the web UI), `@juicesharp/rpiv-todo` (`todo` task-list tool), `pi-web-access` (`fetch_content`/`get_search_content` URL/GitHub/PDF/YouTube extraction), `pi-subagents` (optional subagent support), `pi-sandbox` (optional OS-level sandboxing), `graphology` + `graphology-communities-louvain` (wiki knowledge graph), `yaml` (YAML parsing), `@llamaindex/liteparse` (document parsing).
 
-Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is 56 files (432 tests) and skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
+Tests run with `npm test` (`vitest run`, root script) and also execute in the release CI. The suite is 59 files (469 tests), including backend chat-stream/trace persistence coverage and web chat trace/timeline coverage, while remaining skewed toward `memory/l2`; coverage for channels/scheduler/terminal/L1/L3 is tracked in `docs/quality-remediation-plan.md`. The TypeScript build (`npm run build`) remains the primary sanity check. No ESLint or Prettier configuration exists.
 
 When a PR changes the test count, the size of `server.ts`, or other structural facts stated in this file, update this file in the same PR — AI agents read it as ground truth.
 

--- a/apps/inno-agent/src/agent/document-tools.ts
+++ b/apps/inno-agent/src/agent/document-tools.ts
@@ -29,11 +29,21 @@ export function createDocumentTools(): ToolDefinition[] {
 				}),
 			),
 		}),
-		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+		async execute(_toolCallId, params, _signal, onUpdate, ctx) {
 			const typed = params as {
 				filePath: string;
 				includePageDetails?: boolean;
 				includeScreenshots?: boolean;
+			};
+			const reportProgress = (text: string, phase: string): void => {
+				try {
+					onUpdate?.({
+						content: [{ type: "text" as const, text }],
+						details: { phase, filePath: typed.filePath },
+					});
+				} catch {
+					// Progress reporting is best-effort and must never fail parsing.
+				}
 			};
 
 			// The tool context is session-scoped. The process environment points at
@@ -45,6 +55,7 @@ export function createDocumentTools(): ToolDefinition[] {
 				: resolve(workspaceDir, typed.filePath);
 
 			// Check file existence before attempting parse
+			reportProgress("正在检查文件", "checking");
 			if (!existsSync(resolvedPath)) {
 				return {
 					content: [{ type: "text" as const, text: `文件不存在: ${typed.filePath}` }],
@@ -55,7 +66,9 @@ export function createDocumentTools(): ToolDefinition[] {
 			// Parse document
 			let parsed;
 			try {
+				reportProgress("正在解析文档", "parsing");
 				parsed = await parseDocument(resolvedPath);
+				reportProgress(`已读取 ${parsed.pageCount} 页，正在整理内容`, "parsed");
 			} catch (err) {
 				logger.warn({ err, filePath: resolvedPath }, "parse_document tool: document parsing failed");
 				const msg = err instanceof DocumentParseError
@@ -92,6 +105,7 @@ export function createDocumentTools(): ToolDefinition[] {
 			// Screenshots
 			if (typed.includeScreenshots) {
 				try {
+					reportProgress("正在生成页面截图", "screenshots");
 					const screenshots = await screenshotDocument(resolvedPath);
 					for (const shot of screenshots) {
 						content.push({

--- a/apps/inno-agent/src/agent/inno-extension.ts
+++ b/apps/inno-agent/src/agent/inno-extension.ts
@@ -670,7 +670,7 @@ export function createInnoExtension(
 					}
 
 					// Web mode: delegate to QuestionBridge
-					const bridgeResult = await questionBridge.ask(typed);
+					const bridgeResult = await questionBridge.ask(typed, _toolCallId);
 					return buildQuestionnaireResponse(bridgeResult, typed);
 				},
 			} as Parameters<typeof pi.registerTool>[0]);

--- a/apps/inno-agent/src/agent/observability-extension.ts
+++ b/apps/inno-agent/src/agent/observability-extension.ts
@@ -65,11 +65,11 @@ function summarizeArgs(toolName: string, args: unknown): string {
       case "bash":
         return typeof a.command === "string" ? a.command : safeStringify(args);
       case "read":
-        return typeof a.file_path === "string" ? a.file_path : safeStringify(args);
+        return typeof a.path === "string" ? a.path : typeof a.file_path === "string" ? a.file_path : safeStringify(args);
       case "write":
-        return typeof a.file_path === "string" ? a.file_path : safeStringify(args);
+        return typeof a.path === "string" ? a.path : typeof a.file_path === "string" ? a.file_path : safeStringify(args);
       case "edit":
-        return typeof a.file_path === "string" ? a.file_path : safeStringify(args);
+        return typeof a.path === "string" ? a.path : typeof a.file_path === "string" ? a.file_path : safeStringify(args);
       case "grep":
         return typeof a.pattern === "string" ? `pattern="${a.pattern}"` : safeStringify(args);
       case "find":

--- a/apps/inno-agent/src/agent/question-bridge.test.ts
+++ b/apps/inno-agent/src/agent/question-bridge.test.ts
@@ -6,8 +6,9 @@ describe("QuestionBridge", () => {
 		const bridge = new QuestionBridge();
 		const events: Array<Record<string, unknown>> = [];
 		bridge.bindTurn({ sessionId: "s1", turnId: "t1", emit: (event) => events.push(event), timeoutMs: 10_000 });
-		const answerPromise = bridge.ask({ questions: [] });
+		const answerPromise = bridge.ask({ questions: [] }, "tool-1");
 		const questionId = events[0].questionId as string;
+		expect(events[0]).toMatchObject({ type: "question", toolCallId: "tool-1" });
 
 		expect(bridge.respond({ sessionId: "wrong", turnId: "t1", questionId, result: { answers: [], cancelled: false } })).toBe("scope_mismatch");
 		expect(bridge.respond({ sessionId: "s1", turnId: "t1", questionId, result: { answers: [], cancelled: false } })).toBe("accepted");

--- a/apps/inno-agent/src/agent/question-bridge.ts
+++ b/apps/inno-agent/src/agent/question-bridge.ts
@@ -68,7 +68,7 @@ export class QuestionBridge {
 		this.binding = binding;
 	}
 
-	ask(params: unknown): Promise<QuestionBridgeResult> {
+	ask(params: unknown, toolCallId?: string): Promise<QuestionBridgeResult> {
 		const binding = this.binding;
 		if (!binding) return Promise.resolve({ answers: [], cancelled: true, error: "no_ui" });
 		if (this.pending) this.resolvePending({ answers: [], cancelled: true, error: "superseded" }, false);
@@ -87,7 +87,12 @@ export class QuestionBridge {
 				this.resolvePending({ answers: [], cancelled: true, error: "timeout" }, true);
 			}, binding.timeoutMs);
 			this.pending = { questionId, sessionId: binding.sessionId, turnId: binding.turnId, params, resolve, timer };
-			binding.emit({ type: "question", questionId, params });
+			binding.emit({
+				type: "question",
+				questionId,
+				params,
+				...(toolCallId ? { toolCallId } : {}),
+			});
 		});
 	}
 

--- a/apps/inno-agent/src/chat/stream-registry.test.ts
+++ b/apps/inno-agent/src/chat/stream-registry.test.ts
@@ -39,6 +39,21 @@ describe("StreamRegistry", () => {
 		expect(state.completedTools).toHaveLength(1);
 	});
 
+	it("keeps partial tool output on the active row until the final result arrives", () => {
+		const registry = new StreamRegistry();
+		const state = create(registry);
+		registry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+		registry.publishStreamEvent(state, { type: "tool_start", toolCallId: "tool-1", toolName: "bash", args: { command: "printf ok" } });
+		const partialResult = { content: [{ type: "text", text: "ok" }], details: { phase: "running" } };
+		registry.publishStreamEvent(state, { type: "tool_update", toolCallId: "tool-1", toolName: "bash", args: { command: "printf ok" }, partialResult });
+
+		expect(state.activeTools[0]).toMatchObject({ toolName: "bash", partialResult });
+		expect(state.history.at(-1)?.event).toMatchObject({ type: "tool_update", partialResult });
+
+		registry.publishStreamEvent(state, { type: "tool_end", toolCallId: "tool-1", toolName: "bash", result: "ok", isError: false });
+		expect(state.completedTools[0]).toMatchObject({ toolName: "bash", partialResult, result: "ok" });
+	});
+
 	it("allows only the first terminal transition", () => {
 		const registry = new StreamRegistry();
 		const state = create(registry);

--- a/apps/inno-agent/src/chat/stream-registry.ts
+++ b/apps/inno-agent/src/chat/stream-registry.ts
@@ -11,6 +11,9 @@ export interface StreamEventEnvelope {
 	sessionId: string;
 	turnId: string;
 	clientRequestId: string;
+	/** Stable per-turn trace identity used by the UI sidecar and reconnects. */
+	traceId: string;
+	occurredAt: string;
 	event: ChatStreamEvent;
 }
 
@@ -26,6 +29,8 @@ export interface ActiveStreamTool {
 	toolCallId: string;
 	toolName: string;
 	args?: unknown;
+	/** Latest partial result emitted while the tool is still running. */
+	partialResult?: unknown;
 	startedAt: string;
 }
 
@@ -123,6 +128,7 @@ function compactEvent(event: ChatStreamEvent): ChatStreamEvent {
 	if (typeof next.fullText === "string") next.fullText = compact(next.fullText, MAX_TEXT);
 	if ("args" in next) next.args = compact(next.args);
 	if ("result" in next) next.result = compact(next.result);
+	if ("partialResult" in next) next.partialResult = compact(next.partialResult, 16_000);
 	if ("params" in next) next.params = compact(next.params);
 	if (Array.isArray(next.changes)) {
 		const changes: unknown[] = [];
@@ -141,6 +147,8 @@ function compactEvent(event: ChatStreamEvent): ChatStreamEvent {
 	}
 	if ("preview" in next) next.preview = compact(next.preview);
 	if ("content" in next) next.content = compact(next.content);
+	if ("detail" in next) next.detail = compact(next.detail);
+	if ("skills" in next) next.skills = compact(next.skills);
 	return next;
 }
 
@@ -182,6 +190,31 @@ function reduceStreamState(state: SessionStreamState, event: ChatStreamEvent): v
 			startedAt: new Date().toISOString(),
 		};
 		state.activeTools = [...state.activeTools.filter((item) => item.toolCallId !== toolCallId), tool];
+		return;
+	}
+	if (event.type === "tool_update") {
+		const toolCallId = typeof event.toolCallId === "string" ? event.toolCallId : "";
+		if (!toolCallId) return;
+		const active = state.activeTools.find((item) => item.toolCallId === toolCallId);
+		if (active) {
+			state.activeTools = state.activeTools.map((item) => item.toolCallId === toolCallId
+				? {
+					...item,
+					...(typeof event.toolName === "string" && event.toolName ? { toolName: event.toolName } : {}),
+					...(event.args !== undefined ? { args: event.args } : {}),
+					...(event.partialResult !== undefined ? { partialResult: event.partialResult } : {}),
+				}
+				: item);
+		} else {
+			// Be tolerant of a reconnect that starts at an update event.
+			state.activeTools = [...state.activeTools, {
+				toolCallId,
+				toolName: typeof event.toolName === "string" && event.toolName ? event.toolName : "tool",
+				...(event.args !== undefined ? { args: event.args } : {}),
+				...(event.partialResult !== undefined ? { partialResult: event.partialResult } : {}),
+				startedAt: new Date().toISOString(),
+			}];
+		}
 		return;
 	}
 	if (event.type === "tool_end") {
@@ -286,6 +319,8 @@ export class StreamRegistry {
 			sessionId: state.sessionId,
 			turnId: state.turnId,
 			clientRequestId: state.clientRequestId,
+			traceId: state.turnId,
+			occurredAt: new Date().toISOString(),
 			event: compacted,
 		};
 		state.history.push(envelope);
@@ -320,6 +355,8 @@ export class StreamRegistry {
 			sessionId: state.sessionId,
 			turnId: state.turnId,
 			clientRequestId: state.clientRequestId,
+			traceId: state.turnId,
+			occurredAt: new Date().toISOString(),
 			event: terminalEvent,
 		};
 		state.history.push(envelope);

--- a/apps/inno-agent/src/memory/l2/l2-tools.ts
+++ b/apps/inno-agent/src/memory/l2/l2-tools.ts
@@ -103,8 +103,19 @@ export function createL2Tools(
 			sessionId: Type.Optional(Type.String({ description: "关联的会话 ID" })),
 			force: Type.Optional(Type.Boolean({ description: "为 true 时跳过重复检查，强制归档" })),
 		}),
-			async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+			async execute(_toolCallId, params, signal, onUpdate, ctx) {
 				if (isEnabled && !isEnabled()) return l2DisabledResult();
+				const reportProgress = (text: string, phase: string): void => {
+					try {
+						onUpdate?.({
+							content: [{ type: "text" as const, text }],
+							details: { phase },
+						});
+					} catch {
+						// Progress reporting is best-effort and must never fail archiving.
+					}
+				};
+				reportProgress("等待归档队列", "queued");
 				return enqueueArchive(l2DataDir, async () => {
 				throwIfAborted(signal);
 			ensureL2Directories(l2DataDir);
@@ -112,6 +123,7 @@ export function createL2Tools(
 
 			const sourceType = params.sourceType as RawSourceType;
 			const isFileType = sourceType === "pdf" || sourceType === "word" || sourceType === "image";
+			reportProgress("正在准备归档", "preparing");
 
 			// Resolve content: either from params.content or by parsing a file
 			let content: string;
@@ -126,7 +138,9 @@ export function createL2Tools(
 
 				let parsed;
 				try {
+					reportProgress("正在解析文件", "parsing");
 					parsed = await parseDocument(resolvedFilePath);
+					reportProgress(`已提取 ${parsed.pageCount} 页，正在生成摘要`, "parsed");
 				} catch (err) {
 					logger.warn({ err, filePath: resolvedFilePath }, "l2_archive: failed to parse document");
 					const msg = err instanceof DocumentParseError ? err.message : String(err);
@@ -141,6 +155,7 @@ export function createL2Tools(
 			} else if (params.content) {
 				// Text-based: use content directly
 				content = params.content;
+				reportProgress("正在准备文本内容", "prepared");
 			} else {
 				return {
 					content: [{ type: "text" as const, text: "参数错误：必须提供 content（文本内容）或 filePath（文件路径）。" }],
@@ -164,8 +179,9 @@ export function createL2Tools(
 					&& existing?.wikiPages.length
 					&& existing.wikiPages.every((pagePath) => fileExists(join(l2DataDir, pagePath))),
 				);
-					if (!params.force && existing?.status === "indexed" && completedArtifactsExist) {
-						return {
+				if (!params.force && existing?.status === "indexed" && completedArtifactsExist) {
+					reportProgress("内容已归档，正在返回结果", "completed");
+					return {
 						content: [
 							{
 								type: "text" as const,
@@ -243,6 +259,7 @@ export function createL2Tools(
 					let generationSourceContext = extractedContent;
 					const analysisCheckpointPath = join(l2DataDir, "ingest-progress", `${entry.id}-${entry.contentHash}.json`);
 					if (ctx.model) {
+						reportProgress("正在生成摘要", "summarizing");
 						const summary = await summarizeContent(
 							ctx.model,
 							ctx.modelRegistry,
@@ -265,6 +282,7 @@ export function createL2Tools(
 						generationSourceContext = summary.sourceContext;
 					}
 					wikiPagePath = getSourcePagePath(entry, promptSourceIdentity);
+					if (ctx.model) reportProgress("正在生成 Wiki 页面", "generating");
 					const rich = ctx.model
 						? await generateRichWikiPages(
 							l2DataDir,
@@ -290,6 +308,7 @@ export function createL2Tools(
 						ingestWarnings = rich.warnings;
 						reviewCount = rich.reviews;
 					}
+					reportProgress("正在保存 Wiki 页面", "writing");
 					if (!rich) {
 						createSourcePage(l2DataDir, entry, summaryBody, extractedPath, promptSourceIdentity);
 					}
@@ -342,6 +361,7 @@ export function createL2Tools(
 							logger.warn({ err, source: params.title }, "l2_archive: failed to append ingest log");
 						}
 				}
+				reportProgress("正在更新 Wiki 索引", "indexing");
 				try {
 					updateIndexAfterIngest(l2DataDir, entry.wikiPages);
 				} catch (err) {
@@ -374,8 +394,9 @@ export function createL2Tools(
 					// Retrieval is downstream of the same completeness gate as
 					// The reference flow does not index partial writes. A
 					// single retrieval-index failure is non-critical after the page
-					// set has passed completeness and must not make the source retry.
-						let retrievalIndexFailed = false;
+				// set has passed completeness and must not make the source retry.
+				reportProgress("正在同步检索索引", "retrieving");
+					let retrievalIndexFailed = false;
 						for (const wikiPath of entry.wikiPages) {
 							try {
 								await l2Memory.indexPageByPath(wikiPath);
@@ -399,8 +420,9 @@ export function createL2Tools(
 					entry.updatedAt = new Date().toISOString();
 					upsertManifest(l2DataDir, entry);
 					throw err;
-				}
+					}
 
+				reportProgress("归档完成", "completed");
 				return {
 					content: [
 						{

--- a/apps/inno-agent/src/server.ts
+++ b/apps/inno-agent/src/server.ts
@@ -1005,9 +1005,11 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 				pendingAssistant = null;
 			}
 		};
-		const ensureAssistant = (timestamp: number): SessionMessageSummary => {
+		const ensureAssistant = (timestamp: number, entryId?: string): SessionMessageSummary => {
 			if (!pendingAssistant) {
-				pendingAssistant = { role: "assistant", content: "", timestamp };
+				pendingAssistant = { role: "assistant", content: "", timestamp, entryId };
+			} else if (entryId) {
+				pendingAssistant.entryId = entryId;
 			}
 			return pendingAssistant;
 		};
@@ -1080,7 +1082,7 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 			}
 
 			if (role === "assistant") {
-				const pending = ensureAssistant(ts);
+				const pending = ensureAssistant(ts, typeof entry.id === "string" ? entry.id : undefined);
 				if (entryChannel && !pending.channel) pending.channel = entryChannel;
 				const content = message.content;
 				if (Array.isArray(content)) {
@@ -1112,6 +1114,7 @@ function parseSessionFile(filePath: string): { summary: SessionSummary; messages
 					pending.content = pending.content ? `${pending.content}\n${content}` : content;
 				}
 				pending.timestamp = ts;
+				if (typeof message.stopReason === "string") pending.stopReason = message.stopReason;
 				// If this assistant entry ended the turn (stopReason "stop"), finalize.
 				if (typeof message.stopReason === "string" && message.stopReason !== "toolUse") {
 					finalizeAssistant();

--- a/apps/inno-agent/src/server/routes/chat.ts
+++ b/apps/inno-agent/src/server/routes/chat.ts
@@ -4,6 +4,7 @@ import { isAbsolute, join, relative, resolve } from "node:path";
 import {
 	abortPromptForTurnToken,
 	getCurrentSessionId,
+	getLoadedSkills,
 	persistCancelledQueuedTurn,
 	persistPendingUserTurn,
 	runPromptInSession,
@@ -11,6 +12,7 @@ import {
 	runPromptStreamingInSession,
 	type PromptRunOutcome,
 } from "../../agent/pi-runner.js";
+import { loadSkillsFromDir } from "@earendil-works/pi-coding-agent";
 import { expandInnoSlashCommand } from "../../agent/inno-extension.js";
 import { questionBridge, type QuestionBridgeResult } from "../../agent/question-bridge.js";
 import {
@@ -30,6 +32,7 @@ import {
 } from "../attachments.js";
 import { recordSessionAttachments } from "../attachments-store.js";
 import { recordSessionAgentCommand } from "../agent-command-store.js";
+import { recordSessionTrace } from "../trace-store.js";
 import { WORKSPACE_IGNORES } from "../file-helpers.js";
 import { json, matchRoute, readBody } from "../http-helpers.js";
 import type {
@@ -62,31 +65,89 @@ export interface ChatRouteContext {
 // Helpers moved verbatim from server.ts (P2 route split)
 // ---------------------------------------------------------------------------
 
+function phaseForPiEvent(type: string): "start" | "update" | "end" | undefined {
+	if (type.endsWith("_start")) return "start";
+	if (type.endsWith("_end")) return "end";
+	if (type.endsWith("_update")) return "update";
+	return undefined;
+}
+
+function piEventSummary(event: any): string | undefined {
+	if (!event || typeof event !== "object") return undefined;
+	if (typeof event.errorMessage === "string") return event.errorMessage;
+	if (typeof event.message === "string") return event.message;
+	if (typeof event.reason === "string") return event.reason;
+	if (typeof event.toolName === "string") return event.toolName;
+	if (typeof event.stopReason === "string") return `stopReason: ${event.stopReason}`;
+	if (typeof event.status === "string") return event.status;
+	return undefined;
+}
+
+function piEventDetail(event: any): Record<string, unknown> | undefined {
+	if (!event || typeof event !== "object") return undefined;
+	const detail: Record<string, unknown> = {};
+	for (const key of [
+		"attempt", "maxAttempts", "delayMs", "errorMessage", "finalError", "stopReason",
+		"toolCallId", "toolName", "reason", "status", "command", "cwd", "output",
+		"entryId", "parentId", "filePath", "compactionId",
+	]) {
+		if (event[key] !== undefined) detail[key] = event[key];
+	}
+	return Object.keys(detail).length > 0 ? detail : undefined;
+}
+
+function systemEventFromPi(event: any, eventType = typeof event?.type === "string" ? event.type : "pi_event"): unknown {
+	const attempt = typeof event?.attempt === "number" ? event.attempt : undefined;
+	return {
+		type: "system_event",
+		eventType,
+		phase: phaseForPiEvent(eventType),
+		summary: piEventSummary(event),
+		detail: piEventDetail(event),
+		...(attempt !== undefined ? { attempt } : {}),
+		...(typeof event?.success === "boolean" ? { success: event.success } : {}),
+	};
+}
+
 function piEventToSseEvent(event: any): unknown | null {
+	if (!event || typeof event.type !== "string") return null;
 	switch (event.type) {
 		case "message_update": {
 			const ev = event.assistantMessageEvent;
-			if (ev.type === "text_delta") return { type: "text_delta", delta: ev.delta };
-			if (ev.type === "thinking_delta") return { type: "thinking_delta", delta: ev.delta };
+			if (!ev || typeof ev.type !== "string") return systemEventFromPi(event, "message_update");
+			if (ev.type === "text_start") return { type: "text_start", contentIndex: ev.contentIndex };
+			if (ev.type === "text_delta") return { type: "text_delta", delta: ev.delta, contentIndex: ev.contentIndex };
+			if (ev.type === "text_end") return { type: "text_end", contentIndex: ev.contentIndex };
+			if (ev.type === "thinking_start") return { type: "thinking_start", contentIndex: ev.contentIndex };
+			if (ev.type === "thinking_delta") return { type: "thinking_delta", delta: ev.delta, contentIndex: ev.contentIndex };
+			if (ev.type === "thinking_end") return { type: "thinking_end", contentIndex: ev.contentIndex };
 			if (ev.type === "toolcall_start" || ev.type === "toolcall_delta" || ev.type === "toolcall_end") {
 				return toolCallStreamEventFromAssistantEvent(ev);
 			}
-			if (ev.type === "error") return null;
-			return null;
+			if (ev.type === "error") return { type: "error", message: ev.error?.errorMessage || "LLM API error", code: "pi_message_error", persisted: false };
+			return systemEventFromPi(ev, `message_update:${ev.type}`);
 		}
 		case "message_end": {
 			const msg = event.message;
 			if (msg && typeof msg === "object" && "stopReason" in msg && msg.stopReason === "error") {
-				return null;
+				return { type: "error", message: msg.errorMessage || "The model request failed.", code: "pi_message_error", persisted: false };
 			}
-			return null;
+			return systemEventFromPi(msg ?? event, "message_end");
 		}
 		case "tool_execution_start":
 			return { type: "tool_start", toolCallId: event.toolCallId, toolName: event.toolName, args: event.args };
+		case "tool_execution_update":
+			return {
+				type: "tool_update",
+				toolCallId: event.toolCallId,
+				toolName: event.toolName,
+				args: event.args,
+				partialResult: event.partialResult,
+			};
 		case "tool_execution_end":
 			return { type: "tool_end", toolCallId: event.toolCallId, toolName: event.toolName, result: event.result, isError: event.isError };
-		default:
-			return null;
+      default:
+        return systemEventFromPi(event);
 	}
 }
 
@@ -101,9 +162,10 @@ function toolCallStreamEventFromAssistantEvent(ev: any): unknown | null {
 		? ev.toolCall?.arguments ?? block.arguments
 		: undefined;
 	return {
-		type: "tool_call_delta",
+		type: ev.type === "toolcall_start" ? "tool_call_start" : ev.type === "toolcall_end" ? "tool_call_end" : "tool_call_delta",
 		toolCallId,
 		toolName,
+		contentIndex: ev.contentIndex,
 		...(args !== undefined ? { args } : {}),
 		...(ev.type === "toolcall_delta" && typeof ev.delta === "string" ? { argsDelta: ev.delta } : {}),
 	};
@@ -183,6 +245,79 @@ function recordAgentCommandIfPresent(dataDir: string, sessionId: string, prompt:
 		commandContent: prompt,
 		expandedContent,
 	});
+}
+
+interface TraceSkillInfo {
+	name: string;
+	description?: string;
+	path?: string;
+	source?: string;
+}
+
+function traceSkillInfo(value: unknown, sourceFallback?: string): TraceSkillInfo | null {
+	if (!value || typeof value !== "object") return null;
+	const skill = value as Record<string, unknown>;
+	const sourceInfo = skill.sourceInfo && typeof skill.sourceInfo === "object"
+		? skill.sourceInfo as Record<string, unknown>
+		: undefined;
+	if (typeof skill.name !== "string" || !skill.name) return null;
+	return {
+		name: skill.name,
+		description: typeof skill.description === "string" ? skill.description : undefined,
+		path: typeof skill.filePath === "string"
+			? skill.filePath
+			: typeof skill.path === "string"
+				? skill.path
+				: typeof skill.location === "string" ? skill.location : undefined,
+		source: typeof skill.source === "string"
+			? skill.source
+			: typeof sourceInfo?.source === "string" ? sourceInfo.source : sourceFallback,
+	};
+}
+
+function loadedSkillsForTrace(workspaceRoot: string): TraceSkillInfo[] {
+	const skills: TraceSkillInfo[] = [];
+	try {
+		const loaded = getLoadedSkills().skills;
+		if (Array.isArray(loaded)) {
+			for (const skill of loaded) {
+				const info = traceSkillInfo(skill, "global");
+				if (info) skills.push(info);
+			}
+		}
+	} catch {
+		// Skill diagnostics are optional UI metadata and must not block a turn.
+	}
+	try {
+		const privateSkillsDir = join(workspaceRoot, ".skills");
+		if (existsSync(privateSkillsDir)) {
+			const privateSkills = loadSkillsFromDir({ dir: privateSkillsDir, source: "workspace" }).skills;
+			for (const skill of privateSkills) {
+				const info = traceSkillInfo(skill, "workspace");
+				if (info) skills.push(info);
+			}
+		}
+	} catch {
+		// Private skill discovery is best-effort, matching prompt construction.
+	}
+	const byName = new Map<string, TraceSkillInfo>();
+	for (const skill of skills) byName.set(skill.name, skill);
+	return Array.from(byName.values());
+}
+
+function explicitSkillEvent(prompt: string, skills: TraceSkillInfo[]): unknown | null {
+	const match = prompt.trim().match(/^\/skill:([^\s]+)(?:\s+([\s\S]+))?$/);
+	if (!match) return null;
+	const skillName = match[1]!;
+	const loaded = skills.find((skill) => skill.name === skillName);
+	return {
+		type: "skill_invoked",
+		skillName,
+		args: match[2]?.trim() || undefined,
+		source: loaded?.source,
+		path: loaded?.path,
+		description: loaded?.description,
+	};
 }
 
 function readSessionBaseline(
@@ -688,13 +823,17 @@ export async function handleChatRoutes(
 					}
 					break;
 				}
-				case "tool_execution_start":
-					logger.info(
-						{ toolName: event.toolName, toolCallId: event.toolCallId },
-						"tool call started: %s", event.toolName,
-					);
-					break;
-				case "tool_execution_end":
+					case "tool_execution_start":
+						logger.info(
+							{ toolName: event.toolName, toolCallId: event.toolCallId },
+							"tool call started: %s", event.toolName,
+						);
+						break;
+					case "tool_execution_update":
+						// Partial tool output is forwarded to the stream registry below.
+						// Do not report these normal progress events as unhandled.
+						break;
+					case "tool_execution_end":
 					workspaceChangeMonitor?.noteToolEnd(event.toolCallId, event.toolName);
 					if (event.isError) {
 						const errText = Array.isArray(event.result?.content)
@@ -728,7 +867,13 @@ export async function handleChatRoutes(
 
 			// Convert to an SSE event and publish to broadcaster + live client.
 			const sseEvent = piEventToSseEvent(event);
-			if (sseEvent) streamRegistry.publishStreamEvent(state, sseEvent as { type: string });
+			if (sseEvent) {
+				const piEventType = event.type === "message_update" && event.assistantMessageEvent?.type
+					? event.assistantMessageEvent.type
+					: event.type;
+				const normalizedEvent = sseEvent as { type: string; [key: string]: unknown };
+				streamRegistry.publishStreamEvent(state, { ...normalizedEvent, piEventType });
+			}
 		};
 
 		promptStartTime = Date.now();
@@ -739,6 +884,14 @@ export async function handleChatRoutes(
 				isCancellationRequested: () => state.cancelRequested,
 				onStart: () => {
 					streamRegistry.publishStreamEvent(state, { type: "stream_state", status: "running" });
+					const traceSkills = loadedSkillsForTrace(streamWorkspaceRoot);
+					streamRegistry.publishStreamEvent(state, {
+						type: "skill_loaded",
+						count: traceSkills.length,
+						skills: traceSkills,
+					});
+					const skillEvent = explicitSkillEvent(prompt, traceSkills);
+					if (skillEvent) streamRegistry.publishStreamEvent(state, skillEvent as { type: string });
 					questionBridge.bindTurn({
 						sessionId: state.sessionId,
 						turnId: state.turnId,
@@ -766,13 +919,35 @@ export async function handleChatRoutes(
 					} else if (outcome.type === "completed") {
 						streamRegistry.finishTurn(state, "error", { type: "error", message: "Final chat history could not be confirmed.", code: "persistence_confirmation_failed" }, persistence);
 					} else if (outcome.type === "aborted") {
-						streamRegistry.finishTurn(state, "aborted", { type: "aborted", message: "Stopped by user" }, persistence);
+						const message = outcome.reason === "cancelled"
+							? "Stopped by user"
+							: `Prompt aborted: ${outcome.reason}`;
+						streamRegistry.finishTurn(state, "aborted", { type: "aborted", message }, persistence);
 					} else {
 						const message = outcome.error instanceof Error ? outcome.error.message : "Unknown error";
 						if (state.status === "queued") {
 							streamRegistry.finishTurn(state, "aborted", { type: "aborted", message: `Prompt failed before start: ${message}` }, persistence);
 						} else {
 							streamRegistry.finishTurn(state, "error", { type: "error", message }, persistence);
+						}
+					}
+					// Record the trace after the terminal event is published so historical
+					// messages can distinguish a normal completion from an abort or error.
+					if (persistence.persisted && state.history.length > 0) {
+						try {
+							const persistedMessages = parseSessionFile(targetSessionPath)?.messages ?? [];
+							const assistantMessage = persistedMessages[state.baselineMessageCount + 1];
+							recordSessionTrace(dataDir, state.sessionId, {
+								assistantIndex: state.baselineMessageCount + 1,
+								assistantMessageId: assistantMessage?.role === "assistant" ? assistantMessage.entryId : undefined,
+								startedAt: state.startedAt,
+								finishedAt: state.finishedAt ?? new Date().toISOString(),
+								events: state.history,
+							});
+						} catch (err) {
+							// Trace is observability metadata. Never turn a successful PI
+							// response into a failed chat turn because the sidecar is unwritable.
+							logger.warn({ err, sessionId: state.sessionId, turnId: state.turnId }, "chat trace sidecar write failed");
 						}
 					}
 				},

--- a/apps/inno-agent/src/server/routes/sessions.ts
+++ b/apps/inno-agent/src/server/routes/sessions.ts
@@ -34,6 +34,7 @@ import {
 	mergeSessionAttachments,
 } from "../attachments-store.js";
 import { clearSessionAgentCommands } from "../agent-command-store.js";
+import { clearSessionTraces, mergeSessionTraces } from "../trace-store.js";
 import { contentDispositionAttachment } from "../file-helpers.js";
 import { HttpError, json, matchRoute, readBody } from "../http-helpers.js";
 import {
@@ -395,7 +396,11 @@ export async function handleSessionsRoutes(
 		);
 		json(res, 200, {
 			...summary,
-			messages: mergeSessionAttachments(dataDir, sessionId, parsed.messages),
+				messages: mergeSessionTraces(
+					dataDir,
+					sessionId,
+					mergeSessionAttachments(dataDir, sessionId, parsed.messages),
+				),
 			messageCount: parsed.messages.length,
 			sessionRevision: sessionRevision(sessionPath),
 			// Attach any persisted pending question so the frontend can restore
@@ -678,8 +683,9 @@ export async function handleSessionsRoutes(
 				delete questionMeta[sessionId];
 				writeSessionQuestionMetadata(questionMeta);
 			}
-			clearSessionAttachments(dataDir, sessionId);
-			clearSessionAgentCommands(dataDir, sessionId);
+				clearSessionAttachments(dataDir, sessionId);
+				clearSessionAgentCommands(dataDir, sessionId);
+				clearSessionTraces(dataDir, sessionId);
 			workspaceRegistry.unbindSession(sessionId);
 			if (shouldDropTempWorkspace) {
 				workspaceRegistry.deleteWorkspace(boundWorkspaceId, { removeFiles: true });

--- a/apps/inno-agent/src/server/session-model.ts
+++ b/apps/inno-agent/src/server/session-model.ts
@@ -15,6 +15,9 @@ export interface SessionMessageSummary {
 	entryId?: string;
 	parentEntryId?: string | null;
 	thinking?: string;
+	/** PI's final reason for ending the assistant message. Kept so cold-start
+	 * history can classify legacy traces whose sidecar predates terminal events. */
+	stopReason?: string;
 	tools?: Array<{
 		toolCallId: string;
 		toolName: string;
@@ -23,11 +26,22 @@ export interface SessionMessageSummary {
 		result?: unknown;
 		isError?: boolean;
 	}>;
+	/** Normalized PI stream records restored from the UI-only trace sidecar. */
+	traceEvents?: SessionTraceEvent[];
+	traceStartedAt?: string;
+	traceFinishedAt?: string;
 	channel?: SessionChannel;
 	images?: Array<{ previewUrl: string; mimeType: string }>;
 	/** Structured chat attachments (bubble bindings + loose files) merged in
 	 * from the attachments sidecar; not stored in the session JSONL itself. */
 	attachments?: ChatAttachments;
+}
+
+export interface SessionTraceEvent {
+	eventId?: number;
+	traceId?: string;
+	occurredAt?: string;
+	event: Record<string, unknown>;
 }
 
 export type SessionChannel = "cli" | "web" | "feishu" | "qq" | "wechat" | "scheduler" | "unknown";

--- a/apps/inno-agent/src/server/trace-store.test.ts
+++ b/apps/inno-agent/src/server/trace-store.test.ts
@@ -1,0 +1,91 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { StreamEventEnvelope } from "../chat/stream-registry.js";
+import type { SessionMessageSummary } from "./session-model.js";
+import {
+	clearSessionTraces,
+	mergeSessionTraces,
+	recordSessionTrace,
+	resetTraceStoreForTests,
+	traceMetadataPath,
+} from "./trace-store.js";
+import { readJson } from "../storage/file-store.js";
+
+let dataDir: string;
+
+beforeEach(() => {
+	dataDir = mkdtempSync(join(tmpdir(), "inno-traces-"));
+	resetTraceStoreForTests();
+});
+
+afterEach(() => {
+	resetTraceStoreForTests();
+	rmSync(dataDir, { recursive: true, force: true });
+});
+
+function envelope(eventId: number, event: Record<string, unknown>): StreamEventEnvelope {
+	return {
+		eventId,
+		sessionId: "session-1",
+		turnId: "turn-1",
+		clientRequestId: "request-1",
+		traceId: "turn-1",
+		occurredAt: `2026-09-01T00:00:0${eventId}.000Z`,
+		event: { type: event.type as string, ...event },
+	};
+}
+
+describe("session UI trace sidecar", () => {
+	it("persists normalized events and merges them by assistant message index", () => {
+		recordSessionTrace(dataDir, "session-1", {
+			assistantIndex: 1,
+			assistantMessageId: "assistant-entry",
+			startedAt: "2026-09-01T00:00:00.000Z",
+			finishedAt: "2026-09-01T00:00:03.000Z",
+			events: [envelope(1, { type: "thinking_start" }), envelope(2, { type: "thinking_end" })],
+		});
+
+		const messages: SessionMessageSummary[] = [
+			{ role: "user", content: "hello", timestamp: 1 },
+			{ role: "assistant", content: "answer", timestamp: 2, entryId: "assistant-entry" },
+		];
+		const merged = mergeSessionTraces(dataDir, "session-1", messages);
+
+		expect(merged[0]?.traceEvents).toBeUndefined();
+			expect(merged[1]).toMatchObject({
+			traceStartedAt: "2026-09-01T00:00:00.000Z",
+			traceFinishedAt: "2026-09-01T00:00:03.000Z",
+		});
+		expect(merged[1]?.traceEvents).toEqual([
+			{ eventId: 1, traceId: "turn-1", occurredAt: "2026-09-01T00:00:01.000Z", event: { type: "thinking_start" } },
+			{ eventId: 2, traceId: "turn-1", occurredAt: "2026-09-01T00:00:02.000Z", event: { type: "thinking_end" } },
+		]);
+		expect(readJson(traceMetadataPath(dataDir), null)).toBeTruthy();
+ 	});
+
+	it("can be dropped without changing canonical messages", () => {
+		recordSessionTrace(dataDir, "session-1", {
+			assistantIndex: 0,
+			events: [envelope(1, { type: "text_delta", delta: "answer" })],
+		});
+		clearSessionTraces(dataDir, "session-1");
+
+		const messages: SessionMessageSummary[] = [{ role: "assistant", content: "answer", timestamp: 1 }];
+		expect(mergeSessionTraces(dataDir, "session-1", messages)).toEqual(messages);
+	});
+
+	it("prefers the persisted PI message id when a branch changes message indexes", () => {
+		recordSessionTrace(dataDir, "session-1", {
+			assistantIndex: 4,
+			assistantMessageId: "stable-assistant-entry",
+			events: [envelope(1, { type: "text_delta", delta: "answer" })],
+		});
+
+		const messages: SessionMessageSummary[] = [
+			{ role: "assistant", content: "answer", timestamp: 1, entryId: "stable-assistant-entry" },
+		];
+		expect(mergeSessionTraces(dataDir, "session-1", messages)[0]?.traceEvents).toHaveLength(1);
+	});
+});

--- a/apps/inno-agent/src/server/trace-store.ts
+++ b/apps/inno-agent/src/server/trace-store.ts
@@ -1,0 +1,105 @@
+import { readJson, writeJson } from "../storage/file-store.js";
+import type { StreamEventEnvelope } from "../chat/stream-registry.js";
+import type { SessionMessageSummary, SessionTraceEvent } from "./session-model.js";
+
+/** UI-only trace storage. PI owns the session JSONL; this sidecar is deliberately
+ * kept out of the model context and can be dropped without damaging a session. */
+export interface SessionTraceEntry {
+	/** Index of the assistant message in the parsed visible session history. */
+	assistantIndex: number;
+	/** Stable PI session-tree entry id when the parser can provide one. */
+	assistantMessageId?: string;
+	startedAt?: string;
+	finishedAt?: string;
+	events: SessionTraceEvent[];
+}
+
+export type SessionTraceMetadata = Record<string, SessionTraceEntry[]>;
+
+let cache: SessionTraceMetadata | null = null;
+
+export function traceMetadataPath(dataDir: string): string {
+	return `${dataDir}/sessions/traces.json`.replaceAll("\\", "/");
+}
+
+function read(dataDir: string): SessionTraceMetadata {
+	if (cache === null) cache = readJson<SessionTraceMetadata>(traceMetadataPath(dataDir), {});
+	return cache;
+}
+
+function write(dataDir: string, metadata: SessionTraceMetadata): void {
+	cache = metadata;
+	writeJson(traceMetadataPath(dataDir), metadata);
+}
+
+export function resetTraceStoreForTests(): void {
+	cache = null;
+}
+
+export function recordSessionTrace(
+	dataDir: string,
+	sessionId: string,
+	entry: {
+		assistantIndex: number;
+		assistantMessageId?: string;
+		startedAt?: string;
+		finishedAt?: string;
+		events: StreamEventEnvelope[];
+	},
+): void {
+	if (!sessionId || entry.assistantIndex < 0) return;
+	const metadata = { ...read(dataDir) };
+	const normalizedEvents = entry.events.map((envelope) => ({
+		eventId: envelope.eventId,
+		...(envelope.traceId ? { traceId: envelope.traceId } : {}),
+		...(envelope.occurredAt ? { occurredAt: envelope.occurredAt } : {}),
+		event: envelope.event as Record<string, unknown>,
+	}));
+	const nextEntry: SessionTraceEntry = {
+		assistantIndex: entry.assistantIndex,
+		...(entry.assistantMessageId ? { assistantMessageId: entry.assistantMessageId } : {}),
+		...(entry.startedAt ? { startedAt: entry.startedAt } : {}),
+		...(entry.finishedAt ? { finishedAt: entry.finishedAt } : {}),
+		events: normalizedEvents,
+	};
+	metadata[sessionId] = [
+		...(metadata[sessionId] ?? []).filter((item) => item.assistantIndex !== entry.assistantIndex),
+		nextEntry,
+	];
+	write(dataDir, metadata);
+}
+
+export function mergeSessionTraces(
+	dataDir: string,
+	sessionId: string,
+	messages: SessionMessageSummary[],
+): SessionMessageSummary[] {
+	const entries = read(dataDir)[sessionId];
+	if (!entries?.length) return messages;
+	const byIndex = new Map(entries.map((entry) => [entry.assistantIndex, entry]));
+	return messages.map((message, index) => {
+		const byId = message.role === "assistant" && message.entryId
+			? entries.find((candidate) => candidate.assistantMessageId === message.entryId)
+			: undefined;
+		const byPosition = byIndex.get(index);
+		// Position is only a compatibility fallback for old sidecars that were
+		// written before assistant message ids were recorded. Once an entry has
+		// an id, never let a branched session inherit it by index.
+		const entry = byId ?? (byPosition && !byPosition.assistantMessageId ? byPosition : undefined);
+		if (!entry || message.role !== "assistant") return message;
+		return {
+			...message,
+			traceEvents: entry.events,
+			traceStartedAt: entry.startedAt,
+			traceFinishedAt: entry.finishedAt,
+		};
+	});
+}
+
+export function clearSessionTraces(dataDir: string, sessionId: string): void {
+	const metadata = read(dataDir);
+	if (!(sessionId in metadata)) return;
+	const next = { ...metadata };
+	delete next[sessionId];
+	write(dataDir, next);
+}

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -1531,10 +1531,13 @@ inno-workspace-panel textarea {
 	left: 0;
 	z-index: 50;
 	display: flex;
-	width: min(292px, calc(100vw - 24px));
-	max-height: min(390px, calc(100vh - 24px));
+	width: min(300px, calc(100vw - 16px));
+	min-width: min(280px, calc(100vw - 16px));
+	max-height: min(390px, calc(100dvh - 16px));
+	min-height: 0;
 	flex-direction: column;
 	gap: 6px;
+	overflow: hidden;
 	padding: 7px;
 	transform-origin: bottom left;
 	animation: inno-workspace-menu-in var(--inno-dur-fast) var(--inno-ease-out) both;
@@ -1553,6 +1556,7 @@ inno-workspace-panel textarea {
 
 .inno-workspace-search {
 	display: flex;
+	flex: 0 0 auto;
 	height: 32px;
 	align-items: center;
 	gap: 7px;
@@ -1618,6 +1622,8 @@ inno-workspace-panel textarea {
 }
 
 .inno-workspace-options {
+	min-height: 0;
+	flex: 1 1 auto;
 	max-height: 224px;
 	overflow-y: auto;
 }
@@ -1625,6 +1631,7 @@ inno-workspace-panel textarea {
 .inno-workspace-option,
 .inno-workspace-action {
 	display: flex;
+	flex: 0 0 auto;
 	width: 100%;
 	min-width: 0;
 	align-items: center;
@@ -1689,6 +1696,7 @@ inno-workspace-panel textarea {
 }
 
 .inno-workspace-menu-divider {
+	flex: 0 0 auto;
 	height: 1px;
 	margin: 1px 2px;
 	background: var(--inno-border);
@@ -1708,6 +1716,8 @@ inno-workspace-panel textarea {
 
 .inno-workspace-create-form {
 	display: flex;
+	min-height: 0;
+	overflow-y: auto;
 	flex-direction: column;
 	gap: 8px;
 	padding: 3px 2px 1px;

--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -211,6 +211,69 @@ inno-app-shell {
 	}
 }
 
+/* Keep only the composer card above the conversation. The session footer is
+   intentionally transparent so the card itself masks text as it scrolls
+   underneath, without creating a second full-width container. */
+.inno-conversation-composer-layer {
+	position: absolute;
+	inset-inline: 0;
+	bottom: 12px;
+	z-index: 10;
+	pointer-events: none;
+}
+
+.inno-conversation-composer-content {
+	width: calc(100% - 2rem);
+	pointer-events: auto;
+}
+
+/* Give status strips the same lower-half masking behavior as the composer. */
+.inno-conversation-status-wrap {
+	position: relative;
+	display: flow-root;
+	isolation: isolate;
+}
+
+.inno-conversation-status-content {
+	position: relative;
+	display: flow-root;
+	z-index: 1;
+}
+
+/* Cover the space between a status strip and the composer as well. */
+.inno-conversation-status-gap-mask {
+	position: absolute;
+	inset-inline: -2px;
+	top: 100%;
+	height: 12px;
+	z-index: 0;
+	background: var(--inno-chat-bg);
+	pointer-events: none;
+}
+
+/* Mask the lower half of the composer lane through the bottom of the chat.
+   The composer card sits above this invisible region, so only conversation
+   text is covered while the input remains fully interactive. */
+.inno-conversation-composer-wrap {
+	position: relative;
+	isolation: isolate;
+}
+
+.inno-conversation-composer-mask {
+	position: absolute;
+	inset-inline: -2px;
+	top: 50%;
+	bottom: -12px;
+	z-index: 0;
+	background: var(--inno-chat-bg);
+	pointer-events: none;
+}
+
+.inno-conversation-composer-wrap > .inno-composer {
+	position: relative;
+	z-index: 1;
+}
+
 /* Workspace panel */
 inno-workspace-panel {
 	display: flex;
@@ -236,10 +299,14 @@ inno-workspace-panel textarea {
 .chat-scroll {
 	scrollbar-width: thin;
 	scrollbar-color: var(--inno-scrollbar-thumb) transparent;
+	/* Keep the centered message lane aligned with the overlaid composer even
+	   when the native scrollbar takes space on the right. */
+	scrollbar-gutter: stable both-edges;
 	/* Stick-to-bottom is managed explicitly by the ResizeObserver in
 	   ChatCenter. Browser scroll anchoring would otherwise shift scrollTop
 	   during streaming markdown re-renders and fight that pinning. */
 	overflow-anchor: none;
+	padding-bottom: calc(1rem + var(--inno-conversation-scroll-bottom-space, 0px));
 }
 
 .chat-scroll::-webkit-scrollbar,
@@ -384,8 +451,7 @@ inno-workspace-panel textarea {
 	margin-bottom: 30px;
 }
 
-.inno-message.inno-assistant-message,
-.inno-message.inno-streaming-blocks {
+.inno-message.inno-assistant-message {
 	border: 0;
 	background: transparent;
 	box-shadow: none;
@@ -395,9 +461,357 @@ inno-workspace-panel textarea {
 	margin-bottom: 30px;
 }
 
+/* Keep the live trace and the persisted assistant trace in the same full
+   conversation lane. The completed turn must not shrink into the old
+   assistant max-width/padding while the live trace is being replaced. */
+.inno-trace-shell {
+	width: 100%;
+	min-width: 0;
+}
+
+.inno-trace-assistant-message {
+	width: 100%;
+	max-width: none !important;
+	padding: 0 !important;
+}
+
+/* PI process timeline: intentionally containerless so the conversation reads
+   like a sequence of lightweight status rows rather than nested bubbles. */
+.inno-trace-timeline {
+	width: 100%;
+	min-width: 0;
+	margin: 4px 0 16px;
+	color: var(--inno-text-muted);
+	font-size: 13px;
+}
+
+.inno-trace-work-status {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+	min-width: 0;
+	padding: 5px 0 10px;
+	border-bottom: 1px solid var(--inno-border);
+	color: var(--inno-text-subtle);
+	font-size: 12px;
+	font-variant-numeric: tabular-nums;
+}
+
+.inno-trace-list {
+	min-width: 0;
+}
+
+/* The ordered trace flow contains both process rows and ordinary assistant
+   Markdown blocks. Text has no row chrome so it remains normal body content. */
+.inno-trace-flow {
+	min-width: 0;
+}
+
+.inno-trace-body {
+	min-width: 0;
+	max-width: 100%;
+	margin: 4px 0 16px;
+	color: var(--inno-text);
+	font-size: 13px;
+	line-height: 1.625;
+}
+
+/* Give the first body block after the process rows a readable breathing gap. */
+.inno-trace-row + .inno-trace-body {
+	margin-top: 14px;
+}
+
+.inno-trace-fallback-body {
+	display: contents;
+}
+
+.inno-trace-questionnaire {
+	min-width: 0;
+	margin: 8px 0 16px;
+}
+
+.inno-trace-row {
+	min-width: 0;
+	border-bottom: 1px solid color-mix(in srgb, var(--inno-border) 62%, transparent);
+}
+
+.inno-trace-row.is-system {
+	border-bottom-color: transparent;
+	color: var(--inno-text-subtle);
+	font-size: 12px;
+}
+
+.inno-trace-row.is-error {
+	color: var(--inno-danger);
+}
+
+.inno-trace-row-toggle {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	width: 100%;
+	min-width: 0;
+	min-height: 34px;
+	padding: 8px 0;
+	border: 0;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	line-height: 1.45;
+	text-align: left;
+	cursor: pointer;
+}
+
+.inno-trace-row-toggle:hover {
+	color: var(--inno-text);
+}
+
+.inno-trace-row-toggle:focus-visible {
+	outline: none;
+	border-radius: 4px;
+	box-shadow: var(--inno-ring);
+}
+
+.inno-trace-icon,
+.inno-trace-status,
+.inno-trace-chevron {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0 0 auto;
+}
+
+.inno-trace-icon {
+	width: 18px;
+	color: var(--inno-text-subtle);
+}
+
+.inno-trace-row.is-error .inno-trace-icon,
+.inno-trace-row.is-error .inno-trace-status {
+	color: var(--inno-danger);
+}
+
+.inno-trace-row-title {
+	position: relative;
+	flex: 1 1 auto;
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	overflow-wrap: normal;
+	word-break: normal;
+}
+
+.inno-trace-status {
+	margin-left: auto;
+	color: var(--inno-success);
+}
+
+.inno-trace-status.preparing,
+.inno-trace-status.running,
+.inno-trace-status.waiting,
+.inno-trace-status.active {
+	color: var(--inno-accent);
+}
+
+.inno-trace-chevron {
+	color: var(--inno-text-subtle);
+	transition: transform var(--inno-dur-fast) var(--inno-ease-out);
+}
+
+.inno-trace-chevron.is-open {
+	transform: rotate(90deg);
+}
+
+.inno-trace-row-details {
+	display: block;
+	min-width: 0;
+	margin: 0 0 9px 26px;
+	padding: 2px 0 2px 18px;
+	border-left: 1px solid var(--inno-border);
+	color: var(--inno-text-muted);
+	font-size: 12px;
+	line-height: 1.55;
+	overflow-anchor: none;
+}
+
+.inno-trace-thinking,
+.inno-trace-error-details,
+.inno-trace-payload {
+	max-height: 320px;
+	margin: 0;
+	overflow: auto;
+	white-space: pre-wrap;
+	word-break: break-word;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+	font-size: 11px;
+	line-height: 1.6;
+}
+
+.inno-trace-thinking {
+	color: var(--inno-text-muted);
+}
+
+.inno-trace-detail-block + .inno-trace-detail-block {
+	margin-top: 10px;
+}
+
+.inno-trace-detail-label {
+	display: inline-block;
+	margin-right: 8px;
+	color: var(--inno-text-subtle);
+	font-size: 11px;
+}
+
+.inno-trace-payload {
+	margin-top: 4px;
+	padding: 7px 8px;
+	border: 1px solid var(--inno-border);
+	border-radius: 4px;
+	background: var(--inno-surface-muted);
+}
+
+.inno-trace-change-list {
+	margin: 4px 0 0;
+	padding-left: 18px;
+}
+
+.inno-trace-skill-details,
+.inno-trace-system-details {
+	display: grid;
+	gap: 4px;
+}
+
+.inno-trace-open-skill {
+	justify-self: start;
+	margin-top: 6px;
+	padding: 3px 7px;
+	border: 1px solid var(--inno-border);
+	border-radius: 4px;
+	background: transparent;
+	color: var(--inno-accent);
+	font-size: 11px;
+	cursor: pointer;
+}
+
+.inno-trace-open-skill:hover {
+	background: var(--inno-accent-soft);
+}
+
+.inno-trace-empty {
+	color: var(--inno-text-subtle);
+	font-size: 11px;
+}
+
+.inno-trace-spinner {
+	animation: inno-trace-spin 1s linear infinite;
+}
+
+.inno-trace-row-title.is-shimmering {
+	/* Keep the real labels opaque. The moving highlight only covers the
+	   active title span below, so details never shimmer or disappear. */
+	color: var(--inno-text-muted);
+	-webkit-text-fill-color: currentColor;
+}
+
+.inno-trace-title-shimmer-target {
+	position: relative;
+	display: inline-block;
+}
+
+.inno-trace-title-shimmer-target.is-full-line {
+	display: block;
+	max-width: 100%;
+	white-space: inherit;
+	overflow-wrap: inherit;
+	word-break: inherit;
+}
+
+.inno-trace-title-shimmer {
+	display: block;
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	color: transparent;
+	background-image: linear-gradient(105deg,
+		transparent 40%,
+		color-mix(in srgb, var(--inno-text-muted) 24%, white) 50%,
+		transparent 60%);
+	background-position: 140% 0;
+	background-size: 140% 100%;
+	background-repeat: no-repeat;
+	background-clip: text;
+	-webkit-background-clip: text;
+	-webkit-text-fill-color: transparent;
+	font: inherit;
+	line-height: inherit;
+	white-space: inherit;
+	overflow-wrap: inherit;
+	word-break: inherit;
+	will-change: background-position;
+	animation: inno-trace-shimmer 2s linear infinite;
+}
+
+.inno-latest-row {
+	position: absolute;
+	inset-inline: 0;
+	bottom: calc(100% + 12px);
+	z-index: 4;
+	display: flex;
+	justify-content: center;
+	pointer-events: none;
+}
+
+.inno-latest-button {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 30px;
+	height: 30px;
+	padding: 0;
+	border: 1px solid var(--inno-border);
+	border-radius: 999px;
+	background: var(--inno-surface);
+	box-shadow: var(--inno-shadow-soft);
+	color: var(--inno-text-muted);
+	pointer-events: auto;
+	cursor: pointer;
+	transition: color var(--inno-dur-fast) var(--inno-ease-out), background-color var(--inno-dur-fast) var(--inno-ease-out), border-color var(--inno-dur-fast) var(--inno-ease-out);
+}
+
+.inno-latest-button:hover {
+	border-color: var(--inno-border-strong);
+	background: var(--inno-surface-muted);
+	color: var(--inno-text);
+}
+
+@keyframes inno-trace-spin {
+	to { transform: rotate(360deg); }
+}
+
+@keyframes inno-trace-shimmer {
+	0%, 8% { background-position: 140% 0; }
+	88%, 100% { background-position: -140% 0; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.inno-trace-spinner,
+	.inno-trace-title-shimmer {
+		animation: none;
+	}
+	.inno-trace-row-title.is-shimmering {
+		color: var(--inno-accent);
+	}
+	.inno-trace-title-shimmer {
+		background: none;
+	}
+}
+
 .inno-message-actions {
 	position: absolute;
-	top: calc(100% + 2px);
+	/* Keep the action row's transparent hit area connected to the message so
+	   hovering the row itself can also reveal the actions. */
+	top: calc(100% - 6px);
 	right: 0;
 	display: flex;
 	align-items: center;
@@ -408,10 +822,19 @@ inno-workspace-panel textarea {
 	line-height: 18px;
 	font-variant-numeric: tabular-nums;
 	opacity: 0;
-	visibility: hidden;
-	pointer-events: none;
+	/* Keep the transparent row hit-testable, so moving onto its line keeps the
+	   parent hovered and reveals the controls. */
+	visibility: visible;
+	pointer-events: auto;
 	transform: translateY(-2px);
-	transition: opacity var(--inno-dur-fast) var(--inno-ease-out), transform var(--inno-dur-fast) var(--inno-ease-out), visibility var(--inno-dur-fast);
+	transition: opacity var(--inno-dur-fast) var(--inno-ease-out), transform var(--inno-dur-fast) var(--inno-ease-out);
+	transition-delay: 180ms;
+}
+
+/* Give sent user bubbles a little more breathing room below the bubble. The
+   assistant timeline keeps the tighter shared position above. */
+.inno-message-wrap .inno-message-actions {
+	top: calc(100% + 4px);
 }
 
 .inno-message-wrap:hover .inno-message-actions,
@@ -420,13 +843,17 @@ inno-workspace-panel textarea {
 .inno-assistant-message:focus-within .inno-message-actions {
 	opacity: 1;
 	visibility: visible;
-	pointer-events: auto;
 	transform: translateY(0);
+	transition-delay: 0s;
 }
 
 .inno-assistant-message .inno-message-actions {
 	right: auto;
 	left: 0;
+}
+
+.inno-message.inno-assistant-message.inno-assistant-message--no-actions {
+	margin-bottom: 0;
 }
 
 .inno-message-action {

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -751,6 +751,92 @@
 			"settingsDesc": "Open settings"
 		},
 		"loadingSession": "Loading session…",
+		"trace": {
+			"timeline": "Work process",
+			"working": "Working",
+			"completed": "Completed",
+			"jumpToLatest": "Back to latest",
+			"durationSeconds": "{{seconds}} sec",
+			"duration": "for {{duration}}",
+			"tool": "Tool",
+			"row": {
+				"expand": "Expand {{summary}}",
+				"collapse": "Collapse {{summary}}"
+			},
+			"thinking": {
+				"inProgress": "Thinking",
+				"completed": "Thinking complete"
+			},
+			"status": {
+				"preparing": "Preparing call",
+				"running": "Running",
+				"waiting": "Waiting for your answer",
+				"error": "Failed",
+				"completed": "Completed",
+				"active": "In progress"
+			},
+			"workStatus": {
+				"userPaused": "User paused",
+				"interrupted": "Interrupted for another reason",
+				"incomplete": "Incomplete · reason unknown"
+			},
+			"steps": {
+				"thinking": "Thinking",
+				"organizingReply": "Organizing reply",
+				"workspaceUpdated": "Workspace updated",
+				"waitingForAnswer": "Waiting for your answer",
+				"answerCancelled": "Answer cancelled",
+				"continueExecution": "Continuing",
+				"skillsPreloaded": "{{count}} skill(s) preloaded",
+				"skillLoaded": "Skill loaded · {{skillName}}",
+				"skillExpanded": "Skill expanded · {{skillName}}",
+				"requestFailed": "Request failed",
+				"stopped": "Stopped",
+				"reply": "Reply",
+				"progress": "Progress"
+			},
+			"details": {
+				"noThinkingText": "No thinking text",
+				"noProgressText": "No progress text",
+				"arguments": "Arguments",
+				"partialResult": "Live result",
+				"error": "Error",
+				"result": "Result",
+				"question": "Question",
+				"workspaceChanges": "Workspace changes",
+				"skill": "Skill",
+				"source": "Source",
+				"path": "Path",
+				"description": "Description",
+				"openSkillsPanel": "Open Skills panel",
+				"preloadedSkills": "Preloaded skills",
+				"piEvent": "PI event",
+				"attempt": "Attempt",
+				"details": "Details"
+			},
+			"workspaceChanges": {
+				"created": "Created",
+				"modified": "Modified",
+				"deleted": "Deleted"
+			},
+			"system": {
+				"beforeAgentStart": "Preparing Agent",
+				"agentStart": "Started working",
+				"agentEnd": "Finished working",
+				"turnStart": "Started this turn",
+				"turnEnd": "Turn finished",
+				"messageStart": "Started generating message",
+				"messageEnd": "Message generation complete",
+				"compactionStart": "Organizing context",
+				"compactionEnd": "Context organized",
+				"queueStart": "Entered execution queue",
+				"queueEnd": "Left execution queue",
+				"autoRetryStart": "Retrying automatically",
+				"autoRetryEnd": "Automatic retry finished",
+				"entryAppended": "Session event recorded",
+				"bashExecutionUpdate": "Terminal execution updated"
+			}
+		},
 		"emptySessionTitle": "No messages in this conversation",
 		"emptySessionHint": "Type a message below to start the conversation.",
 		"uploadFiles": "Upload files to workspace",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -751,6 +751,92 @@
 			"settingsDesc": "打开设置"
 		},
 		"loadingSession": "正在加载会话…",
+		"trace": {
+			"timeline": "工作过程",
+			"working": "工作中",
+			"completed": "已完成",
+			"jumpToLatest": "回到最新位置",
+			"durationSeconds": "{{seconds}} 秒",
+			"duration": "持续了 {{duration}}",
+			"tool": "工具",
+			"row": {
+				"expand": "展开{{summary}}",
+				"collapse": "收起{{summary}}"
+			},
+			"thinking": {
+				"inProgress": "思考中",
+				"completed": "思考完成"
+			},
+			"status": {
+				"preparing": "准备调用",
+				"running": "执行中",
+				"waiting": "等待你的回答",
+				"error": "失败",
+				"completed": "已完成",
+				"active": "进行中"
+			},
+			"workStatus": {
+				"userPaused": "用户主动暂停",
+				"interrupted": "因其他原因中断",
+				"incomplete": "未完成 · 原因未知"
+			},
+			"steps": {
+				"thinking": "思考",
+				"organizingReply": "正在组织回复",
+				"workspaceUpdated": "工作区已更新",
+				"waitingForAnswer": "等待你的回答",
+				"answerCancelled": "已取消回答",
+				"continueExecution": "继续执行",
+				"skillsPreloaded": "已预载 {{count}} 个技能",
+				"skillLoaded": "已载入技能 · {{skillName}}",
+				"skillExpanded": "已展开技能 · {{skillName}}",
+				"requestFailed": "请求失败",
+				"stopped": "已停止",
+				"reply": "回复",
+				"progress": "进度"
+			},
+			"details": {
+				"noThinkingText": "暂无思考文本",
+				"noProgressText": "暂无进度文本",
+				"arguments": "参数",
+				"partialResult": "实时结果",
+				"error": "错误",
+				"result": "结果",
+				"question": "提问",
+				"workspaceChanges": "工作区变化",
+				"skill": "技能",
+				"source": "来源",
+				"path": "路径",
+				"description": "说明",
+				"openSkillsPanel": "打开 Skills 面板",
+				"preloadedSkills": "已预载技能",
+				"piEvent": "PI 事件",
+				"attempt": "尝试",
+				"details": "详情"
+			},
+			"workspaceChanges": {
+				"created": "已创建",
+				"modified": "已修改",
+				"deleted": "已删除"
+			},
+			"system": {
+				"beforeAgentStart": "准备 Agent",
+				"agentStart": "开始工作",
+				"agentEnd": "结束工作",
+				"turnStart": "开始本轮任务",
+				"turnEnd": "本轮任务结束",
+				"messageStart": "开始生成消息",
+				"messageEnd": "消息生成完成",
+				"compactionStart": "正在整理上下文",
+				"compactionEnd": "上下文整理完成",
+				"queueStart": "进入执行队列",
+				"queueEnd": "离开执行队列",
+				"autoRetryStart": "正在自动重试",
+				"autoRetryEnd": "自动重试结束",
+				"entryAppended": "已记录会话事件",
+				"bashExecutionUpdate": "终端执行更新"
+			}
+		},
 		"emptySessionTitle": "此会话暂无消息",
 		"emptySessionHint": "在下方输入消息，开始新的对话。",
 		"uploadFiles": "上传文件到工作区",

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -1007,7 +1007,10 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 				}
 
 				resetComposer();
-				engine?.postSendCleanup();
+				// Creating a session can remount the composer (welcome → chat), so
+				// the engine captured before the async work may no longer own the
+				// visible mirror. Clean up the currently mounted engine instead.
+				engineRef.current?.postSendCleanup();
 				setUploads((current) => current.filter((entry) => entry.status === "failed"));
 				setInlineImages([]);
 				setWsError("");

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -267,6 +267,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 	const workspaceTreeError = useStoreSnapshot(workspaceStore, () => workspaceStore.error);
 	const workspaceFiles = useMemo(() => workspaceTree ? flattenWorkspaceFiles(workspaceTree) : [], [workspaceTree]);
 	const isWelcome = sessions.isWelcome;
+	const hasConversationStatus = Boolean(chat.pendingQuestion || sessions.busyBlocker);
 	// Sidebar/workspace layout shifts (e.g. after desktop window expansion) move
 	// the composer by translation without resizing it, so neither window resize
 	// nor ResizeObserver fires. Track the layout values that shift the chat
@@ -496,12 +497,18 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 				+ Number.parseFloat(window.getComputedStyle(attachmentRow).marginTop || "0")
 				+ Number.parseFloat(window.getComputedStyle(attachmentRow).marginBottom || "0")
 			: 0;
+		const composerContent = composer.closest<HTMLElement>(".inno-conversation-composer-content");
+		const overlayBeforeComposerHeight = composerContent
+			? Math.max(0, composerContent.getBoundingClientRect().height - composerHeight)
+			: 0;
 		const scroll = scrollRef.current;
 		if (scroll) {
 			// Attachments grow from the top of the composer. The center mask only
 			// accounts for half of that row, so add the other half to keep the
-			// conversation body moving up by the attachment's full height.
-			const nextBottomSpace = `${composerHeight / 2 + attachmentHeight / 2 + 12 + CONVERSATION_ACTION_ROW_RESERVE}px`;
+			// conversation body moving up by the attachment's full height. Status
+			// banners and the gap above the composer are also overlaid, so reserve
+			// the whole area before the composer to keep the last message visible.
+			const nextBottomSpace = `${composerHeight / 2 + attachmentHeight / 2 + 12 + CONVERSATION_ACTION_ROW_RESERVE + overlayBeforeComposerHeight}px`;
 			if (scroll.style.getPropertyValue("--inno-conversation-scroll-bottom-space") !== nextBottomSpace) {
 				scroll.style.setProperty("--inno-conversation-scroll-bottom-space", nextBottomSpace);
 				if (shouldStickToBottomRef.current) scroll.scrollTop = scroll.scrollHeight;
@@ -545,16 +552,18 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		const composer = el.closest<HTMLElement>(".inno-composer");
 		if (!composer) return;
 		if (typeof ResizeObserver === "undefined") return;
-		// Observe the whole composer: attachment rows and smart bubbles can
-		// change its height without changing the textarea width.
+		// Observe the composer and its overlay lane: attachment rows, smart
+		// bubbles, and status banners can change the covered area independently.
 		const observer = new ResizeObserver(() => resizeInput());
 		observer.observe(composer);
+		const composerContent = composer.closest<HTMLElement>(".inno-conversation-composer-content");
+		if (composerContent) observer.observe(composerContent);
 		return () => observer.disconnect();
 	}, [isWelcome, resizeInput]);
 
 	useEffect(() => {
 		resizeInput();
-	}, [isWelcome, inlineImages, pasteBlocks, uploads, resizeInput]);
+	}, [isWelcome, inlineImages, pasteBlocks, uploads, hasConversationStatus, resizeInput]);
 
 	const isComposingRef = useRef(false);
 

--- a/apps/inno-agent/web/src/react/ChatCenter.tsx
+++ b/apps/inno-agent/web/src/react/ChatCenter.tsx
@@ -61,7 +61,7 @@ import type { EngineAttachmentItem } from "./chat/smart-input/engine.js";
 import type { KwRange } from "./chat/smart-input/rules.js";
 import { useSmartInput } from "./chat/smart-input/useSmartInput.js";
 import { SmartInputOverlay, type SmartPanelState } from "./chat/smart-input/SmartInputOverlay.js";
-import { collapseSkillMessage } from "./chat/skill-message-collapse.js";
+import { skillMessageFromContent } from "./chat/skill-message-collapse.js";
 import { parseAgentCommandMessage } from "./chat/agent-command-message.js";
 
 type PresetRefreshStatus = "success" | "error";
@@ -99,6 +99,8 @@ function rememberWsChoice(mode: WsMode, existingId: string): void {
 
 const SMART_FILE_PREVIEW_WIDTH = 560;
 const SMART_HOVER_OPEN_MS = 250;
+// Keep the copy/time action row below the last message above the composer mask.
+const CONVERSATION_ACTION_ROW_RESERVE = 40;
 
 function pendingUploadsFromRefs(refs: AttachmentRef[]): PendingUpload[] {
 	const seen = new Set<string>();
@@ -124,6 +126,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 	const scrollRef = useRef<HTMLDivElement | null>(null);
 	const shouldStickToBottomRef = useRef(true);
 	const userScrollGestureRef = useRef(false);
+	const [showLatestButton, setShowLatestButton] = useState(false);
 	const pasteBlockIdRef = useRef(0);
 	const [uploads, setUploads] = useState<PendingUpload[]>([]);
 	const [isUploading, setIsUploading] = useState(false);
@@ -231,9 +234,6 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		messages: chatStore.messages,
 		isSending: chatStore.isSending,
 		isLoadingHistory: chatStore.isLoadingHistory,
-		streamingActivity: chatStore.streamingActivity,
-		streamingActivityDetail: chatStore.streamingActivityDetail,
-		streamingError: chatStore.streamingError,
 		canReconnect: chatStore.canReconnect,
 		activeTools: chatStore.activeTools,
 		completedTools: chatStore.completedTools,
@@ -443,6 +443,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 
 	useEffect(() => {
 		shouldStickToBottomRef.current = true;
+		setShowLatestButton(false);
 		editTargetRef.current = null;
 	}, [sessions.currentSessionId]);
 
@@ -460,35 +461,57 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		if (distanceFromBottom < 96) {
 			shouldStickToBottomRef.current = true;
 			userScrollGestureRef.current = false;
+			setShowLatestButton(false);
 			return;
 		}
 		if (!userScrollGestureRef.current) return;
 		userScrollGestureRef.current = false;
 		shouldStickToBottomRef.current = false;
+		setShowLatestButton(true);
 	}, []);
 	const pauseAutoScroll = useCallback(() => {
 		shouldStickToBottomRef.current = false;
+		setShowLatestButton(true);
+	}, []);
+	const jumpToLatest = useCallback(() => {
+		const el = scrollRef.current;
+		if (!el) return;
+		shouldStickToBottomRef.current = true;
+		userScrollGestureRef.current = false;
+		setShowLatestButton(false);
+		el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
 	}, []);
 
 	const resizeInput = useCallback(() => {
 		const el = inputRef.current;
 		if (!el) return;
 		const minHeight = resizeComposerTextarea(el);
-		const welcomeLayout = welcomeLayoutRef.current;
-		if (!welcomeLayout) return;
 		const composer = el.closest<HTMLElement>(".inno-composer");
 		if (!composer) return;
 		const textareaHeight = el.getBoundingClientRect().height;
 		const composerHeight = composer.getBoundingClientRect().height;
-		// The attachment row is an independent, variable-height block above the
-		// textarea. Exclude it from the baseline so adding/removing a file cannot
-		// leave a stale welcome-page offset behind when a bubble is rebuilt.
 		const attachmentRow = composer.querySelector<HTMLElement>(".inno-composer-attachments");
 		const attachmentHeight = attachmentRow
 			? attachmentRow.getBoundingClientRect().height
 				+ Number.parseFloat(window.getComputedStyle(attachmentRow).marginTop || "0")
 				+ Number.parseFloat(window.getComputedStyle(attachmentRow).marginBottom || "0")
 			: 0;
+		const scroll = scrollRef.current;
+		if (scroll) {
+			// Attachments grow from the top of the composer. The center mask only
+			// accounts for half of that row, so add the other half to keep the
+			// conversation body moving up by the attachment's full height.
+			const nextBottomSpace = `${composerHeight / 2 + attachmentHeight / 2 + 12 + CONVERSATION_ACTION_ROW_RESERVE}px`;
+			if (scroll.style.getPropertyValue("--inno-conversation-scroll-bottom-space") !== nextBottomSpace) {
+				scroll.style.setProperty("--inno-conversation-scroll-bottom-space", nextBottomSpace);
+				if (shouldStickToBottomRef.current) scroll.scrollTop = scroll.scrollHeight;
+			}
+		}
+		const welcomeLayout = welcomeLayoutRef.current;
+		if (!welcomeLayout) return;
+		// The attachment row is an independent, variable-height block above the
+		// textarea. Exclude it from the baseline so adding/removing a file cannot
+		// leave a stale welcome-page offset behind when a bubble is rebuilt.
 		const baseComposerHeight = composerHeight - textareaHeight - attachmentHeight + minHeight;
 		const composerGrowth = Math.max(0, composerHeight - baseComposerHeight);
 		welcomeLayout.style.setProperty("--inno-welcome-composer-half-growth", `${composerGrowth / 2}px`);
@@ -530,8 +553,8 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 	}, [isWelcome, resizeInput]);
 
 	useEffect(() => {
-		if (isWelcome) resizeInput();
-	}, [isWelcome, inlineImages, pasteBlocks, resizeInput]);
+		resizeInput();
+	}, [isWelcome, inlineImages, pasteBlocks, uploads, resizeInput]);
 
 	const isComposingRef = useRef(false);
 
@@ -1068,7 +1091,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 		const bindingFiles = attachments?.bindings.flatMap((binding) => binding.files) ?? [];
 		const hasAttachments = bindingFiles.length > 0 || Boolean(attachments?.loose.length);
 		if (!content && !hasAttachments) return;
-		const collapsedSkill = collapseSkillMessage(content);
+		const collapsedSkill = skillMessageFromContent(content);
 		const command = collapsedSkill
 			? { command: `skill:${collapsedSkill.skillName}`, args: collapsedSkill.args }
 			: parseAgentCommandMessage(content);
@@ -1434,7 +1457,7 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 	) : null;
 
 	const questionHint = chat.pendingQuestion ? <QuestionHint scrollRef={scrollRef} /> : null;
-	const busyBlocker = <BusyBlocker busyBlocker={sessions.busyBlocker} />;
+	const busyBlocker = sessions.busyBlocker ? <BusyBlocker busyBlocker={sessions.busyBlocker} /> : null;
 	const smartToastNode = smartToast ? (
 		<div className={`inno-smart-toast ${smartToast.error ? "is-error" : ""}`} role="status">{smartToast.message}</div>
 	) : null;
@@ -1508,6 +1531,8 @@ export function ChatCenter({ onOpenPresetPanels, onOpenRightPanel, onPreviewFile
 			onTouchStart={markUserScrollGesture}
 			onPointerDown={handleScrollerPointerDown}
 			onPauseAutoScroll={pauseAutoScroll}
+			showLatestButton={showLatestButton}
+			onJumpToLatest={jumpToLatest}
 			questionHint={questionHint}
 			busyBlocker={busyBlocker}
 			smartToast={smartToastNode}

--- a/apps/inno-agent/web/src/react/WorkspaceSwitcher.tsx
+++ b/apps/inno-agent/web/src/react/WorkspaceSwitcher.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
+import { createPortal } from "react-dom";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { Check, ChevronDown, ChevronUp, Folder, FolderInput, Plus, Search, X, Ban, LoaderCircle } from "lucide-react";
 import type { WorkspaceMeta } from "../api/workspaces.js";
@@ -27,6 +28,18 @@ interface WorkspaceSwitcherProps {
 	onImport?: (file: File) => void;
 }
 
+type WorkspaceMenuPlacement = "above" | "below";
+
+interface WorkspaceMenuPosition {
+	left: number;
+	top: number;
+	maxHeight: number;
+	placement: WorkspaceMenuPlacement;
+}
+
+const WORKSPACE_MENU_MARGIN = 8;
+const WORKSPACE_MENU_MAX_HEIGHT = 390;
+
 /**
  * Compact workspace context selector shared by the welcome view and active
  * conversations. It deliberately owns only the popover UI; session binding
@@ -45,6 +58,8 @@ export function WorkspaceSwitcher({
 }: WorkspaceSwitcherProps) {
 	const { t } = useTranslation();
 	const rootRef = useRef<HTMLDivElement | null>(null);
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
+	const menuRef = useRef<HTMLDivElement | null>(null);
 	const searchRef = useRef<HTMLInputElement | null>(null);
 	const createInputRef = useRef<HTMLInputElement | null>(null);
 	const importInputRef = useRef<HTMLInputElement | null>(null);
@@ -52,6 +67,12 @@ export function WorkspaceSwitcher({
 	const [query, setQuery] = useState("");
 	const [creating, setCreating] = useState(false);
 	const [draftName, setDraftName] = useState(newWorkspaceName);
+	const [menuPosition, setMenuPosition] = useState<WorkspaceMenuPosition>({
+		left: WORKSPACE_MENU_MARGIN,
+		top: WORKSPACE_MENU_MARGIN,
+		maxHeight: WORKSPACE_MENU_MAX_HEIGHT,
+		placement: "above",
+	});
 
 	const selectedWorkspace = useMemo(
 		() => (selectedWorkspaceId ? workspaces.find((workspace) => workspace.id === selectedWorkspaceId) : undefined),
@@ -78,7 +99,9 @@ export function WorkspaceSwitcher({
 	useEffect(() => {
 		if (!open) return;
 		const closeOnPointerDown = (event: PointerEvent) => {
-			if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+			const target = event.target as Node;
+			if (rootRef.current?.contains(target) || menuRef.current?.contains(target)) return;
+			setOpen(false);
 		};
 		const closeOnEscape = (event: KeyboardEvent) => {
 			if (event.key === "Escape") {
@@ -93,6 +116,59 @@ export function WorkspaceSwitcher({
 			window.removeEventListener("keydown", closeOnEscape);
 		};
 	}, [open]);
+
+	const repositionMenu = useCallback(() => {
+		if (!open) return;
+		const trigger = triggerRef.current;
+		const menu = menuRef.current;
+		if (!trigger || !menu || typeof window === "undefined") return;
+
+		const triggerRect = trigger.getBoundingClientRect();
+		const aboveSpace = Math.max(0, triggerRect.top - WORKSPACE_MENU_MARGIN);
+		const belowSpace = Math.max(0, window.innerHeight - triggerRect.bottom - WORKSPACE_MENU_MARGIN);
+		const placement: WorkspaceMenuPlacement = aboveSpace >= belowSpace ? "above" : "below";
+		const availableSpace = placement === "above" ? aboveSpace : belowSpace;
+		const maxHeight = Math.max(1, Math.min(WORKSPACE_MENU_MAX_HEIGHT, availableSpace));
+
+		// Apply the available height before measuring so the first layout already
+		// reserves a scrollable list instead of painting past the viewport.
+		menu.style.maxHeight = `${maxHeight}px`;
+		const menuRect = menu.getBoundingClientRect();
+		const width = Math.min(menuRect.width || 300, Math.max(1, window.innerWidth - WORKSPACE_MENU_MARGIN * 2));
+		const height = Math.min(menuRect.height || maxHeight, maxHeight);
+		const maxLeft = Math.max(WORKSPACE_MENU_MARGIN, window.innerWidth - width - WORKSPACE_MENU_MARGIN);
+		const left = Math.max(WORKSPACE_MENU_MARGIN, Math.min(triggerRect.left, maxLeft));
+		const preferredTop = placement === "above"
+			? triggerRect.top - height - WORKSPACE_MENU_MARGIN
+			: triggerRect.bottom + WORKSPACE_MENU_MARGIN;
+		const maxTop = Math.max(WORKSPACE_MENU_MARGIN, window.innerHeight - height - WORKSPACE_MENU_MARGIN);
+		const top = Math.max(WORKSPACE_MENU_MARGIN, Math.min(preferredTop, maxTop));
+
+		setMenuPosition((previous) => (
+			previous.left === left
+				&& previous.top === top
+				&& previous.maxHeight === maxHeight
+				&& previous.placement === placement
+				? previous
+				: { left, top, maxHeight, placement }
+		));
+	}, [open]);
+
+	useLayoutEffect(() => {
+		if (!open) return;
+		repositionMenu();
+		const resizeObserver = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(repositionMenu);
+		for (const target of [triggerRef.current, menuRef.current]) {
+			if (target) resizeObserver?.observe(target);
+		}
+		window.addEventListener("resize", repositionMenu);
+		document.addEventListener("scroll", repositionMenu, true);
+		return () => {
+			resizeObserver?.disconnect();
+			window.removeEventListener("resize", repositionMenu);
+			document.removeEventListener("scroll", repositionMenu, true);
+		};
+	}, [creating, open, repositionMenu, visibleWorkspaces.length]);
 
 	useEffect(() => {
 		if (!open) {
@@ -141,6 +217,7 @@ export function WorkspaceSwitcher({
 		<div ref={rootRef} className={`inno-workspace-switcher ${className}`}>
 			<button
 				type="button"
+				ref={triggerRef}
 				className="inno-workspace-switcher-trigger"
 				disabled={disabled || busy}
 				aria-haspopup="menu"
@@ -155,8 +232,23 @@ export function WorkspaceSwitcher({
 				{busy ? <LoaderCircle size={13} className="inno-workspace-switcher-spinner" aria-hidden="true" /> : open ? <ChevronUp size={13} aria-hidden="true" /> : <ChevronDown size={13} aria-hidden="true" />}
 			</button>
 
-			{open ? (
-				<PopoverSurface className="inno-workspace-switcher-menu" role="menu" aria-label={t("workspace.switch")}>
+			{open && typeof document !== "undefined" ? createPortal(
+				<PopoverSurface
+					ref={menuRef}
+					className="inno-workspace-switcher-menu"
+					role="menu"
+					aria-label={t("workspace.switch")}
+					style={{
+						position: "fixed",
+						left: menuPosition.left,
+						top: menuPosition.top,
+						right: "auto",
+						bottom: "auto",
+						maxHeight: menuPosition.maxHeight,
+						zIndex: 100,
+						transformOrigin: menuPosition.placement === "above" ? "bottom left" : "top left",
+					}}
+				>
 					{creating ? (
 						<div className="inno-workspace-create-form">
 							<div className="inno-workspace-menu-heading">{t("workspace.newWorkspace")}</div>
@@ -267,7 +359,8 @@ export function WorkspaceSwitcher({
 							</button>
 						</>
 					)}
-				</PopoverSurface>
+				</PopoverSurface>,
+				document.body,
 			) : null}
 			{onImport ? (
 				<input

--- a/apps/inno-agent/web/src/react/chat/AgentTraceTimeline.test.tsx
+++ b/apps/inno-agent/web/src/react/chat/AgentTraceTimeline.test.tsx
@@ -91,7 +91,7 @@ describe("AgentTraceTimeline", () => {
 		expect(rows[1]!.getAttribute("aria-expanded")).toBe("false");
 	});
 
-	it("anchors a pending question card before its waiting trace row", () => {
+	it("anchors a pending question card after its waiting trace row", () => {
 		render(
 			<AgentTraceTimeline
 				showText
@@ -119,8 +119,28 @@ describe("AgentTraceTimeline", () => {
 			if (child.classList.contains("inno-trace-body")) return "body";
 			if (child.classList.contains("inno-trace-questionnaire")) return "question";
 			return "trace";
-		})).toEqual(["trace", "question", "trace"]);
+		})).toEqual(["trace", "trace", "question"]);
 		expect(screen.getByTestId("pending-question-card").textContent).toBe("问题卡片");
+	});
+
+	it("keeps a pending question below an ask row while the trace is still being prepared", () => {
+		render(
+			<AgentTraceTimeline
+				showText
+				steps={[{ ...thinking, text: "正在生成问题" }]}
+				pendingQuestion={{
+					questionId: "q2",
+					card: <div data-testid="pending-question-card">问题卡片</div>,
+				}}
+			/>,
+		);
+
+		const flow = document.querySelector(".inno-trace-flow");
+		expect(flow).not.toBeNull();
+		expect(flow!.querySelectorAll(".inno-trace-row")).toHaveLength(2);
+		expect(flow!.querySelectorAll(".inno-trace-row").item(1).textContent).toContain("等待你的回答");
+		expect(Array.from(flow!.children).map((child) => child.classList.contains("inno-trace-questionnaire") ? "question" : "trace"))
+			.toEqual(["trace", "trace", "question"]);
 	});
 
 	it("shimmers only the active thinking title and keeps completed text stable", () => {

--- a/apps/inno-agent/web/src/react/chat/AgentTraceTimeline.test.tsx
+++ b/apps/inno-agent/web/src/react/chat/AgentTraceTimeline.test.tsx
@@ -1,0 +1,403 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatTraceStep } from "../../types/chat.js";
+
+vi.mock("react-i18next", () => ({
+	useTranslation: () => ({
+		t: (_key: string, fallback: string, options?: Record<string, unknown>) => fallback.replace(/\{\{(\w+)\}\}/g, (_match, name: string) => String(options?.[name] ?? `{{${name}}}`)),
+	}),
+}));
+
+import { AgentTraceTimeline } from "./AgentTraceTimeline.js";
+
+afterEach(cleanup);
+
+const thinking: ChatTraceStep = {
+	id: "thinking:0",
+	kind: "thinking",
+	status: "completed",
+	title: "思考",
+	text: "先检查输入，再给出结论。",
+};
+
+describe("AgentTraceTimeline", () => {
+	it("renders a collapsed one-line row and expands the full payload inline", () => {
+		render(<AgentTraceTimeline steps={[thinking]} />);
+
+		const row = screen.getByRole("button", { name: /展开思考/ });
+		expect(row).toBeTruthy();
+		expect(row.textContent).toContain("思考完成");
+		expect(document.querySelector(".inno-trace-row-details")).toBeNull();
+
+		fireEvent.click(row);
+		expect(document.querySelector(".inno-trace-row-details")?.textContent).toContain("先检查输入，再给出结论。");
+		expect(row.getAttribute("aria-expanded")).toBe("true");
+	});
+
+	it("labels pauses and failures instead of claiming the turn completed", () => {
+		const interrupted: ChatTraceStep = {
+			id: "aborted:1",
+			kind: "error",
+			status: "error",
+			title: "已停止",
+			text: "Stopped by user",
+		};
+		const view = render(
+			<AgentTraceTimeline
+				steps={[interrupted]}
+				terminalState={{ status: "aborted", reason: "Stopped by user" }}
+			/>,
+		);
+		expect(document.querySelector(".inno-trace-work-status")?.textContent).toContain("用户主动暂停");
+		expect(document.querySelector(".inno-trace-work-status")?.textContent).not.toContain("已完成");
+
+		view.rerender(
+			<AgentTraceTimeline
+				steps={[{ ...interrupted, title: "请求失败", text: "provider timeout" }]}
+				terminalState={{ status: "error", reason: "provider timeout" }}
+			/>,
+		);
+		expect(document.querySelector(".inno-trace-work-status")?.textContent).toContain("因其他原因中断");
+	});
+
+	it("marks a trace without a terminal event as incomplete", () => {
+		render(
+			<AgentTraceTimeline
+				steps={[{ ...thinking, status: "completed" }]}
+				terminalState={{ status: "unknown" }}
+			/>,
+		);
+		expect(document.querySelector(".inno-trace-work-status")?.textContent).toContain("未完成 · 原因未知");
+	});
+
+	it("expands only the clicked thinking row when trace ids are duplicated", () => {
+		render(
+			<AgentTraceTimeline
+				steps={[
+					{ ...thinking, text: "第一段思考" },
+					{ ...thinking, text: "第二段思考" },
+				]}
+			/>,
+		);
+
+		const rows = screen.getAllByRole("button");
+		expect(rows).toHaveLength(2);
+
+		fireEvent.click(rows[0]!);
+
+		expect(document.querySelectorAll(".inno-trace-row-details")).toHaveLength(1);
+		expect(rows[0]!.getAttribute("aria-expanded")).toBe("true");
+		expect(rows[1]!.getAttribute("aria-expanded")).toBe("false");
+	});
+
+	it("anchors a pending question card before its waiting trace row", () => {
+		render(
+			<AgentTraceTimeline
+				showText
+				steps={[
+					{ ...thinking, text: "先准备问题" },
+					{
+						id: "question:q1",
+						kind: "tool",
+						status: "waiting",
+						title: "等待你的回答",
+						toolName: "ask_user_question",
+						questionId: "q1",
+					},
+				]}
+				pendingQuestion={{
+					questionId: "q1",
+					card: <div data-testid="pending-question-card">问题卡片</div>,
+				}}
+			/>,
+		);
+
+		const flow = document.querySelector(".inno-trace-flow");
+		expect(flow).not.toBeNull();
+		expect(Array.from(flow!.children).map((child) => {
+			if (child.classList.contains("inno-trace-body")) return "body";
+			if (child.classList.contains("inno-trace-questionnaire")) return "question";
+			return "trace";
+		})).toEqual(["trace", "question", "trace"]);
+		expect(screen.getByTestId("pending-question-card").textContent).toBe("问题卡片");
+	});
+
+	it("shimmers only the active thinking title and keeps completed text stable", () => {
+		render(
+			<AgentTraceTimeline
+				isSending
+				steps={[{ ...thinking, status: "active", text: "正在分析" }]}
+			/>,
+		);
+
+		const title = document.querySelector(".inno-trace-row-title.is-shimmering");
+		expect(title?.textContent).toContain("思考");
+		expect(title?.querySelector(".inno-trace-title-shimmer")?.textContent).toBe("思考中");
+		expect(title?.querySelector(".inno-trace-title-shimmer")?.getAttribute("aria-hidden")).toBe("true");
+		expect(document.querySelector(".inno-trace-row-details")).toBeNull();
+	});
+
+	it("keeps a long live thinking summary on one line and follows its tail", () => {
+		const longThinking = `开头 ${"中间内容 ".repeat(30)}最新一个字`;
+		render(
+			<AgentTraceTimeline
+				isSending
+				steps={[{ ...thinking, status: "active", text: longThinking }]}
+			/>,
+		);
+
+		const title = document.querySelector(".inno-trace-row-title");
+		expect(title?.textContent).toContain("最新一个字");
+		expect(title?.textContent).not.toContain("开头");
+	});
+
+	it("shimmers only the last active thinking row", () => {
+		render(
+			<AgentTraceTimeline
+				isSending
+				steps={[
+					{ ...thinking, id: "thinking:1", status: "active", text: "旧阶段" },
+					{ ...thinking, id: "thinking:2", status: "active", text: "当前阶段" },
+				]}
+			/>,
+		);
+
+		expect(document.querySelectorAll(".inno-trace-row-title.is-shimmering")).toHaveLength(1);
+		expect(document.querySelector(".inno-trace-row-title.is-shimmering")?.textContent).toContain("思考");
+	});
+
+	it("shimmers the current running tool title instead of completed stages", () => {
+		render(
+			<AgentTraceTimeline
+				isSending
+				steps={[
+					{
+						id: "tool:read",
+						kind: "tool",
+						status: "completed",
+						title: "read",
+						toolName: "read",
+						toolCallId: "read",
+						args: { path: "notes.md" },
+					},
+					{
+						id: "tool:bash",
+						kind: "tool",
+						status: "running",
+						title: "bash",
+						toolName: "bash",
+						toolCallId: "bash",
+						args: { command: "printf hello" },
+					},
+				]}
+			/> ,
+		);
+
+		const shimmering = document.querySelector(".inno-trace-row-title.is-shimmering");
+		expect(document.querySelectorAll(".inno-trace-row-title.is-shimmering")).toHaveLength(1);
+		expect(shimmering?.textContent).toContain("bash");
+		expect(shimmering?.querySelector(".inno-trace-title-shimmer")?.textContent).toBe("执行中 · bash · printf hello");
+		expect(shimmering?.querySelector(".inno-trace-title-shimmer-target")?.classList.contains("is-full-line")).toBe(true);
+		expect(document.querySelectorAll(".inno-trace-title-shimmer")).toHaveLength(1);
+	});
+
+	it("shimmers an open tool row even when the sending flag is unavailable", () => {
+		render(
+			<AgentTraceTimeline
+				steps={[{
+					id: "tool:question",
+					kind: "tool",
+					status: "waiting",
+					title: "等待你的回答",
+					toolName: "ask_user_question",
+					toolCallId: "question",
+					args: { questions: [{ header: "问题方向" }] },
+				}]}
+			/>,
+		);
+
+		const shimmering = document.querySelector(".inno-trace-row-title.is-shimmering");
+		expect(shimmering).not.toBeNull();
+		expect(shimmering?.querySelector(".inno-trace-title-shimmer")?.textContent).toContain("等待你的回答");
+	});
+
+	it("shows the concrete tool name and the latest one-line partial output", () => {
+		render(
+			<AgentTraceTimeline
+				steps={[
+					{
+						id: "tool:bash",
+						kind: "tool",
+						status: "running",
+						title: "bash",
+						toolName: "bash",
+						toolCallId: "bash",
+						args: { command: "printf hello" },
+						partialResult: { content: [{ type: "text", text: "hello" }] },
+					},
+					{
+						id: "tool:read",
+						kind: "tool",
+						status: "running",
+						title: "read",
+						toolName: "read",
+						toolCallId: "read",
+						args: { path: "notes.md" },
+					},
+				]}
+			/>,
+		);
+
+		const rows = document.querySelectorAll(".inno-trace-row");
+		expect(rows[0]?.textContent).toContain("执行中 · bash · printf hello · hello");
+		expect(rows[1]?.textContent).toContain("执行中 · read · notes.md");
+
+		fireEvent.click(screen.getAllByRole("button")[0]!);
+		expect(document.querySelector(".inno-trace-row-details")?.textContent).toContain("实时结果");
+	});
+
+	it("leaves assistant progress text to the normal body renderer", () => {
+		render(
+			<AgentTraceTimeline
+				steps={[
+					{
+						id: "progress:0",
+						kind: "progress",
+						status: "completed",
+						title: "正在组织回复",
+						text: "这是正文，不是工具调用。",
+					},
+					{
+						id: "tool:t1",
+						kind: "tool",
+						status: "completed",
+						title: "已完成 · 查询资料",
+						toolName: "search",
+						toolCallId: "t1",
+					},
+				]}
+			/>,
+		);
+
+		expect(document.querySelectorAll(".inno-trace-row")).toHaveLength(1);
+		expect(document.querySelector(".inno-trace-row")?.textContent).not.toContain("这是正文");
+	});
+
+	it("keeps ordinary body blocks in their original position in the process flow", () => {
+		render(
+			<AgentTraceTimeline
+				showText
+				steps={[
+					{ ...thinking, id: "thinking:before", text: "先思考" },
+					{
+						id: "progress:0",
+						kind: "progress",
+						status: "completed",
+						title: "正在组织回复",
+						text: "第一段正文",
+					},
+					{
+						id: "tool:t1",
+						kind: "tool",
+						status: "completed",
+						title: "查询资料",
+						toolName: "search",
+						toolCallId: "t1",
+					},
+					{
+						id: "answer:1",
+						kind: "answer",
+						status: "completed",
+						title: "回复",
+						text: "第二段正文",
+					},
+				]}
+			/>,
+		);
+
+		const flow = document.querySelector(".inno-trace-flow");
+		expect(flow).not.toBeNull();
+		expect(Array.from(flow!.children).map((child) => child.classList.contains("inno-trace-body"))).toEqual([
+			false,
+			true,
+			false,
+			true,
+		]);
+		expect(flow?.querySelectorAll(".inno-trace-body")).toHaveLength(2);
+	});
+
+	it("keeps tool and skill details behind the same row interaction", () => {
+		const onOpenSkill = vi.fn();
+		render(
+			<AgentTraceTimeline
+				steps={[
+					{
+						id: "tool:t1",
+						kind: "tool",
+						status: "error",
+						title: "读取 notes.md",
+						toolName: "read_file",
+						toolCallId: "t1",
+						args: { path: "notes.md" },
+						result: "not found",
+						isError: true,
+					},
+					{
+						id: "skill:docs",
+						kind: "skill",
+						status: "completed",
+						title: "已载入技能 · docs",
+						skillName: "docs",
+						skillState: "expanded",
+					},
+				]}
+				onOpenSkill={onOpenSkill}
+			/>,
+		);
+
+		const rows = screen.getAllByRole("button");
+		expect(rows).toHaveLength(2);
+		fireEvent.click(rows[1]);
+		fireEvent.click(screen.getByRole("button", { name: "打开 Skills 面板" }));
+		expect(onOpenSkill).toHaveBeenCalledWith("docs");
+	});
+
+	it("keeps internal bookkeeping and child-task timing out of the surface", () => {
+		render(
+			<AgentTraceTimeline
+				steps={[
+					{
+						id: "system:turn",
+						kind: "system",
+						status: "completed",
+						title: "开始本轮任务",
+						eventType: "turn_start",
+						durationMs: 2_000,
+					},
+					{
+						id: "skill:loaded",
+						kind: "skill",
+						status: "completed",
+						title: "已预载 1 个技能",
+						durationMs: 2_000,
+					},
+					{
+						id: "tool:t2",
+						kind: "tool",
+						status: "completed",
+						title: "读取 notes.md",
+						toolName: "read_file",
+						toolCallId: "t2",
+						durationMs: 3_000,
+					},
+				]}
+			/>,
+		);
+
+		const content = document.body.textContent ?? "";
+		expect(content).not.toContain("开始本轮任务");
+		expect(content).not.toContain("2 秒");
+		expect(content).not.toContain("3 秒");
+	});
+});

--- a/apps/inno-agent/web/src/react/chat/AgentTraceTimeline.tsx
+++ b/apps/inno-agent/web/src/react/chat/AgentTraceTimeline.tsx
@@ -42,7 +42,7 @@ export interface AgentTraceTimelineProps {
 	fallbackText?: string;
 	/** Completed question cards to anchor after their ask_user_question row. */
 	answeredQuestionnaires?: AnsweredQuestionnaireView[];
-	/** Live question card anchored before the trace row that puts the turn into waiting state. */
+	/** Live question card anchored after the trace row that represents the tool call. */
 	pendingQuestion?: {
 		questionId: string;
 		card: ReactNode;
@@ -414,6 +414,19 @@ function TraceBody({ content }: { content: string }) {
 	);
 }
 
+function pendingQuestionTraceStep(questionId: string): ChatTraceStep {
+	return {
+		id: `tool:ask_user_question:${questionId}`,
+		kind: "tool",
+		status: "waiting",
+		title: "等待你的回答",
+		titleKey: "chat.trace.steps.waitingForAnswer",
+		toolCallId: questionId,
+		toolName: "ask_user_question",
+		questionId,
+	};
+}
+
 export function AgentTraceTimeline({
 	steps,
 	isSending = false,
@@ -519,11 +532,6 @@ export function AgentTraceTimeline({
 						: undefined;
 					return (
 						<Fragment key={rowId}>
-							{pendingQuestionIndex === index ? (
-								<div className="inno-trace-questionnaire">
-									{pendingQuestion!.card}
-								</div>
-							) : null}
 							<TraceRow
 								step={step}
 								now={now}
@@ -533,6 +541,11 @@ export function AgentTraceTimeline({
 								t={t}
 								onOpenSkill={onOpenSkill}
 							/>
+							{pendingQuestionIndex === index ? (
+								<div className="inno-trace-questionnaire">
+									{pendingQuestion!.card}
+								</div>
+							) : null}
 							{questionnaire ? (
 								<div className="inno-trace-questionnaire">
 									<AnsweredQuestionCard questionnaire={questionnaire.questionnaire} />
@@ -542,9 +555,20 @@ export function AgentTraceTimeline({
 					);
 				})}
 				{pendingQuestion && pendingQuestionIndex < 0 ? (
-					<div className="inno-trace-questionnaire">
-						{pendingQuestion.card}
-					</div>
+					<>
+						<TraceRow
+							step={pendingQuestionTraceStep(pendingQuestion.questionId)}
+							now={now}
+							isCurrentLiveStep
+							expanded={false}
+							onToggle={() => undefined}
+							t={t}
+							onOpenSkill={onOpenSkill}
+						/>
+						<div className="inno-trace-questionnaire">
+							{pendingQuestion.card}
+						</div>
+					</>
 				) : null}
 				{showFallbackText ? (
 					<div className="inno-trace-fallback-body">

--- a/apps/inno-agent/web/src/react/chat/AgentTraceTimeline.tsx
+++ b/apps/inno-agent/web/src/react/chat/AgentTraceTimeline.tsx
@@ -1,0 +1,562 @@
+import { Fragment, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
+import {
+	Brain,
+	Check,
+	ChevronRight,
+	CircleAlert,
+	Clock3,
+	FileText,
+	LoaderCircle,
+	Puzzle,
+	Settings2,
+	TerminalSquare,
+	Wrench,
+} from "lucide-react";
+import type { ChatTraceStep, ChatTraceStepKind, ChatTraceStepStatus } from "../../types/chat.js";
+import type { AnsweredQuestionnaireView } from "../../utils/questionnaire.js";
+import { normalizeMarkdownMath } from "../../utils/markdown-math.js";
+import { MarkdownArtifact } from "../MarkdownArtifact.js";
+import { AnsweredQuestionCard } from "./AnsweredQuestionCard.js";
+import {
+	isOpenStatus,
+	isTextKind,
+	parseTraceTime,
+	safeJson,
+	visibleTraceSteps,
+	type ChatTraceTerminalState,
+} from "../../utils/chat-trace.js";
+
+export interface AgentTraceTimelineProps {
+	steps: ChatTraceStep[];
+	isSending?: boolean;
+	startedAt?: string | null;
+	finishedAt?: string | null;
+	error?: string;
+	terminalState?: ChatTraceTerminalState;
+	onOpenSkill?: (skillName: string) => void;
+	/** Render text records in their original position among process records. */
+	showText?: boolean;
+	/** Fallback for legacy messages whose trace has no text records. */
+	fallbackText?: string;
+	/** Completed question cards to anchor after their ask_user_question row. */
+	answeredQuestionnaires?: AnsweredQuestionnaireView[];
+	/** Live question card anchored before the trace row that puts the turn into waiting state. */
+	pendingQuestion?: {
+		questionId: string;
+		card: ReactNode;
+	};
+}
+
+function formatDuration(durationMs: number | undefined, t: TFunction): string {
+	if (durationMs === undefined) return "";
+	const seconds = Math.max(0, Math.round(durationMs / 1000));
+	return t("chat.trace.durationSeconds", "{{seconds}} 秒", { seconds });
+}
+
+function liveDuration(startedAt: number | undefined, endedAt: number | undefined, now: number): number | undefined {
+	if (startedAt === undefined) return undefined;
+	return Math.max(0, (endedAt ?? now) - startedAt);
+}
+
+function stepDuration(step: ChatTraceStep, now: number): number | undefined {
+	if (step.durationMs !== undefined) return step.durationMs;
+	return isOpenStatus(step.status) ? liveDuration(step.startedAt, step.endedAt, now) : undefined;
+}
+
+function compactText(value: string, max = 180): string {
+	const compacted = value.replace(/[`*_#>|\[\]()]/g, "").replace(/\s+/g, " ").trim();
+	return compacted.length > max ? `${compacted.slice(0, max - 1)}…` : compacted;
+}
+
+/** Keep the live thinking indicator on one line while following its newest text. */
+function tailText(value: string, max = 96): string {
+	const compacted = value.replace(/[`*_#>|\[\]()]/g, "").replace(/\s+/g, " ").trim();
+	return compacted.length > max ? `…${compacted.slice(-max)}` : compacted;
+}
+
+function firstTarget(value: unknown, depth = 0): string | undefined {
+	if (depth > 4 || value == null) return undefined;
+	if (typeof value === "string") {
+		const text = value.trim();
+		if (!text || text.length > 260 || text.includes("\n")) return undefined;
+		return text;
+	}
+	if (typeof value !== "object") return undefined;
+	if (Array.isArray(value)) {
+		for (const item of value) {
+			const target = firstTarget(item, depth + 1);
+			if (target) return target;
+		}
+		return undefined;
+	}
+	const record = value as Record<string, unknown>;
+	for (const key of [
+		"path", "filePath", "file_path", "filename", "fileName", "targetPath", "target_path",
+		"query", "pattern", "command", "cmd", "url", "name", "title",
+	]) {
+		const target = record[key];
+		if (typeof target === "string" && target.trim()) return target.trim();
+	}
+	for (const child of Object.values(record)) {
+		const target = firstTarget(child, depth + 1);
+		if (target) return target;
+	}
+	return undefined;
+}
+
+function textFromToolPayload(value: unknown): string | undefined {
+	if (typeof value === "string") return value;
+	if (!value || typeof value !== "object") return undefined;
+	const record = value as Record<string, unknown>;
+	if (Array.isArray(record.content)) {
+		const text = record.content
+			.map((item) => item && typeof item === "object" && typeof (item as Record<string, unknown>).text === "string"
+				? (item as Record<string, string>).text
+				: "")
+			.filter(Boolean)
+			.join("\n");
+		if (text.trim()) return text;
+	}
+	if (typeof record.text === "string" && record.text.trim()) return record.text;
+	return undefined;
+}
+
+function liveToolText(value: unknown): string | undefined {
+	const text = textFromToolPayload(value);
+	if (!text) return undefined;
+	const lines = text.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+	const lastLine = lines.at(-1);
+	return lastLine ? compactText(lastLine, 96) : undefined;
+}
+
+function isDiagnosticSummary(value?: string): boolean {
+	return Boolean(value?.trim() && /(abort|aborted|cancel|cancelled|canceled|fail|failed|error|timeout|错误|失败|中断|取消|停止)/i.test(value));
+}
+
+function localizedStepTitle(step: ChatTraceStep, t: TFunction): string {
+	if (step.kind === "system" && step.summary?.trim() && isDiagnosticSummary(step.summary)) return step.title;
+	return step.titleKey ? t(step.titleKey, step.title, step.titleParams) : step.title;
+}
+
+function toolSummary(step: ChatTraceStep, t: TFunction): string {
+	const toolName = step.toolName?.trim() || localizedStepTitle(step, t);
+	const target = firstTarget(step.args) ?? firstTarget(step.argsText);
+	const live = step.status === "running" ? liveToolText(step.partialResult) : undefined;
+	return [
+		toolName,
+		target ? compactText(target, 120) : undefined,
+		live && live !== target ? live : undefined,
+	].filter(Boolean).join(" · ") || t("chat.trace.tool", "工具");
+}
+
+function thinkingSummary(step: ChatTraceStep, durationMs: number | undefined, t: TFunction): string {
+	if (step.status === "completed") {
+		return durationMs !== undefined
+			? `${t("chat.trace.thinking.completed", "思考完成")} · ${t("chat.trace.duration", "持续了 {{duration}}", { duration: formatDuration(durationMs, t) })}`
+			: t("chat.trace.thinking.completed", "思考完成");
+	}
+	const latestLine = step.text
+		?.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.at(-1);
+	return [
+		t("chat.trace.thinking.inProgress", "思考中"),
+		durationMs !== undefined ? t("chat.trace.duration", "持续了 {{duration}}", { duration: formatDuration(durationMs, t) }) : undefined,
+		latestLine ? tailText(latestLine, 96) : undefined,
+	].filter(Boolean).join(" · ");
+}
+
+function statusLabel(status: ChatTraceStepStatus, t: TFunction): string {
+	switch (status) {
+		case "preparing": return t("chat.trace.status.preparing", "准备调用");
+		case "running": return t("chat.trace.status.running", "执行中");
+		case "waiting": return t("chat.trace.status.waiting", "等待你的回答");
+		case "error": return t("chat.trace.status.error", "失败");
+		case "completed": return t("chat.trace.status.completed", "已完成");
+		default: return t("chat.trace.status.active", "进行中");
+	}
+}
+
+function isUserPauseReason(value?: string): boolean {
+	if (!value?.trim()) return false;
+	return /(stopped by user|cancel(?:led|ed)? by user|user (?:stopped|cancel(?:led|ed)?)|用户(?:主动)?(?:暂停|停止|取消)|主动(?:暂停|停止|取消))/i.test(value);
+}
+
+function failureStepFor(steps: ChatTraceStep[]): ChatTraceStep | undefined {
+	return [...steps].reverse().find((step) => {
+		if (step.kind === "error") return true;
+		if (step.kind !== "system") return false;
+		if (step.status === "error") return true;
+		const searchable = [step.title, step.summary, step.text, step.eventType]
+			.filter(Boolean)
+			.join(" ");
+		return /(terminal event|stopreason\s*:\s*error|error|错误|失败|中断|取消|停止)/i.test(searchable);
+	});
+}
+
+function workStatusText(
+	isSending: boolean,
+	terminalState: ChatTraceTerminalState | undefined,
+	steps: ChatTraceStep[],
+	t: TFunction,
+	error?: string,
+): string {
+	if (isSending) return t("chat.trace.working", "工作中");
+	if (terminalState?.status === "completed") return t("chat.trace.completed", "已完成");
+	if (terminalState?.status === "aborted") {
+		return isUserPauseReason(terminalState.reason)
+			? t("chat.trace.workStatus.userPaused", "用户主动暂停")
+			: t("chat.trace.workStatus.interrupted", "因其他原因中断");
+	}
+	if (terminalState?.status === "error") return t("chat.trace.workStatus.interrupted", "因其他原因中断");
+
+	const failureStep = failureStepFor(steps);
+	const reason = [error, failureStep?.title, failureStep?.text, failureStep?.summary]
+		.filter(Boolean)
+		.join(" ");
+	if (!reason) {
+		return terminalState?.status === "unknown"
+			? t("chat.trace.workStatus.incomplete", "未完成 · 原因未知")
+			: t("chat.trace.completed", "已完成");
+	}
+	return isUserPauseReason(reason)
+		? t("chat.trace.workStatus.userPaused", "用户主动暂停")
+		: t("chat.trace.workStatus.interrupted", "因其他原因中断");
+}
+
+function iconFor(kind: ChatTraceStepKind, status: ChatTraceStepStatus) {
+	if (kind === "thinking") return <Brain size={15} strokeWidth={1.7} aria-hidden="true" />;
+	if (kind === "tool") return status === "running" || status === "preparing" ? <Wrench size={15} strokeWidth={1.7} aria-hidden="true" /> : <TerminalSquare size={15} strokeWidth={1.7} aria-hidden="true" />;
+	if (kind === "skill") return <Puzzle size={15} strokeWidth={1.7} aria-hidden="true" />;
+	if (kind === "system") return <Settings2 size={15} strokeWidth={1.7} aria-hidden="true" />;
+	if (kind === "error") return <CircleAlert size={15} strokeWidth={1.7} aria-hidden="true" />;
+	return <FileText size={15} strokeWidth={1.7} aria-hidden="true" />;
+}
+
+function statusIcon(status: ChatTraceStepStatus) {
+	if (status === "completed") return <Check size={13} strokeWidth={2} aria-hidden="true" />;
+	if (status === "error") return <CircleAlert size={13} strokeWidth={2} aria-hidden="true" />;
+	if (status === "active" || status === "preparing" || status === "running" || status === "waiting") {
+		return <LoaderCircle size={13} className="inno-trace-spinner" aria-hidden="true" />;
+	}
+	return null;
+}
+
+function DetailPayload({ label, value }: { label: string; value: unknown }) {
+	const content = safeJson(value);
+	if (!content) return null;
+	return (
+		<div className="inno-trace-detail-block">
+			<div className="inno-trace-detail-label">{label}</div>
+			<pre className="inno-trace-payload">{content}</pre>
+		</div>
+	);
+}
+
+function workspaceChangeLabel(change: string, t: TFunction): string {
+	const key = {
+		created: "chat.trace.workspaceChanges.created",
+		modified: "chat.trace.workspaceChanges.modified",
+		deleted: "chat.trace.workspaceChanges.deleted",
+	}[change];
+	return key ? t(key, change) : change;
+}
+
+function TraceDetails({ step, onOpenSkill, t }: { step: ChatTraceStep; onOpenSkill?: (skillName: string) => void; t: TFunction }) {
+	if (step.kind === "thinking") {
+		return step.text
+			? <pre className="inno-trace-thinking">{step.text}</pre>
+			: <span className="inno-trace-empty">{t("chat.trace.details.noThinkingText", "暂无思考文本")}</span>;
+	}
+	if (step.kind === "progress") {
+		return step.text
+			? <MarkdownArtifact content={step.text} />
+			: <span className="inno-trace-empty">{t("chat.trace.details.noProgressText", "暂无进度文本")}</span>;
+	}
+	if (step.kind === "tool") {
+		return (
+			<div className="inno-trace-tool-details">
+				<DetailPayload label={t("chat.trace.details.arguments", "参数")} value={step.args ?? step.argsText} />
+				<DetailPayload label={t("chat.trace.details.partialResult", "实时结果")} value={step.partialResult} />
+				<DetailPayload label={step.isError ? t("chat.trace.details.error", "错误") : t("chat.trace.details.result", "结果")} value={step.result} />
+				{step.questionParams ? <DetailPayload label={t("chat.trace.details.question", "提问")} value={step.questionParams} /> : null}
+				{step.workspaceChanges?.length ? (
+					<div className="inno-trace-detail-block">
+						<div className="inno-trace-detail-label">{t("chat.trace.details.workspaceChanges", "工作区变化")}</div>
+						<ul className="inno-trace-change-list">
+							{step.workspaceChanges.map((change) => <li key={`${change.change}:${change.path}`}>{workspaceChangeLabel(change.change, t)} · {change.path}</li>)}
+						</ul>
+					</div>
+				) : null}
+			</div>
+		);
+	}
+	if (step.kind === "skill") {
+		return (
+			<div className="inno-trace-skill-details">
+				{step.skillName ? <div><span className="inno-trace-detail-label">{t("chat.trace.details.skill", "技能")}</span>{step.skillName}</div> : null}
+				{step.skillSource ? <div><span className="inno-trace-detail-label">{t("chat.trace.details.source", "来源")}</span>{step.skillSource}</div> : null}
+				{step.skillPath ? <div className="break-all"><span className="inno-trace-detail-label">{t("chat.trace.details.path", "路径")}</span>{step.skillPath}</div> : null}
+				{step.skillDescription ? <div><span className="inno-trace-detail-label">{t("chat.trace.details.description", "说明")}</span>{step.skillDescription}</div> : null}
+				{step.skillArgs ? <DetailPayload label={t("chat.trace.details.arguments", "参数")} value={step.skillArgs} /> : null}
+				{step.skillName && onOpenSkill ? (
+					<button type="button" className="inno-trace-open-skill" onClick={() => onOpenSkill(step.skillName!)}>
+						{t("chat.trace.details.openSkillsPanel", "打开 Skills 面板")}
+					</button>
+				) : null}
+				{step.skillState === "loaded" && step.eventDetail ? <DetailPayload label={t("chat.trace.details.preloadedSkills", "已预载技能")} value={step.eventDetail} /> : null}
+			</div>
+		);
+	}
+	if (step.kind === "system") {
+		return (
+			<div className="inno-trace-system-details">
+				{step.eventType ? <div><span className="inno-trace-detail-label">{t("chat.trace.details.piEvent", "PI 事件")}</span>{step.eventType}</div> : null}
+				{step.attempt !== undefined ? <div><span className="inno-trace-detail-label">{t("chat.trace.details.attempt", "尝试")}</span>{step.attempt}</div> : null}
+				<DetailPayload label={t("chat.trace.details.details", "详情")} value={step.eventDetail} />
+			</div>
+		);
+	}
+	return step.text ? <pre className="inno-trace-error-details">{step.text}</pre> : null;
+}
+
+function rowSummary(step: ChatTraceStep, durationMs: number | undefined, t: TFunction): string {
+	const title = localizedStepTitle(step, t);
+	if (step.kind === "thinking") return thinkingSummary(step, durationMs, t);
+	if (step.kind === "progress") return compactText(step.text ?? title) || t("chat.trace.steps.progress", "进度");
+	if (step.kind === "tool") {
+		const summary = toolSummary(step, t);
+		if (step.status === "error") return `${t("chat.trace.status.error", "失败")} · ${summary}`;
+		if (step.status === "preparing" || step.status === "running") return `${t("chat.trace.status.running", "执行中")} · ${summary}`;
+		if (step.status === "waiting") return t("chat.trace.status.waiting", "等待你的回答");
+		return summary;
+	}
+	return title;
+}
+
+function shimmerTitleFor(step: ChatTraceStep, t: TFunction): string | undefined {
+	if (step.kind === "thinking" && step.status === "active") return t("chat.trace.thinking.inProgress", "思考中");
+	if (step.kind === "tool" && (step.status === "active" || step.status === "preparing" || step.status === "running")) {
+		return step.toolName?.trim() || localizedStepTitle(step, t);
+	}
+	return undefined;
+}
+
+function TraceRow({ step, now, isCurrentLiveStep, expanded, onToggle, t, onOpenSkill }: {
+	step: ChatTraceStep;
+	now: number;
+	isCurrentLiveStep: boolean;
+	expanded: boolean;
+	onToggle: () => void;
+	t: TFunction;
+	onOpenSkill?: (skillName: string) => void;
+}) {
+	const durationMs = stepDuration(step, now);
+	const summary = rowSummary(step, durationMs, t);
+	const shimmerTitle = isCurrentLiveStep
+		? step.kind === "tool" ? summary : shimmerTitleFor(step, t)
+		: undefined;
+	const shimmerStart = shimmerTitle ? summary.indexOf(shimmerTitle) : -1;
+	const isShimmering = shimmerStart >= 0;
+	const isFullLineShimmer = isShimmering && step.kind === "tool";
+	const isSystem = step.kind === "system";
+	const isLive = isOpenStatus(step.status);
+	return (
+		<div className={`inno-trace-row ${isSystem ? "is-system" : ""} ${step.kind === "error" ? "is-error" : ""} ${isLive ? "is-live" : ""}`}>
+			<button
+				type="button"
+				className="inno-trace-row-toggle"
+				aria-expanded={expanded}
+				aria-label={expanded
+					? t("chat.trace.row.collapse", "收起{{summary}}", { summary })
+					: t("chat.trace.row.expand", "展开{{summary}}", { summary })}
+				onClick={onToggle}
+			>
+				<span className="inno-trace-icon">{iconFor(step.kind, step.status)}</span>
+				<span
+					className={`inno-trace-row-title ${isShimmering ? "is-shimmering" : ""}`}
+				>
+					{isFullLineShimmer ? (
+						<span className="inno-trace-title-shimmer-target is-full-line">
+							{summary}
+							<span className="inno-trace-title-shimmer" aria-hidden="true">{summary}</span>
+						</span>
+					) : isShimmering ? (
+						<>
+							{summary.slice(0, shimmerStart)}
+							<span className="inno-trace-title-shimmer-target">
+								{shimmerTitle}
+								<span className="inno-trace-title-shimmer" aria-hidden="true">{shimmerTitle}</span>
+							</span>
+							{summary.slice(shimmerStart + shimmerTitle!.length)}
+						</>
+					) : summary}
+				</span>
+				<span className={`inno-trace-status ${step.status}`} title={statusLabel(step.status, t)}>{statusIcon(step.status)}</span>
+				<ChevronRight size={14} className={`inno-trace-chevron ${expanded ? "is-open" : ""}`} aria-hidden="true" />
+			</button>
+			{expanded ? <div className="inno-trace-row-details"><TraceDetails step={step} onOpenSkill={onOpenSkill} t={t} /></div> : null}
+		</div>
+	);
+}
+
+function TraceBody({ content }: { content: string }) {
+	const trimmed = content.trim();
+	const normalized = useMemo(() => normalizeMarkdownMath(trimmed), [trimmed]);
+	if (!trimmed) return null;
+	return (
+		<div className="inno-trace-body">
+			<MarkdownArtifact content={normalized} />
+		</div>
+	);
+}
+
+export function AgentTraceTimeline({
+	steps,
+	isSending = false,
+	startedAt,
+	finishedAt,
+	error,
+	terminalState,
+	onOpenSkill,
+	showText = false,
+	fallbackText,
+	answeredQuestionnaires = [],
+	pendingQuestion,
+}: AgentTraceTimelineProps) {
+	const { t } = useTranslation();
+	const [, setClock] = useState(0);
+	const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+
+	useEffect(() => {
+		if (!isSending) return;
+		const timer = window.setInterval(() => setClock((value) => value + 1), 1_000);
+		return () => window.clearInterval(timer);
+	}, [isSending]);
+
+	const now = Date.now();
+	const visibleSteps = useMemo(() => {
+		const nextSteps = visibleTraceSteps(steps);
+		const normalizedError = error?.trim().toLowerCase();
+		const hasMatchingError = normalizedError
+			? nextSteps.some((step) => [step.text, step.title, step.summary, step.eventType]
+				.filter(Boolean)
+				.some((value) => value!.trim().toLowerCase().includes(normalizedError)))
+			: false;
+		if (error && !hasMatchingError) {
+			return [...nextSteps, {
+				id: "stream-error",
+				kind: "error",
+				status: "error",
+				title: "请求失败",
+				titleKey: "chat.trace.steps.requestFailed",
+				text: error,
+			} satisfies ChatTraceStep];
+		}
+		return nextSteps;
+	}, [error, steps]);
+	const processSteps = useMemo(
+		() => visibleSteps.filter((step) => !isTextKind(step.kind)),
+		[visibleSteps],
+	);
+	const flowSteps = showText ? visibleSteps : processSteps;
+	const hasTextPayload = flowSteps.some((step) => isTextKind(step.kind) && Boolean(step.text?.trim()));
+	const showFallbackText = showText && !hasTextPayload && Boolean(fallbackText?.trim());
+	const pendingQuestionIndex = pendingQuestion
+		? flowSteps.findIndex((step) => !isTextKind(step.kind) && step.questionId === pendingQuestion.questionId)
+		: -1;
+	const questionnaireByToolCallId = useMemo(
+		() => new Map(answeredQuestionnaires.map((view) => [view.tool.toolCallId, view])),
+		[answeredQuestionnaires],
+	);
+	const matchedQuestionnaireIds = useMemo(
+		() => new Set(flowSteps.flatMap((step) => step.kind === "tool" && step.toolCallId ? [step.toolCallId] : [])),
+		[flowSteps],
+	);
+
+	const started = parseTraceTime(startedAt);
+	const finished = parseTraceTime(finishedAt);
+	const durationMs = isSending
+		? liveDuration(started, undefined, now)
+		: liveDuration(started, finished, now);
+	const showHeader = isSending || Boolean(error) || processSteps.length > 0;
+	const hasUnmatchedQuestionnaires = answeredQuestionnaires.some((view) => !matchedQuestionnaireIds.has(view.tool.toolCallId));
+	if (!showHeader && !flowSteps.length && !showFallbackText && !hasUnmatchedQuestionnaires && !pendingQuestion) return null;
+	// The step status is the source of truth for the live indicator. During a
+	// question pause or a reconnect, `isSending` can briefly be false while the
+	// trace still correctly reports a running/waiting step.
+	const currentLiveStep = [...processSteps].reverse().find((step) => isOpenStatus(step.status));
+
+	const toggle = (id: string) => {
+		setExpanded((current) => {
+			const next = new Set(current);
+			if (next.has(id)) next.delete(id);
+			else next.add(id);
+			return next;
+		});
+	};
+
+	return (
+		<div className="inno-trace-timeline" aria-label={t("chat.trace.timeline", "工作过程")}>
+			{showHeader ? (
+				<div className="inno-trace-work-status">
+					<Clock3 size={14} aria-hidden="true" />
+					<span>{workStatusText(isSending, terminalState, visibleSteps, t, error)}</span>
+					{durationMs !== undefined ? <span>· {formatDuration(durationMs, t)}</span> : null}
+				</div>
+			) : null}
+			<div className={showText ? "inno-trace-flow" : "inno-trace-list"} role="list">
+				{flowSteps.map((step, index) => {
+					if (isTextKind(step.kind)) {
+						return <TraceBody key={`trace-body:${index}:${step.id}`} content={step.text ?? ""} />;
+					}
+					const rowId = `trace-row:${index}:${step.id}`;
+					const questionnaire = showText && step.kind === "tool" && step.toolCallId
+						? questionnaireByToolCallId.get(step.toolCallId)
+						: undefined;
+					return (
+						<Fragment key={rowId}>
+							{pendingQuestionIndex === index ? (
+								<div className="inno-trace-questionnaire">
+									{pendingQuestion!.card}
+								</div>
+							) : null}
+							<TraceRow
+								step={step}
+								now={now}
+								isCurrentLiveStep={step === currentLiveStep}
+								expanded={expanded.has(rowId)}
+								onToggle={() => toggle(rowId)}
+								t={t}
+								onOpenSkill={onOpenSkill}
+							/>
+							{questionnaire ? (
+								<div className="inno-trace-questionnaire">
+									<AnsweredQuestionCard questionnaire={questionnaire.questionnaire} />
+								</div>
+							) : null}
+						</Fragment>
+					);
+				})}
+				{pendingQuestion && pendingQuestionIndex < 0 ? (
+					<div className="inno-trace-questionnaire">
+						{pendingQuestion.card}
+					</div>
+				) : null}
+				{showFallbackText ? (
+					<div className="inno-trace-fallback-body">
+						<TraceBody content={fallbackText ?? ""} />
+					</div>
+				) : null}
+				{showText ? answeredQuestionnaires.filter((view) => !matchedQuestionnaireIds.has(view.tool.toolCallId)).map((view) => (
+					<div className="inno-trace-questionnaire" key={`questionnaire:${view.tool.toolCallId}`}>
+						<AnsweredQuestionCard questionnaire={view.questionnaire} />
+					</div>
+				)) : null}
+			</div>
+		</div>
+	);
+}

--- a/apps/inno-agent/web/src/react/chat/ChatConversation.tsx
+++ b/apps/inno-agent/web/src/react/chat/ChatConversation.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useMemo, type PointerEvent as ReactPointerEvent, type ReactNode, type RefObject } from "react";
-import { motion } from "motion/react";
-import { Sparkles } from "lucide-react";
+import { ArrowDown, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { AttachmentRef, ChatMessage, ChatToolRecord, PendingQuestion } from "../../types/chat.js";
 import { workspaceFileUrl } from "../../api/workspace.js";
@@ -8,19 +7,24 @@ import { workspaceStore } from "../../stores/workspace-store.js";
 import { buildConversationTurns, ConversationMinimap } from "../ConversationMinimap.js";
 import { useStoreSnapshot } from "../hooks.js";
 import { Spinner } from "../ui/Spinner.js";
-import { QuestionDialog } from "../QuestionDialog.js";
-import { ErrorBlock, MessageBubble } from "./MessageBubble.js";
-import { CompletedToolRecords, StreamingBubbles } from "./StreamingBubbles.js";
+import { MessageBubble } from "./MessageBubble.js";
+import { StreamingBubbles } from "./StreamingBubbles.js";
 import { TodoWidget, extractTodoTasks } from "./TodoWidget.js";
+import { answeredQuestionnaireFromTool } from "../../utils/questionnaire.js";
+import type { AnsweredQuestionnaireView } from "../../utils/questionnaire.js";
+
+function traceContainsAssistantText(message: ChatMessage): boolean {
+	if (message.trace?.some((step) => (step.kind === "progress" || step.kind === "answer") && Boolean(step.text?.trim()))) return true;
+	return Boolean(message.traceEvents?.some((record) => (
+		record.event.type === "text_delta" && Boolean(record.event.delta.trim())
+	)));
+}
 
 interface ChatConversationProps {
 	chat: {
 		messages: ChatMessage[];
 		isSending: boolean;
 		isLoadingHistory: boolean;
-		streamingActivity: string;
-		streamingActivityDetail: string;
-		streamingError: string;
 		activeTools: ChatToolRecord[];
 		completedTools: ChatToolRecord[];
 		pendingQuestion: PendingQuestion | null;
@@ -31,6 +35,8 @@ interface ChatConversationProps {
 	onTouchStart: () => void;
 	onPointerDown: (event: ReactPointerEvent<HTMLDivElement>) => void;
 	onPauseAutoScroll: () => void;
+	showLatestButton: boolean;
+	onJumpToLatest: () => void;
 	questionHint: ReactNode;
 	busyBlocker: ReactNode;
 	smartToast: ReactNode;
@@ -51,6 +57,8 @@ export function ChatConversation({
 	onTouchStart,
 	onPointerDown,
 	onPauseAutoScroll,
+	showLatestButton,
+	onJumpToLatest,
 	questionHint,
 	busyBlocker,
 	smartToast,
@@ -63,10 +71,51 @@ export function ChatConversation({
 	wsError,
 }: ChatConversationProps) {
 	const { t } = useTranslation();
+	const conversationTurns = useMemo(() => buildConversationTurns(chat.messages), [chat.messages]);
 	const turnIndexByStartMessage = useMemo(
-		() => new Map(buildConversationTurns(chat.messages).map((turn) => [turn.startMessageIndex, turn.index])),
-		[chat.messages],
+		() => new Map(conversationTurns.map((turn) => [turn.startMessageIndex, turn.index])),
+		[conversationTurns],
 	);
+	const lastAssistantMessageIndexes = useMemo(() => {
+		const indexes = new Set<number>();
+		for (const turn of conversationTurns) {
+			for (let index = turn.endMessageIndex; index >= turn.startMessageIndex; index -= 1) {
+				if (chat.messages[index]?.role === "assistant") {
+					indexes.add(index);
+					break;
+				}
+			}
+		}
+		return indexes;
+	}, [chat.messages, conversationTurns]);
+	const activeTurnStartMessage = chat.isSending ? conversationTurns.at(-1)?.startMessageIndex : undefined;
+	const traceTurnPresentation = useMemo(() => {
+		const coveredAssistantIndexes = new Set<number>();
+		const actionOwnerIndexes = new Set<number>();
+		const questionnairesByOwner = new Map<number, AnsweredQuestionnaireView[]>();
+		for (const turn of conversationTurns) {
+			const assistantIndexes: number[] = [];
+			for (let index = turn.startMessageIndex; index <= turn.endMessageIndex; index += 1) {
+				if (chat.messages[index]?.role === "assistant") assistantIndexes.push(index);
+			}
+			const traceCandidates = assistantIndexes.filter((index) => {
+				const message = chat.messages[index];
+				return Boolean(message?.trace?.length || message?.traceEvents?.length) && traceContainsAssistantText(message);
+			});
+			const ownerIndex = traceCandidates.find((index) => Boolean(chat.messages[index]?.traceEvents?.length)) ?? traceCandidates.at(-1);
+			if (ownerIndex === undefined) continue;
+			actionOwnerIndexes.add(ownerIndex);
+			for (const index of assistantIndexes) {
+				if (index !== ownerIndex) coveredAssistantIndexes.add(index);
+			}
+			const questionnaires = assistantIndexes.flatMap((index) => (chat.messages[index]?.tools ?? []).flatMap((tool) => {
+				const questionnaire = answeredQuestionnaireFromTool(tool);
+				return questionnaire ? [{ tool, questionnaire }] : [];
+			}));
+			if (questionnaires.length) questionnairesByOwner.set(ownerIndex, questionnaires);
+		}
+		return { coveredAssistantIndexes, actionOwnerIndexes, questionnairesByOwner };
+	}, [chat.messages, conversationTurns]);
 	const todoTasks = useMemo(
 		() => extractTodoTasks(chat),
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -111,6 +160,15 @@ export function ChatConversation({
 							const multiChannel = channels.size > 1;
 							return chat.messages.map((message, index) => {
 								const turnIndex = turnIndexByStartMessage.get(index);
+								if (message.role === "assistant" && traceTurnPresentation.coveredAssistantIndexes.has(index)) return null;
+								// The canonical assistant record can arrive just before the
+								// terminal stream event. Keep the live trace as the only
+								// visible representation until the turn is finalized, so the
+								// trace does not briefly duplicate or change its geometry.
+								if (chat.isSending && index === chat.messages.length - 1 && message.role === "assistant") return null;
+								const isActiveTurnAssistant = activeTurnStartMessage !== undefined && index >= activeTurnStartMessage && message.role === "assistant";
+								const isTurnActionOwner = lastAssistantMessageIndexes.has(index) || traceTurnPresentation.actionOwnerIndexes.has(index);
+								const showActions = message.role === "user" || (isTurnActionOwner && !isActiveTurnAssistant);
 								return (
 									<div key={`${message.timestamp}-${index}`} data-conversation-turn={turnIndex}>
 										<MessageBubble
@@ -119,8 +177,10 @@ export function ChatConversation({
 											resolveAttachmentUrl={resolveAttachmentUrl}
 											onOpenAttachment={onOpenAttachment}
 											onOpenSkill={onOpenSkill}
-											onEdit={chat.isSending || chat.pendingQuestion ? undefined : onEditMessage}
+												onEdit={chat.isSending || chat.pendingQuestion ? undefined : onEditMessage}
 											showRetry={canRetry && index === chat.messages.length - 1}
+											showActions={showActions}
+											answeredQuestionnaires={traceTurnPresentation.questionnairesByOwner.get(index)}
 											onRetry={onRetry}
 										/>
 									</div>
@@ -128,54 +188,41 @@ export function ChatConversation({
 							});
 						})()}
 
-						{chat.isSending && chat.streamingActivity ? (
-							<motion.div className="flex justify-start" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2, ease: "easeOut" }}>
-								<div className="inno-message min-w-0 max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] text-[var(--inno-text-muted)] shadow-sm">
-									<div className="flex min-w-0 items-center gap-2">
-										<span className="inno-stream-status-dot is-streaming shrink-0" />
-										<Sparkles size={14} className="shrink-0 text-[var(--inno-accent)]" />
-										<span className="min-w-0 font-medium text-[var(--inno-text)]">{chat.streamingActivity}</span>
-										{chat.streamingActivityDetail ? <span className="min-w-0 truncate text-xs text-[var(--inno-text-subtle)]">{chat.streamingActivityDetail}</span> : null}
-									</div>
-								</div>
-							</motion.div>
-						) : null}
-
-						{chat.activeTools.length > 0 ? (
-							<motion.div className="flex justify-start" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2, ease: "easeOut" }}>
-								<div className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-accent-soft)] bg-[var(--inno-accent-soft)] px-3 py-2 text-[13px]">
-									{chat.activeTools.map((tool) => (
-										<div key={tool.toolCallId} className="flex min-w-0 items-center gap-2 text-[var(--inno-text-muted)]">
-											<Spinner size={12} className="shrink-0" />
-											<span className="min-w-0 break-words font-mono text-xs [overflow-wrap:anywhere]">{tool.toolName}</span>
-										</div>
-									))}
-								</div>
-							</motion.div>
-						) : null}
-
-						{chat.completedTools.length > 0 ? <CompletedToolRecords tools={chat.completedTools} /> : null}
-						<StreamingBubbles />
-
-						{chat.streamingError ? (
-							<motion.div className="flex justify-start" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2, ease: "easeOut" }}>
-								<div className="inno-message max-w-[78%]"><ErrorBlock error={chat.streamingError} /></div>
-							</motion.div>
-						) : null}
-
-						{chat.pendingQuestion ? <QuestionDialog pending={chat.pendingQuestion} /> : null}
+						<StreamingBubbles onOpenSkill={onOpenSkill} />
 					</div>
 				</div>
 				<ConversationMinimap messages={chat.messages} scrollContainerRef={scrollRef} onNavigateStart={onPauseAutoScroll} />
-			</div>
-
-			<div className="shrink-0 border-t border-[var(--inno-border)] bg-[var(--inno-surface)] p-3">
-				<div className="mx-auto max-w-3xl">
-					{questionHint}
-					{busyBlocker}
-					{todoTasks ? <TodoWidget tasks={todoTasks} /> : null}
-					{wsError ? <p className="mb-2 text-xs text-[var(--inno-danger)]">{wsError}</p> : null}
-					{composer}
+				<div className="inno-conversation-composer-layer">
+					{showLatestButton ? (
+						<div className="inno-latest-row">
+							<button
+								type="button"
+								className="inno-latest-button"
+								aria-label={t("chat.trace.jumpToLatest", "回到最新位置")}
+								onClick={onJumpToLatest}
+							>
+								<ArrowDown size={15} aria-hidden="true" />
+							</button>
+						</div>
+					) : null}
+					<div className="inno-conversation-composer-content mx-auto max-w-3xl">
+						{questionHint || busyBlocker ? (
+							<div className="inno-conversation-status-wrap">
+								<div className="inno-conversation-composer-mask" aria-hidden="true" />
+								<div className="inno-conversation-status-content">
+									{questionHint}
+									{busyBlocker}
+								</div>
+								<div className="inno-conversation-status-gap-mask" aria-hidden="true" />
+							</div>
+						) : null}
+						{todoTasks ? <TodoWidget tasks={todoTasks} /> : null}
+						{wsError ? <p className="mb-2 text-xs text-[var(--inno-danger)]">{wsError}</p> : null}
+						<div className="inno-conversation-composer-wrap">
+							<div className="inno-conversation-composer-mask" aria-hidden="true" />
+							{composer}
+						</div>
+					</div>
 				</div>
 			</div>
 		</section>

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.agent-command.test.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.agent-command.test.tsx
@@ -17,17 +17,17 @@ function renderCommand(content: string, onOpenSkill?: (skillName: string) => voi
 }
 
 describe("sent Agent command bubbles", () => {
-	it("uses the same sent bubble surface as file references", () => {
+	it("renders a user-side skill command bubble immediately after sending", () => {
 		const chip = renderCommand("/skill:backwards-design-unit-planner");
 
-		expect(chip).not.toBeNull();
-		expect(chip?.classList.contains("inno-smart-ref-word")).toBe(true);
-		expect(chip?.classList.contains("inno-smart-agent-surface")).toBe(true);
 		expect(chip?.textContent).toContain("backwards-design-unit-planner");
-		expect(chip?.textContent).not.toContain("/skill:");
-		expect(chip?.querySelector(".inno-smart-agent-mark")?.getAttribute("width")).toBe("11");
-		expect(chip?.getAttribute("title")).toBeNull();
-		expect(chip?.parentElement?.classList.contains("inno-smart-agent-ref-content")).toBe(true);
+	});
+
+	it("renders persisted expanded skill messages as the same compact bubble", () => {
+		const chip = renderCommand('<skill name="backwards-design-unit-planner" location="/tmp/SKILL.md">\nbody\n</skill>\n\n请帮我规划课程');
+
+		expect(chip?.textContent).toContain("backwards-design-unit-planner");
+		expect(document.querySelector(".inno-smart-agent-ref-args")?.textContent).toBe("请帮我规划课程");
 	});
 
 	it("keeps native command hints on non-skill bubbles", () => {
@@ -37,26 +37,53 @@ describe("sent Agent command bubbles", () => {
 		expect(chip?.getAttribute("title")).toBe("查找并回顾以前的对话");
 	});
 
-	it("opens the skill detail panel when its sent bubble is clicked", () => {
+	it("opens the skill detail panel from the assistant timeline row", () => {
 		let openedSkill = "";
-		const chip = renderCommand("/skill:backwards-design-unit-planner", (skillName) => { openedSkill = skillName; });
+		render(
+			<MessageBubble
+				message={{
+					role: "assistant",
+					content: "",
+					timestamp: Date.now(),
+					trace: [{
+						id: "skill:planner",
+						kind: "skill",
+						status: "completed",
+						title: "已载入技能 · backwards-design-unit-planner",
+						skillName: "backwards-design-unit-planner",
+						skillState: "expanded",
+					}],
+				}}
+				onOpenSkill={(skillName) => { openedSkill = skillName; }}
+			/>,
+		);
 
-		expect(chip?.tagName).toBe("BUTTON");
-		if (chip) fireEvent.click(chip);
+		fireEvent.click(document.querySelector<HTMLElement>(".inno-trace-row-toggle")!);
+		fireEvent.click(document.querySelector<HTMLElement>(".inno-trace-open-skill")!);
 		expect(openedSkill).toBe("backwards-design-unit-planner");
 	});
 
-	it("keeps the original thinking details surface", () => {
+	it("renders legacy thinking as a timeline row", () => {
 		render(
 			<MessageBubble
 				message={{ role: "assistant", content: "", thinking: "Planning", timestamp: Date.now() }}
 			/>,
 		);
 
-		const details = document.querySelector<HTMLElement>("details");
-		expect(details).not.toBeNull();
-		expect(details?.className).toBe("mb-2 min-w-0 max-w-full overflow-hidden rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1.5 text-xs text-[var(--inno-text-muted)]");
-		expect(details?.querySelector("summary")?.className).toContain("font-medium");
-		expect(details?.querySelector("summary")?.textContent).toContain("Thinking & tool calls");
+		const row = document.querySelector<HTMLElement>(".inno-trace-row");
+		expect(row).not.toBeNull();
+		expect(row?.textContent).toContain("思考");
+		expect(document.querySelector("details")).toBeNull();
+	});
+
+	it("can hide actions on an intermediate assistant fragment", () => {
+		render(
+			<MessageBubble
+				message={{ role: "assistant", content: "前一段", timestamp: Date.now() }}
+				showActions={false}
+			/>,
+		);
+
+		expect(document.querySelector(".inno-message-actions")).toBeNull();
 	});
 });

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
 import { X, AlertTriangle, FileCode2, History, BookmarkPlus, BookOpen, Check, Copy, Pencil, RotateCcw, TerminalSquare } from "lucide-react";
-import type { AttachmentBinding, AttachmentRef, ChatMessage, ChatToolRecord } from "../../types/chat.js";
+import type { AttachmentBinding, AttachmentRef, ChatMessage, ChatToolRecord, ChatTraceStep } from "../../types/chat.js";
 import { normalizeMarkdownMath } from "../../utils/markdown-math.js";
 import { splitContentByBindings } from "../../utils/attachment-render.js";
 import { answeredQuestionnaireFromTool, buildAnsweredQuestionnaireTimeline } from "../../utils/questionnaire.js";
@@ -13,9 +13,11 @@ import { MarkdownArtifact } from "../MarkdownArtifact.js";
 import { AnsweredQuestionCard } from "./AnsweredQuestionCard.js";
 import { FileName } from "../FileName.js";
 import { FileTypeIcon } from "../FileTypeIcon.js";
-import { collapseSkillMessage } from "./skill-message-collapse.js";
+import { skillMessageFromContent } from "./skill-message-collapse.js";
 import { parseAgentCommandMessage, type AgentCommandMessage } from "./agent-command-message.js";
 import { PopoverSurface } from "../ui/PopoverSurface.js";
+import { AgentTraceTimeline } from "./AgentTraceTimeline.js";
+import { finalizeTraceSteps, hasVisibleTraceSteps, traceStepsFromEvents, traceStepsFromLegacy, traceTerminalState } from "../../utils/chat-trace.js";
 
 // Pure, props-driven chat rendering components. This module must NOT import
 // stores or the api/ layer — apps/showcase reuses it to replay recorded
@@ -23,6 +25,49 @@ import { PopoverSurface } from "../ui/PopoverSurface.js";
 
 const LONG_ASSISTANT_CHARS = 6000;
 const LONG_ASSISTANT_LINES = 140;
+
+type RecordedMessageStreamSegment =
+	| { kind: "thinking"; text: string }
+	| { kind: "text"; text: string }
+	| { kind: "tool"; toolCallId: string; toolName: string; args: unknown; result?: unknown; isError?: boolean };
+
+function traceStepsFromRecordedStream(message: ChatMessage): ChatTraceStep[] | undefined {
+	const segments = (message as ChatMessage & { stream?: RecordedMessageStreamSegment[] }).stream;
+	if (!segments?.length) return undefined;
+	return segments.map((segment, index) => {
+		if (segment.kind === "thinking") {
+			return {
+				id: `recorded:thinking:${index}`,
+				kind: "thinking",
+				status: "completed",
+				title: "思考",
+				titleKey: "chat.trace.steps.thinking",
+				text: segment.text,
+			} satisfies ChatTraceStep;
+		}
+		if (segment.kind === "text") {
+			return {
+				id: `recorded:text:${index}`,
+				kind: "answer",
+				status: "completed",
+				title: "回复",
+				titleKey: "chat.trace.steps.reply",
+				text: segment.text,
+			} satisfies ChatTraceStep;
+		}
+		return {
+			id: `recorded:tool:${segment.toolCallId}:${index}`,
+			kind: "tool",
+			status: segment.isError ? "error" : "completed",
+			title: segment.toolName,
+			toolCallId: segment.toolCallId,
+			toolName: segment.toolName,
+			args: segment.args,
+			result: segment.result,
+			isError: segment.isError,
+		} satisfies ChatTraceStep;
+	});
+}
 
 const CHANNEL_BADGE_CLASS: Record<string, string> = {
 	cli: "bg-[var(--inno-surface-muted)] text-[var(--inno-text-muted)]",
@@ -440,7 +485,7 @@ export function ToolRecordDetails({ tool, className }: { tool: ChatToolRecord; c
 	);
 }
 
-export const MessageBubble = memo(function MessageBubble({ message, showChannel, resolveAttachmentUrl, onOpenAttachment, onOpenSkill, onEdit, showRetry, onRetry }: {
+export const MessageBubble = memo(function MessageBubble({ message, showChannel, resolveAttachmentUrl, onOpenAttachment, onOpenSkill, onEdit, showRetry, showActions = true, answeredQuestionnaires: suppliedQuestionnaires, onRetry }: {
 	message: ChatMessage;
 	showChannel?: boolean;
 	/** Optional URL resolver for attachment chips (workspace raw link). Kept as
@@ -454,19 +499,39 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 	onEdit?: (message: ChatMessage) => void;
 	/** Show the retry action in this message's action row. */
 	showRetry?: boolean;
+	/** Hide actions for assistant fragments that are not the last message in a turn. */
+	showActions?: boolean;
+	/** Optional whole-turn questionnaire views when a trace represents several assistant records. */
+	answeredQuestionnaires?: AnsweredQuestionnaireView[];
 	onRetry?: () => void;
 }) {
 	const { t } = useTranslation();
 	const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
 	const [copied, setCopied] = useState(false);
 	const copyResetTimerRef = useRef<number | null>(null);
-	const answeredQuestionnaires = (message.tools ?? []).flatMap((tool): AnsweredQuestionnaireView[] => {
+	const answeredQuestionnaires = suppliedQuestionnaires ?? (message.tools ?? []).flatMap((tool): AnsweredQuestionnaireView[] => {
 		const questionnaire = answeredQuestionnaireFromTool(tool);
 		return questionnaire ? [{ tool, questionnaire }] : [];
 	});
 	const hasAnsweredQuestionnaire = answeredQuestionnaires.length > 0;
-	const answeredToolCallIds = new Set(answeredQuestionnaires.map((view) => view.tool.toolCallId));
-	const regularTools = (message.tools ?? []).filter((tool) => !answeredToolCallIds.has(tool.toolCallId));
+	const terminalState = useMemo(
+		() => traceTerminalState(message.traceEvents, message.stopReason, message.error),
+		[message.error, message.stopReason, message.traceEvents],
+	);
+	const traceSteps = useMemo(() => {
+		if (message.trace?.length) return message.trace;
+		if (message.traceEvents?.length) {
+			const steps = traceStepsFromEvents(message.traceEvents);
+			return terminalState?.status === "unknown" ? steps : finalizeTraceSteps(steps);
+		}
+		const recordedStream = traceStepsFromRecordedStream(message);
+		if (recordedStream?.length) return recordedStream;
+		return traceStepsFromLegacy(message.content, message.thinking, message.tools);
+	}, [message.content, message.thinking, message.tools, message.trace, message.traceEvents, terminalState]);
+	// When process records exist, the trace renderer owns the whole assistant
+	// flow so text stays at its original position among thinking/tool rows.
+	const hasTraceTimeline = hasVisibleTraceSteps(traceSteps.filter((step) => step.kind !== "progress" && step.kind !== "answer"));
+	const hasTraceError = traceSteps.some((step) => step.kind === "error");
 	const messageTime = formatMessageTime(message.timestamp);
 
 	useEffect(() => () => {
@@ -489,7 +554,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 	};
 
 	if (message.role === "user") {
-		const skillMessage = collapseSkillMessage(message.content);
+		const skillMessage = skillMessageFromContent(message.content);
 		const agentCommandMessage = skillMessage
 			? { command: `skill:${skillMessage.skillName}`, args: skillMessage.args }
 			: parseAgentCommandMessage(message.content);
@@ -588,33 +653,33 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ duration: 0.25, ease: "easeOut" }}
 		>
-			<div className={`inno-message inno-assistant-message group relative min-w-0 ${hasAnsweredQuestionnaire ? "w-full max-w-[76%]" : "max-w-[78%]"} overflow-visible px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
+			<div className={`inno-message inno-assistant-message group relative min-w-0 ${hasTraceTimeline ? "inno-trace-assistant-message" : hasAnsweredQuestionnaire ? "w-full max-w-[76%]" : "max-w-[78%]"} ${showActions ? "" : "inno-assistant-message--no-actions"} overflow-visible px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
 				{showChannel && message.channel ? (
 					<div className="mb-1"><ChannelBadge channel={message.channel} /></div>
 				) : null}
-				{message.thinking || regularTools.length ? (
-					<details className="mb-2 min-w-0 max-w-full overflow-hidden rounded-md border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1.5 text-xs text-[var(--inno-text-muted)]">
-						<summary className="cursor-pointer select-none break-words font-medium text-[var(--inno-text-muted)] [overflow-wrap:anywhere]">
-							Thinking & tool calls
-							{regularTools.length ? ` · ${regularTools.length}` : ""}
-						</summary>
-						{message.thinking ? <pre className="mt-2 max-h-44 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono [overflow-wrap:anywhere]">{message.thinking}</pre> : null}
-						{regularTools.length ? (
-							<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
-								{regularTools.map((tool) => (
-									<ToolRecordDetails key={tool.toolCallId} tool={tool} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface)] px-2 py-1" />
-								))}
-							</div>
-						) : null}
-					</details>
-				) : null}
-				<AssistantTimelineContent content={message.content} questionnaires={answeredQuestionnaires} />
-				{message.error ? (
+				{hasTraceTimeline ? (
+					<div className="inno-trace-shell">
+						<AgentTraceTimeline
+							steps={traceSteps}
+							startedAt={message.traceStartedAt}
+							finishedAt={message.traceFinishedAt}
+							error={message.error}
+							terminalState={terminalState}
+							showText
+							fallbackText={message.content}
+							answeredQuestionnaires={answeredQuestionnaires}
+							onOpenSkill={onOpenSkill}
+						/>
+					</div>
+				) : (
+					<AssistantTimelineContent content={message.content} questionnaires={answeredQuestionnaires} />
+				)}
+				{message.error && !hasTraceError ? (
 					<div className={message.content.trim() ? "mt-2" : ""}>
 						<ErrorBlock error={message.error} />
 					</div>
 				) : null}
-				<div className="inno-message-actions">
+				{showActions ? <div className="inno-message-actions">
 					<button
 						type="button"
 						className="inno-message-action"
@@ -638,7 +703,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 					{messageTime ? (
 						<time dateTime={new Date(message.timestamp).toISOString()}>{messageTime}</time>
 					) : null}
-				</div>
+				</div> : null}
 			</div>
 		</motion.div>
 	);

--- a/apps/inno-agent/web/src/react/chat/StreamingBubbles.tsx
+++ b/apps/inno-agent/web/src/react/chat/StreamingBubbles.tsx
@@ -1,135 +1,59 @@
-import { Fragment, memo, useCallback, useMemo, useRef } from "react";
+import { useMemo } from "react";
 import { motion } from "motion/react";
-import { useTranslation } from "react-i18next";
-import type { ChatToolRecord } from "../../types/chat.js";
 import { chatStore } from "../../stores/chat-store.js";
-import { normalizeMarkdownMath } from "../../utils/markdown-math.js";
-import { splitStreamingMarkdown } from "../../utils/markdown-blocks.js";
-import { answeredQuestionnaireFromTool, buildAnsweredQuestionnaireTimeline } from "../../utils/questionnaire.js";
-import type { AnsweredQuestionnaireView } from "../../utils/questionnaire.js";
 import { useStoreSnapshot } from "../hooks.js";
-import { AnsweredQuestionCard } from "./AnsweredQuestionCard.js";
-import { MarkdownArtifact } from "../MarkdownArtifact.js";
-import { ToolRecordDetails } from "./MessageBubble.js";
+import { answeredQuestionnaireFromTool } from "../../utils/questionnaire.js";
+import type { AnsweredQuestionnaireView } from "../../utils/questionnaire.js";
+import { QuestionDialog } from "../QuestionDialog.js";
+import { AgentTraceTimeline } from "./AgentTraceTimeline.js";
 
-/** Closed streaming blocks are parsed once and never re-rendered. */
-const StableStreamingMarkdown = memo(function StableStreamingMarkdown({ content }: { content: string }) {
-	return <MarkdownArtifact content={content} />;
-});
-
-export function CompletedToolRecords({ tools }: { tools: ChatToolRecord[] }) {
-	const views = tools.map((tool) => ({ tool, questionnaire: answeredQuestionnaireFromTool(tool) }));
-	const regularTools = views.filter((item) => item.questionnaire === null).map((item) => item.tool);
-
-	return regularTools.length ? (
-		<motion.div
-			className="flex justify-start"
-			initial={{ opacity: 0 }}
-			animate={{ opacity: 1 }}
-			transition={{ duration: 0.2 }}
-		>
-			<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
-				<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Completed tool calls · {regularTools.length}</summary>
-				<div className="mt-2 grid min-w-0 max-w-full gap-1.5">
-					{regularTools.map((tool) => (
-						<ToolRecordDetails key={tool.toolCallId} tool={tool} className="min-w-0 max-w-full overflow-hidden rounded border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-2 py-1" />
-					))}
-				</div>
-			</details>
-		</motion.div>
-	) : null;
-}
-
-/** Owns the high-frequency streaming subscription so the page shell stays stable. */
-export function StreamingBubbles() {
-	const { t } = useTranslation();
+/** Render the live turn as one ordered flow. Text records stay in the same
+ * sequence as thinking and tool records instead of being painted as a
+ * separate answer block above the process timeline. */
+export function StreamingBubbles({ onOpenSkill }: { onOpenSkill?: (skillName: string) => void }) {
 	const stream = useStoreSnapshot(chatStore, () => ({
 		text: chatStore.streamingText,
-		thinking: chatStore.streamingThinking,
-		target: chatStore.streamingTarget,
-		isSending: chatStore.isSending,
-		hasError: chatStore.streamingError !== "",
-		hasPendingQuestion: chatStore.pendingQuestion !== null,
-		activeToolCount: chatStore.activeTools.length,
+		trace: chatStore.streamingTrace,
 		completedTools: chatStore.completedTools,
+		isSending: chatStore.isSending,
+		streamingError: chatStore.streamingError,
+		streamingStartedAt: chatStore.streamingStartedAt,
+		streamingFinishedAt: chatStore.streamingFinishedAt,
+		pendingQuestion: chatStore.pendingQuestion,
 	}));
 
 	const questionnaires = useMemo(() => stream.completedTools.flatMap((tool): AnsweredQuestionnaireView[] => {
 		const questionnaire = answeredQuestionnaireFromTool(tool);
 		return questionnaire ? [{ tool, questionnaire }] : [];
 	}), [stream.completedTools]);
-	const timeline = useMemo(
-		() => buildAnsweredQuestionnaireTimeline(stream.text, questionnaires),
-		[stream.text, questionnaires],
-	);
-	const normalized = useMemo(() => normalizeMarkdownMath(timeline.tail), [timeline.tail]);
-	const { blocks, tail } = useMemo(() => splitStreamingMarkdown(normalized), [normalized]);
+	const pendingQuestion = stream.pendingQuestion
+		? {
+			questionId: stream.pendingQuestion.questionId,
+			card: <QuestionDialog pending={stream.pendingQuestion} />,
+		}
+		: undefined;
 
-	// Keep the bubble at its tallest observed height while markdown is reparsed.
-	const heightWatermarkRef = useRef(0);
-	const bubbleObserverRef = useRef<ResizeObserver | null>(null);
-	const streamingBubbleRef = useCallback((el: HTMLDivElement | null) => {
-		bubbleObserverRef.current?.disconnect();
-		bubbleObserverRef.current = null;
-		if (!el) return;
-		heightWatermarkRef.current = 0;
-		el.style.minHeight = "";
-		const observer = new ResizeObserver(() => {
-			const height = el.offsetHeight;
-			if (height > heightWatermarkRef.current) heightWatermarkRef.current = height;
-			const minHeight = `${heightWatermarkRef.current}px`;
-			if (el.style.minHeight !== minHeight) el.style.minHeight = minHeight;
-		});
-		observer.observe(el);
-		bubbleObserverRef.current = observer;
-	}, []);
-
+	const hasText = Boolean(stream.text.trim());
+	if (!hasText && stream.trace.length === 0 && questionnaires.length === 0 && !pendingQuestion && !stream.streamingError && !stream.isSending) return null;
 	return (
-		<>
-			{stream.thinking ? (
-				<motion.div className="flex justify-start" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2, ease: "easeOut" }}>
-					<details className="inno-message min-w-0 max-w-[78%] overflow-hidden rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-xs text-[var(--inno-text-muted)]">
-						<summary className="cursor-pointer break-words [overflow-wrap:anywhere]">Thinking...</summary>
-						<pre className="mt-1 max-w-full overflow-auto whitespace-pre-wrap break-words font-mono [overflow-wrap:anywhere]">{stream.thinking}</pre>
-					</details>
-				</motion.div>
-			) : null}
-
-			{stream.text && stream.target === "workspace" ? (
-				<motion.div key="workspace-streaming-status" className="flex justify-start" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2, ease: "easeOut" }}>
-					<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface)] px-3 py-2 text-[13px] text-[var(--inno-text-muted)]">
-						<div className="flex min-w-0 items-center gap-2">
-							<span className="inno-stream-status-dot is-streaming shrink-0" />
-							<span className="min-w-0 break-words [overflow-wrap:anywhere]">{t("chat.streamingInWorkspace", "长内容正在右侧文件区生成")}</span>
-						</div>
-					</div>
-				</motion.div>
-			) : stream.text || questionnaires.length ? (
-				<motion.div key="chat-streaming-bubble" className="flex justify-start" initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.2, ease: "easeOut" }}>
-					<div ref={streamingBubbleRef} className={`inno-message inno-streaming-blocks ${questionnaires.length > 0 ? "w-full max-w-[76%]" : "max-w-[78%]"} px-3.5 py-2.5 text-[13px] leading-relaxed text-[var(--inno-text)]`}>
-						{timeline.entries.map(({ tool, questionnaire, before }) => (
-							<Fragment key={tool.toolCallId}>
-								{before.trim() ? <StableStreamingMarkdown content={normalizeMarkdownMath(before.trim())} /> : null}
-								<div className="my-2"><AnsweredQuestionCard questionnaire={questionnaire} /></div>
-							</Fragment>
-						))}
-						{blocks.map((block, index) => <StableStreamingMarkdown key={index} content={block} />)}
-						<MarkdownArtifact content={tail} />
-					</div>
-				</motion.div>
-			) : null}
-
-			{stream.isSending && !stream.hasPendingQuestion && !stream.text && questionnaires.length === 0 && !stream.hasError && stream.activeToolCount === 0 ? (
-				<motion.div className="flex justify-start" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.15 }}>
-					<div className="inno-message max-w-[78%] rounded-lg border border-[var(--inno-border)] bg-[var(--inno-surface-muted)] px-3 py-2 text-sm text-[var(--inno-text-muted)]">
-						<span className="inline-flex gap-1">
-							<span className="animate-bounce">·</span>
-							<span className="animate-bounce" style={{ animationDelay: "150ms" }}>·</span>
-							<span className="animate-bounce" style={{ animationDelay: "300ms" }}>·</span>
-						</span>
-					</div>
-				</motion.div>
-			) : null}
-		</>
+		<motion.div
+			className="inno-trace-shell inno-trace-shell-live"
+			initial={{ opacity: 0, y: 8 }}
+			animate={{ opacity: 1, y: 0 }}
+			transition={{ duration: 0.2, ease: "easeOut" }}
+		>
+			<AgentTraceTimeline
+				steps={stream.trace}
+				isSending={stream.isSending}
+				startedAt={stream.streamingStartedAt}
+				finishedAt={stream.streamingFinishedAt}
+				error={stream.streamingError}
+				showText
+				fallbackText={stream.text}
+				answeredQuestionnaires={questionnaires}
+				pendingQuestion={pendingQuestion}
+				onOpenSkill={onOpenSkill}
+			/>
+		</motion.div>
 	);
 }

--- a/apps/inno-agent/web/src/react/chat/TodoWidget.tsx
+++ b/apps/inno-agent/web/src/react/chat/TodoWidget.tsx
@@ -51,7 +51,16 @@ export function extractTodoTasks(chat: {
 	completedTools: ChatToolRecord[];
 }): TodoTaskItem[] | null {
 	let latest: TodoTaskItem[] | null = null;
-	for (const message of chat.messages) {
+	// A new user message starts a new turn. Do not carry the previous turn's
+	// snapshot into the composer while the next request is being prepared.
+	const lastUserMessageIndex = chat.messages.reduce(
+		(lastIndex, message, index) => message.role === "user" ? index : lastIndex,
+		-1,
+	);
+	const currentTurnMessages = lastUserMessageIndex >= 0
+		? chat.messages.slice(lastUserMessageIndex)
+		: chat.messages;
+	for (const message of currentTurnMessages) {
 		for (const tool of message.tools ?? []) {
 			const tasks = tasksFromToolRecord(tool);
 			if (tasks) latest = tasks;
@@ -127,8 +136,8 @@ export function TodoWidget({ tasks }: { tasks: TodoTaskItem[] }) {
 					>
 						<div className="max-h-56 overflow-y-auto px-3 py-2">
 							{visible.map((task) => (
-								<div key={task.id} className="flex items-start gap-2 py-1.5">
-									<span className="mt-0.5"><TaskStatusIcon task={task} /></span>
+								<div key={task.id} className="flex items-center gap-2 py-1.5">
+									<span className="shrink-0"><TaskStatusIcon task={task} /></span>
 									<div className="min-w-0 flex-1">
 										<span
 											className={`break-words text-[13px] leading-snug ${

--- a/apps/inno-agent/web/src/react/chat/skill-message-collapse.test.ts
+++ b/apps/inno-agent/web/src/react/chat/skill-message-collapse.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { collapseSkillMessage } from "./skill-message-collapse.js";
+import {
+	collapseSkillMessage,
+	isSkillCommandMessage,
+	parseSkillCommandMessage,
+	skillMessageFromContent,
+} from "./skill-message-collapse.js";
 
 const ENVELOPE = (body: string) => `<skill name="lesson-plan" location="/tmp/skills/lesson-plan/SKILL.md">\nReferences are relative to /tmp/skills/lesson-plan.\n\n${body}\n</skill>`;
 
@@ -29,5 +34,17 @@ describe("collapseSkillMessage", () => {
 	it("returns null for an unclosed or malformed envelope", () => {
 		expect(collapseSkillMessage('<skill name="x" location="y">\nbody')).toBeNull();
 		expect(collapseSkillMessage('<skill name="x">body</skill>')).toBeNull();
+	});
+
+	it("parses compact commands for history recovery", () => {
+		expect(parseSkillCommandMessage("/skill:review-code fix the bug")).toEqual({
+			skillName: "review-code",
+			args: "fix the bug",
+		});
+		expect(skillMessageFromContent("/skill review-code")).toEqual({
+			skillName: "review-code",
+			args: "",
+		});
+		expect(isSkillCommandMessage("/skill review-code")).toBe(true);
 	});
 });

--- a/apps/inno-agent/web/src/react/chat/skill-message-collapse.ts
+++ b/apps/inno-agent/web/src/react/chat/skill-message-collapse.ts
@@ -14,9 +14,27 @@ export interface CollapsedSkillMessage {
 //   <skill name="…" location="…">\n…\n</skill>            (no args)
 //   <skill name="…" location="…">\n…\n</skill>\n\n<args>  (with args)
 const SKILL_MESSAGE_RE = /^<skill name="([^"]+)" location="[^"]*">\n[\s\S]*?\n<\/skill>(?:\n\n([\s\S]+))?$/;
+const SKILL_COMMAND_RE = /^\/skill(?::|\s+)([^\s]+)(?:\s+([\s\S]+))?$/;
 
 export function collapseSkillMessage(text: string): CollapsedSkillMessage | null {
 	const match = SKILL_MESSAGE_RE.exec(text.trim());
 	if (!match) return null;
 	return { skillName: match[1], args: (match[2] ?? "").trim() };
+}
+
+export function parseSkillCommandMessage(text: string): CollapsedSkillMessage | null {
+	const match = SKILL_COMMAND_RE.exec(text.trim());
+	if (!match) return null;
+	return { skillName: match[1], args: (match[2] ?? "").trim() };
+}
+
+export function skillMessageFromContent(text: string): CollapsedSkillMessage | null {
+	return collapseSkillMessage(text) ?? parseSkillCommandMessage(text);
+}
+
+/** True for both the persisted expanded PI envelope and the compact command
+ * form used by the live composer. Both are represented by a timeline skill
+ * row instead of a user-side message bubble. */
+export function isSkillCommandMessage(text: string): boolean {
+	return Boolean(skillMessageFromContent(text));
 }

--- a/apps/inno-agent/web/src/stores/chat-store.test.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.test.ts
@@ -153,6 +153,33 @@ describe("ChatStore stream ownership", () => {
 		});
 	});
 
+	it("publishes an ask-user-question row as soon as tool-call generation begins", async () => {
+		let release!: () => void;
+		const toolCallFinished = new Promise<void>((resolve) => { release = resolve; });
+		let sawPreparingRow = false;
+		mocks.streamChat.mockImplementation(async function* () {
+			yield envelope(1, { type: "stream_state", status: "running" });
+			yield envelope(2, { type: "tool_call_start", toolCallId: "question-1", toolName: "ask_user_question" });
+			await toolCallFinished;
+			yield envelope(3, { type: "aborted", message: "Stopped", persisted: false });
+		});
+
+		const store = new ChatStoreImpl();
+		const unsubscribe = store.on("change", () => {
+			if (store.streamingTrace.some((step) => step.toolCallId === "question-1" && step.status === "preparing")) {
+				sawPreparingRow = true;
+			}
+		});
+		const sending = store.send("hello");
+		try {
+			await vi.waitFor(() => expect(sawPreparingRow).toBe(true));
+		} finally {
+			release();
+			unsubscribe();
+		}
+		await sending;
+	});
+
 	it("keeps opening the streaming preview when native window expansion is unavailable", async () => {
 		mocks.appStore.workspaceWidth = 520;
 		mocks.appStore.workspaceMode = "collapsed";

--- a/apps/inno-agent/web/src/stores/chat-store.test.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.test.ts
@@ -400,6 +400,43 @@ describe("ChatStore stream ownership", () => {
 		expect(store.pendingQuestion).toBeNull();
 	});
 
+	it("restores a hidden skill row from expanded cold-start history", () => {
+		const store = new ChatStoreImpl();
+		store.loadHistory([
+			{
+				role: "user",
+				content: '<skill name="lesson-plan" location="/tmp/skills/lesson-plan/SKILL.md">\nbody\n</skill>\n\n给初二学生讲一次函数',
+				timestamp: 1,
+			},
+			{ role: "assistant", content: "下面是一次函数的讲解。", timestamp: 2 },
+		], "session.jsonl");
+
+		expect(store.messages[1]).toMatchObject({
+			role: "assistant",
+			content: "下面是一次函数的讲解。",
+		});
+		expect(store.messages[1]?.trace).toEqual([
+			expect.objectContaining({
+				kind: "skill",
+				skillName: "lesson-plan",
+				skillArgs: "给初二学生讲一次函数",
+				skillState: "expanded",
+			}),
+		]);
+	});
+
+	it("restores a hidden skill row from a compact cold-start command", () => {
+		const store = new ChatStoreImpl();
+		store.loadHistory([
+			{ role: "user", content: "/skill:lesson-plan 给初二学生讲一次函数", timestamp: 1 },
+			{ role: "assistant", content: "下面是一次函数的讲解。", timestamp: 2 },
+		], "session.jsonl");
+
+		expect(store.messages[1]?.trace).toEqual([
+			expect.objectContaining({ kind: "skill", skillName: "lesson-plan", skillArgs: "给初二学生讲一次函数" }),
+		]);
+	});
+
 	it("rechecks isSending after the async session-store import", async () => {
 		let release!: () => void;
 		const gate = new Promise<void>((resolve) => { release = resolve; });

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -550,6 +550,12 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 					event.args,
 					"argsDelta" in event ? event.argsDelta : undefined,
 				);
+				// The trace row is created from the assistant's tool-call events,
+				// before the tool has finished generating its arguments or emitted
+				// the question event. Publish the start immediately so the row stays
+				// above the question card for the whole interaction.
+				if (event.type === "tool_call_delta") this.scheduleStreamChange();
+				else this.flushStreamChange();
 				break;
 			case "tool_start":
 				this.flushStreamChange();

--- a/apps/inno-agent/web/src/stores/chat-store.ts
+++ b/apps/inno-agent/web/src/stores/chat-store.ts
@@ -1,11 +1,13 @@
 import { EventEmitter } from "./event-emitter.js";
 import { streamChat, abortChat, getChatStatus, streamSessionEvents, submitChatQuestion, formatQuestionnaireAsPrompt } from "../api/chat.js";
 import type { InlineImage } from "../api/chat.js";
-import type { ChatAttachments, ChatMessage, ChatStreamEvent, ChatToolRecord, PendingQuestion, QuestionnaireResult, StreamEventEnvelope, StreamSnapshot, WorkspaceFileChange } from "../types/chat.js";
+import type { ChatAttachments, ChatMessage, ChatStreamEvent, ChatToolRecord, ChatTraceStep, PendingQuestion, QuestionnaireResult, StreamEventEnvelope, StreamSnapshot, WorkspaceFileChange } from "../types/chat.js";
 import { notebookStore } from "./notebook-store.js";
 import { appStore } from "./app-store.js";
 import { workspaceStore, type StreamingWorkspacePreview } from "./workspace-store.js";
 import { ensureWindowForPanel } from "./window-expansion.js";
+import { applyChatTraceEvent, finalizeTraceSteps, traceStepsFromEvents, traceTerminalState } from "../utils/chat-trace.js";
+import { skillMessageFromContent } from "../react/chat/skill-message-collapse.js";
 
 function hasAttachmentFiles(attachments?: ChatAttachments): boolean {
 	return Boolean(attachments && (attachments.bindings.some((binding) => binding.files.length > 0) || attachments.loose.length > 0));
@@ -68,6 +70,10 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 	isLoadingHistory = false;
 	streamingText = "";
 	streamingThinking = "";
+	/** Ordered logical process rows for the in-flight PI turn. */
+	streamingTrace: ChatTraceStep[] = [];
+	streamingStartedAt: string | null = null;
+	streamingFinishedAt: string | null = null;
 	streamingTarget: StreamingTarget = "chat";
 	streamingActivity = "";
 	streamingActivityDetail = "";
@@ -131,6 +137,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			complete: false,
 		}];
 		this.resetTransientStreamState();
+		this.streamingStartedAt = new Date().toISOString();
 		this.isSending = true;
 		this.setStreamingActivity("正在分析请求");
 		this.wikiInvalidated = false;
@@ -234,6 +241,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		}
 		this.currentSessionContext = sessionId;
 		this.resetTransientStreamState();
+		this.streamingStartedAt = stream.startedAt ?? stream.createdAt;
 		this.isSending = true;
 		this.streamingActivity = "正在恢复生成";
 		const controller = new AbortController();
@@ -358,7 +366,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		if (owner.turnId !== envelope.turnId || envelope.eventId <= owner.lastAppliedEventId) return;
 		owner.lastAppliedEventId = envelope.eventId;
 		if (envelope.event.type === "stream_state" && envelope.event.status === "running") owner.phase = "streaming";
-		this._handleStreamEvent(envelope.event, owner);
+		this._handleStreamEvent(envelope.event, owner, envelope.occurredAt);
 		if (!["done", "error", "aborted"].includes(envelope.event.type)) return;
 		await this.handleTerminal(owner, envelope.event as TerminalChatStreamEvent);
 	}
@@ -387,7 +395,34 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				const countMatches = finalMessageCount !== undefined && session.messageCount >= finalMessageCount;
 				const revisionMatches = Boolean(finalRevision) && session.sessionRevision === finalRevision;
 				if (countMatches || revisionMatches) {
-					this.messages = session.messages.map((message) => ({ ...message, complete: true, transient: false }));
+					const history = this.withTraceMessages(session.messages);
+					// Showcase replay and older servers do not return the new sidecar
+					// fields. Keep the just-rendered live trace attached to the newest
+					// canonical assistant message so the timeline does not disappear at
+					// the done -> history swap boundary.
+					let assistantIndex = -1;
+					for (let index = history.length - 1; index >= 0; index -= 1) {
+						if (history[index]?.role === "assistant") {
+							assistantIndex = index;
+							break;
+						}
+					}
+					const canonicalTrace = assistantIndex >= 0 ? history[assistantIndex] : undefined;
+					const hasCanonicalTrace = Boolean(
+						canonicalTrace?.traceEvents?.length
+						|| canonicalTrace?.trace?.some((step) => step.kind !== "skill"),
+					);
+					if (this.streamingTrace.length && !hasCanonicalTrace) {
+						if (assistantIndex >= 0) {
+							history[assistantIndex] = {
+								...history[assistantIndex]!,
+								trace: finalizeTraceSteps(this.streamingTrace),
+								traceStartedAt: this.streamingStartedAt ?? undefined,
+								traceFinishedAt: this.streamingFinishedAt ?? new Date().toISOString(),
+							};
+						}
+					}
+					this.messages = history.map((message) => ({ ...message, complete: true, transient: false }));
 					this.emit("change", undefined);
 					return true;
 				}
@@ -399,6 +434,51 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		return false;
 	}
 
+	private withTraceMessages(messages: ChatMessage[]): ChatMessage[] {
+		const tracedMessages = messages.map((message) => {
+			if (message.role !== "assistant" || message.trace || !message.traceEvents?.length) return message;
+			const terminalState = traceTerminalState(message.traceEvents, message.stopReason, message.error);
+			const traceSteps = traceStepsFromEvents(message.traceEvents);
+			return {
+				...message,
+				trace: terminalState?.status === "unknown" ? traceSteps : finalizeTraceSteps(traceSteps),
+			};
+		});
+
+		// Skill user messages are intentionally hidden in the conversation. If a
+		// cold-start history predates trace sidecars (or the sidecar is missing),
+		// keep the skill invocation visible in the assistant timeline instead of
+		// losing both the skill row and the answer that follows it.
+		return tracedMessages.map((message, index) => {
+			if (message.role !== "assistant") return message;
+
+			const skillMessage = skillMessageFromContent(tracedMessages[index - 1]?.content ?? "");
+			if (!skillMessage) return message;
+
+			const hasSkillStep = message.trace?.some(
+				(step) => step.kind === "skill" && step.skillName === skillMessage.skillName,
+			);
+			if (hasSkillStep) return message;
+
+			const skillStep: ChatTraceStep = {
+				id: `skill:restored:${index}:${skillMessage.skillName}`,
+				kind: "skill",
+				status: "completed",
+				title: `已展开技能 · ${skillMessage.skillName}`,
+				titleKey: "chat.trace.steps.skillExpanded",
+				titleParams: { skillName: skillMessage.skillName },
+				skillName: skillMessage.skillName,
+				...(skillMessage.args ? { skillArgs: skillMessage.args } : {}),
+				skillState: "expanded",
+			};
+
+			return {
+				...message,
+				trace: [skillStep, ...(message.trace ?? [])],
+			};
+		});
+	}
+
 	private materializeTransientTurn(owner: ActiveStreamOwner, error: string): void {
 		if (!this.owns(owner)) return;
 		this.messages = [...this.messages, {
@@ -407,6 +487,9 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 			timestamp: Date.now(),
 			thinking: this.streamingThinking || undefined,
 			tools: this.completedTools.length ? this.completedTools : undefined,
+			trace: this.streamingTrace.length ? finalizeTraceSteps(this.streamingTrace) : undefined,
+			traceStartedAt: this.streamingStartedAt ?? undefined,
+			traceFinishedAt: this.streamingFinishedAt ?? new Date().toISOString(),
 			error,
 			turnId: owner.turnId ?? undefined,
 			transient: true,
@@ -436,7 +519,14 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		void import("./sessions-store.js").then((module) => module.sessionsStore.refreshUntilTopic(owner.sessionId));
 	}
 
-	private _handleStreamEvent(event: ChatStreamEvent, owner: ActiveStreamOwner) {
+	private _handleStreamEvent(event: ChatStreamEvent, owner: ActiveStreamOwner, occurredAt?: string) {
+		this.streamingTrace = applyChatTraceEvent(this.streamingTrace, event, occurredAt);
+		if (event.type === "stream_state" && event.status === "running" && occurredAt) {
+			this.streamingStartedAt = occurredAt;
+		}
+		if (["done", "error", "aborted"].includes(event.type)) {
+			this.streamingFinishedAt = occurredAt ?? new Date().toISOString();
+		}
 		switch (event.type) {
 			case "stream_state":
 				this.setStreamingActivity(event.status === "queued" ? "等待执行" : "正在分析请求");
@@ -451,23 +541,55 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 				this.streamingThinking += event.delta;
 				this.scheduleStreamChange();
 				break;
+			case "tool_call_start":
 			case "tool_call_delta":
-				this.maybePrepareFileToolPreview(event.toolCallId, event.toolName, event.args, event.argsDelta);
+			case "tool_call_end":
+				this.maybePrepareFileToolPreview(
+					event.toolCallId,
+					event.toolName,
+					event.args,
+					"argsDelta" in event ? event.argsDelta : undefined,
+				);
 				break;
 			case "tool_start":
 				this.flushStreamChange();
 				this.maybeStartFileToolPreview(event.toolCallId, event.toolName, event.args);
-				this.activeTools = [...this.activeTools.filter((tool) => tool.toolCallId !== event.toolCallId), {
-					toolCallId: event.toolCallId,
-					toolName: event.toolName,
+					this.activeTools = [...this.activeTools.filter((tool) => tool.toolCallId !== event.toolCallId), {
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
 					// Questionnaire options sit one level deeper than the generic tool
 					// payload compactor keeps. Preserve this small, bounded payload so
 					// the completed card can render every option immediately.
 					args: event.toolName === "ask_user_question" ? event.args : compactToolPayload(event.args),
 					contentOffset: this.streamingText.length,
 				}];
-				this.emit("change", undefined);
+					this.emit("change", undefined);
+					break;
+			case "tool_update": {
+				if (event.args !== undefined) {
+					this.maybePrepareFileToolPreview(event.toolCallId, event.toolName, event.args);
+				}
+				const existingTool = this.activeTools.find((tool) => tool.toolCallId === event.toolCallId);
+				const updatedTool: ChatToolRecord = {
+					...(existingTool ?? {
+						toolCallId: event.toolCallId,
+						toolName: event.toolName,
+						args: undefined,
+						contentOffset: this.streamingText.length,
+					}),
+					toolName: event.toolName || existingTool?.toolName || "tool",
+					...(event.args !== undefined
+						? { args: event.toolName === "ask_user_question" ? event.args : compactToolPayload(event.args) }
+						: {}),
+					...(event.partialResult !== undefined ? { partialResult: compactToolPayload(event.partialResult) } : {}),
+				};
+				this.activeTools = [
+					...this.activeTools.filter((tool) => tool.toolCallId !== event.toolCallId),
+					updatedTool,
+				];
+				this.scheduleStreamChange();
 				break;
+			}
 			case "tool_end":
 				this.flushStreamChange();
 				this.maybeFinishFileToolPreview(event.toolCallId, event.toolName, event.result, event.isError, owner);
@@ -562,6 +684,9 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 		this.resetStreamTimers();
 		this.streamingText = "";
 		this.streamingThinking = "";
+		this.streamingTrace = [];
+		this.streamingStartedAt = null;
+		this.streamingFinishedAt = null;
 		this.streamingTarget = "chat";
 		this.streamingActivity = "";
 		this.streamingActivityDetail = "";
@@ -789,7 +914,7 @@ export class ChatStoreImpl extends EventEmitter<ChatStoreEvents> {
 
 	loadHistory(messages: ChatMessage[], sessionId?: string) {
 		this.isLoadingHistory = false;
-		this.messages = messages;
+		this.messages = this.withTraceMessages(messages);
 		this.isSending = false;
 		this.canReconnect = false;
 		this.currentSessionContext = sessionId ?? null;

--- a/apps/inno-agent/web/src/types/chat.ts
+++ b/apps/inno-agent/web/src/types/chat.ts
@@ -7,7 +7,17 @@ export interface ChatMessage {
 	entryId?: string;
 	parentEntryId?: string | null;
 	thinking?: string;
+	/** PI's persisted assistant termination reason, used for legacy trace replay. */
+	stopReason?: string;
 	tools?: ChatToolRecord[];
+	/** Ordered PI-derived process records. Older messages may only have the
+	 * aggregate thinking/tools fields above. */
+	trace?: ChatTraceStep[];
+	/** Raw normalized stream records persisted in the UI sidecar. Kept separate
+	 * from `trace` so the same reducer can rebuild live and historical rows. */
+	traceEvents?: ChatTraceEventRecord[];
+	traceStartedAt?: string;
+	traceFinishedAt?: string;
 	channel?: string;
 	images?: Array<{ previewUrl: string; mimeType: string }>;
 	/** Structured attachments sent with this user turn (keyword-bubble
@@ -50,6 +60,8 @@ export interface ChatToolRecord {
 	args: unknown;
 	/** Character offset in the assistant text at which the tool was called. */
 	contentOffset?: number;
+	/** Latest partial result while the tool is still running. */
+	partialResult?: unknown;
 	result?: unknown;
 	isError?: boolean;
 }
@@ -57,6 +69,49 @@ export interface ChatToolRecord {
 export interface WorkspaceFileChange {
 	path: string;
 	change: "created" | "modified" | "deleted";
+}
+
+export type ChatTraceStepKind = "thinking" | "progress" | "answer" | "tool" | "skill" | "system" | "error";
+export type ChatTraceStepStatus = "active" | "preparing" | "running" | "waiting" | "completed" | "error";
+
+/** One visible, expandable row in the PI process timeline. */
+export interface ChatTraceStep {
+	id: string;
+	kind: ChatTraceStepKind;
+	status: ChatTraceStepStatus;
+	title: string;
+	/** Locale key for generated UI titles. `title` remains the fallback/raw text. */
+	titleKey?: string;
+	titleParams?: Record<string, string | number>;
+	text?: string;
+	/** A short live summary separate from the full expandable payload. */
+	summary?: string;
+	toolCallId?: string;
+	toolName?: string;
+	args?: unknown;
+	argsText?: string;
+	/** Latest partial result emitted during tool execution. */
+	partialResult?: unknown;
+	result?: unknown;
+	isError?: boolean;
+	questionId?: string;
+	questionParams?: { questions: QuestionData[] };
+	skillName?: string;
+	skillArgs?: string;
+	skillSource?: string;
+	skillPath?: string;
+	skillDescription?: string;
+	skillState?: "loaded" | "expanded";
+	eventType?: string;
+	eventPhase?: "start" | "update" | "end";
+	eventDetail?: unknown;
+	workspaceChanges?: WorkspaceFileChange[];
+	attempt?: number;
+	contentIndex?: number;
+	preparationStartedAt?: number;
+	startedAt?: number;
+	endedAt?: number;
+	durationMs?: number;
 }
 
 // --- Question types ---
@@ -138,20 +193,45 @@ export interface StreamEventEnvelope {
 	sessionId: string;
 	turnId: string;
 	clientRequestId: string;
+	/** Stable UI trace identity for this PI turn; older servers may omit it. */
+	traceId?: string;
+	/** Server-side time at which the normalized PI event was published. */
+	occurredAt?: string;
 	event: ChatStreamEvent;
 }
 
 // Turn-scoped SSE event types
-export type ChatStreamEvent =
+export type ChatStreamEvent = (
 	| { type: "stream_state"; status: "queued" | "running" }
-	| { type: "text_delta"; delta: string }
-	| { type: "thinking_delta"; delta: string }
-	| { type: "tool_call_delta"; toolCallId: string; toolName: string; args?: unknown; argsDelta?: string }
-	| { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
-	| { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean }
+	| { type: "text_start"; contentIndex?: number }
+	| { type: "text_delta"; delta: string; contentIndex?: number }
+	| { type: "text_end"; contentIndex?: number }
+	| { type: "thinking_start"; contentIndex?: number }
+	| { type: "thinking_delta"; delta: string; contentIndex?: number }
+	| { type: "thinking_end"; contentIndex?: number }
+	| { type: "tool_call_start"; toolCallId: string; toolName: string; contentIndex?: number; args?: unknown }
+	| { type: "tool_call_delta"; toolCallId: string; toolName: string; contentIndex?: number; args?: unknown; argsDelta?: string }
+		| { type: "tool_call_end"; toolCallId: string; toolName: string; contentIndex?: number; args?: unknown }
+		| { type: "tool_start"; toolCallId: string; toolName: string; args?: unknown; contentIndex?: number }
+		| { type: "tool_update"; toolCallId: string; toolName: string; args?: unknown; partialResult?: unknown; contentIndex?: number }
+		| { type: "tool_end"; toolCallId: string; toolName: string; result: unknown; isError: boolean; contentIndex?: number }
 	| { type: "workspace_change"; changes: WorkspaceFileChange[]; toolCallId?: string; toolName?: string; workspaceId?: string; truncated?: boolean }
-	| { type: "question"; questionId: string; params: { questions: QuestionData[] } }
+	| { type: "question"; questionId: string; params: { questions: QuestionData[] }; toolCallId?: string }
 	| { type: "question_resolved"; questionId: string; cancelled?: boolean; error?: string }
+	| { type: "skill_loaded"; count: number; skills?: Array<{ name: string; description?: string; path?: string; source?: string }> }
+	| { type: "skill_invoked"; skillName: string; args?: string; source?: string; path?: string; description?: string }
+	| { type: "system_event"; eventType: string; phase?: "start" | "update" | "end"; summary?: string; detail?: unknown; attempt?: number; success?: boolean }
 	| { type: "done"; fullText: string; persisted: true; finalMessageCount: number; finalSessionRevision: string }
 	| { type: "error"; message: string; code?: string; persisted: boolean; finalMessageCount?: number; finalSessionRevision?: string }
-	| { type: "aborted"; message?: string; persisted: boolean; finalMessageCount?: number; finalSessionRevision?: string };
+	| { type: "aborted"; message?: string; persisted: boolean; finalMessageCount?: number; finalSessionRevision?: string }
+) & {
+	/** Original PI event name before the server's UI normalization. */
+	piEventType?: string;
+};
+
+export interface ChatTraceEventRecord {
+	eventId?: number;
+	traceId?: string;
+	occurredAt?: string;
+	event: ChatStreamEvent;
+}

--- a/apps/inno-agent/web/src/utils/chat-trace.test.ts
+++ b/apps/inno-agent/web/src/utils/chat-trace.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import type { ChatStreamEvent, ChatTraceStep } from "../types/chat.js";
+import {
+	applyChatTraceEvent,
+	finalizeTraceSteps,
+	traceStepsFromEvents,
+	traceTerminalState,
+	visibleTraceSteps,
+} from "./chat-trace.js";
+
+const at = (seconds: number): string => `2026-09-01T00:00:${String(seconds).padStart(2, "0")}.000Z`;
+
+function apply(events: Array<[ChatStreamEvent, number]>): ChatTraceStep[] {
+	return events.reduce(
+		(steps, [event, seconds]) => applyChatTraceEvent(steps, event, at(seconds)),
+		[] as ChatTraceStep[],
+	);
+}
+
+describe("PI chat trace reducer", () => {
+	it("keeps native thinking blocks separate and measures only native boundaries", () => {
+		const steps = apply([
+			[{ type: "thinking_start", contentIndex: 0 }, 0],
+			[{ type: "thinking_delta", contentIndex: 0, delta: "先判断" }, 1],
+			[{ type: "thinking_end", contentIndex: 0 }, 2],
+			[{ type: "thinking_start", contentIndex: 1 }, 3],
+			[{ type: "thinking_delta", contentIndex: 1, delta: "再验证" }, 4],
+			[{ type: "thinking_end", contentIndex: 1 }, 5],
+		]);
+
+		expect(steps).toHaveLength(2);
+		expect(steps[0]).toMatchObject({ kind: "thinking", text: "先判断", status: "completed", durationMs: 2_000 });
+		expect(steps[1]).toMatchObject({ kind: "thinking", text: "再验证", status: "completed", durationMs: 2_000 });
+	});
+
+	it("keeps a streamed tool call in one row through preparation and execution", () => {
+		const preparing = apply([
+			[{ type: "tool_call_start", toolCallId: "t1", toolName: "read_file" }, 0],
+			[{ type: "tool_call_delta", toolCallId: "t1", toolName: "read_file", argsDelta: '{"path":"notes' }, 1],
+			[{ type: "tool_call_delta", toolCallId: "t1", toolName: "read_file", argsDelta: '.md"}' }, 2],
+		]);
+		expect(preparing).toHaveLength(1);
+		expect(preparing[0]).toMatchObject({ status: "preparing", argsText: '{"path":"notes.md"}' });
+
+		const completed = apply([
+			[{ type: "tool_call_start", toolCallId: "t1", toolName: "read_file" }, 0],
+			[{ type: "tool_call_delta", toolCallId: "t1", toolName: "read_file", argsDelta: '{"path":"notes.md"}' }, 1],
+			[{ type: "tool_call_end", toolCallId: "t1", toolName: "read_file", args: { path: "notes.md" } }, 2],
+			[{ type: "tool_start", toolCallId: "t1", toolName: "read_file", args: { path: "notes.md" } }, 3],
+			[{ type: "tool_update", toolCallId: "t1", toolName: "read_file", partialResult: { content: [{ type: "text", text: "正在读取" }] } }, 4],
+			[{ type: "tool_end", toolCallId: "t1", toolName: "read_file", result: "contents", isError: false }, 6],
+		]);
+		expect(completed).toHaveLength(1);
+		expect(completed[0]).toMatchObject({
+			status: "completed",
+			args: { path: "notes.md" },
+			partialResult: { content: [{ type: "text", text: "正在读取" }] },
+			result: "contents",
+			durationMs: 3_000,
+		});
+	});
+
+	it("stops a thinking timer when final text starts without thinking_end", () => {
+		const steps = apply([
+			[{ type: "thinking_start", contentIndex: 0 }, 0],
+			[{ type: "thinking_delta", contentIndex: 0, delta: "先分析" }, 1],
+			[{ type: "text_start", contentIndex: 1 }, 2],
+			[{ type: "text_delta", contentIndex: 1, delta: "最终答案" }, 3],
+		]);
+
+		expect(steps[0]).toMatchObject({
+			kind: "thinking",
+			status: "completed",
+			endedAt: Date.parse(at(2)),
+			durationMs: 2_000,
+		});
+		expect(steps[1]).toMatchObject({ kind: "answer", text: "最终答案", status: "active" });
+	});
+
+	it("separates progress text before the last tool from the final answer", () => {
+		const steps = apply([
+			[{ type: "text_start", contentIndex: 0 }, 0],
+			[{ type: "text_delta", contentIndex: 0, delta: "先查资料" }, 1],
+			[{ type: "text_end", contentIndex: 0 }, 2],
+			[{ type: "tool_call_start", toolCallId: "t1", toolName: "search" }, 3],
+			[{ type: "tool_start", toolCallId: "t1", toolName: "search" }, 4],
+			[{ type: "tool_end", toolCallId: "t1", toolName: "search", result: [], isError: false }, 5],
+			[{ type: "text_start", contentIndex: 1 }, 6],
+			[{ type: "text_delta", contentIndex: 1, delta: "最终结论" }, 7],
+			[{ type: "text_end", contentIndex: 1 }, 8],
+		]);
+		const finalized = finalizeTraceSteps(steps);
+
+		expect(finalized.map((step) => step.kind)).toEqual(["progress", "tool", "answer"]);
+	});
+
+	it("preserves each retry attempt instead of overwriting a failed tool row", () => {
+		const steps = finalizeTraceSteps(apply([
+			[{ type: "tool_call_start", toolCallId: "retry", toolName: "search" }, 0],
+			[{ type: "tool_start", toolCallId: "retry", toolName: "search" }, 1],
+			[{ type: "tool_end", toolCallId: "retry", toolName: "search", result: "timeout", isError: true }, 2],
+			[{ type: "system_event", eventType: "auto_retry_start", phase: "start", attempt: 2 }, 3],
+			[{ type: "tool_call_start", toolCallId: "retry", toolName: "search" }, 4],
+			[{ type: "tool_start", toolCallId: "retry", toolName: "search" }, 5],
+			[{ type: "tool_end", toolCallId: "retry", toolName: "search", result: "ok", isError: false }, 6],
+		]));
+		const tools = steps.filter((step) => step.kind === "tool");
+
+		expect(tools).toHaveLength(2);
+		expect(tools[0]).toMatchObject({ status: "error", result: "timeout", isError: true });
+		expect(tools[1]).toMatchObject({ status: "completed", result: "ok", attempt: 2 });
+		expect(steps.some((step) => step.kind === "system" && step.attempt === 2)).toBe(true);
+	});
+
+	it("attaches questions, skills, system events, and workspace changes to the timeline", () => {
+		const steps = finalizeTraceSteps(apply([
+			[{ type: "skill_loaded", count: 2, skills: [{ name: "docs" }] }, 0],
+			[{ type: "skill_invoked", skillName: "docs", args: "read report", source: "workspace" }, 1],
+			[{ type: "system_event", eventType: "compaction_start", phase: "start" }, 2],
+			[{ type: "system_event", eventType: "compaction_end", phase: "end", success: true }, 3],
+			[{ type: "tool_call_start", toolCallId: "ask", toolName: "ask_user_question" }, 4],
+			[{ type: "tool_start", toolCallId: "ask", toolName: "ask_user_question" }, 5],
+			[{ type: "question", questionId: "q1", toolCallId: "ask", params: { questions: [] } }, 6],
+			[{ type: "workspace_change", toolCallId: "ask", changes: [{ path: "report.md", change: "modified" }] }, 7],
+			[{ type: "question_resolved", questionId: "q1" }, 8],
+			[{ type: "tool_end", toolCallId: "ask", toolName: "ask_user_question", result: "answer", isError: false }, 9],
+		]));
+
+		expect(steps.find((step) => step.id === "skill:loaded")).toMatchObject({ title: "已预载 2 个技能" });
+		expect(steps.find((step) => step.kind === "skill" && step.skillState === "expanded")).toMatchObject({ skillName: "docs" });
+		expect(steps.some((step) => step.kind === "system" && step.eventType === "compaction_start" && step.durationMs === 1_000)).toBe(true);
+		expect(steps.find((step) => step.toolCallId === "ask")).toMatchObject({ status: "completed", workspaceChanges: [{ path: "report.md", change: "modified" }] });
+	});
+
+	it("reuses the open question tool when a question event has no tool id", () => {
+		const waiting = apply([
+			[{ type: "tool_start", toolCallId: "ask", toolName: "ask_user_question", args: { questions: [] } }, 0],
+			[{ type: "question", questionId: "q1", params: { questions: [] } }, 1],
+			[{ type: "question_resolved", questionId: "q1" }, 2],
+		]);
+
+		expect(waiting.filter((step) => step.kind === "tool")).toHaveLength(1);
+		expect(waiting[0]).toMatchObject({
+			toolCallId: "ask",
+			questionId: "q1",
+			status: "running",
+		});
+
+		const completed = applyChatTraceEvent(
+			waiting,
+			{ type: "tool_end", toolCallId: "ask", toolName: "ask_user_question", result: "answer", isError: false },
+			at(3),
+		);
+		expect(completed).toHaveLength(1);
+		expect(completed[0]).toMatchObject({ toolCallId: "ask", status: "completed", result: "answer" });
+	});
+
+	it("does not create a row for an empty skill inventory and hides PI bookkeeping", () => {
+		const steps = apply([
+			[{ type: "skill_loaded", count: 0, skills: [] }, 0],
+			[{ type: "system_event", eventType: "turn_start", phase: "start" }, 1],
+			[{ type: "system_event", eventType: "agent_start", phase: "start" }, 2],
+			[{ type: "system_event", eventType: "message_start", phase: "start" }, 3],
+			[{ type: "system_event", eventType: "message_start", summary: "Request was aborted", detail: { stopReason: "aborted" } }, 4],
+		]);
+
+		expect(steps.some((step) => step.kind === "skill")).toBe(false);
+		expect(visibleTraceSteps(steps).map((step) => step.title)).toEqual(["Request was aborted"]);
+	});
+
+	it("keeps content when native boundaries are missing without inventing its duration", () => {
+		const steps = finalizeTraceSteps(traceStepsFromEvents([
+			{ eventId: 1, occurredAt: at(0), event: { type: "thinking_delta", delta: "fallback" } },
+			{ eventId: 2, occurredAt: at(2), event: { type: "thinking_end" } },
+			{ eventId: 3, occurredAt: at(3), event: { type: "system_event", eventType: "queue_update", phase: "update" } },
+		]));
+
+		expect(steps.find((step) => step.kind === "thinking")).toMatchObject({ text: "fallback", status: "completed" });
+		expect(steps.find((step) => step.kind === "thinking")?.durationMs).toBeUndefined();
+		expect(steps.find((step) => step.kind === "system")?.durationMs).toBeUndefined();
+	});
+
+	it("keeps terminal status separate from an incomplete trace", () => {
+		expect(traceTerminalState([
+			{ eventId: 1, event: { type: "aborted", message: "Stopped by user", persisted: false } },
+		])).toEqual({ status: "aborted", reason: "Stopped by user" });
+		expect(traceTerminalState([
+			{ eventId: 1, event: { type: "system_event", eventType: "message_start" } },
+		])).toEqual({ status: "unknown" });
+		expect(traceTerminalState([])).toBeUndefined();
+	});
+
+	it("restores terminal status for legacy traces during cold start", () => {
+		expect(traceTerminalState([
+			{
+				eventId: 1,
+				event: {
+					type: "system_event",
+					eventType: "message_end",
+					summary: "stopReason: stop",
+					detail: { stopReason: "stop" },
+				},
+			},
+		])).toEqual({ status: "completed" });
+		expect(traceTerminalState([
+			{
+				eventId: 1,
+				event: { type: "system_event", eventType: "message_end", summary: "stopReason: toolUse", detail: { stopReason: "toolUse" } },
+			},
+		])).toEqual({ status: "unknown" });
+		expect(traceTerminalState([
+			{
+				eventId: 1,
+				event: { type: "system_event", eventType: "message_end", summary: "stopReason: error", detail: { stopReason: "error" } },
+			},
+		])).toMatchObject({ status: "error" });
+		expect(traceTerminalState(undefined, "stop")).toEqual({ status: "completed" });
+		expect(traceTerminalState(undefined, "length")).toMatchObject({ status: "error" });
+	});
+
+});

--- a/apps/inno-agent/web/src/utils/chat-trace.ts
+++ b/apps/inno-agent/web/src/utils/chat-trace.ts
@@ -1,0 +1,769 @@
+import type {
+	ChatStreamEvent,
+	ChatToolRecord,
+	ChatTraceEventRecord,
+	ChatTraceStep,
+	ChatTraceStepKind,
+	ChatTraceStepStatus,
+	WorkspaceFileChange,
+} from "../types/chat.js";
+
+type TraceTime = number | undefined;
+
+export function parseTraceTime(value?: string | null): TraceTime {
+	if (!value) return undefined;
+	const parsed = Date.parse(value);
+	return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function durationFor(startedAt: TraceTime, endedAt: TraceTime): number | undefined {
+	if (startedAt === undefined || endedAt === undefined) return undefined;
+	return Math.max(0, endedAt - startedAt);
+}
+
+export function safeJson(value: unknown): string {
+	if (value === undefined) return "";
+	if (typeof value === "string") return value;
+	try {
+		return JSON.stringify(value, null, 2) ?? String(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function parseJson(value: string | undefined): unknown {
+	if (!value?.trim()) return undefined;
+	try {
+		return JSON.parse(value);
+	} catch {
+		return undefined;
+	}
+}
+
+export function isTextKind(kind: ChatTraceStepKind): boolean {
+	return kind === "progress" || kind === "answer";
+}
+
+export function isOpenStatus(status: ChatTraceStepStatus): boolean {
+	return status === "active" || status === "preparing" || status === "running" || status === "waiting";
+}
+
+const ACTIONABLE_SYSTEM_EVENTS = new Set(["auto_retry_start", "auto_retry_end"]);
+
+/**
+ * PI emits a useful event stream for recovery and debugging, but most of its
+ * lifecycle bookkeeping is not a user-facing process step. Keep the raw
+ * events in the sidecar and filter only at presentation time so history can
+ * still be reconstructed without turning the chat into an event log.
+ */
+export function isTraceStepVisible(step: ChatTraceStep): boolean {
+	if (step.kind !== "system") return true;
+	if (step.workspaceChanges?.length) return true;
+	if (step.status === "error") return true;
+	const eventType = step.eventType?.toLowerCase();
+	if (eventType && ACTIONABLE_SYSTEM_EVENTS.has(eventType)) return true;
+	const searchable = [
+		step.title,
+		step.summary,
+		step.text,
+		step.eventType,
+		step.eventDetail ? safeJson(step.eventDetail) : "",
+	].filter(Boolean).join(" ");
+	return /(abort|aborted|cancel|cancelled|canceled|fail|failed|error|错误|失败|中断|取消|停止)/i.test(searchable);
+}
+
+export function visibleTraceSteps(steps: ChatTraceStep[]): ChatTraceStep[] {
+	return steps.filter(isTraceStepVisible);
+}
+
+export function hasVisibleTraceSteps(steps: ChatTraceStep[]): boolean {
+	return steps.some((step) => step.kind !== "answer" && isTraceStepVisible(step));
+}
+
+function nextContentId(kind: "thinking" | "progress", steps: ChatTraceStep[]): string {
+	const count = steps.filter((step) => step.kind === kind || (kind === "progress" && step.kind === "answer")).length;
+	return `${kind}:auto:${count}`;
+}
+
+function findContentStepIndex(
+	steps: ChatTraceStep[],
+	kind: "thinking" | "progress",
+	contentIndex?: number,
+): number {
+	for (let index = steps.length - 1; index >= 0; index -= 1) {
+		const step = steps[index];
+		if (!step || !isOpenStatus(step.status)) continue;
+		if (kind === "thinking" && step.kind !== "thinking") continue;
+		if (kind === "progress" && !isTextKind(step.kind)) continue;
+		if (contentIndex !== undefined && step.contentIndex !== contentIndex) continue;
+		return index;
+	}
+	return -1;
+}
+
+function reclassifyTextSteps(steps: ChatTraceStep[]): ChatTraceStep[] {
+	let lastToolIndex = -1;
+	for (let index = steps.length - 1; index >= 0; index -= 1) {
+		if (steps[index]?.kind === "tool") {
+			lastToolIndex = index;
+			break;
+		}
+	}
+	return steps.map((step, index) => {
+		if (!isTextKind(step.kind)) return step;
+		const kind: ChatTraceStepKind = lastToolIndex === -1 || index > lastToolIndex ? "answer" : "progress";
+		return { ...step, kind };
+	});
+}
+
+function createContentStep(
+	steps: ChatTraceStep[],
+	kind: "thinking" | "progress",
+	contentIndex: number | undefined,
+	at: TraceTime,
+	phase: "start" | "update" = "start",
+): ChatTraceStep {
+	return {
+		id: contentIndex === undefined ? nextContentId(kind, steps) : `${kind}:${contentIndex}`,
+		kind,
+		status: "active",
+		title: kind === "thinking" ? "思考" : "正在组织回复",
+		titleKey: kind === "thinking" ? "chat.trace.steps.thinking" : "chat.trace.steps.organizingReply",
+		text: "",
+		contentIndex,
+		eventPhase: phase,
+		...(at !== undefined ? { startedAt: at } : {}),
+	};
+}
+
+function appendContent(
+	steps: ChatTraceStep[],
+	kind: "thinking" | "progress",
+	delta: string,
+	contentIndex?: number,
+	at?: TraceTime,
+): ChatTraceStep[] {
+	if (!delta) return steps;
+	const index = findContentStepIndex(steps, kind, contentIndex);
+	const next = steps.slice();
+		const current = index >= 0 ? next[index]! : createContentStep(next, kind, contentIndex, at, "update");
+	const targetIndex = index >= 0 ? index : next.length;
+	if (index < 0) next.push(current);
+	next[targetIndex] = {
+		...current,
+		status: "active",
+		text: `${current.text ?? ""}${delta}`,
+		...(current.startedAt === undefined && at !== undefined ? { startedAt: at } : {}),
+	};
+	return reclassifyTextSteps(next);
+}
+
+function finishContent(
+	steps: ChatTraceStep[],
+	kind: "thinking" | "progress",
+	contentIndex?: number,
+	at?: TraceTime,
+): ChatTraceStep[] {
+	const index = findContentStepIndex(steps, kind, contentIndex);
+	if (index < 0) return steps;
+	const current = steps[index]!;
+	const next = steps.slice();
+	next[index] = {
+		...current,
+		status: "completed",
+		eventPhase: "end",
+		...(at !== undefined ? { endedAt: at } : {}),
+		...(at !== undefined && current.startedAt !== undefined && current.eventPhase === "start"
+			? { durationMs: durationFor(current.startedAt, at) }
+			: {}),
+	};
+	return reclassifyTextSteps(next);
+}
+
+/**
+ * Some providers omit thinking_end when they switch to the final answer.
+ * Treat the next text/tool event as the boundary so a live thinking timer
+ * cannot continue while the assistant is already producing the answer.
+ */
+function finishOpenThinking(steps: ChatTraceStep[], at?: TraceTime): ChatTraceStep[] {
+	let changed = false;
+	const next = steps.map((step) => {
+		if (step.kind !== "thinking" || !isOpenStatus(step.status)) return step;
+		changed = true;
+		return {
+			...step,
+			status: "completed" as const,
+			eventPhase: "end" as const,
+			...(at !== undefined ? { endedAt: at } : {}),
+			...(at !== undefined && step.startedAt !== undefined
+				? { durationMs: durationFor(step.startedAt, at) }
+				: {}),
+		};
+	});
+	return changed ? next : steps;
+}
+
+function findToolIndex(steps: ChatTraceStep[], toolCallId: string): number {
+	for (let index = steps.length - 1; index >= 0; index -= 1) {
+		if (steps[index]?.kind === "tool" && steps[index]?.toolCallId === toolCallId) return index;
+	}
+	return -1;
+}
+
+function findOpenQuestionToolIndex(steps: ChatTraceStep[]): number {
+	for (let index = steps.length - 1; index >= 0; index -= 1) {
+		const step = steps[index];
+		if (step?.kind === "tool" && step.toolName === "ask_user_question" && isOpenStatus(step.status)) return index;
+	}
+	return -1;
+}
+
+function ensureTool(
+	steps: ChatTraceStep[],
+	toolCallId: string,
+	toolName: string,
+	at?: TraceTime,
+	args?: unknown,
+	options: { forceNew?: boolean; createNewIfClosed?: boolean } = {},
+): { steps: ChatTraceStep[]; index: number } {
+	const existingIndex = findToolIndex(steps, toolCallId);
+	const existing = existingIndex >= 0 ? steps[existingIndex] : undefined;
+	const closed = existing ? existing.status === "completed" || existing.status === "error" : false;
+	if (existingIndex >= 0 && !options.forceNew && !(options.createNewIfClosed && closed)) {
+		const next = steps.slice();
+		const current = next[existingIndex]!;
+		next[existingIndex] = {
+			...current,
+			toolName: toolName || current.toolName,
+			...(args !== undefined ? { args, argsText: safeJson(args) } : {}),
+		};
+		return { steps: next, index: existingIndex };
+	}
+	const previousAttempts = steps
+		.filter((step) => step.kind === "tool" && step.toolCallId === toolCallId)
+		.map((step) => step.attempt ?? 1);
+	const attempt = previousAttempts.length > 0 ? Math.max(...previousAttempts) + 1 : undefined;
+	const step: ChatTraceStep = {
+		id: attempt === undefined ? `tool:${toolCallId}` : `tool:${toolCallId}:attempt:${attempt}`,
+		kind: "tool",
+		status: "preparing",
+		title: toolName || "tool",
+		toolCallId,
+		toolName: toolName || "tool",
+		...(args !== undefined ? { args, argsText: safeJson(args) } : {}),
+		...(at !== undefined ? { preparationStartedAt: at } : {}),
+		...(attempt !== undefined ? { attempt } : {}),
+	};
+	return { steps: [...steps, step], index: steps.length };
+}
+
+function updateToolArgs(
+	steps: ChatTraceStep[],
+	toolCallId: string,
+	toolName: string,
+	at?: TraceTime,
+	args?: unknown,
+	argsDelta?: string,
+	options?: { forceNew?: boolean; createNewIfClosed?: boolean },
+): ChatTraceStep[] {
+	const ensured = ensureTool(steps, toolCallId, toolName, at, args, options);
+	const next = ensured.steps.slice();
+	const current = next[ensured.index]!;
+	const argsText = args !== undefined
+		? safeJson(args)
+		: argsDelta
+			? `${current.argsText ?? ""}${argsDelta}`
+			: current.argsText;
+	const parsedArgs = args !== undefined ? args : parseJson(argsText);
+	next[ensured.index] = {
+		...current,
+		...(argsText !== undefined ? { argsText } : {}),
+		...(parsedArgs !== undefined ? { args: parsedArgs } : {}),
+	};
+	return next;
+}
+
+function updateToolExecution(
+	steps: ChatTraceStep[],
+	event: Extract<ChatStreamEvent, { type: "tool_start" }>,
+	at?: TraceTime,
+): ChatTraceStep[] {
+	const ensured = ensureTool(steps, event.toolCallId, event.toolName, at, event.args, { createNewIfClosed: true });
+	const next = ensured.steps.slice();
+	const current = next[ensured.index]!;
+	next[ensured.index] = {
+		...current,
+		status: "running",
+		toolName: event.toolName || current.toolName,
+		...(event.args !== undefined ? { args: event.args, argsText: safeJson(event.args) } : {}),
+		...(at !== undefined ? { startedAt: at } : {}),
+	};
+	return next;
+}
+
+function updateToolPartial(
+	steps: ChatTraceStep[],
+	event: Extract<ChatStreamEvent, { type: "tool_update" }>,
+	at?: TraceTime,
+): ChatTraceStep[] {
+	const existingIndex = findToolIndex(steps, event.toolCallId);
+	const existing = existingIndex >= 0 ? steps[existingIndex] : undefined;
+	// A delayed update from a previous attempt must not reopen a completed row.
+	if (existing && (existing.status === "completed" || existing.status === "error")) return steps;
+	const ensured = ensureTool(steps, event.toolCallId, event.toolName, at, event.args);
+	const next = ensured.steps.slice();
+	const current = next[ensured.index]!;
+	next[ensured.index] = {
+		...current,
+		status: "running",
+		toolName: event.toolName || current.toolName,
+		...(event.args !== undefined ? { args: event.args, argsText: safeJson(event.args) } : {}),
+		...(event.partialResult !== undefined ? { partialResult: event.partialResult } : {}),
+		...(current.startedAt === undefined && at !== undefined ? { startedAt: at } : {}),
+	};
+	return next;
+}
+
+function finishTool(
+	steps: ChatTraceStep[],
+	event: Extract<ChatStreamEvent, { type: "tool_end" }>,
+	at?: TraceTime,
+): ChatTraceStep[] {
+	const ensured = ensureTool(steps, event.toolCallId, event.toolName, undefined, undefined, { createNewIfClosed: true });
+	const next = ensured.steps.slice();
+	const current = next[ensured.index]!;
+	next[ensured.index] = {
+		...current,
+		status: event.isError ? "error" : "completed",
+		result: event.result,
+		isError: event.isError,
+		...(at !== undefined ? { endedAt: at } : {}),
+		...(at !== undefined && current.startedAt !== undefined
+			? { durationMs: durationFor(current.startedAt, at) }
+			: {}),
+	};
+	return next;
+}
+
+function addWorkspaceChanges(steps: ChatTraceStep[], changes: WorkspaceFileChange[], toolCallId?: string): ChatTraceStep[] {
+	if (!changes.length) return steps;
+	const index = toolCallId ? findToolIndex(steps, toolCallId) : -1;
+	if (index < 0) {
+		return [
+			...steps,
+			{
+				id: `workspace:${steps.length}`,
+					kind: "system",
+					status: "completed",
+					title: "工作区已更新",
+					titleKey: "chat.trace.steps.workspaceUpdated",
+					workspaceChanges: changes,
+			},
+		];
+	}
+	const next = steps.slice();
+	const current = next[index]!;
+	const previous = current.workspaceChanges ?? [];
+	const seen = new Set(previous.map((change) => `${change.change}:${change.path}`));
+	next[index] = {
+		...current,
+		workspaceChanges: [...previous, ...changes.filter((change) => !seen.has(`${change.change}:${change.path}`))],
+	};
+	return next;
+}
+
+function systemFamily(eventType: string): string {
+	return eventType.replace(/_(start|end|update)$/i, "");
+}
+
+function systemTitle(eventType: string, summary?: string): string {
+	if (summary?.trim()) return summary.trim();
+	const labels: Record<string, string> = {
+		before_agent_start: "准备 Agent",
+		agent_start: "开始工作",
+		agent_end: "结束工作",
+		turn_start: "开始本轮任务",
+		turn_end: "本轮任务结束",
+		message_start: "开始生成消息",
+		message_end: "消息生成完成",
+		compaction_start: "正在整理上下文",
+		compaction_end: "上下文整理完成",
+		queue_start: "进入执行队列",
+		queue_end: "离开执行队列",
+		auto_retry_start: "正在自动重试",
+		auto_retry_end: "自动重试结束",
+		entry_appended: "已记录会话事件",
+		bash_execution_update: "终端执行更新",
+	};
+	return labels[eventType] ?? eventType.replaceAll("_", " ");
+}
+
+const SYSTEM_TITLE_KEYS: Record<string, string> = {
+	before_agent_start: "chat.trace.system.beforeAgentStart",
+	agent_start: "chat.trace.system.agentStart",
+	agent_end: "chat.trace.system.agentEnd",
+	turn_start: "chat.trace.system.turnStart",
+	turn_end: "chat.trace.system.turnEnd",
+	message_start: "chat.trace.system.messageStart",
+	message_end: "chat.trace.system.messageEnd",
+	compaction_start: "chat.trace.system.compactionStart",
+	compaction_end: "chat.trace.system.compactionEnd",
+	queue_start: "chat.trace.system.queueStart",
+	queue_end: "chat.trace.system.queueEnd",
+	auto_retry_start: "chat.trace.system.autoRetryStart",
+	auto_retry_end: "chat.trace.system.autoRetryEnd",
+	entry_appended: "chat.trace.system.entryAppended",
+	bash_execution_update: "chat.trace.system.bashExecutionUpdate",
+};
+
+function appendSystemEvent(
+	steps: ChatTraceStep[],
+	event: Extract<ChatStreamEvent, { type: "system_event" }>,
+	at?: TraceTime,
+): ChatTraceStep[] {
+	const family = systemFamily(event.eventType);
+	let existingIndex = -1;
+	for (let index = steps.length - 1; index >= 0; index -= 1) {
+		const current = steps[index];
+		if (current?.kind !== "system" || !isOpenStatus(current.status)) continue;
+		if (current.eventType && systemFamily(current.eventType) === family && current.attempt === event.attempt) {
+			existingIndex = index;
+			break;
+		}
+		if (index < steps.length - 4) break;
+	}
+	const ended = event.phase === "end";
+	const status: ChatTraceStepStatus = event.success === false ? "error" : ended ? "completed" : "active";
+	const next = steps.slice();
+	const current = existingIndex >= 0 ? next[existingIndex]! : undefined;
+	const step: ChatTraceStep = {
+		...(current ?? {
+			id: `system:${family}:${event.attempt ?? steps.length}`,
+			kind: "system" as const,
+			status: "active" as const,
+			title: systemTitle(event.eventType, event.summary),
+		}),
+		status,
+		title: systemTitle(event.eventType, event.summary) || current?.title || event.eventType,
+		titleKey: current?.titleKey ?? SYSTEM_TITLE_KEYS[event.eventType],
+		summary: event.summary ?? current?.summary,
+		eventType: current?.eventType ?? event.eventType,
+		eventPhase: event.phase,
+		eventDetail: event.detail,
+		...(event.attempt !== undefined ? { attempt: event.attempt } : {}),
+		...(current?.startedAt === undefined && at !== undefined ? { startedAt: at } : {}),
+		...(ended && at !== undefined ? { endedAt: at } : {}),
+		...(ended && at !== undefined && current?.startedAt !== undefined && current.eventPhase === "start"
+			? { durationMs: durationFor(current.startedAt, at) }
+			: {}),
+	};
+	if (existingIndex >= 0) next[existingIndex] = step;
+	else next.push(step);
+	return next;
+}
+
+/** Apply one normalized PI/SSE event to the visible logical timeline. */
+export function applyChatTraceEvent(
+	steps: ChatTraceStep[],
+	event: ChatStreamEvent,
+	occurredAt?: string,
+): ChatTraceStep[] {
+	const at = parseTraceTime(occurredAt);
+	switch (event.type) {
+		case "stream_state":
+			return steps;
+		case "thinking_start": {
+			return [...steps, createContentStep(steps, "thinking", event.contentIndex, at)];
+		}
+		case "thinking_delta":
+			return appendContent(steps, "thinking", event.delta, event.contentIndex, at);
+		case "thinking_end":
+			return finishContent(steps, "thinking", event.contentIndex, at);
+		case "text_start": {
+			const closed = finishOpenThinking(steps, at);
+			return reclassifyTextSteps([...closed, createContentStep(closed, "progress", event.contentIndex, at)]);
+		}
+		case "text_delta":
+			return appendContent(finishOpenThinking(steps, at), "progress", event.delta, event.contentIndex, at);
+		case "text_end":
+			return finishContent(steps, "progress", event.contentIndex, at);
+		case "tool_call_start":
+			return updateToolArgs(finishOpenThinking(steps, at), event.toolCallId, event.toolName, at, event.args, undefined, { forceNew: true });
+		case "tool_call_delta":
+			return updateToolArgs(finishOpenThinking(steps, at), event.toolCallId, event.toolName, at, event.args, event.argsDelta);
+		case "tool_call_end":
+			return updateToolArgs(finishOpenThinking(steps, at), event.toolCallId, event.toolName, at, event.args);
+		case "tool_start":
+			return updateToolExecution(finishOpenThinking(steps, at), event, at);
+		case "tool_update":
+			return updateToolPartial(finishOpenThinking(steps, at), event, at);
+		case "tool_end":
+			return finishTool(steps, event, at);
+		case "workspace_change":
+			return addWorkspaceChanges(steps, event.changes, event.toolCallId);
+		case "question": {
+			// Older question events did not carry the PI tool id. Reuse the latest
+			// open ask_user_question row so question_resolved/tool_end cannot leave
+			// behind a second row that stays "running" while the next thinking starts.
+			const existingIndex = event.toolCallId
+				? findToolIndex(steps, event.toolCallId)
+				: findOpenQuestionToolIndex(steps);
+			const toolCallId = existingIndex >= 0
+				? steps[existingIndex]!.toolCallId ?? event.questionId
+				: event.toolCallId ?? event.questionId;
+			const ensured = ensureTool(steps, toolCallId, "ask_user_question", at, event.params, { createNewIfClosed: true });
+			const next = ensured.steps.slice();
+			next[ensured.index] = {
+				...next[ensured.index]!,
+				status: "waiting",
+				title: "等待你的回答",
+				titleKey: "chat.trace.steps.waitingForAnswer",
+				questionId: event.questionId,
+				questionParams: event.params,
+			};
+			return next;
+		}
+		case "question_resolved": {
+			const index = steps.findIndex((step) => step.questionId === event.questionId);
+			if (index < 0) return steps;
+			const next = steps.slice();
+			next[index] = {
+				...next[index]!,
+				status: "running",
+				title: event.cancelled ? "已取消回答" : "继续执行",
+				titleKey: event.cancelled ? "chat.trace.steps.answerCancelled" : "chat.trace.steps.continueExecution",
+				summary: event.error,
+			};
+			return next;
+		}
+		case "skill_loaded":
+			if (event.count <= 0 && !event.skills?.length) return steps;
+			return [
+				...steps,
+				{
+					id: "skill:loaded",
+					kind: "skill",
+					status: "completed",
+					title: `已预载 ${event.count} 个技能`,
+					titleKey: "chat.trace.steps.skillsPreloaded",
+					titleParams: { count: event.count },
+					skillState: "loaded",
+					eventDetail: event.skills,
+				},
+			];
+		case "skill_invoked":
+			return [
+				...steps,
+				{
+					id: `skill:${event.skillName}:${steps.length}`,
+					kind: "skill",
+					status: "completed",
+					title: `已载入技能 · ${event.skillName}`,
+					titleKey: "chat.trace.steps.skillLoaded",
+					titleParams: { skillName: event.skillName },
+					skillName: event.skillName,
+					skillArgs: event.args,
+					skillSource: event.source,
+					skillPath: event.path,
+					skillDescription: event.description,
+					skillState: "expanded",
+				},
+			];
+		case "system_event":
+			return appendSystemEvent(steps, event, at);
+		case "error":
+			return [
+				...steps,
+				{
+					id: `error:${steps.length}`,
+					kind: "error",
+					status: "error",
+					title: "请求失败",
+					titleKey: "chat.trace.steps.requestFailed",
+					text: event.message,
+					summary: event.code,
+					...(at !== undefined ? { endedAt: at } : {}),
+				},
+			];
+		case "done":
+			return finalizeTraceSteps(steps);
+		case "aborted":
+			return finalizeTraceSteps([
+				...steps,
+				{
+					id: `aborted:${steps.length}`,
+					kind: "error",
+					status: "error",
+					title: "已停止",
+					titleKey: "chat.trace.steps.stopped",
+					text: event.message,
+				},
+			]);
+	}
+}
+
+/** Close open rows and classify text after the last tool as final answer. */
+export function finalizeTraceSteps(steps: ChatTraceStep[]): ChatTraceStep[] {
+	const closed = steps.map((step) => {
+		if (!isOpenStatus(step.status)) return step;
+		return {
+			...step,
+			status: step.kind === "error" ? "error" : step.isError ? "error" : "completed",
+		} satisfies ChatTraceStep;
+	});
+	return reclassifyTextSteps(closed);
+}
+
+/** Rebuild logical rows from a persisted sidecar or a replayed SSE history. */
+export function traceStepsFromEvents(records: ChatTraceEventRecord[]): ChatTraceStep[] {
+	return records.reduce<ChatTraceStep[]>(
+		(steps, record) => applyChatTraceEvent(steps, record.event, record.occurredAt),
+		[],
+	);
+}
+
+export type ChatTraceTerminalStatus = "completed" | "aborted" | "error" | "unknown";
+
+export interface ChatTraceTerminalState {
+	status: ChatTraceTerminalStatus;
+	reason?: string;
+}
+
+const SUCCESSFUL_STOP_REASONS = new Set(["stop", "end", "end_turn", "complete", "completed"]);
+const ABORTED_STOP_REASONS = new Set(["abort", "aborted", "cancel", "cancelled", "canceled", "user_cancelled", "user_canceled"]);
+const FAILED_STOP_REASONS = new Set(["error", "failed", "failure", "length", "max_tokens", "content_filter"]);
+
+function normalizedStopReason(value?: string): string | undefined {
+	return value?.trim().toLowerCase().replace(/[\s-]+/g, "_");
+}
+
+function detailStopReason(detail: unknown): string | undefined {
+	if (!detail || typeof detail !== "object") return undefined;
+	const value = (detail as Record<string, unknown>).stopReason;
+	return typeof value === "string" ? value : undefined;
+}
+
+function systemEventText(event: Extract<ChatStreamEvent, { type: "system_event" }>): string {
+	return [
+		event.eventType,
+		event.summary,
+		typeof event.detail === "string" ? event.detail : event.detail ? safeJson(event.detail) : "",
+	].filter(Boolean).join(" ");
+}
+
+function systemEventStopReason(event: Extract<ChatStreamEvent, { type: "system_event" }>): string | undefined {
+	const direct = detailStopReason(event.detail);
+	if (direct) return direct;
+	const text = systemEventText(event);
+	const match = text.match(/(?:["']?stopReason["']?|stop reason)\s*[:=]\s*["']?([a-z][a-z0-9_-]*)/i);
+	return match?.[1];
+}
+
+function terminalStateFromStopReason(stopReason?: string, reason?: string): ChatTraceTerminalState | undefined {
+	const normalized = normalizedStopReason(stopReason);
+	if (!normalized) return undefined;
+	if (SUCCESSFUL_STOP_REASONS.has(normalized)) return { status: "completed" };
+	if (ABORTED_STOP_REASONS.has(normalized)) {
+		return { status: "aborted", reason: reason ?? `stopReason: ${stopReason}` };
+	}
+	if (FAILED_STOP_REASONS.has(normalized)) {
+		return { status: "error", reason: reason ?? `stopReason: ${stopReason}` };
+	}
+	return undefined;
+}
+
+/** Infer a terminal result from legacy PI lifecycle records. */
+function legacySystemTerminalState(
+	event: Extract<ChatStreamEvent, { type: "system_event" }>,
+): ChatTraceTerminalState | undefined {
+	const text = systemEventText(event);
+	const stopReason = systemEventStopReason(event);
+	const fromStopReason = terminalStateFromStopReason(stopReason, event.summary ?? text);
+	if (fromStopReason) return fromStopReason;
+
+	if (/(request was aborted|prompt aborted|stopped by user|cancel(?:led|ed)? by user|用户(?:主动)?(?:暂停|停止|取消)|主动(?:暂停|停止|取消))/i.test(text)) {
+		return { status: "aborted", reason: event.summary ?? text };
+	}
+	const isTurnBoundary = event.eventType === "message_end" || event.eventType === "turn_end";
+	if (
+		(event.success === false && isTurnBoundary)
+		|| /terminal event .*finishTurn|prompt failed|model request failed|llm api error/i.test(text)
+	) {
+		return { status: "error", reason: event.summary ?? text };
+	}
+	return undefined;
+}
+
+/** Return the terminal result for a live/new trace or a legacy persisted one.
+ * Older sidecars predate terminal events, so the assistant message's PI
+ * stopReason is accepted as a second source of truth during cold-start replay. */
+export function traceTerminalState(
+	records?: ChatTraceEventRecord[],
+	fallbackStopReason?: string,
+	fallbackReason?: string,
+): ChatTraceTerminalState | undefined {
+	if (records?.length) {
+		for (let index = records.length - 1; index >= 0; index -= 1) {
+			const event = records[index]?.event;
+			if (!event) continue;
+			if (event.type === "done") return { status: "completed" };
+			if (event.type === "error") return { status: "error", reason: event.message };
+			if (event.type === "aborted") return { status: "aborted", reason: event.message };
+			if (event.type === "system_event") {
+				const legacyState = legacySystemTerminalState(event);
+				if (legacyState) return legacyState;
+			}
+		}
+	}
+
+	const fromFallback = terminalStateFromStopReason(fallbackStopReason, fallbackReason);
+	if (fromFallback) return fromFallback;
+	if (records?.length || fallbackStopReason) return { status: "unknown" };
+	return undefined;
+}
+
+/** Best-effort presentation fallback for sessions created before the trace
+ * sidecar existed. PI's JSONL parser still exposes aggregate thinking/tools;
+ * keep those records visible while leaving the canonical message untouched. */
+export function traceStepsFromLegacy(
+	content: string,
+	thinking?: string,
+	tools?: ChatToolRecord[],
+): ChatTraceStep[] {
+	const steps: ChatTraceStep[] = [];
+	if (thinking?.trim()) {
+		steps.push({
+			id: "legacy:thinking",
+				kind: "thinking",
+				status: "completed",
+				title: "思考",
+				titleKey: "chat.trace.steps.thinking",
+				text: thinking,
+		});
+	}
+	for (const tool of tools ?? []) {
+		steps.push({
+			id: `legacy:tool:${tool.toolCallId}`,
+			kind: "tool",
+			status: tool.isError ? "error" : "completed",
+			title: tool.toolName,
+			toolCallId: tool.toolCallId,
+			toolName: tool.toolName,
+				args: tool.args,
+				partialResult: tool.partialResult,
+				result: tool.result,
+			isError: tool.isError,
+		});
+	}
+	if (content.trim()) {
+		steps.push({
+			id: "legacy:answer",
+			kind: "answer",
+			status: "completed",
+			title: "回复",
+			titleKey: "chat.trace.steps.reply",
+			text: content,
+		});
+	}
+	return steps;
+}

--- a/apps/showcase/src/App.tsx
+++ b/apps/showcase/src/App.tsx
@@ -85,6 +85,20 @@ export function App() {
 	const setTab = useCallback((tab: RightPanelTab) => appStore.setRightPanelTab(tab), []);
 	const setWorkspaceMode = useCallback((mode: WorkspaceMode) => appStore.setWorkspaceMode(mode), []);
 	const setWorkspaceWidth = useCallback((width: number) => appStore.setWorkspaceWidth(width), []);
+	const openSidebar = useCallback(() => appStore.setSidebarCollapsed(false), []);
+	const openPresetPanels = useCallback(() => {
+		appStore.setRightPanelTab("preview");
+		appStore.setWorkspaceMode("half");
+	}, []);
+	const openRightPanel = useCallback((tab: Exclude<RightPanelTab, "preview">) => {
+		appStore.setRightPanelTab(tab);
+		appStore.setWorkspaceMode("quarter");
+	}, []);
+	const openPreviewFile = useCallback((minimumWidth: number) => {
+		appStore.setRightPanelTab("preview");
+		appStore.setWorkspaceWidth(Math.max(minimumWidth, appStore.workspaceWidth));
+		appStore.setWorkspaceMode("half");
+	}, []);
 
 	// Same viewport breakpoint behavior as the product shell: collapse the
 	// sidebar and workspace panel when the window narrows.
@@ -123,9 +137,13 @@ export function App() {
 			className={`app-layout app-layout--sidebar-${app.sidebarCollapsed ? "collapsed" : "expanded"} app-layout--workspace-${app.workspaceMode}`}
 			style={{ "--inno-workspace-width": `${app.workspaceWidth}px` } as React.CSSProperties}
 		>
-			<SessionSidebar collapsed={app.sidebarCollapsed} />
+			<SessionSidebar collapsed={app.sidebarCollapsed} onOpen={openSidebar} />
 			<div className="relative h-full min-h-0 min-w-0">
-				<ChatCenter />
+				<ChatCenter
+					onOpenPresetPanels={openPresetPanels}
+					onOpenRightPanel={openRightPanel}
+					onPreviewFile={openPreviewFile}
+				/>
 				<ReplayTransport />
 			</div>
 			<WorkspacePanel
@@ -135,6 +153,7 @@ export function App() {
 				onTabChange={setTab}
 				onModeChange={setWorkspaceMode}
 				onWidthChange={setWorkspaceWidth}
+				onPreviewFile={openPreviewFile}
 			/>
 		</div>
 	);

--- a/apps/showcase/src/desktop-bridge.d.ts
+++ b/apps/showcase/src/desktop-bridge.d.ts
@@ -1,0 +1,18 @@
+declare global {
+	interface Window {
+		innoDesktop?: {
+			setCloseDialogCopy(copy: {
+				title: string;
+				message: string;
+				detail: string;
+				buttons: { hide: string; quit: string; cancel: string };
+				remember: string;
+			}): void;
+			expandWindowWidth(side: "left" | "right", additionalWidth: number): Promise<boolean>;
+			getWindowWidthCapacity(side: "left" | "right"): Promise<number>;
+			openLocalFile(file: File): Promise<boolean>;
+		};
+	}
+}
+
+export {};

--- a/apps/showcase/src/mock/streaming.ts
+++ b/apps/showcase/src/mock/streaming.ts
@@ -113,6 +113,8 @@ export function createTurnStream(options: TurnStreamOptions): Response {
 				sessionId,
 				turnId,
 				clientRequestId,
+				traceId: turnId,
+				occurredAt: new Date().toISOString(),
 				event,
 			};
 			try {
@@ -125,6 +127,8 @@ export function createTurnStream(options: TurnStreamOptions): Response {
 		emit({ type: "stream_state", status: "queued" });
 		await wait(QUEUED_WAIT_MS, isCancelled);
 		emit({ type: "stream_state", status: "running" });
+		emit({ type: "system_event", eventType: "agent_start", phase: "start", summary: "开始工作" });
+		emit({ type: "skill_loaded", count: 0, skills: [] });
 
 		let prevAt = doc.messages[turnStart]?.timestamp ?? 0;
 		for (let msgIdx = turnStart + 1; msgIdx < turnEnd && !cancelled; msgIdx++) {
@@ -135,23 +139,28 @@ export function createTurnStream(options: TurnStreamOptions): Response {
 				prevAt = Math.max(prevAt, segment.at);
 
 				if (segment.kind === "thinking") {
+					emit({ type: "thinking_start" });
 					for (let i = 0; i < segment.text.length && !cancelled; i += THINKING_CHUNK) {
 						emit({ type: "thinking_delta", delta: segment.text.slice(i, i + THINKING_CHUNK) });
 						await wait(TICK_MS, isCancelled);
 					}
+					emit({ type: "thinking_end" });
 					continue;
 				}
 				if (segment.kind === "text") {
+					emit({ type: "text_start" });
 					for (let i = 0; i < segment.text.length && !cancelled; i += TEXT_CHUNK) {
 						emit({ type: "text_delta", delta: segment.text.slice(i, i + TEXT_CHUNK) });
 						await wait(TICK_MS, isCancelled);
 					}
+					emit({ type: "text_end" });
 					continue;
 				}
 
 				// --- tool segment ---
 				// Stream args into the file preview first (drives the live
 				// "正在生成内容" workspace preview in the product UI).
+				emit({ type: "tool_call_start", toolCallId: segment.toolCallId, toolName: segment.toolName });
 				if (isFileWritingTool(segment.toolName)) {
 					const argsText = JSON.stringify(segment.args ?? {});
 					const slice = Math.max(1, Math.ceil(argsText.length / ARGS_CHUNKS));
@@ -165,6 +174,7 @@ export function createTurnStream(options: TurnStreamOptions): Response {
 						await wait(TICK_MS * 2, isCancelled);
 					}
 				}
+				emit({ type: "tool_call_end", toolCallId: segment.toolCallId, toolName: segment.toolName, args: segment.args });
 				emit({ type: "tool_start", toolCallId: segment.toolCallId, toolName: segment.toolName, args: segment.args });
 
 				let waited = 0;
@@ -200,6 +210,7 @@ export function createTurnStream(options: TurnStreamOptions): Response {
 				prevAt = Math.max(prevAt, segment.endAt);
 			}
 		}
+		emit({ type: "system_event", eventType: "agent_end", phase: "end", summary: "结束工作", success: true });
 
 		if (!cancelled) {
 			const fullText = doc.messages


### PR DESCRIPTION
## Background

The web chat previously exposed only a coarse streaming status plus aggregate thinking/tool fields. That made long or interactive turns difficult to follow: users could not see the ordered sequence of thinking, tool-call preparation, tool execution, partial tool output, workspace changes, questions, retries, and the final answer. The process view was also lost or duplicated when a stream reconnected or when canonical session history replaced the live turn.

This PR adds a complete, replayable Agent Trace Timeline while preserving the existing PI session JSONL as the source of truth for model history.

## Scope

- Base: `upstream/main`
- Head: `36a8e56`
- Commits: 9 total — 8 feature commits (`3988679` through `431949f`) plus docs-only `36a8e56`
- Files changed: 36
- Diff: +3,860 / -307 lines
- `CLAUDE.md` now records the verified suite size: 59 test files and 469 tests.

## End-to-end data flow

```text
PI session events
  -> normalized chat SSE events
  -> StreamRegistry envelopes with ordered cursors and timestamps
  -> live ChatStore trace reducer
  -> AgentTraceTimeline

completed turn
  -> UI-only sessions/traces.json sidecar
  -> session history merge
  -> the same reducer and renderer used for live replay
```

### 1. Normalize PI events into a stable chat trace contract

`apps/inno-agent/src/server/routes/chat.ts` now converts native PI events into a small UI-facing event vocabulary:

- Assistant text: `text_start`, `text_delta`, `text_end`.
- Thinking blocks: `thinking_start`, `thinking_delta`, `thinking_end`.
- Tool-call argument generation: `tool_call_start`, `tool_call_delta`, `tool_call_end`.
- Tool execution: `tool_start`, `tool_update`, `tool_end`, including partial results while a tool is running.
- Interaction and environment state: `question`, `question_resolved`, `workspace_change`.
- Skill diagnostics: `skill_loaded` and explicit `/skill:<name>` as `skill_invoked`, with source, path, description, and arguments when available.
- PI lifecycle and diagnostics: `system_event` for agent/turn/message/compaction/queue/retry events, plus explicit `error`, `done`, and `aborted` terminal events.

The original PI event name is retained as `piEventType` for diagnostics. Error responses are no longer silently discarded, and model `message_end` failures are surfaced as trace errors.

`StreamEventEnvelope` now carries:

- Monotonic `eventId` for cursor-based replay and duplicate protection.
- `sessionId`, `turnId`, `clientRequestId`, and stable per-turn `traceId`.
- Server-side `occurredAt` timestamps used for durations and ordering.
- The normalized event payload.

`StreamRegistry` also keeps aggregate active/completed tool state, updates partial results in place, tolerates an update arriving before its start event, enforces valid queued/running/terminal transitions, publishes only one terminal event, and replays events strictly after the requested cursor. Payloads are compacted before storage and delivery so large text, arguments, results, workspace changes, skill inventories, and details cannot grow without bounds.

### 2. Persist traces without changing model history

`apps/inno-agent/src/server/trace-store.ts` introduces a deliberately separate UI metadata store at `sessions/traces.json`:

- Stores the normalized event sequence, start/end timestamps, and assistant-message association.
- Keeps trace data out of the PI session JSONL and therefore out of future model context.
- Associates entries by the PI assistant entry id when available; older sidecars can fall back to assistant position for compatibility.
- Merges trace records into `/api/sessions/:id` responses and removes them when a session is deleted.
- Treats sidecar persistence as observability metadata: a sidecar write failure is logged but does not turn a successful chat response into a failed turn.

`apps/inno-agent/src/server/server.ts` and the session model now preserve assistant entry ids, parent ids, stop reasons, tool result details, and trace timestamps so branch-aware history can reconstruct the right assistant turn.

### 3. Rebuild one logical timeline from live or historical events

`apps/inno-agent/web/src/utils/chat-trace.ts` is the shared reducer for live SSE and persisted history. It converts raw records into typed `ChatTraceStep` rows with kinds (`thinking`, `progress`, `answer`, `tool`, `skill`, `system`, `error`), statuses, timing, summaries, and expandable details.

The reducer handles the following edge cases:

- Keeps a streamed tool call in one row from argument preparation through execution and final result.
- Accumulates incremental JSON argument deltas and keeps the parsed value when it becomes valid.
- Preserves separate retry attempts instead of overwriting a completed/failed tool row.
- Refuses to reopen a completed row when a delayed update arrives.
- Closes an open thinking row when a provider omits `thinking_end` and begins final text/tool output.
- Classifies text before the last tool as progress and text after the last tool as the final answer.
- Matches question events to the active `ask_user_question` row even when older events do not include a tool id; turns the row into waiting/continuing/cancelled states as the question resolves.
- Groups related system lifecycle events, exposes actionable retries/errors/workspace changes, and filters internal bookkeeping at presentation time instead of deleting it from the sidecar.
- Infers completed, aborted, failed, or unknown terminal states from explicit terminal events, legacy PI lifecycle records, and older `stopReason` values.
- Replays old sessions that only have aggregate `thinking`/`tools` fields or recorded stream segments, so the new UI does not require every historical session to have a trace sidecar.

### 4. Render live and historical traces consistently

`apps/inno-agent/web/src/react/chat/AgentTraceTimeline.tsx` provides the shared renderer for both persisted assistant bubbles and the active streaming turn.

Each row supports:

- One-line status summaries with icons, durations, and an animated indicator only on the current live step.
- Collapsible details for thinking text, tool arguments, live partial result, final result/error, question parameters, workspace file changes, system-event details, retry attempts, and errors.
- Skill metadata including source, path, description, arguments, preloaded skill count, and a shortcut to open the Skills panel.
- Inline pending question cards immediately after the waiting tool row.
- Answered questionnaire cards attached to the corresponding `ask_user_question` tool.
- Clear work status for working, completed, user-paused, interrupted, and incomplete/unknown turns.
- A fallback body renderer for messages that contain text but no visible process rows.

`StreamingBubbles.tsx` now renders text and process records as one ordered flow rather than separate status/tool blocks. `MessageBubble.tsx` uses the same timeline for new traces, legacy aggregate records, and recorded showcase streams. `ChatConversation.tsx` selects one canonical assistant owner per turn, hides intermediate assistant fragments, and prevents a live trace from being duplicated during the done-to-history replacement.

### 5. Tool, skill, and interaction instrumentation

The backend changes provide richer events for real work instead of only generic tool boundaries:

- `document-tools.ts` reports checking, parsing, parsed-page, and screenshot phases.
- `l2-tools.ts` reports queueing, preparation, parsing, summarizing, Wiki generation/writing, indexing, retrieval sync, and completion phases.
- `question-bridge.ts` passes the question tool id through to the web event so the waiting card is anchored to the right row.
- Skill discovery records globally loaded skills and workspace `.skills` entries; explicit skill commands retain metadata for the trace.
- Observability argument summaries recognize both `path` and `file_path` for file tools.

### 6. Chat lifecycle and layout fixes included in the same change

- Clear the current mounted composer engine after sending, including the welcome-screen to session transition where the composer can remount.
- Reset the todo snapshot at the start of a new user turn so the previous turn is not shown in the composer; retain the latest task-list snapshot for the current turn and ignore deleted tasks.
- Keep question and busy-status banners in a dedicated composer overlay/mask area so they cannot cover or intercept the composer.
- Recalculate the welcome/composer layout when uploads, attachments, status banners, or the composer content height changes.
- Keep a jump-to-latest control available when the user scrolls away from a live trace.
- Preserve the trace as the only visible live assistant representation until canonical history is ready, avoiding flicker and duplicate geometry.

### 6a. Composer/input box and scrolling details

The input-area changes are a complete layout and interaction adjustment, not only a visual restyle:

- **Dedicated composer layers.** `ChatConversation.tsx` separates the scrollable message lane from `inno-conversation-composer-layer`, `inno-conversation-composer-content`, and `inno-conversation-composer-wrap`. The question hint, busy blocker, todo widget, upload error, and composer are laid out in one measured column while the conversation remains independently scrollable.
- **Non-blocking masks.** Status banners get their own mask and gap mask; the composer gets a lower-half background mask with the input card above it. The masks use `pointer-events: none`, so the last message can be visually covered without covering or intercepting the input, upload controls, Smart Input bubbles, or question controls.
- **Correct bottom spacing.** `ChatCenter.resizeInput()` now measures the textarea, whole composer, attachment row, and the overlay area above the composer. It writes `--inno-conversation-scroll-bottom-space` so the last message remains visible when any of these areas grows. The calculation reserves the composer half-height, the full attachment-row contribution, status/gap height, and the message action-row reserve. The welcome view continues to use `--inno-welcome-composer-half-growth`, with the attachment row excluded from the baseline so adding/removing files does not leave a stale vertical offset.
- **All height-changing inputs are observed.** A `ResizeObserver` watches both `.inno-composer` and `.inno-conversation-composer-content`; the effect also recalculates when the view changes between welcome/session, inline images or paste blocks change, uploads change, or a question/busy status appears. Rapid typing is coalesced through `requestAnimationFrame`.
- **IME-safe auto-grow.** The existing textarea auto-grow remains active, but resize is deferred during IME composition and applied on `compositionend` so Safari does not lose in-progress Chinese/Japanese input when textarea height or selection changes.
- **Streaming scroll behavior.** The message content ResizeObserver keeps the view pinned to the bottom while the user has not intentionally scrolled away. Deliberate wheel/touch/scroll interaction pauses auto-follow and reveals a localized “back to latest” button; clicking it smoothly scrolls to the latest content, resumes pinning, and hides the button. Switching sessions resets both the pinning state and button.
- **Send and remount cleanup.** After a send, the composer draft is reset, successful inline images/uploads are cleared while failed uploads remain retryable, and the currently mounted Smart Input engine receives `postSendCleanup()`. Using `engineRef.current` is important when creating a session causes the welcome composer to remount; it prevents stale mirrored text or agent-command bubbles from surviving in the newly mounted input.
- **CSS scroll coordination.** `app.css` uses stable scrollbar gutters, disables browser scroll anchoring for the chat lane, and combines native bottom padding with `--inno-conversation-scroll-bottom-space`. This prevents streaming markdown/timeline re-renders from fighting explicit stick-to-bottom behavior.

### 7. Localization and showcase coverage

- Adds the complete trace vocabulary in `apps/inno-agent/web/src/i18n/locales/en.json` and `zh-CN.json`: timeline/work status, step statuses, thinking/reply/tool/skill/system labels, expandable-detail labels, workspace changes, errors, and accessibility text.
- Extends `apps/showcase` with a mock streaming/replay path and desktop bridge typings so the feature can be reviewed without a live agent backend.

## Documentation

The docs-only follow-up commit `36a8e56` updates `CLAUDE.md` in the same PR, as required by the repository guidance:

- Changes the test-suite fact from 56 files / 432 tests to 59 files / 469 tests.
- Records that the suite now includes backend chat-stream/trace persistence tests and web chat trace/timeline tests.
- Keeps the existing notes about the suite being skewed toward `memory/l2`, the tracked quality-remediation coverage, and `npm run build` as the primary sanity check.

## Key files

| Area | Files | Responsibility |
| --- | --- | --- |
| Server event contract | `apps/inno-agent/src/server/routes/chat.ts`, `src/chat/stream-registry.ts` | Normalize PI events, publish/replay ordered envelopes, enforce terminal state, compact payloads |
| Durable trace metadata | `src/server/trace-store.ts`, `trace-store.test.ts`, `src/server/session-model.ts` | Persist and merge UI-only traces, branch-safe assistant association |
| Session integration | `src/server.ts`, `src/server/routes/sessions.ts` | Preserve message identity/details and attach traces to history responses |
| Trace reducer | `apps/inno-agent/web/src/utils/chat-trace.ts` | Convert events to logical rows, timing, retries, terminal inference, legacy fallback |
| Chat state | `apps/inno-agent/web/src/stores/chat-store.ts` | Apply live events, reconnect from cursors, merge canonical history, restore traces |
| Renderer | `apps/inno-agent/web/src/react/chat/AgentTraceTimeline.tsx`, `MessageBubble.tsx`, `StreamingBubbles.tsx`, `ChatConversation.tsx` | Live/history timeline, details, questions, questionnaires, duplicate suppression |
| Supporting UX | `ChatCenter.tsx`, `TodoWidget.tsx`, `app.css`, locale files | Composer/status masks, todo reset, scroll/layout behavior, translations |
| Repository guidance | `CLAUDE.md` | Keep test-suite size and testing guidance aligned with verified repository facts |
| Showcase | `apps/showcase/src/App.tsx`, `src/mock/streaming.ts` | Deterministic trace replay for review |

## Tests added or updated

- `apps/inno-agent/src/chat/stream-registry.test.ts`: monotonic ids, cursor replay, duplicate tool handling, partial results, terminal transition rules, compaction, and baseline validation.
- `apps/inno-agent/src/server/trace-store.test.ts`: sidecar persistence/merge, safe removal, and preference for PI message ids when branching changes indexes.
- `apps/inno-agent/web/src/utils/chat-trace.test.ts`: thinking boundaries/timing, tool preparation/execution, retries, questions, skills, system events, workspace changes, filtering, missing boundaries, terminal inference, and legacy cold-start recovery.
- `apps/inno-agent/web/src/react/chat/AgentTraceTimeline.test.tsx`: collapsed/expanded rows, status wording, pending questions, live shimmer behavior, partial tool output, text placement, skill/tool details, and hidden bookkeeping.
- `apps/inno-agent/web/src/stores/chat-store.test.ts`: reconnect/cancellation ownership, cursor replay, question submission failure recovery, answered questionnaires, transient/canonical history merging, welcome sends, and skill restoration.
- `apps/inno-agent/web/src/react/chat/MessageBubble.agent-command.test.tsx` and `skill-message-collapse.test.ts`: immediate/persisted skill-command rendering and legacy skill recovery.

## Validation

- `npm test` — 59 test files passed, 469 tests passed.
- `npm run build` — server TypeScript build and main web production build passed.
- `npm run showcase:build` — TypeScript check and showcase production build passed.
- Build output contains existing Vite circular-chunk, dynamic/static import, and large-chunk warnings only; no build failures.

## Review focus

1. Verify normalized event ordering and cursor replay across reconnects, including a single terminal event.
2. Verify sidecar-to-session association across assistant fragments, session branching, deletion, and cold-start history.
3. Verify reducer behavior for provider omissions, retries, delayed tool updates, questions, and terminal/error states.
4. Verify that the timeline remains readable while streaming and does not duplicate the canonical assistant bubble after reload.
5. Verify composer/status masks, todo reset, jump-to-latest behavior, and English/Simplified Chinese labels.

