### PR TITLE
feat(web): show relative message timestamps

### DIFF
--- a/apps/inno-agent/web/src/app.css
+++ b/apps/inno-agent/web/src/app.css
@@ -1934,6 +1934,8 @@ inno-workspace-panel textarea {
 	display: flex;
 	align-items: center;
 	gap: 4px;
+	/* Date + time (e.g. "9月3日 22:53") must stay on a single line. */
+	white-space: nowrap;
 	min-height: 28px;
 	color: var(--inno-text-muted);
 	font-size: 12px;

--- a/apps/inno-agent/web/src/i18n/locales/en.json
+++ b/apps/inno-agent/web/src/i18n/locales/en.json
@@ -877,6 +877,7 @@
 		"removeImage": "Remove image",
 		"streamingInWorkspace": "Long output is generating in the file panel",
 		"longContentCollapsed": "Long content collapsed to keep the page responsive",
+		"yesterday": "Yesterday",
 		"expandFullContent": "Expand full content",
 		"collapseFullContent": "Collapse full content",
 		"composerPlaceholder": "Type a message…",

--- a/apps/inno-agent/web/src/i18n/locales/zh-CN.json
+++ b/apps/inno-agent/web/src/i18n/locales/zh-CN.json
@@ -877,6 +877,7 @@
 		"removeImage": "移除图片",
 		"streamingInWorkspace": "长内容正在右侧文件区生成",
 		"longContentCollapsed": "内容较长，已折叠以保持页面流畅",
+		"yesterday": "昨天",
 		"expandFullContent": "展开完整内容",
 		"collapseFullContent": "收起完整内容",
 		"composerPlaceholder": "输入消息…",

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.edit.test.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.edit.test.tsx
@@ -76,7 +76,8 @@ describe("MessageBubble edit and resend", () => {
 		});
 
 		try {
-			const timestamp = new Date(2026, 7, 30, 22, 35).getTime();
+			const now = new Date();
+			const timestamp = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 22, 35).getTime();
 			render(<MessageBubble message={{ ...plainUserMessage, timestamp }} />);
 
 			expect(screen.getByText("22:35")).toBeTruthy();
@@ -95,7 +96,8 @@ describe("MessageBubble edit and resend", () => {
 
 	it("shows copy, time, and retry actions for the last assistant message", () => {
 		const onRetry = vi.fn();
-		const timestamp = new Date(2026, 7, 30, 22, 35).getTime();
+		const now = new Date();
+		const timestamp = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 22, 35).getTime();
 		render(
 			<MessageBubble
 				message={{ role: "assistant", content: "answer", timestamp }}

--- a/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
+++ b/apps/inno-agent/web/src/react/chat/MessageBubble.tsx
@@ -2,6 +2,7 @@ import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { motion } from "motion/react";
 import { useTranslation } from "react-i18next";
+import type { TFunction } from "i18next";
 import { X, AlertTriangle, FileCode2, History, BookmarkPlus, BookOpen, Check, Copy, Pencil, RotateCcw, TerminalSquare } from "lucide-react";
 import type { AttachmentBinding, AttachmentRef, ChatMessage, ChatToolRecord, ChatTraceStep } from "../../types/chat.js";
 import { splitContentByBindings } from "../../utils/attachment-render.js";
@@ -395,11 +396,35 @@ function shouldCollapseAssistantContent(content: string): boolean {
 	return content.split(/\r\n|\r|\n/).length > LONG_ASSISTANT_LINES;
 }
 
-function formatMessageTime(timestamp: number): string {
+function formatMessageTime(timestamp: number, t: TFunction, language?: string): string {
 	if (!Number.isFinite(timestamp)) return "";
 	const date = new Date(timestamp);
 	if (Number.isNaN(date.getTime())) return "";
-	return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+	const time = `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+	const now = new Date();
+	const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	if (date >= startOfToday) return time;
+	const startOfYesterday = new Date(startOfToday);
+	startOfYesterday.setDate(startOfYesterday.getDate() - 1);
+	if (date >= startOfYesterday) return `${t("chat.yesterday")} ${time}`;
+	// Weeks start on Monday; anything from this week shows the weekday name.
+	const startOfWeek = new Date(startOfToday);
+	startOfWeek.setDate(startOfWeek.getDate() - ((startOfToday.getDay() + 6) % 7));
+	if (date >= startOfWeek) return `${formatWeekday(date, language)} ${time}`;
+	const withYear = date.getFullYear() !== now.getFullYear();
+	return `${formatDayLabel(date, language, withYear)} ${time}`;
+}
+
+function formatWeekday(date: Date, language?: string): string {
+	return new Intl.DateTimeFormat(language || undefined, { weekday: "short" }).format(date);
+}
+
+function formatDayLabel(date: Date, language: string | undefined, withYear: boolean): string {
+	return new Intl.DateTimeFormat(language || undefined, {
+		year: withYear ? "numeric" : undefined,
+		month: (language ?? "").toLowerCase().startsWith("zh") ? "long" : "short",
+		day: "numeric",
+	}).format(date);
 }
 
 function AssistantContent({ content }: { content: string }) {
@@ -507,7 +532,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 	liveBodies?: boolean;
 	onRetry?: () => void;
 }) {
-	const { t } = useTranslation();
+	const { t, i18n } = useTranslation();
 	const [lightboxSrc, setLightboxSrc] = useState<string | null>(null);
 	const [copied, setCopied] = useState(false);
 	const copyResetTimerRef = useRef<number | null>(null);
@@ -534,7 +559,7 @@ export const MessageBubble = memo(function MessageBubble({ message, showChannel,
 	// flow so text stays at its original position among thinking/tool rows.
 	const hasTraceTimeline = hasVisibleTraceSteps(traceSteps.filter((step) => step.kind !== "progress" && step.kind !== "answer"));
 	const hasTraceError = traceSteps.some((step) => step.kind === "error");
-	const messageTime = formatMessageTime(message.timestamp);
+	const messageTime = formatMessageTime(message.timestamp, t, i18n?.language);
 
 	useEffect(() => () => {
 		if (copyResetTimerRef.current !== null) window.clearTimeout(copyResetTimerRef.current);


### PR DESCRIPTION
## Summary
- Chat message timestamps now adapt to distance from today instead of always showing `HH:mm`:
  - today → `22:53`
  - yesterday → `昨天 22:53` / `Yesterday 22:53`
  - other days of the current week (Monday-based) → `周三 22:53` / `Wed 22:53`
  - older, same year → `9月3日 22:53` / `Sep 3, 22:53`
  - different year → `2025年12月3日 22:53` / `Dec 3, 2025 22:53`
- Weekday and date labels are localized through `Intl.DateTimeFormat` with the active i18n language; the `昨天` label uses a new `chat.yesterday` locale key.
- The message action row is now `white-space: nowrap` so date and time stay on a single line.
- `MessageBubble.edit.test.tsx` builds its time fixture from the current date instead of a hardcoded date that drifted into "last week".

## Test plan
- `npx tsc --noEmit` clean
- `vitest run apps/inno-agent/web` → 31 files / 235 tests passing