### PR TITLE
fix(chat): stop publishing mid-stream model errors as terminal events

### DIFF
--- a/apps/inno-agent/src/server/routes/chat.ts
+++ b/apps/inno-agent/src/server/routes/chat.ts
@@ -124,13 +124,20 @@ function piEventToSseEvent(event: any): unknown | null {
 			if (ev.type === "toolcall_start" || ev.type === "toolcall_delta" || ev.type === "toolcall_end") {
 				return toolCallStreamEventFromAssistantEvent(ev);
 			}
-			if (ev.type === "error") return { type: "error", message: ev.error?.errorMessage || "LLM API error", code: "pi_message_error", persisted: false };
+			// Mid-stream model errors must not be published as "error" events:
+			// "error" is a terminal type reserved for finishTurn(), and the
+			// publishStreamEvent guard throws "terminal event error must use
+			// finishTurn()", masking the real provider error. The terminal error
+			// event published from onFinish carries this same message.
+			if (ev.type === "error") return null;
 			return systemEventFromPi(ev, `message_update:${ev.type}`);
 		}
 		case "message_end": {
 			const msg = event.message;
 			if (msg && typeof msg === "object" && "stopReason" in msg && msg.stopReason === "error") {
-				return { type: "error", message: msg.errorMessage || "The model request failed.", code: "pi_message_error", persisted: false };
+				// See the message_update error case above — the terminal event
+				// from onFinish surfaces this error; publishing it here throws.
+				return null;
 			}
 			return systemEventFromPi(msg ?? event, "message_end");
 		}


### PR DESCRIPTION
## Problem

When a model request fails mid-stream (PI `message_end` with `stopReason: "error"`, or a `message_update` error event), `piEventToSseEvent` mapped it to `{ type: "error" }` and published it via `publishStreamEvent`. But `done`/`error`/`aborted` are terminal types reserved for `finishTurn()`, so the stream registry threw:

```
terminal event error must use finishTurn()
```

Worse, the throw happened inside the pi-runner subscriber **before** `streamError` was recorded, so the turn's terminal error event also carried this internal message — the real provider error (e.g. a `400` context-length rejection) was completely masked from the user.

## Fix

Return `null` for these two mid-stream error mappings in `piEventToSseEvent`. The real error still reaches the client: pi-runner records it as `streamError`, converts it to an error outcome, and `onFinish` publishes the terminal error event via `finishTurn()` with the actual provider message — which the frontend already renders (ErrorBlock + trace row).

## Verification

- Reproduced with a model returning 400 (context length): before the fix the UI showed `terminal event error must use finishTurn()`; after, the real 400 message is surfaced.
- `npm run build` passes; `vitest run apps/inno-agent/src/chat apps/inno-agent/src/server` — 80/80 green.